### PR TITLE
Conformance test results for v1.11/gardener-*

### DIFF
--- a/v1.11/gardener-aws/PRODUCT.yaml
+++ b/v1.11/gardener-aws/PRODUCT.yaml
@@ -1,0 +1,8 @@
+vendor: SAP
+name: Gardener (https://github.com/gardener/gardener) shoot cluster deployed on Amazon Web Services
+version: 0.8.0
+website_url: https://gardener.cloud
+documentation_url: https://github.com/gardener/documentation/wiki
+product_logo_url: https://raw.githubusercontent.com/gardener/documentation/master/images/logo_w_saplogo.svg
+type: installer
+description: The Gardener implements automated management and operation of Kubernetes clusters as a service and aims to support that service on multiple Cloud providers.

--- a/v1.11/gardener-aws/README.md
+++ b/v1.11/gardener-aws/README.md
@@ -1,0 +1,43 @@
+# To reproduce:
+
+## Create Kubernetes Cluster
+
+Login to SAP Gardener Dashboard to create a Kubernetes Clusters on Amazon Web Services, Microsoft Azure, Google Cloud Platform, or OpenStack cloud provider.
+
+After the creation completed, copy the cluster's kubeconfig, which is provided by the Gardener Dashboard in the cluster's detail view, to ~/.kube/config and launch the Kubernetes E2E conformance tests.
+
+## Launch E2E Conformance Tests
+1. Launch e2e pod and sonobuoy master under namespace `sonobuoy`   
+    ```shell
+    curl -L https://raw.githubusercontent.com/cncf/k8s-conformance/master/sonobuoy-conformance.yaml | kubectl apply -f -
+    ```
+
+2. Check logs of `sonobuoy` pod to see when test can be finished   
+Run
+
+    ```shell
+    kubectl logs -f -n sonobuoy sonobuoy
+    ```
+    and wait for line `no-exit was specified, sonobuoy is now blocking`.
+
+3. Use `kubectl cp` to copy the results to the client   
+Get the name of the <result archive> from the log output in step 2.
+
+    ```shell
+    kubectl cp sonobuoy/sonobuoy:/tmp/sonobuoy/<result archive> /home/result
+    ```
+
+4. Delete the conformance test resources
+
+    ```shell
+    curl -L https://raw.githubusercontent.com/cncf/k8s-conformance/master/sonobuoy-conformance.yaml | kubectl delete -f -
+    ```
+
+5. Untar the tarball
+
+    ```shell
+    cd /home/result
+    tar -xzf *_sonobuoy_*.tar.gz
+    ```
+
+    The result files `e2e.log` and `junit_01.xml` are located in the in the directory `plugins/e2e/results/`.

--- a/v1.11/gardener-aws/e2e.log
+++ b/v1.11/gardener-aws/e2e.log
@@ -1,0 +1,7457 @@
+Jul  2 12:53:52.658: INFO: Overriding default scale value of zero to 1
+Jul  2 12:53:52.659: INFO: Overriding default milliseconds value of zero to 5000
+I0702 12:53:52.906338      14 test_context.go:382] Using a temporary kubeconfig file from in-cluster config : /tmp/kubeconfig-411378559
+I0702 12:53:52.908135      14 e2e.go:333] Starting e2e run "f8ce21c2-7df6-11e8-bae1-da96248f62d7" on Ginkgo node 1
+Running Suite: Kubernetes e2e suite
+===================================
+Random Seed: 1530536032 - Will randomize all specs
+Will run 144 of 998 specs
+
+Jul  2 12:53:53.012: INFO: >>> kubeConfig: /tmp/kubeconfig-411378559
+Jul  2 12:53:53.014: INFO: Waiting up to 30m0s for all (but 0) nodes to be schedulable
+Jul  2 12:53:53.028: INFO: Waiting up to 10m0s for all pods (need at least 0) in namespace 'kube-system' to be running and ready
+Jul  2 12:53:53.059: INFO: 14 / 14 pods in namespace 'kube-system' are running and ready (0 seconds elapsed)
+Jul  2 12:53:53.059: INFO: expected 8 pod replicas in namespace 'kube-system', 8 are Running and Ready.
+Jul  2 12:53:53.063: INFO: Waiting for pods to enter Success, but no pods in "kube-system" match label map[name:e2e-image-puller]
+Jul  2 12:53:53.063: INFO: Dumping network health container logs from all nodes to file /tmp/results/nethealth.txt
+Jul  2 12:53:53.067: INFO: e2e test version: v1.11.0
+Jul  2 12:53:53.069: INFO: kube-apiserver version: v1.11.0
+SSSSSSSSSSSSSSSSSSSSSSSSS
+------------------------------
+[sig-storage] Secrets 
+  should be consumable from pods in volume [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-storage] Secrets
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 12:53:53.070: INFO: >>> kubeConfig: /tmp/kubeconfig-411378559
+STEP: Building a namespace api object
+Jul  2 12:53:53.159: INFO: No PodSecurityPolicies found; assuming PodSecurityPolicy is disabled.
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should be consumable from pods in volume [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating secret with name secret-test-f93af3dd-7df6-11e8-bae1-da96248f62d7
+STEP: Creating a pod to test consume secrets
+Jul  2 12:53:53.170: INFO: Waiting up to 5m0s for pod "pod-secrets-f93b759e-7df6-11e8-bae1-da96248f62d7" in namespace "e2e-tests-secrets-hmtdb" to be "success or failure"
+Jul  2 12:53:53.178: INFO: Pod "pod-secrets-f93b759e-7df6-11e8-bae1-da96248f62d7": Phase="Pending", Reason="", readiness=false. Elapsed: 7.46382ms
+Jul  2 12:53:55.181: INFO: Pod "pod-secrets-f93b759e-7df6-11e8-bae1-da96248f62d7": Phase="Pending", Reason="", readiness=false. Elapsed: 2.011193938s
+Jul  2 12:53:57.188: INFO: Pod "pod-secrets-f93b759e-7df6-11e8-bae1-da96248f62d7": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.017475408s
+STEP: Saw pod success
+Jul  2 12:53:57.188: INFO: Pod "pod-secrets-f93b759e-7df6-11e8-bae1-da96248f62d7" satisfied condition "success or failure"
+Jul  2 12:53:57.190: INFO: Trying to get logs from node ip-10-250-24-1.ec2.internal pod pod-secrets-f93b759e-7df6-11e8-bae1-da96248f62d7 container secret-volume-test: <nil>
+STEP: delete the pod
+Jul  2 12:53:57.455: INFO: Waiting for pod pod-secrets-f93b759e-7df6-11e8-bae1-da96248f62d7 to disappear
+Jul  2 12:53:57.460: INFO: Pod pod-secrets-f93b759e-7df6-11e8-bae1-da96248f62d7 no longer exists
+[AfterEach] [sig-storage] Secrets
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 12:53:57.460: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-secrets-hmtdb" for this suite.
+Jul  2 12:54:03.480: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 12:54:03.572: INFO: namespace: e2e-tests-secrets-hmtdb, resource: bindings, ignored listing per whitelist
+Jul  2 12:54:03.632: INFO: namespace e2e-tests-secrets-hmtdb deletion completed in 6.162886364s
+
+• [SLOW TEST:10.563 seconds]
+[sig-storage] Secrets
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/secrets_volume.go:33
+  should be consumable from pods in volume [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS
+------------------------------
+[sig-storage] EmptyDir volumes 
+  should support (non-root,0644,default) [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-storage] EmptyDir volumes
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 12:54:03.633: INFO: >>> kubeConfig: /tmp/kubeconfig-411378559
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should support (non-root,0644,default) [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating a pod to test emptydir 0644 on node default medium
+Jul  2 12:54:03.727: INFO: Waiting up to 5m0s for pod "pod-ff8647da-7df6-11e8-bae1-da96248f62d7" in namespace "e2e-tests-emptydir-9t5g7" to be "success or failure"
+Jul  2 12:54:03.730: INFO: Pod "pod-ff8647da-7df6-11e8-bae1-da96248f62d7": Phase="Pending", Reason="", readiness=false. Elapsed: 3.115909ms
+Jul  2 12:54:05.734: INFO: Pod "pod-ff8647da-7df6-11e8-bae1-da96248f62d7": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.006462071s
+STEP: Saw pod success
+Jul  2 12:54:05.734: INFO: Pod "pod-ff8647da-7df6-11e8-bae1-da96248f62d7" satisfied condition "success or failure"
+Jul  2 12:54:05.736: INFO: Trying to get logs from node ip-10-250-24-1.ec2.internal pod pod-ff8647da-7df6-11e8-bae1-da96248f62d7 container test-container: <nil>
+STEP: delete the pod
+Jul  2 12:54:05.824: INFO: Waiting for pod pod-ff8647da-7df6-11e8-bae1-da96248f62d7 to disappear
+Jul  2 12:54:05.828: INFO: Pod pod-ff8647da-7df6-11e8-bae1-da96248f62d7 no longer exists
+[AfterEach] [sig-storage] EmptyDir volumes
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 12:54:05.828: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-emptydir-9t5g7" for this suite.
+Jul  2 12:54:11.848: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 12:54:11.864: INFO: namespace: e2e-tests-emptydir-9t5g7, resource: bindings, ignored listing per whitelist
+Jul  2 12:54:12.004: INFO: namespace e2e-tests-emptydir-9t5g7 deletion completed in 6.169785656s
+
+• [SLOW TEST:8.371 seconds]
+[sig-storage] EmptyDir volumes
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/empty_dir.go:40
+  should support (non-root,0644,default) [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSS
+------------------------------
+[sig-network] Services 
+  should provide secure master service  [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-network] Services
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 12:54:12.004: INFO: >>> kubeConfig: /tmp/kubeconfig-411378559
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-network] Services
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/network/service.go:83
+[It] should provide secure master service  [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[AfterEach] [sig-network] Services
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 12:54:12.091: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-services-htjxf" for this suite.
+Jul  2 12:54:18.148: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 12:54:18.191: INFO: namespace: e2e-tests-services-htjxf, resource: bindings, ignored listing per whitelist
+Jul  2 12:54:18.243: INFO: namespace e2e-tests-services-htjxf deletion completed in 6.148505684s
+[AfterEach] [sig-network] Services
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/network/service.go:88
+
+• [SLOW TEST:6.240 seconds]
+[sig-network] Services
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/network/framework.go:22
+  should provide secure master service  [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+[sig-apps] ReplicaSet 
+  should serve a basic image on each replica with a public image  [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-apps] ReplicaSet
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 12:54:18.244: INFO: >>> kubeConfig: /tmp/kubeconfig-411378559
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should serve a basic image on each replica with a public image  [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+Jul  2 12:54:18.335: INFO: Creating ReplicaSet my-hostname-basic-083c3921-7df7-11e8-bae1-da96248f62d7
+Jul  2 12:54:18.344: INFO: Pod name my-hostname-basic-083c3921-7df7-11e8-bae1-da96248f62d7: Found 0 pods out of 1
+Jul  2 12:54:23.348: INFO: Pod name my-hostname-basic-083c3921-7df7-11e8-bae1-da96248f62d7: Found 1 pods out of 1
+Jul  2 12:54:23.348: INFO: Ensuring a pod for ReplicaSet "my-hostname-basic-083c3921-7df7-11e8-bae1-da96248f62d7" is running
+Jul  2 12:54:23.351: INFO: Pod "my-hostname-basic-083c3921-7df7-11e8-bae1-da96248f62d7-n99b8" is running (conditions: [{Type:Initialized Status:True LastProbeTime:0001-01-01 00:00:00 +0000 UTC LastTransitionTime:2018-07-02 12:54:18 +0000 UTC Reason: Message:} {Type:Ready Status:True LastProbeTime:0001-01-01 00:00:00 +0000 UTC LastTransitionTime:2018-07-02 12:54:20 +0000 UTC Reason: Message:} {Type:ContainersReady Status:True LastProbeTime:0001-01-01 00:00:00 +0000 UTC LastTransitionTime:0001-01-01 00:00:00 +0000 UTC Reason: Message:} {Type:PodScheduled Status:True LastProbeTime:0001-01-01 00:00:00 +0000 UTC LastTransitionTime:2018-07-02 12:54:18 +0000 UTC Reason: Message:}])
+Jul  2 12:54:23.351: INFO: Trying to dial the pod
+Jul  2 12:54:28.441: INFO: Controller my-hostname-basic-083c3921-7df7-11e8-bae1-da96248f62d7: Got expected result from replica 1 [my-hostname-basic-083c3921-7df7-11e8-bae1-da96248f62d7-n99b8]: "my-hostname-basic-083c3921-7df7-11e8-bae1-da96248f62d7-n99b8", 1 of 1 required successes so far
+[AfterEach] [sig-apps] ReplicaSet
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 12:54:28.441: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-replicaset-nzmm9" for this suite.
+Jul  2 12:54:34.461: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 12:54:34.615: INFO: namespace: e2e-tests-replicaset-nzmm9, resource: bindings, ignored listing per whitelist
+Jul  2 12:54:34.675: INFO: namespace e2e-tests-replicaset-nzmm9 deletion completed in 6.226293216s
+
+• [SLOW TEST:16.431 seconds]
+[sig-apps] ReplicaSet
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/framework.go:22
+  should serve a basic image on each replica with a public image  [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSSSSSS
+------------------------------
+[sig-storage] Projected 
+  should be consumable from pods in volume as non-root with defaultMode and fsGroup set [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 12:54:34.675: INFO: >>> kubeConfig: /tmp/kubeconfig-411378559
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:858
+[It] should be consumable from pods in volume as non-root with defaultMode and fsGroup set [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating projection with secret that has name projected-secret-test-1206bec4-7df7-11e8-bae1-da96248f62d7
+STEP: Creating a pod to test consume secrets
+Jul  2 12:54:34.771: INFO: Waiting up to 5m0s for pod "pod-projected-secrets-1207454a-7df7-11e8-bae1-da96248f62d7" in namespace "e2e-tests-projected-hgfzn" to be "success or failure"
+Jul  2 12:54:34.774: INFO: Pod "pod-projected-secrets-1207454a-7df7-11e8-bae1-da96248f62d7": Phase="Pending", Reason="", readiness=false. Elapsed: 3.369258ms
+Jul  2 12:54:36.778: INFO: Pod "pod-projected-secrets-1207454a-7df7-11e8-bae1-da96248f62d7": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.007120846s
+STEP: Saw pod success
+Jul  2 12:54:36.778: INFO: Pod "pod-projected-secrets-1207454a-7df7-11e8-bae1-da96248f62d7" satisfied condition "success or failure"
+Jul  2 12:54:36.781: INFO: Trying to get logs from node ip-10-250-24-1.ec2.internal pod pod-projected-secrets-1207454a-7df7-11e8-bae1-da96248f62d7 container projected-secret-volume-test: <nil>
+STEP: delete the pod
+Jul  2 12:54:36.863: INFO: Waiting for pod pod-projected-secrets-1207454a-7df7-11e8-bae1-da96248f62d7 to disappear
+Jul  2 12:54:36.867: INFO: Pod pod-projected-secrets-1207454a-7df7-11e8-bae1-da96248f62d7 no longer exists
+[AfterEach] [sig-storage] Projected
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 12:54:36.868: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-hgfzn" for this suite.
+Jul  2 12:54:42.948: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 12:54:43.040: INFO: namespace: e2e-tests-projected-hgfzn, resource: bindings, ignored listing per whitelist
+Jul  2 12:54:43.045: INFO: namespace e2e-tests-projected-hgfzn deletion completed in 6.173869475s
+
+• [SLOW TEST:8.370 seconds]
+[sig-storage] Projected
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:34
+  should be consumable from pods in volume as non-root with defaultMode and fsGroup set [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSS
+------------------------------
+[sig-storage] Downward API volume 
+  should set mode on item file [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 12:54:43.045: INFO: >>> kubeConfig: /tmp/kubeconfig-411378559
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downwardapi_volume.go:38
+[It] should set mode on item file [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating a pod to test downward API volume plugin
+Jul  2 12:54:43.136: INFO: Waiting up to 5m0s for pod "downwardapi-volume-1703b868-7df7-11e8-bae1-da96248f62d7" in namespace "e2e-tests-downward-api-k2tdx" to be "success or failure"
+Jul  2 12:54:43.139: INFO: Pod "downwardapi-volume-1703b868-7df7-11e8-bae1-da96248f62d7": Phase="Pending", Reason="", readiness=false. Elapsed: 2.676374ms
+Jul  2 12:54:45.143: INFO: Pod "downwardapi-volume-1703b868-7df7-11e8-bae1-da96248f62d7": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.006590878s
+STEP: Saw pod success
+Jul  2 12:54:45.143: INFO: Pod "downwardapi-volume-1703b868-7df7-11e8-bae1-da96248f62d7" satisfied condition "success or failure"
+Jul  2 12:54:45.146: INFO: Trying to get logs from node ip-10-250-24-1.ec2.internal pod downwardapi-volume-1703b868-7df7-11e8-bae1-da96248f62d7 container client-container: <nil>
+STEP: delete the pod
+Jul  2 12:54:45.164: INFO: Waiting for pod downwardapi-volume-1703b868-7df7-11e8-bae1-da96248f62d7 to disappear
+Jul  2 12:54:45.168: INFO: Pod downwardapi-volume-1703b868-7df7-11e8-bae1-da96248f62d7 no longer exists
+[AfterEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 12:54:45.168: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-downward-api-k2tdx" for this suite.
+Jul  2 12:54:51.183: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 12:54:51.223: INFO: namespace: e2e-tests-downward-api-k2tdx, resource: bindings, ignored listing per whitelist
+Jul  2 12:54:51.280: INFO: namespace e2e-tests-downward-api-k2tdx deletion completed in 6.106238425s
+
+• [SLOW TEST:8.235 seconds]
+[sig-storage] Downward API volume
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downwardapi_volume.go:33
+  should set mode on item file [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SS
+------------------------------
+[sig-storage] EmptyDir volumes 
+  should support (non-root,0644,tmpfs) [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-storage] EmptyDir volumes
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 12:54:51.280: INFO: >>> kubeConfig: /tmp/kubeconfig-411378559
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should support (non-root,0644,tmpfs) [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating a pod to test emptydir 0644 on tmpfs
+Jul  2 12:54:51.373: INFO: Waiting up to 5m0s for pod "pod-1beca3a5-7df7-11e8-bae1-da96248f62d7" in namespace "e2e-tests-emptydir-gzsnd" to be "success or failure"
+Jul  2 12:54:51.379: INFO: Pod "pod-1beca3a5-7df7-11e8-bae1-da96248f62d7": Phase="Pending", Reason="", readiness=false. Elapsed: 5.748048ms
+Jul  2 12:54:53.384: INFO: Pod "pod-1beca3a5-7df7-11e8-bae1-da96248f62d7": Phase="Running", Reason="", readiness=true. Elapsed: 2.010131667s
+Jul  2 12:54:55.387: INFO: Pod "pod-1beca3a5-7df7-11e8-bae1-da96248f62d7": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.013167413s
+STEP: Saw pod success
+Jul  2 12:54:55.387: INFO: Pod "pod-1beca3a5-7df7-11e8-bae1-da96248f62d7" satisfied condition "success or failure"
+Jul  2 12:54:55.389: INFO: Trying to get logs from node ip-10-250-24-1.ec2.internal pod pod-1beca3a5-7df7-11e8-bae1-da96248f62d7 container test-container: <nil>
+STEP: delete the pod
+Jul  2 12:54:55.408: INFO: Waiting for pod pod-1beca3a5-7df7-11e8-bae1-da96248f62d7 to disappear
+Jul  2 12:54:55.447: INFO: Pod pod-1beca3a5-7df7-11e8-bae1-da96248f62d7 no longer exists
+[AfterEach] [sig-storage] EmptyDir volumes
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 12:54:55.447: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-emptydir-gzsnd" for this suite.
+Jul  2 12:55:01.471: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 12:55:01.563: INFO: namespace: e2e-tests-emptydir-gzsnd, resource: bindings, ignored listing per whitelist
+Jul  2 12:55:01.636: INFO: namespace e2e-tests-emptydir-gzsnd deletion completed in 6.178741707s
+
+• [SLOW TEST:10.357 seconds]
+[sig-storage] EmptyDir volumes
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/empty_dir.go:40
+  should support (non-root,0644,tmpfs) [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSSSSSSSSSSSSSSSSSSS
+------------------------------
+[sig-network] Networking Granular Checks: Pods 
+  should function for node-pod communication: udp [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-network] Networking
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 12:55:01.637: INFO: >>> kubeConfig: /tmp/kubeconfig-411378559
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should function for node-pod communication: udp [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Performing setup for networking test in namespace e2e-tests-pod-network-test-bc7kf
+STEP: creating a selector
+STEP: Creating the service pods in kubernetes
+Jul  2 12:55:01.740: INFO: Waiting up to 10m0s for all (but 0) nodes to be schedulable
+STEP: Creating test pods
+Jul  2 12:55:19.975: INFO: ExecWithOptions {Command:[/bin/sh -c echo 'hostName' | timeout -t 2 nc -w 1 -u 100.96.1.12 8081 | grep -v '^\s*$'] Namespace:e2e-tests-pod-network-test-bc7kf PodName:host-test-container-pod ContainerName:hostexec Stdin:<nil> CaptureStdout:true CaptureStderr:true PreserveWhitespace:false}
+Jul  2 12:55:19.976: INFO: >>> kubeConfig: /tmp/kubeconfig-411378559
+Jul  2 12:55:21.340: INFO: Found all expected endpoints: [netserver-0]
+Jul  2 12:55:21.348: INFO: ExecWithOptions {Command:[/bin/sh -c echo 'hostName' | timeout -t 2 nc -w 1 -u 100.96.0.10 8081 | grep -v '^\s*$'] Namespace:e2e-tests-pod-network-test-bc7kf PodName:host-test-container-pod ContainerName:hostexec Stdin:<nil> CaptureStdout:true CaptureStderr:true PreserveWhitespace:false}
+Jul  2 12:55:21.348: INFO: >>> kubeConfig: /tmp/kubeconfig-411378559
+Jul  2 12:55:22.754: INFO: Found all expected endpoints: [netserver-1]
+[AfterEach] [sig-network] Networking
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 12:55:22.754: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-pod-network-test-bc7kf" for this suite.
+Jul  2 12:55:44.773: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 12:55:44.887: INFO: namespace: e2e-tests-pod-network-test-bc7kf, resource: bindings, ignored listing per whitelist
+Jul  2 12:55:44.932: INFO: namespace e2e-tests-pod-network-test-bc7kf deletion completed in 22.170237245s
+
+• [SLOW TEST:43.295 seconds]
+[sig-network] Networking
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/networking.go:25
+  Granular Checks: Pods
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/networking.go:28
+    should function for node-pod communication: udp [NodeConformance] [Conformance]
+    /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSSSSSS
+------------------------------
+[sig-network] DNS 
+  should provide DNS for services  [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-network] DNS
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 12:55:44.932: INFO: >>> kubeConfig: /tmp/kubeconfig-411378559
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should provide DNS for services  [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating a test headless service
+STEP: Running these commands on wheezy: for i in `seq 1 600`; do test -n "$$(dig +notcp +noall +answer +search dns-test-service A)" && echo OK > /results/wheezy_udp@dns-test-service;test -n "$$(dig +tcp +noall +answer +search dns-test-service A)" && echo OK > /results/wheezy_tcp@dns-test-service;test -n "$$(dig +notcp +noall +answer +search dns-test-service.e2e-tests-dns-qlpwl A)" && echo OK > /results/wheezy_udp@dns-test-service.e2e-tests-dns-qlpwl;test -n "$$(dig +tcp +noall +answer +search dns-test-service.e2e-tests-dns-qlpwl A)" && echo OK > /results/wheezy_tcp@dns-test-service.e2e-tests-dns-qlpwl;test -n "$$(dig +notcp +noall +answer +search dns-test-service.e2e-tests-dns-qlpwl.svc A)" && echo OK > /results/wheezy_udp@dns-test-service.e2e-tests-dns-qlpwl.svc;test -n "$$(dig +tcp +noall +answer +search dns-test-service.e2e-tests-dns-qlpwl.svc A)" && echo OK > /results/wheezy_tcp@dns-test-service.e2e-tests-dns-qlpwl.svc;test -n "$$(dig +notcp +noall +answer +search _http._tcp.dns-test-service.e2e-tests-dns-qlpwl.svc SRV)" && echo OK > /results/wheezy_udp@_http._tcp.dns-test-service.e2e-tests-dns-qlpwl.svc;test -n "$$(dig +tcp +noall +answer +search _http._tcp.dns-test-service.e2e-tests-dns-qlpwl.svc SRV)" && echo OK > /results/wheezy_tcp@_http._tcp.dns-test-service.e2e-tests-dns-qlpwl.svc;test -n "$$(dig +notcp +noall +answer +search _http._tcp.test-service-2.e2e-tests-dns-qlpwl.svc SRV)" && echo OK > /results/wheezy_udp@_http._tcp.test-service-2.e2e-tests-dns-qlpwl.svc;test -n "$$(dig +tcp +noall +answer +search _http._tcp.test-service-2.e2e-tests-dns-qlpwl.svc SRV)" && echo OK > /results/wheezy_tcp@_http._tcp.test-service-2.e2e-tests-dns-qlpwl.svc;podARec=$$(hostname -i| awk -F. '{print $$1"-"$$2"-"$$3"-"$$4".e2e-tests-dns-qlpwl.pod.cluster.local"}');test -n "$$(dig +notcp +noall +answer +search $${podARec} A)" && echo OK > /results/wheezy_udp@PodARecord;test -n "$$(dig +tcp +noall +answer +search $${podARec} A)" && echo OK > /results/wheezy_tcp@PodARecord;test -n "$$(dig +notcp +noall +answer +search 144.167.67.100.in-addr.arpa. PTR)" && echo OK > /results/100.67.167.144_udp@PTR;test -n "$$(dig +tcp +noall +answer +search 144.167.67.100.in-addr.arpa. PTR)" && echo OK > /results/100.67.167.144_tcp@PTR;sleep 1; done
+
+STEP: Running these commands on jessie: for i in `seq 1 600`; do test -n "$$(dig +notcp +noall +answer +search dns-test-service A)" && echo OK > /results/jessie_udp@dns-test-service;test -n "$$(dig +tcp +noall +answer +search dns-test-service A)" && echo OK > /results/jessie_tcp@dns-test-service;test -n "$$(dig +notcp +noall +answer +search dns-test-service.e2e-tests-dns-qlpwl A)" && echo OK > /results/jessie_udp@dns-test-service.e2e-tests-dns-qlpwl;test -n "$$(dig +tcp +noall +answer +search dns-test-service.e2e-tests-dns-qlpwl A)" && echo OK > /results/jessie_tcp@dns-test-service.e2e-tests-dns-qlpwl;test -n "$$(dig +notcp +noall +answer +search dns-test-service.e2e-tests-dns-qlpwl.svc A)" && echo OK > /results/jessie_udp@dns-test-service.e2e-tests-dns-qlpwl.svc;test -n "$$(dig +tcp +noall +answer +search dns-test-service.e2e-tests-dns-qlpwl.svc A)" && echo OK > /results/jessie_tcp@dns-test-service.e2e-tests-dns-qlpwl.svc;test -n "$$(dig +notcp +noall +answer +search _http._tcp.dns-test-service.e2e-tests-dns-qlpwl.svc SRV)" && echo OK > /results/jessie_udp@_http._tcp.dns-test-service.e2e-tests-dns-qlpwl.svc;test -n "$$(dig +tcp +noall +answer +search _http._tcp.dns-test-service.e2e-tests-dns-qlpwl.svc SRV)" && echo OK > /results/jessie_tcp@_http._tcp.dns-test-service.e2e-tests-dns-qlpwl.svc;test -n "$$(dig +notcp +noall +answer +search _http._tcp.test-service-2.e2e-tests-dns-qlpwl.svc SRV)" && echo OK > /results/jessie_udp@_http._tcp.test-service-2.e2e-tests-dns-qlpwl.svc;test -n "$$(dig +tcp +noall +answer +search _http._tcp.test-service-2.e2e-tests-dns-qlpwl.svc SRV)" && echo OK > /results/jessie_tcp@_http._tcp.test-service-2.e2e-tests-dns-qlpwl.svc;podARec=$$(hostname -i| awk -F. '{print $$1"-"$$2"-"$$3"-"$$4".e2e-tests-dns-qlpwl.pod.cluster.local"}');test -n "$$(dig +notcp +noall +answer +search $${podARec} A)" && echo OK > /results/jessie_udp@PodARecord;test -n "$$(dig +tcp +noall +answer +search $${podARec} A)" && echo OK > /results/jessie_tcp@PodARecord;test -n "$$(dig +notcp +noall +answer +search 144.167.67.100.in-addr.arpa. PTR)" && echo OK > /results/100.67.167.144_udp@PTR;test -n "$$(dig +tcp +noall +answer +search 144.167.67.100.in-addr.arpa. PTR)" && echo OK > /results/100.67.167.144_tcp@PTR;sleep 1; done
+
+STEP: creating a pod to probe DNS
+STEP: submitting the pod to kubernetes
+STEP: retrieving the pod
+STEP: looking for the results for each expected name from probers
+Jul  2 12:56:07.297: INFO: DNS probes using dns-test-3be96929-7df7-11e8-bae1-da96248f62d7 succeeded
+
+STEP: deleting the pod
+STEP: deleting the test service
+STEP: deleting the test headless service
+[AfterEach] [sig-network] DNS
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 12:56:07.357: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-dns-qlpwl" for this suite.
+Jul  2 12:56:13.381: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 12:56:13.526: INFO: namespace: e2e-tests-dns-qlpwl, resource: bindings, ignored listing per whitelist
+Jul  2 12:56:13.539: INFO: namespace e2e-tests-dns-qlpwl deletion completed in 6.169956302s
+
+• [SLOW TEST:28.607 seconds]
+[sig-network] DNS
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/network/framework.go:22
+  should provide DNS for services  [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSSS
+------------------------------
+[k8s.io] Docker Containers 
+  should be able to override the image's default command (docker entrypoint) [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [k8s.io] Docker Containers
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 12:56:13.539: INFO: >>> kubeConfig: /tmp/kubeconfig-411378559
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should be able to override the image's default command (docker entrypoint) [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating a pod to test override command
+Jul  2 12:56:13.635: INFO: Waiting up to 5m0s for pod "client-containers-4cf4a145-7df7-11e8-bae1-da96248f62d7" in namespace "e2e-tests-containers-xqc54" to be "success or failure"
+Jul  2 12:56:13.639: INFO: Pod "client-containers-4cf4a145-7df7-11e8-bae1-da96248f62d7": Phase="Pending", Reason="", readiness=false. Elapsed: 3.377042ms
+Jul  2 12:56:15.642: INFO: Pod "client-containers-4cf4a145-7df7-11e8-bae1-da96248f62d7": Phase="Pending", Reason="", readiness=false. Elapsed: 2.00669122s
+Jul  2 12:56:17.645: INFO: Pod "client-containers-4cf4a145-7df7-11e8-bae1-da96248f62d7": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.010171195s
+STEP: Saw pod success
+Jul  2 12:56:17.645: INFO: Pod "client-containers-4cf4a145-7df7-11e8-bae1-da96248f62d7" satisfied condition "success or failure"
+Jul  2 12:56:17.648: INFO: Trying to get logs from node ip-10-250-24-1.ec2.internal pod client-containers-4cf4a145-7df7-11e8-bae1-da96248f62d7 container test-container: <nil>
+STEP: delete the pod
+Jul  2 12:56:17.669: INFO: Waiting for pod client-containers-4cf4a145-7df7-11e8-bae1-da96248f62d7 to disappear
+Jul  2 12:56:17.686: INFO: Pod client-containers-4cf4a145-7df7-11e8-bae1-da96248f62d7 no longer exists
+[AfterEach] [k8s.io] Docker Containers
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 12:56:17.686: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-containers-xqc54" for this suite.
+Jul  2 12:56:23.704: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 12:56:23.882: INFO: namespace: e2e-tests-containers-xqc54, resource: bindings, ignored listing per whitelist
+Jul  2 12:56:23.927: INFO: namespace e2e-tests-containers-xqc54 deletion completed in 6.235867885s
+
+• [SLOW TEST:10.388 seconds]
+[k8s.io] Docker Containers
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:679
+  should be able to override the image's default command (docker entrypoint) [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+[sig-api-machinery] CustomResourceDefinition resources Simple CustomResourceDefinition 
+  creating/deleting custom resource definition objects works  [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-api-machinery] CustomResourceDefinition resources
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 12:56:23.928: INFO: >>> kubeConfig: /tmp/kubeconfig-411378559
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] creating/deleting custom resource definition objects works  [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+Jul  2 12:56:24.020: INFO: >>> kubeConfig: /tmp/kubeconfig-411378559
+[AfterEach] [sig-api-machinery] CustomResourceDefinition resources
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 12:56:25.064: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-custom-resource-definition-n4frd" for this suite.
+Jul  2 12:56:31.155: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 12:56:31.264: INFO: namespace: e2e-tests-custom-resource-definition-n4frd, resource: bindings, ignored listing per whitelist
+Jul  2 12:56:31.331: INFO: namespace e2e-tests-custom-resource-definition-n4frd deletion completed in 6.262541687s
+
+• [SLOW TEST:7.403 seconds]
+[sig-api-machinery] CustomResourceDefinition resources
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apimachinery/framework.go:22
+  Simple CustomResourceDefinition
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apimachinery/custom_resource_definition.go:35
+    creating/deleting custom resource definition objects works  [Conformance]
+    /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+[k8s.io] Probing container 
+  should *not* be restarted with a /healthz http liveness probe [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [k8s.io] Probing container
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 12:56:31.331: INFO: >>> kubeConfig: /tmp/kubeconfig-411378559
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [k8s.io] Probing container
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/container_probe.go:48
+[It] should *not* be restarted with a /healthz http liveness probe [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating pod liveness-http in namespace e2e-tests-container-probe-s9j5d
+Jul  2 12:56:37.427: INFO: Started pod liveness-http in namespace e2e-tests-container-probe-s9j5d
+STEP: checking the pod's current state and verifying that restartCount is present
+Jul  2 12:56:37.430: INFO: Initial restart count of pod liveness-http is 0
+STEP: deleting the pod
+[AfterEach] [k8s.io] Probing container
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:00:39.061: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-container-probe-s9j5d" for this suite.
+Jul  2 13:00:45.107: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:00:45.135: INFO: namespace: e2e-tests-container-probe-s9j5d, resource: bindings, ignored listing per whitelist
+Jul  2 13:00:45.205: INFO: namespace e2e-tests-container-probe-s9j5d deletion completed in 6.109967624s
+
+• [SLOW TEST:253.874 seconds]
+[k8s.io] Probing container
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:679
+  should *not* be restarted with a /healthz http liveness probe [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSSS
+------------------------------
+[sig-api-machinery] Secrets 
+  should be consumable from pods in env vars [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-api-machinery] Secrets
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:00:45.206: INFO: >>> kubeConfig: /tmp/kubeconfig-411378559
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should be consumable from pods in env vars [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating secret with name secret-test-eee202f8-7df7-11e8-bae1-da96248f62d7
+STEP: Creating a pod to test consume secrets
+Jul  2 13:00:45.307: INFO: Waiting up to 5m0s for pod "pod-secrets-eee281c0-7df7-11e8-bae1-da96248f62d7" in namespace "e2e-tests-secrets-4z4tj" to be "success or failure"
+Jul  2 13:00:45.312: INFO: Pod "pod-secrets-eee281c0-7df7-11e8-bae1-da96248f62d7": Phase="Pending", Reason="", readiness=false. Elapsed: 4.65019ms
+Jul  2 13:00:47.320: INFO: Pod "pod-secrets-eee281c0-7df7-11e8-bae1-da96248f62d7": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.012554746s
+STEP: Saw pod success
+Jul  2 13:00:47.320: INFO: Pod "pod-secrets-eee281c0-7df7-11e8-bae1-da96248f62d7" satisfied condition "success or failure"
+Jul  2 13:00:47.322: INFO: Trying to get logs from node ip-10-250-24-1.ec2.internal pod pod-secrets-eee281c0-7df7-11e8-bae1-da96248f62d7 container secret-env-test: <nil>
+STEP: delete the pod
+Jul  2 13:00:47.442: INFO: Waiting for pod pod-secrets-eee281c0-7df7-11e8-bae1-da96248f62d7 to disappear
+Jul  2 13:00:47.444: INFO: Pod pod-secrets-eee281c0-7df7-11e8-bae1-da96248f62d7 no longer exists
+[AfterEach] [sig-api-machinery] Secrets
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:00:47.444: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-secrets-4z4tj" for this suite.
+Jul  2 13:00:53.458: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:00:53.523: INFO: namespace: e2e-tests-secrets-4z4tj, resource: bindings, ignored listing per whitelist
+Jul  2 13:00:53.564: INFO: namespace e2e-tests-secrets-4z4tj deletion completed in 6.116018176s
+
+• [SLOW TEST:8.358 seconds]
+[sig-api-machinery] Secrets
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/secrets.go:30
+  should be consumable from pods in env vars [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+[sig-storage] ConfigMap 
+  should be consumable from pods in volume [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-storage] ConfigMap
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:00:53.564: INFO: >>> kubeConfig: /tmp/kubeconfig-411378559
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should be consumable from pods in volume [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating configMap with name configmap-test-volume-f3dcdc31-7df7-11e8-bae1-da96248f62d7
+STEP: Creating a pod to test consume configMaps
+Jul  2 13:00:53.664: INFO: Waiting up to 5m0s for pod "pod-configmaps-f3ddb781-7df7-11e8-bae1-da96248f62d7" in namespace "e2e-tests-configmap-lqllc" to be "success or failure"
+Jul  2 13:00:53.669: INFO: Pod "pod-configmaps-f3ddb781-7df7-11e8-bae1-da96248f62d7": Phase="Pending", Reason="", readiness=false. Elapsed: 5.392767ms
+Jul  2 13:00:55.673: INFO: Pod "pod-configmaps-f3ddb781-7df7-11e8-bae1-da96248f62d7": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.009323082s
+STEP: Saw pod success
+Jul  2 13:00:55.673: INFO: Pod "pod-configmaps-f3ddb781-7df7-11e8-bae1-da96248f62d7" satisfied condition "success or failure"
+Jul  2 13:00:55.676: INFO: Trying to get logs from node ip-10-250-24-1.ec2.internal pod pod-configmaps-f3ddb781-7df7-11e8-bae1-da96248f62d7 container configmap-volume-test: <nil>
+STEP: delete the pod
+Jul  2 13:00:55.695: INFO: Waiting for pod pod-configmaps-f3ddb781-7df7-11e8-bae1-da96248f62d7 to disappear
+Jul  2 13:00:55.700: INFO: Pod pod-configmaps-f3ddb781-7df7-11e8-bae1-da96248f62d7 no longer exists
+[AfterEach] [sig-storage] ConfigMap
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:00:55.700: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-configmap-lqllc" for this suite.
+Jul  2 13:01:01.730: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:01:01.947: INFO: namespace: e2e-tests-configmap-lqllc, resource: bindings, ignored listing per whitelist
+Jul  2 13:01:01.953: INFO: namespace e2e-tests-configmap-lqllc deletion completed in 6.242384609s
+
+• [SLOW TEST:8.389 seconds]
+[sig-storage] ConfigMap
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/configmap_volume.go:32
+  should be consumable from pods in volume [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSS
+------------------------------
+[sig-storage] Projected 
+  should provide container's cpu limit [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:01:01.953: INFO: >>> kubeConfig: /tmp/kubeconfig-411378559
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:858
+[It] should provide container's cpu limit [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating a pod to test downward API volume plugin
+Jul  2 13:01:02.068: INFO: Waiting up to 5m0s for pod "downwardapi-volume-f8dfcf06-7df7-11e8-bae1-da96248f62d7" in namespace "e2e-tests-projected-4hkl9" to be "success or failure"
+Jul  2 13:01:02.072: INFO: Pod "downwardapi-volume-f8dfcf06-7df7-11e8-bae1-da96248f62d7": Phase="Pending", Reason="", readiness=false. Elapsed: 4.475863ms
+Jul  2 13:01:04.077: INFO: Pod "downwardapi-volume-f8dfcf06-7df7-11e8-bae1-da96248f62d7": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.008689532s
+STEP: Saw pod success
+Jul  2 13:01:04.077: INFO: Pod "downwardapi-volume-f8dfcf06-7df7-11e8-bae1-da96248f62d7" satisfied condition "success or failure"
+Jul  2 13:01:04.080: INFO: Trying to get logs from node ip-10-250-24-1.ec2.internal pod downwardapi-volume-f8dfcf06-7df7-11e8-bae1-da96248f62d7 container client-container: <nil>
+STEP: delete the pod
+Jul  2 13:01:04.098: INFO: Waiting for pod downwardapi-volume-f8dfcf06-7df7-11e8-bae1-da96248f62d7 to disappear
+Jul  2 13:01:04.101: INFO: Pod downwardapi-volume-f8dfcf06-7df7-11e8-bae1-da96248f62d7 no longer exists
+[AfterEach] [sig-storage] Projected
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:01:04.101: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-4hkl9" for this suite.
+Jul  2 13:01:10.115: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:01:10.160: INFO: namespace: e2e-tests-projected-4hkl9, resource: bindings, ignored listing per whitelist
+Jul  2 13:01:10.222: INFO: namespace e2e-tests-projected-4hkl9 deletion completed in 6.116645884s
+
+• [SLOW TEST:8.269 seconds]
+[sig-storage] Projected
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:34
+  should provide container's cpu limit [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSS
+------------------------------
+[sig-storage] Downward API volume 
+  should provide container's cpu limit [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:01:10.222: INFO: >>> kubeConfig: /tmp/kubeconfig-411378559
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downwardapi_volume.go:38
+[It] should provide container's cpu limit [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating a pod to test downward API volume plugin
+Jul  2 13:01:10.324: INFO: Waiting up to 5m0s for pod "downwardapi-volume-fdcbc845-7df7-11e8-bae1-da96248f62d7" in namespace "e2e-tests-downward-api-4k86b" to be "success or failure"
+Jul  2 13:01:10.327: INFO: Pod "downwardapi-volume-fdcbc845-7df7-11e8-bae1-da96248f62d7": Phase="Pending", Reason="", readiness=false. Elapsed: 2.893467ms
+Jul  2 13:01:12.331: INFO: Pod "downwardapi-volume-fdcbc845-7df7-11e8-bae1-da96248f62d7": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.006482177s
+STEP: Saw pod success
+Jul  2 13:01:12.331: INFO: Pod "downwardapi-volume-fdcbc845-7df7-11e8-bae1-da96248f62d7" satisfied condition "success or failure"
+Jul  2 13:01:12.336: INFO: Trying to get logs from node ip-10-250-24-1.ec2.internal pod downwardapi-volume-fdcbc845-7df7-11e8-bae1-da96248f62d7 container client-container: <nil>
+STEP: delete the pod
+Jul  2 13:01:12.356: INFO: Waiting for pod downwardapi-volume-fdcbc845-7df7-11e8-bae1-da96248f62d7 to disappear
+Jul  2 13:01:12.359: INFO: Pod downwardapi-volume-fdcbc845-7df7-11e8-bae1-da96248f62d7 no longer exists
+[AfterEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:01:12.359: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-downward-api-4k86b" for this suite.
+Jul  2 13:01:18.449: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:01:18.475: INFO: namespace: e2e-tests-downward-api-4k86b, resource: bindings, ignored listing per whitelist
+Jul  2 13:01:18.551: INFO: namespace e2e-tests-downward-api-4k86b deletion completed in 6.188715131s
+
+• [SLOW TEST:8.329 seconds]
+[sig-storage] Downward API volume
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downwardapi_volume.go:33
+  should provide container's cpu limit [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSSSSSSSSSSSSSS
+------------------------------
+[sig-apps] Daemon set [Serial] 
+  should run and stop simple daemon [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-apps] Daemon set [Serial]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:01:18.552: INFO: >>> kubeConfig: /tmp/kubeconfig-411378559
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-apps] Daemon set [Serial]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/daemon_set.go:99
+[It] should run and stop simple daemon [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating simple DaemonSet "daemon-set"
+STEP: Check that daemon pods launch on every node of the cluster.
+Jul  2 13:01:18.665: INFO: Number of nodes with available pods: 0
+Jul  2 13:01:18.665: INFO: Node ip-10-250-20-212.ec2.internal is running more than one daemon pod
+Jul  2 13:01:19.673: INFO: Number of nodes with available pods: 0
+Jul  2 13:01:19.673: INFO: Node ip-10-250-20-212.ec2.internal is running more than one daemon pod
+Jul  2 13:01:20.673: INFO: Number of nodes with available pods: 2
+Jul  2 13:01:20.673: INFO: Number of running nodes: 2, number of available pods: 2
+STEP: Stop a daemon pod, check that the daemon pod is revived.
+Jul  2 13:01:20.690: INFO: Number of nodes with available pods: 1
+Jul  2 13:01:20.690: INFO: Node ip-10-250-20-212.ec2.internal is running more than one daemon pod
+Jul  2 13:01:21.697: INFO: Number of nodes with available pods: 1
+Jul  2 13:01:21.697: INFO: Node ip-10-250-20-212.ec2.internal is running more than one daemon pod
+Jul  2 13:01:22.698: INFO: Number of nodes with available pods: 1
+Jul  2 13:01:22.698: INFO: Node ip-10-250-20-212.ec2.internal is running more than one daemon pod
+Jul  2 13:01:23.749: INFO: Number of nodes with available pods: 1
+Jul  2 13:01:23.750: INFO: Node ip-10-250-20-212.ec2.internal is running more than one daemon pod
+Jul  2 13:01:24.698: INFO: Number of nodes with available pods: 1
+Jul  2 13:01:24.698: INFO: Node ip-10-250-20-212.ec2.internal is running more than one daemon pod
+Jul  2 13:01:25.698: INFO: Number of nodes with available pods: 2
+Jul  2 13:01:25.698: INFO: Number of running nodes: 2, number of available pods: 2
+[AfterEach] [sig-apps] Daemon set [Serial]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/daemon_set.go:65
+STEP: Deleting DaemonSet "daemon-set"
+STEP: deleting {extensions DaemonSet} daemon-set in namespace e2e-tests-daemonsets-cl98v, will wait for the garbage collector to delete the pods
+Jul  2 13:01:25.760: INFO: Deleting {extensions DaemonSet} daemon-set took: 5.548342ms
+Jul  2 13:01:25.860: INFO: Terminating {extensions DaemonSet} daemon-set pods took: 100.266717ms
+Jul  2 13:01:40.263: INFO: Number of nodes with available pods: 0
+Jul  2 13:01:40.263: INFO: Number of running nodes: 0, number of available pods: 0
+Jul  2 13:01:40.271: INFO: daemonset: {"kind":"DaemonSetList","apiVersion":"apps/v1","metadata":{"selfLink":"/apis/apps/v1/namespaces/e2e-tests-daemonsets-cl98v/daemonsets","resourceVersion":"2659"},"items":null}
+
+Jul  2 13:01:40.277: INFO: pods: {"kind":"PodList","apiVersion":"v1","metadata":{"selfLink":"/api/v1/namespaces/e2e-tests-daemonsets-cl98v/pods","resourceVersion":"2659"},"items":null}
+
+[AfterEach] [sig-apps] Daemon set [Serial]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:01:40.288: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-daemonsets-cl98v" for this suite.
+Jul  2 13:01:46.302: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:01:46.364: INFO: namespace: e2e-tests-daemonsets-cl98v, resource: bindings, ignored listing per whitelist
+Jul  2 13:01:46.439: INFO: namespace e2e-tests-daemonsets-cl98v deletion completed in 6.147073292s
+
+• [SLOW TEST:27.887 seconds]
+[sig-apps] Daemon set [Serial]
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/framework.go:22
+  should run and stop simple daemon [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSSSSSSSS
+------------------------------
+[k8s.io] Variable Expansion 
+  should allow substituting values in a container's args [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [k8s.io] Variable Expansion
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:01:46.439: INFO: >>> kubeConfig: /tmp/kubeconfig-411378559
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should allow substituting values in a container's args [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating a pod to test substitution in container's args
+Jul  2 13:01:46.536: INFO: Waiting up to 5m0s for pod "var-expansion-136153d8-7df8-11e8-bae1-da96248f62d7" in namespace "e2e-tests-var-expansion-zh5mk" to be "success or failure"
+Jul  2 13:01:46.541: INFO: Pod "var-expansion-136153d8-7df8-11e8-bae1-da96248f62d7": Phase="Pending", Reason="", readiness=false. Elapsed: 5.17089ms
+Jul  2 13:01:48.545: INFO: Pod "var-expansion-136153d8-7df8-11e8-bae1-da96248f62d7": Phase="Pending", Reason="", readiness=false. Elapsed: 2.008850716s
+Jul  2 13:01:50.549: INFO: Pod "var-expansion-136153d8-7df8-11e8-bae1-da96248f62d7": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.012794527s
+STEP: Saw pod success
+Jul  2 13:01:50.549: INFO: Pod "var-expansion-136153d8-7df8-11e8-bae1-da96248f62d7" satisfied condition "success or failure"
+Jul  2 13:01:50.645: INFO: Trying to get logs from node ip-10-250-24-1.ec2.internal pod var-expansion-136153d8-7df8-11e8-bae1-da96248f62d7 container dapi-container: <nil>
+STEP: delete the pod
+Jul  2 13:01:50.665: INFO: Waiting for pod var-expansion-136153d8-7df8-11e8-bae1-da96248f62d7 to disappear
+Jul  2 13:01:50.678: INFO: Pod var-expansion-136153d8-7df8-11e8-bae1-da96248f62d7 no longer exists
+[AfterEach] [k8s.io] Variable Expansion
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:01:50.678: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-var-expansion-zh5mk" for this suite.
+Jul  2 13:01:56.701: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:01:56.894: INFO: namespace: e2e-tests-var-expansion-zh5mk, resource: bindings, ignored listing per whitelist
+Jul  2 13:01:56.911: INFO: namespace e2e-tests-var-expansion-zh5mk deletion completed in 6.222906078s
+
+• [SLOW TEST:10.472 seconds]
+[k8s.io] Variable Expansion
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:679
+  should allow substituting values in a container's args [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSSSSSS
+------------------------------
+[sig-storage] Projected 
+  should provide node allocatable (memory) as default memory limit if the limit is not set [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:01:56.911: INFO: >>> kubeConfig: /tmp/kubeconfig-411378559
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:858
+[It] should provide node allocatable (memory) as default memory limit if the limit is not set [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating a pod to test downward API volume plugin
+Jul  2 13:01:57.021: INFO: Waiting up to 5m0s for pod "downwardapi-volume-19a13f1d-7df8-11e8-bae1-da96248f62d7" in namespace "e2e-tests-projected-fvgng" to be "success or failure"
+Jul  2 13:01:57.025: INFO: Pod "downwardapi-volume-19a13f1d-7df8-11e8-bae1-da96248f62d7": Phase="Pending", Reason="", readiness=false. Elapsed: 4.008648ms
+Jul  2 13:01:59.044: INFO: Pod "downwardapi-volume-19a13f1d-7df8-11e8-bae1-da96248f62d7": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.023422427s
+STEP: Saw pod success
+Jul  2 13:01:59.044: INFO: Pod "downwardapi-volume-19a13f1d-7df8-11e8-bae1-da96248f62d7" satisfied condition "success or failure"
+Jul  2 13:01:59.047: INFO: Trying to get logs from node ip-10-250-24-1.ec2.internal pod downwardapi-volume-19a13f1d-7df8-11e8-bae1-da96248f62d7 container client-container: <nil>
+STEP: delete the pod
+Jul  2 13:01:59.065: INFO: Waiting for pod downwardapi-volume-19a13f1d-7df8-11e8-bae1-da96248f62d7 to disappear
+Jul  2 13:01:59.068: INFO: Pod downwardapi-volume-19a13f1d-7df8-11e8-bae1-da96248f62d7 no longer exists
+[AfterEach] [sig-storage] Projected
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:01:59.068: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-fvgng" for this suite.
+Jul  2 13:02:05.088: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:02:05.191: INFO: namespace: e2e-tests-projected-fvgng, resource: bindings, ignored listing per whitelist
+Jul  2 13:02:05.191: INFO: namespace e2e-tests-projected-fvgng deletion completed in 6.118123508s
+
+• [SLOW TEST:8.279 seconds]
+[sig-storage] Projected
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:34
+  should provide node allocatable (memory) as default memory limit if the limit is not set [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSSSSSS
+------------------------------
+[k8s.io] Probing container 
+  should *not* be restarted with a exec "cat /tmp/health" liveness probe [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [k8s.io] Probing container
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:02:05.191: INFO: >>> kubeConfig: /tmp/kubeconfig-411378559
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [k8s.io] Probing container
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/container_probe.go:48
+[It] should *not* be restarted with a exec "cat /tmp/health" liveness probe [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating pod liveness-exec in namespace e2e-tests-container-probe-wlh92
+Jul  2 13:02:07.352: INFO: Started pod liveness-exec in namespace e2e-tests-container-probe-wlh92
+STEP: checking the pod's current state and verifying that restartCount is present
+Jul  2 13:02:07.355: INFO: Initial restart count of pod liveness-exec is 0
+STEP: deleting the pod
+[AfterEach] [k8s.io] Probing container
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:06:09.178: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-container-probe-wlh92" for this suite.
+Jul  2 13:06:15.204: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:06:15.233: INFO: namespace: e2e-tests-container-probe-wlh92, resource: bindings, ignored listing per whitelist
+Jul  2 13:06:15.314: INFO: namespace e2e-tests-container-probe-wlh92 deletion completed in 6.127524611s
+
+• [SLOW TEST:250.123 seconds]
+[k8s.io] Probing container
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:679
+  should *not* be restarted with a exec "cat /tmp/health" liveness probe [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSSSS
+------------------------------
+[k8s.io] Pods 
+  should be updated [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [k8s.io] Pods
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:06:15.314: INFO: >>> kubeConfig: /tmp/kubeconfig-411378559
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [k8s.io] Pods
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/pods.go:127
+[It] should be updated [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: creating the pod
+STEP: submitting the pod to kubernetes
+STEP: verifying the pod is in kubernetes
+STEP: updating the pod
+Jul  2 13:06:17.946: INFO: Successfully updated pod "pod-update-b3a4a245-7df8-11e8-bae1-da96248f62d7"
+STEP: verifying the updated pod is in kubernetes
+Jul  2 13:06:17.954: INFO: Pod update OK
+[AfterEach] [k8s.io] Pods
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:06:17.954: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-pods-c678c" for this suite.
+Jul  2 13:06:39.971: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:06:40.033: INFO: namespace: e2e-tests-pods-c678c, resource: bindings, ignored listing per whitelist
+Jul  2 13:06:40.072: INFO: namespace e2e-tests-pods-c678c deletion completed in 22.111969845s
+
+• [SLOW TEST:24.758 seconds]
+[k8s.io] Pods
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:679
+  should be updated [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSSS
+------------------------------
+[sig-auth] ServiceAccounts 
+  should mount an API token into pods  [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-auth] ServiceAccounts
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:06:40.072: INFO: >>> kubeConfig: /tmp/kubeconfig-411378559
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should mount an API token into pods  [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: getting the auto-created API token
+STEP: Creating a pod to test consume service account token
+Jul  2 13:06:40.750: INFO: Waiting up to 5m0s for pod "pod-service-account-c2b3af77-7df8-11e8-bae1-da96248f62d7-8jt9q" in namespace "e2e-tests-svcaccounts-48gsw" to be "success or failure"
+Jul  2 13:06:40.755: INFO: Pod "pod-service-account-c2b3af77-7df8-11e8-bae1-da96248f62d7-8jt9q": Phase="Pending", Reason="", readiness=false. Elapsed: 4.918719ms
+Jul  2 13:06:42.759: INFO: Pod "pod-service-account-c2b3af77-7df8-11e8-bae1-da96248f62d7-8jt9q": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.00868657s
+STEP: Saw pod success
+Jul  2 13:06:42.759: INFO: Pod "pod-service-account-c2b3af77-7df8-11e8-bae1-da96248f62d7-8jt9q" satisfied condition "success or failure"
+Jul  2 13:06:42.762: INFO: Trying to get logs from node ip-10-250-24-1.ec2.internal pod pod-service-account-c2b3af77-7df8-11e8-bae1-da96248f62d7-8jt9q container token-test: <nil>
+STEP: delete the pod
+Jul  2 13:06:42.868: INFO: Waiting for pod pod-service-account-c2b3af77-7df8-11e8-bae1-da96248f62d7-8jt9q to disappear
+Jul  2 13:06:42.871: INFO: Pod pod-service-account-c2b3af77-7df8-11e8-bae1-da96248f62d7-8jt9q no longer exists
+STEP: Creating a pod to test consume service account root CA
+Jul  2 13:06:42.899: INFO: Waiting up to 5m0s for pod "pod-service-account-c2b3af77-7df8-11e8-bae1-da96248f62d7-4nntl" in namespace "e2e-tests-svcaccounts-48gsw" to be "success or failure"
+Jul  2 13:06:42.903: INFO: Pod "pod-service-account-c2b3af77-7df8-11e8-bae1-da96248f62d7-4nntl": Phase="Pending", Reason="", readiness=false. Elapsed: 3.415685ms
+Jul  2 13:06:44.906: INFO: Pod "pod-service-account-c2b3af77-7df8-11e8-bae1-da96248f62d7-4nntl": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.007156626s
+STEP: Saw pod success
+Jul  2 13:06:44.906: INFO: Pod "pod-service-account-c2b3af77-7df8-11e8-bae1-da96248f62d7-4nntl" satisfied condition "success or failure"
+Jul  2 13:06:44.909: INFO: Trying to get logs from node ip-10-250-24-1.ec2.internal pod pod-service-account-c2b3af77-7df8-11e8-bae1-da96248f62d7-4nntl container root-ca-test: <nil>
+STEP: delete the pod
+Jul  2 13:06:44.931: INFO: Waiting for pod pod-service-account-c2b3af77-7df8-11e8-bae1-da96248f62d7-4nntl to disappear
+Jul  2 13:06:44.935: INFO: Pod pod-service-account-c2b3af77-7df8-11e8-bae1-da96248f62d7-4nntl no longer exists
+STEP: Creating a pod to test consume service account namespace
+Jul  2 13:06:44.940: INFO: Waiting up to 5m0s for pod "pod-service-account-c2b3af77-7df8-11e8-bae1-da96248f62d7-kclrs" in namespace "e2e-tests-svcaccounts-48gsw" to be "success or failure"
+Jul  2 13:06:44.945: INFO: Pod "pod-service-account-c2b3af77-7df8-11e8-bae1-da96248f62d7-kclrs": Phase="Pending", Reason="", readiness=false. Elapsed: 4.829482ms
+Jul  2 13:06:46.956: INFO: Pod "pod-service-account-c2b3af77-7df8-11e8-bae1-da96248f62d7-kclrs": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.01613342s
+STEP: Saw pod success
+Jul  2 13:06:46.957: INFO: Pod "pod-service-account-c2b3af77-7df8-11e8-bae1-da96248f62d7-kclrs" satisfied condition "success or failure"
+Jul  2 13:06:46.962: INFO: Trying to get logs from node ip-10-250-24-1.ec2.internal pod pod-service-account-c2b3af77-7df8-11e8-bae1-da96248f62d7-kclrs container namespace-test: <nil>
+STEP: delete the pod
+Jul  2 13:06:46.985: INFO: Waiting for pod pod-service-account-c2b3af77-7df8-11e8-bae1-da96248f62d7-kclrs to disappear
+Jul  2 13:06:46.988: INFO: Pod pod-service-account-c2b3af77-7df8-11e8-bae1-da96248f62d7-kclrs no longer exists
+[AfterEach] [sig-auth] ServiceAccounts
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:06:46.988: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-svcaccounts-48gsw" for this suite.
+Jul  2 13:06:53.008: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:06:53.041: INFO: namespace: e2e-tests-svcaccounts-48gsw, resource: bindings, ignored listing per whitelist
+Jul  2 13:06:53.122: INFO: namespace e2e-tests-svcaccounts-48gsw deletion completed in 6.129470234s
+
+• [SLOW TEST:13.050 seconds]
+[sig-auth] ServiceAccounts
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/auth/framework.go:22
+  should mount an API token into pods  [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+S
+------------------------------
+[k8s.io] [sig-node] Pods Extended [k8s.io] Pods Set QOS Class 
+  should be submitted and removed  [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [k8s.io] [sig-node] Pods Extended
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:06:53.122: INFO: >>> kubeConfig: /tmp/kubeconfig-411378559
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [k8s.io] Pods Set QOS Class
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/node/pods.go:199
+[It] should be submitted and removed  [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: creating the pod
+STEP: submitting the pod to kubernetes
+STEP: verifying QOS class is set on the pod
+[AfterEach] [k8s.io] [sig-node] Pods Extended
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:06:53.228: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-pods-pjkd6" for this suite.
+Jul  2 13:07:15.246: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:07:15.285: INFO: namespace: e2e-tests-pods-pjkd6, resource: bindings, ignored listing per whitelist
+Jul  2 13:07:15.346: INFO: namespace e2e-tests-pods-pjkd6 deletion completed in 22.11391884s
+
+• [SLOW TEST:22.224 seconds]
+[k8s.io] [sig-node] Pods Extended
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:679
+  [k8s.io] Pods Set QOS Class
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:679
+    should be submitted and removed  [Conformance]
+    /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSSSSSSSSSSSSSS
+------------------------------
+[sig-storage] Projected 
+  should project all components that make up the projection API [Projection][NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:07:15.347: INFO: >>> kubeConfig: /tmp/kubeconfig-411378559
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:858
+[It] should project all components that make up the projection API [Projection][NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating configMap with name configmap-projected-all-test-volume-d76c858a-7df8-11e8-bae1-da96248f62d7
+STEP: Creating secret with name secret-projected-all-test-volume-d76c851f-7df8-11e8-bae1-da96248f62d7
+STEP: Creating a pod to test Check all projections for projected volume plugin
+Jul  2 13:07:15.449: INFO: Waiting up to 5m0s for pod "projected-volume-d76c8307-7df8-11e8-bae1-da96248f62d7" in namespace "e2e-tests-projected-5m578" to be "success or failure"
+Jul  2 13:07:15.452: INFO: Pod "projected-volume-d76c8307-7df8-11e8-bae1-da96248f62d7": Phase="Pending", Reason="", readiness=false. Elapsed: 2.807039ms
+Jul  2 13:07:17.455: INFO: Pod "projected-volume-d76c8307-7df8-11e8-bae1-da96248f62d7": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.006688346s
+STEP: Saw pod success
+Jul  2 13:07:17.455: INFO: Pod "projected-volume-d76c8307-7df8-11e8-bae1-da96248f62d7" satisfied condition "success or failure"
+Jul  2 13:07:17.458: INFO: Trying to get logs from node ip-10-250-24-1.ec2.internal pod projected-volume-d76c8307-7df8-11e8-bae1-da96248f62d7 container projected-all-volume-test: <nil>
+STEP: delete the pod
+Jul  2 13:07:17.475: INFO: Waiting for pod projected-volume-d76c8307-7df8-11e8-bae1-da96248f62d7 to disappear
+Jul  2 13:07:17.478: INFO: Pod projected-volume-d76c8307-7df8-11e8-bae1-da96248f62d7 no longer exists
+[AfterEach] [sig-storage] Projected
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:07:17.478: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-5m578" for this suite.
+Jul  2 13:07:23.491: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:07:23.576: INFO: namespace: e2e-tests-projected-5m578, resource: bindings, ignored listing per whitelist
+Jul  2 13:07:23.595: INFO: namespace e2e-tests-projected-5m578 deletion completed in 6.113396475s
+
+• [SLOW TEST:8.248 seconds]
+[sig-storage] Projected
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:34
+  should project all components that make up the projection API [Projection][NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSSSSSSSS
+------------------------------
+[sig-storage] Projected 
+  should be consumable from pods in volume with mappings [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:07:23.595: INFO: >>> kubeConfig: /tmp/kubeconfig-411378559
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:858
+[It] should be consumable from pods in volume with mappings [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating configMap with name projected-configmap-test-volume-map-dc585004-7df8-11e8-bae1-da96248f62d7
+STEP: Creating a pod to test consume configMaps
+Jul  2 13:07:23.704: INFO: Waiting up to 5m0s for pod "pod-projected-configmaps-dc58eadb-7df8-11e8-bae1-da96248f62d7" in namespace "e2e-tests-projected-xsf5t" to be "success or failure"
+Jul  2 13:07:23.709: INFO: Pod "pod-projected-configmaps-dc58eadb-7df8-11e8-bae1-da96248f62d7": Phase="Pending", Reason="", readiness=false. Elapsed: 4.955608ms
+Jul  2 13:07:25.712: INFO: Pod "pod-projected-configmaps-dc58eadb-7df8-11e8-bae1-da96248f62d7": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.008688496s
+STEP: Saw pod success
+Jul  2 13:07:25.712: INFO: Pod "pod-projected-configmaps-dc58eadb-7df8-11e8-bae1-da96248f62d7" satisfied condition "success or failure"
+Jul  2 13:07:25.715: INFO: Trying to get logs from node ip-10-250-24-1.ec2.internal pod pod-projected-configmaps-dc58eadb-7df8-11e8-bae1-da96248f62d7 container projected-configmap-volume-test: <nil>
+STEP: delete the pod
+Jul  2 13:07:25.734: INFO: Waiting for pod pod-projected-configmaps-dc58eadb-7df8-11e8-bae1-da96248f62d7 to disappear
+Jul  2 13:07:25.738: INFO: Pod pod-projected-configmaps-dc58eadb-7df8-11e8-bae1-da96248f62d7 no longer exists
+[AfterEach] [sig-storage] Projected
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:07:25.738: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-xsf5t" for this suite.
+Jul  2 13:07:31.758: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:07:31.766: INFO: namespace: e2e-tests-projected-xsf5t, resource: bindings, ignored listing per whitelist
+Jul  2 13:07:31.938: INFO: namespace e2e-tests-projected-xsf5t deletion completed in 6.191670638s
+
+• [SLOW TEST:8.342 seconds]
+[sig-storage] Projected
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:34
+  should be consumable from pods in volume with mappings [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+S
+------------------------------
+[sig-apps] StatefulSet [k8s.io] Basic StatefulSet functionality [StatefulSetBasic] 
+  should perform canary updates and phased rolling updates of template modifications [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-apps] StatefulSet
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:07:31.938: INFO: >>> kubeConfig: /tmp/kubeconfig-411378559
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-apps] StatefulSet
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/statefulset.go:57
+[BeforeEach] [k8s.io] Basic StatefulSet functionality [StatefulSetBasic]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/statefulset.go:72
+STEP: Creating service test in namespace e2e-tests-statefulset-4s6bh
+[It] should perform canary updates and phased rolling updates of template modifications [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating a new StaefulSet
+Jul  2 13:07:32.039: INFO: Found 0 stateful pods, waiting for 3
+Jul  2 13:07:42.043: INFO: Waiting for pod ss2-0 to enter Running - Ready=true, currently Running - Ready=true
+Jul  2 13:07:42.043: INFO: Waiting for pod ss2-1 to enter Running - Ready=true, currently Running - Ready=true
+Jul  2 13:07:42.043: INFO: Waiting for pod ss2-2 to enter Running - Ready=true, currently Running - Ready=true
+STEP: Updating stateful set template: update image from k8s.gcr.io/nginx-slim-amd64:0.20 to k8s.gcr.io/nginx-slim-amd64:0.21
+Jul  2 13:07:42.070: INFO: Updating stateful set ss2
+STEP: Creating a new revision
+STEP: Not applying an update when the partition is greater than the number of replicas
+STEP: Performing a canary update
+Jul  2 13:07:52.166: INFO: Updating stateful set ss2
+Jul  2 13:07:52.173: INFO: Waiting for Pod e2e-tests-statefulset-4s6bh/ss2-2 to have revision ss2-56dd5fb9c4 update revision ss2-76cb68b6ff
+STEP: Restoring Pods to the correct revision when they are deleted
+Jul  2 13:08:02.315: INFO: Found 2 stateful pods, waiting for 3
+Jul  2 13:08:12.320: INFO: Waiting for pod ss2-0 to enter Running - Ready=true, currently Running - Ready=true
+Jul  2 13:08:12.320: INFO: Waiting for pod ss2-1 to enter Running - Ready=true, currently Running - Ready=true
+Jul  2 13:08:12.320: INFO: Waiting for pod ss2-2 to enter Running - Ready=true, currently Running - Ready=true
+STEP: Performing a phased rolling update
+Jul  2 13:08:12.343: INFO: Updating stateful set ss2
+Jul  2 13:08:12.349: INFO: Waiting for Pod e2e-tests-statefulset-4s6bh/ss2-1 to have revision ss2-56dd5fb9c4 update revision ss2-76cb68b6ff
+Jul  2 13:08:22.373: INFO: Updating stateful set ss2
+Jul  2 13:08:22.379: INFO: Waiting for StatefulSet e2e-tests-statefulset-4s6bh/ss2 to complete update
+Jul  2 13:08:22.379: INFO: Waiting for Pod e2e-tests-statefulset-4s6bh/ss2-0 to have revision ss2-56dd5fb9c4 update revision ss2-76cb68b6ff
+[AfterEach] [k8s.io] Basic StatefulSet functionality [StatefulSetBasic]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/statefulset.go:83
+Jul  2 13:08:32.387: INFO: Deleting all statefulset in ns e2e-tests-statefulset-4s6bh
+Jul  2 13:08:32.389: INFO: Scaling statefulset ss2 to 0
+Jul  2 13:09:02.450: INFO: Waiting for statefulset status.replicas updated to 0
+Jul  2 13:09:02.455: INFO: Deleting statefulset ss2
+[AfterEach] [sig-apps] StatefulSet
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:09:02.466: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-statefulset-4s6bh" for this suite.
+Jul  2 13:09:08.550: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:09:08.571: INFO: namespace: e2e-tests-statefulset-4s6bh, resource: bindings, ignored listing per whitelist
+Jul  2 13:09:08.656: INFO: namespace e2e-tests-statefulset-4s6bh deletion completed in 6.186260605s
+
+• [SLOW TEST:96.718 seconds]
+[sig-apps] StatefulSet
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/framework.go:22
+  [k8s.io] Basic StatefulSet functionality [StatefulSetBasic]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:679
+    should perform canary updates and phased rolling updates of template modifications [Conformance]
+    /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SS
+------------------------------
+[sig-storage] Projected 
+  should provide node allocatable (cpu) as default cpu limit if the limit is not set [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:09:08.656: INFO: >>> kubeConfig: /tmp/kubeconfig-411378559
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:858
+[It] should provide node allocatable (cpu) as default cpu limit if the limit is not set [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating a pod to test downward API volume plugin
+Jul  2 13:09:08.753: INFO: Waiting up to 5m0s for pod "downwardapi-volume-1af619d9-7df9-11e8-bae1-da96248f62d7" in namespace "e2e-tests-projected-2fj2b" to be "success or failure"
+Jul  2 13:09:08.757: INFO: Pod "downwardapi-volume-1af619d9-7df9-11e8-bae1-da96248f62d7": Phase="Pending", Reason="", readiness=false. Elapsed: 4.15673ms
+Jul  2 13:09:10.761: INFO: Pod "downwardapi-volume-1af619d9-7df9-11e8-bae1-da96248f62d7": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.007801329s
+STEP: Saw pod success
+Jul  2 13:09:10.761: INFO: Pod "downwardapi-volume-1af619d9-7df9-11e8-bae1-da96248f62d7" satisfied condition "success or failure"
+Jul  2 13:09:10.763: INFO: Trying to get logs from node ip-10-250-24-1.ec2.internal pod downwardapi-volume-1af619d9-7df9-11e8-bae1-da96248f62d7 container client-container: <nil>
+STEP: delete the pod
+Jul  2 13:09:10.787: INFO: Waiting for pod downwardapi-volume-1af619d9-7df9-11e8-bae1-da96248f62d7 to disappear
+Jul  2 13:09:10.801: INFO: Pod downwardapi-volume-1af619d9-7df9-11e8-bae1-da96248f62d7 no longer exists
+[AfterEach] [sig-storage] Projected
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:09:10.801: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-2fj2b" for this suite.
+Jul  2 13:09:16.821: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:09:16.896: INFO: namespace: e2e-tests-projected-2fj2b, resource: bindings, ignored listing per whitelist
+Jul  2 13:09:16.921: INFO: namespace e2e-tests-projected-2fj2b deletion completed in 6.111004565s
+
+• [SLOW TEST:8.264 seconds]
+[sig-storage] Projected
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:34
+  should provide node allocatable (cpu) as default cpu limit if the limit is not set [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSS
+------------------------------
+[sig-storage] EmptyDir volumes 
+  should support (non-root,0666,default) [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-storage] EmptyDir volumes
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:09:16.921: INFO: >>> kubeConfig: /tmp/kubeconfig-411378559
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should support (non-root,0666,default) [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating a pod to test emptydir 0666 on node default medium
+Jul  2 13:09:17.023: INFO: Waiting up to 5m0s for pod "pod-1fe42b1c-7df9-11e8-bae1-da96248f62d7" in namespace "e2e-tests-emptydir-48jwm" to be "success or failure"
+Jul  2 13:09:17.026: INFO: Pod "pod-1fe42b1c-7df9-11e8-bae1-da96248f62d7": Phase="Pending", Reason="", readiness=false. Elapsed: 3.01713ms
+Jul  2 13:09:19.030: INFO: Pod "pod-1fe42b1c-7df9-11e8-bae1-da96248f62d7": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.006835477s
+STEP: Saw pod success
+Jul  2 13:09:19.030: INFO: Pod "pod-1fe42b1c-7df9-11e8-bae1-da96248f62d7" satisfied condition "success or failure"
+Jul  2 13:09:19.049: INFO: Trying to get logs from node ip-10-250-24-1.ec2.internal pod pod-1fe42b1c-7df9-11e8-bae1-da96248f62d7 container test-container: <nil>
+STEP: delete the pod
+Jul  2 13:09:19.067: INFO: Waiting for pod pod-1fe42b1c-7df9-11e8-bae1-da96248f62d7 to disappear
+Jul  2 13:09:19.070: INFO: Pod pod-1fe42b1c-7df9-11e8-bae1-da96248f62d7 no longer exists
+[AfterEach] [sig-storage] EmptyDir volumes
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:09:19.070: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-emptydir-48jwm" for this suite.
+Jul  2 13:09:25.083: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:09:25.151: INFO: namespace: e2e-tests-emptydir-48jwm, resource: bindings, ignored listing per whitelist
+Jul  2 13:09:25.183: INFO: namespace e2e-tests-emptydir-48jwm deletion completed in 6.109532545s
+
+• [SLOW TEST:8.262 seconds]
+[sig-storage] EmptyDir volumes
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/empty_dir.go:40
+  should support (non-root,0666,default) [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+[sig-storage] ConfigMap 
+  should be consumable from pods in volume with mappings [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-storage] ConfigMap
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:09:25.183: INFO: >>> kubeConfig: /tmp/kubeconfig-411378559
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should be consumable from pods in volume with mappings [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating configMap with name configmap-test-volume-map-24cfd5fd-7df9-11e8-bae1-da96248f62d7
+STEP: Creating a pod to test consume configMaps
+Jul  2 13:09:25.281: INFO: Waiting up to 5m0s for pod "pod-configmaps-24d05e58-7df9-11e8-bae1-da96248f62d7" in namespace "e2e-tests-configmap-5gzf2" to be "success or failure"
+Jul  2 13:09:25.285: INFO: Pod "pod-configmaps-24d05e58-7df9-11e8-bae1-da96248f62d7": Phase="Pending", Reason="", readiness=false. Elapsed: 3.92225ms
+Jul  2 13:09:27.289: INFO: Pod "pod-configmaps-24d05e58-7df9-11e8-bae1-da96248f62d7": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.00770311s
+STEP: Saw pod success
+Jul  2 13:09:27.289: INFO: Pod "pod-configmaps-24d05e58-7df9-11e8-bae1-da96248f62d7" satisfied condition "success or failure"
+Jul  2 13:09:27.292: INFO: Trying to get logs from node ip-10-250-24-1.ec2.internal pod pod-configmaps-24d05e58-7df9-11e8-bae1-da96248f62d7 container configmap-volume-test: <nil>
+STEP: delete the pod
+Jul  2 13:09:27.312: INFO: Waiting for pod pod-configmaps-24d05e58-7df9-11e8-bae1-da96248f62d7 to disappear
+Jul  2 13:09:27.315: INFO: Pod pod-configmaps-24d05e58-7df9-11e8-bae1-da96248f62d7 no longer exists
+[AfterEach] [sig-storage] ConfigMap
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:09:27.315: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-configmap-5gzf2" for this suite.
+Jul  2 13:09:33.339: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:09:33.373: INFO: namespace: e2e-tests-configmap-5gzf2, resource: bindings, ignored listing per whitelist
+Jul  2 13:09:33.437: INFO: namespace e2e-tests-configmap-5gzf2 deletion completed in 6.11824798s
+
+• [SLOW TEST:8.254 seconds]
+[sig-storage] ConfigMap
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/configmap_volume.go:32
+  should be consumable from pods in volume with mappings [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSSSSSSSSS
+------------------------------
+[sig-storage] Projected 
+  should be consumable from pods in volume with defaultMode set [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:09:33.438: INFO: >>> kubeConfig: /tmp/kubeconfig-411378559
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:858
+[It] should be consumable from pods in volume with defaultMode set [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating configMap with name projected-configmap-test-volume-29bae08e-7df9-11e8-bae1-da96248f62d7
+STEP: Creating a pod to test consume configMaps
+Jul  2 13:09:33.532: INFO: Waiting up to 5m0s for pod "pod-projected-configmaps-29bb67e8-7df9-11e8-bae1-da96248f62d7" in namespace "e2e-tests-projected-4llmp" to be "success or failure"
+Jul  2 13:09:33.536: INFO: Pod "pod-projected-configmaps-29bb67e8-7df9-11e8-bae1-da96248f62d7": Phase="Pending", Reason="", readiness=false. Elapsed: 3.809699ms
+Jul  2 13:09:35.539: INFO: Pod "pod-projected-configmaps-29bb67e8-7df9-11e8-bae1-da96248f62d7": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.007208027s
+STEP: Saw pod success
+Jul  2 13:09:35.540: INFO: Pod "pod-projected-configmaps-29bb67e8-7df9-11e8-bae1-da96248f62d7" satisfied condition "success or failure"
+Jul  2 13:09:35.542: INFO: Trying to get logs from node ip-10-250-24-1.ec2.internal pod pod-projected-configmaps-29bb67e8-7df9-11e8-bae1-da96248f62d7 container projected-configmap-volume-test: <nil>
+STEP: delete the pod
+Jul  2 13:09:35.559: INFO: Waiting for pod pod-projected-configmaps-29bb67e8-7df9-11e8-bae1-da96248f62d7 to disappear
+Jul  2 13:09:35.563: INFO: Pod pod-projected-configmaps-29bb67e8-7df9-11e8-bae1-da96248f62d7 no longer exists
+[AfterEach] [sig-storage] Projected
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:09:35.563: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-4llmp" for this suite.
+Jul  2 13:09:41.583: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:09:41.728: INFO: namespace: e2e-tests-projected-4llmp, resource: bindings, ignored listing per whitelist
+Jul  2 13:09:41.739: INFO: namespace e2e-tests-projected-4llmp deletion completed in 6.172605377s
+
+• [SLOW TEST:8.302 seconds]
+[sig-storage] Projected
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:34
+  should be consumable from pods in volume with defaultMode set [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+[sig-api-machinery] Downward API 
+  should provide host IP as an env var [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-api-machinery] Downward API
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:09:41.739: INFO: >>> kubeConfig: /tmp/kubeconfig-411378559
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should provide host IP as an env var [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating a pod to test downward api env vars
+Jul  2 13:09:41.865: INFO: Waiting up to 5m0s for pod "downward-api-2eb2cb99-7df9-11e8-bae1-da96248f62d7" in namespace "e2e-tests-downward-api-958vc" to be "success or failure"
+Jul  2 13:09:41.867: INFO: Pod "downward-api-2eb2cb99-7df9-11e8-bae1-da96248f62d7": Phase="Pending", Reason="", readiness=false. Elapsed: 2.582139ms
+Jul  2 13:09:43.871: INFO: Pod "downward-api-2eb2cb99-7df9-11e8-bae1-da96248f62d7": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.006641238s
+STEP: Saw pod success
+Jul  2 13:09:43.871: INFO: Pod "downward-api-2eb2cb99-7df9-11e8-bae1-da96248f62d7" satisfied condition "success or failure"
+Jul  2 13:09:43.949: INFO: Trying to get logs from node ip-10-250-24-1.ec2.internal pod downward-api-2eb2cb99-7df9-11e8-bae1-da96248f62d7 container dapi-container: <nil>
+STEP: delete the pod
+Jul  2 13:09:43.966: INFO: Waiting for pod downward-api-2eb2cb99-7df9-11e8-bae1-da96248f62d7 to disappear
+Jul  2 13:09:43.968: INFO: Pod downward-api-2eb2cb99-7df9-11e8-bae1-da96248f62d7 no longer exists
+[AfterEach] [sig-api-machinery] Downward API
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:09:43.968: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-downward-api-958vc" for this suite.
+Jul  2 13:09:49.982: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:09:50.222: INFO: namespace: e2e-tests-downward-api-958vc, resource: bindings, ignored listing per whitelist
+Jul  2 13:09:50.242: INFO: namespace e2e-tests-downward-api-958vc deletion completed in 6.26983105s
+
+• [SLOW TEST:8.502 seconds]
+[sig-api-machinery] Downward API
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downward_api.go:37
+  should provide host IP as an env var [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+S
+------------------------------
+[sig-api-machinery] Garbage collector 
+  should delete RS created by deployment when not orphaning [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-api-machinery] Garbage collector
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:09:50.242: INFO: >>> kubeConfig: /tmp/kubeconfig-411378559
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should delete RS created by deployment when not orphaning [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: create the deployment
+STEP: Wait for the Deployment to create new ReplicaSet
+STEP: delete the deployment
+STEP: wait for all rs to be garbage collected
+STEP: expected 0 rs, got 1 rs
+STEP: expected 0 Pods, got 2 Pods
+STEP: Gathering metrics
+W0702 13:09:51.384620      14 metrics_grabber.go:81] Master node is not registered. Grabbing metrics from Scheduler, ControllerManager and ClusterAutoscaler is disabled.
+Jul  2 13:09:51.384: INFO: For apiserver_request_count:
+For apiserver_request_latencies_summary:
+For etcd_helper_cache_entry_count:
+For etcd_helper_cache_hit_count:
+For etcd_helper_cache_miss_count:
+For etcd_request_cache_add_latencies_summary:
+For etcd_request_cache_get_latencies_summary:
+For etcd_request_latencies_summary:
+For garbage_collector_attempt_to_delete_queue_latency:
+For garbage_collector_attempt_to_delete_work_duration:
+For garbage_collector_attempt_to_orphan_queue_latency:
+For garbage_collector_attempt_to_orphan_work_duration:
+For garbage_collector_dirty_processing_latency_microseconds:
+For garbage_collector_event_processing_latency_microseconds:
+For garbage_collector_graph_changes_queue_latency:
+For garbage_collector_graph_changes_work_duration:
+For garbage_collector_orphan_processing_latency_microseconds:
+For namespace_queue_latency:
+For namespace_queue_latency_sum:
+For namespace_queue_latency_count:
+For namespace_retries:
+For namespace_work_duration:
+For namespace_work_duration_sum:
+For namespace_work_duration_count:
+For function_duration_seconds:
+For errors_total:
+For evicted_pods_total:
+
+[AfterEach] [sig-api-machinery] Garbage collector
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:09:51.384: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-gc-ljhnm" for this suite.
+Jul  2 13:09:57.399: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:09:57.516: INFO: namespace: e2e-tests-gc-ljhnm, resource: bindings, ignored listing per whitelist
+Jul  2 13:09:57.532: INFO: namespace e2e-tests-gc-ljhnm deletion completed in 6.143854109s
+
+• [SLOW TEST:7.290 seconds]
+[sig-api-machinery] Garbage collector
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apimachinery/framework.go:22
+  should delete RS created by deployment when not orphaning [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+[k8s.io] Probing container 
+  with readiness probe that fails should never be ready and never restart [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [k8s.io] Probing container
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:09:57.532: INFO: >>> kubeConfig: /tmp/kubeconfig-411378559
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [k8s.io] Probing container
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/container_probe.go:48
+[It] with readiness probe that fails should never be ready and never restart [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[AfterEach] [k8s.io] Probing container
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:10:57.631: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-container-probe-6zm85" for this suite.
+Jul  2 13:11:19.658: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:11:19.824: INFO: namespace: e2e-tests-container-probe-6zm85, resource: bindings, ignored listing per whitelist
+Jul  2 13:11:19.841: INFO: namespace e2e-tests-container-probe-6zm85 deletion completed in 22.2066636s
+
+• [SLOW TEST:82.309 seconds]
+[k8s.io] Probing container
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:679
+  with readiness probe that fails should never be ready and never restart [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSSSSSSSSSSS
+------------------------------
+[sig-apps] Daemon set [Serial] 
+  should rollback without unnecessary restarts [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-apps] Daemon set [Serial]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:11:19.842: INFO: >>> kubeConfig: /tmp/kubeconfig-411378559
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-apps] Daemon set [Serial]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/daemon_set.go:99
+[It] should rollback without unnecessary restarts [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+Jul  2 13:11:19.947: INFO: Requires at least 2 nodes (not -1)
+[AfterEach] [sig-apps] Daemon set [Serial]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/daemon_set.go:65
+Jul  2 13:11:19.953: INFO: daemonset: {"kind":"DaemonSetList","apiVersion":"apps/v1","metadata":{"selfLink":"/apis/apps/v1/namespaces/e2e-tests-daemonsets-9mhnk/daemonsets","resourceVersion":"4273"},"items":null}
+
+Jul  2 13:11:19.956: INFO: pods: {"kind":"PodList","apiVersion":"v1","metadata":{"selfLink":"/api/v1/namespaces/e2e-tests-daemonsets-9mhnk/pods","resourceVersion":"4273"},"items":null}
+
+[AfterEach] [sig-apps] Daemon set [Serial]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:11:19.966: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-daemonsets-9mhnk" for this suite.
+Jul  2 13:11:25.980: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:11:26.028: INFO: namespace: e2e-tests-daemonsets-9mhnk, resource: bindings, ignored listing per whitelist
+Jul  2 13:11:26.080: INFO: namespace e2e-tests-daemonsets-9mhnk deletion completed in 6.109814393s
+
+S [SKIPPING] [6.239 seconds]
+[sig-apps] Daemon set [Serial]
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/framework.go:22
+  should rollback without unnecessary restarts [Conformance] [It]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+
+  Jul  2 13:11:19.947: Requires at least 2 nodes (not -1)
+
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/util.go:305
+------------------------------
+SSS
+------------------------------
+[sig-network] DNS 
+  should provide DNS for the cluster  [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-network] DNS
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:11:26.081: INFO: >>> kubeConfig: /tmp/kubeconfig-411378559
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should provide DNS for the cluster  [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Running these commands on wheezy: for i in `seq 1 600`; do test -n "$$(dig +notcp +noall +answer +search kubernetes.default A)" && echo OK > /results/wheezy_udp@kubernetes.default;test -n "$$(dig +tcp +noall +answer +search kubernetes.default A)" && echo OK > /results/wheezy_tcp@kubernetes.default;test -n "$$(dig +notcp +noall +answer +search kubernetes.default.svc A)" && echo OK > /results/wheezy_udp@kubernetes.default.svc;test -n "$$(dig +tcp +noall +answer +search kubernetes.default.svc A)" && echo OK > /results/wheezy_tcp@kubernetes.default.svc;test -n "$$(dig +notcp +noall +answer +search kubernetes.default.svc.cluster.local A)" && echo OK > /results/wheezy_udp@kubernetes.default.svc.cluster.local;test -n "$$(dig +tcp +noall +answer +search kubernetes.default.svc.cluster.local A)" && echo OK > /results/wheezy_tcp@kubernetes.default.svc.cluster.local;test -n "$$(getent hosts dns-querier-1.dns-test-service.e2e-tests-dns-8hdmk.svc.cluster.local)" && echo OK > /results/wheezy_hosts@dns-querier-1.dns-test-service.e2e-tests-dns-8hdmk.svc.cluster.local;test -n "$$(getent hosts dns-querier-1)" && echo OK > /results/wheezy_hosts@dns-querier-1;podARec=$$(hostname -i| awk -F. '{print $$1"-"$$2"-"$$3"-"$$4".e2e-tests-dns-8hdmk.pod.cluster.local"}');test -n "$$(dig +notcp +noall +answer +search $${podARec} A)" && echo OK > /results/wheezy_udp@PodARecord;test -n "$$(dig +tcp +noall +answer +search $${podARec} A)" && echo OK > /results/wheezy_tcp@PodARecord;sleep 1; done
+
+STEP: Running these commands on jessie: for i in `seq 1 600`; do test -n "$$(dig +notcp +noall +answer +search kubernetes.default A)" && echo OK > /results/jessie_udp@kubernetes.default;test -n "$$(dig +tcp +noall +answer +search kubernetes.default A)" && echo OK > /results/jessie_tcp@kubernetes.default;test -n "$$(dig +notcp +noall +answer +search kubernetes.default.svc A)" && echo OK > /results/jessie_udp@kubernetes.default.svc;test -n "$$(dig +tcp +noall +answer +search kubernetes.default.svc A)" && echo OK > /results/jessie_tcp@kubernetes.default.svc;test -n "$$(dig +notcp +noall +answer +search kubernetes.default.svc.cluster.local A)" && echo OK > /results/jessie_udp@kubernetes.default.svc.cluster.local;test -n "$$(dig +tcp +noall +answer +search kubernetes.default.svc.cluster.local A)" && echo OK > /results/jessie_tcp@kubernetes.default.svc.cluster.local;test -n "$$(getent hosts dns-querier-1.dns-test-service.e2e-tests-dns-8hdmk.svc.cluster.local)" && echo OK > /results/jessie_hosts@dns-querier-1.dns-test-service.e2e-tests-dns-8hdmk.svc.cluster.local;test -n "$$(getent hosts dns-querier-1)" && echo OK > /results/jessie_hosts@dns-querier-1;podARec=$$(hostname -i| awk -F. '{print $$1"-"$$2"-"$$3"-"$$4".e2e-tests-dns-8hdmk.pod.cluster.local"}');test -n "$$(dig +notcp +noall +answer +search $${podARec} A)" && echo OK > /results/jessie_udp@PodARecord;test -n "$$(dig +tcp +noall +answer +search $${podARec} A)" && echo OK > /results/jessie_tcp@PodARecord;sleep 1; done
+
+STEP: creating a pod to probe DNS
+STEP: submitting the pod to kubernetes
+STEP: retrieving the pod
+STEP: looking for the results for each expected name from probers
+Jul  2 13:11:41.802: INFO: DNS probes using dns-test-6ce08a04-7df9-11e8-bae1-da96248f62d7 succeeded
+
+STEP: deleting the pod
+[AfterEach] [sig-network] DNS
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:11:41.821: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-dns-8hdmk" for this suite.
+Jul  2 13:11:47.856: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:11:47.953: INFO: namespace: e2e-tests-dns-8hdmk, resource: bindings, ignored listing per whitelist
+Jul  2 13:11:48.036: INFO: namespace e2e-tests-dns-8hdmk deletion completed in 6.195842753s
+
+• [SLOW TEST:21.955 seconds]
+[sig-network] DNS
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/network/framework.go:22
+  should provide DNS for the cluster  [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSSSSS
+------------------------------
+[sig-api-machinery] Watchers 
+  should be able to restart watching from the last resource version observed by the previous watch [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-api-machinery] Watchers
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:11:48.036: INFO: >>> kubeConfig: /tmp/kubeconfig-411378559
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should be able to restart watching from the last resource version observed by the previous watch [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: creating a watch on configmaps
+STEP: creating a new configmap
+STEP: modifying the configmap once
+STEP: closing the watch once it receives two notifications
+Jul  2 13:11:48.138: INFO: Got : ADDED &ConfigMap{ObjectMeta:k8s_io_apimachinery_pkg_apis_meta_v1.ObjectMeta{Name:e2e-watch-test-watch-closed,GenerateName:,Namespace:e2e-tests-watch-hqvkm,SelfLink:/api/v1/namespaces/e2e-tests-watch-hqvkm/configmaps/e2e-watch-test-watch-closed,UID:79f59ac6-7df9-11e8-9deb-8e4c5ec544fb,ResourceVersion:4354,Generation:0,CreationTimestamp:2018-07-02 13:11:48 +0000 UTC,DeletionTimestamp:<nil>,DeletionGracePeriodSeconds:nil,Labels:map[string]string{watch-this-configmap: watch-closed-and-restarted,},Annotations:map[string]string{},OwnerReferences:[],Finalizers:[],ClusterName:,Initializers:nil,},Data:map[string]string{},BinaryData:map[string][]byte{},}
+Jul  2 13:11:48.139: INFO: Got : MODIFIED &ConfigMap{ObjectMeta:k8s_io_apimachinery_pkg_apis_meta_v1.ObjectMeta{Name:e2e-watch-test-watch-closed,GenerateName:,Namespace:e2e-tests-watch-hqvkm,SelfLink:/api/v1/namespaces/e2e-tests-watch-hqvkm/configmaps/e2e-watch-test-watch-closed,UID:79f59ac6-7df9-11e8-9deb-8e4c5ec544fb,ResourceVersion:4355,Generation:0,CreationTimestamp:2018-07-02 13:11:48 +0000 UTC,DeletionTimestamp:<nil>,DeletionGracePeriodSeconds:nil,Labels:map[string]string{watch-this-configmap: watch-closed-and-restarted,},Annotations:map[string]string{},OwnerReferences:[],Finalizers:[],ClusterName:,Initializers:nil,},Data:map[string]string{mutation: 1,},BinaryData:map[string][]byte{},}
+STEP: modifying the configmap a second time, while the watch is closed
+STEP: creating a new watch on configmaps from the last resource version observed by the first watch
+STEP: deleting the configmap
+STEP: Expecting to observe notifications for all changes to the configmap since the first watch closed
+Jul  2 13:11:48.152: INFO: Got : MODIFIED &ConfigMap{ObjectMeta:k8s_io_apimachinery_pkg_apis_meta_v1.ObjectMeta{Name:e2e-watch-test-watch-closed,GenerateName:,Namespace:e2e-tests-watch-hqvkm,SelfLink:/api/v1/namespaces/e2e-tests-watch-hqvkm/configmaps/e2e-watch-test-watch-closed,UID:79f59ac6-7df9-11e8-9deb-8e4c5ec544fb,ResourceVersion:4356,Generation:0,CreationTimestamp:2018-07-02 13:11:48 +0000 UTC,DeletionTimestamp:<nil>,DeletionGracePeriodSeconds:nil,Labels:map[string]string{watch-this-configmap: watch-closed-and-restarted,},Annotations:map[string]string{},OwnerReferences:[],Finalizers:[],ClusterName:,Initializers:nil,},Data:map[string]string{mutation: 2,},BinaryData:map[string][]byte{},}
+Jul  2 13:11:48.152: INFO: Got : DELETED &ConfigMap{ObjectMeta:k8s_io_apimachinery_pkg_apis_meta_v1.ObjectMeta{Name:e2e-watch-test-watch-closed,GenerateName:,Namespace:e2e-tests-watch-hqvkm,SelfLink:/api/v1/namespaces/e2e-tests-watch-hqvkm/configmaps/e2e-watch-test-watch-closed,UID:79f59ac6-7df9-11e8-9deb-8e4c5ec544fb,ResourceVersion:4357,Generation:0,CreationTimestamp:2018-07-02 13:11:48 +0000 UTC,DeletionTimestamp:<nil>,DeletionGracePeriodSeconds:nil,Labels:map[string]string{watch-this-configmap: watch-closed-and-restarted,},Annotations:map[string]string{},OwnerReferences:[],Finalizers:[],ClusterName:,Initializers:nil,},Data:map[string]string{mutation: 2,},BinaryData:map[string][]byte{},}
+[AfterEach] [sig-api-machinery] Watchers
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:11:48.152: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-watch-hqvkm" for this suite.
+Jul  2 13:11:54.167: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:11:54.252: INFO: namespace: e2e-tests-watch-hqvkm, resource: bindings, ignored listing per whitelist
+Jul  2 13:11:54.320: INFO: namespace e2e-tests-watch-hqvkm deletion completed in 6.163708814s
+
+• [SLOW TEST:6.284 seconds]
+[sig-api-machinery] Watchers
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apimachinery/framework.go:22
+  should be able to restart watching from the last resource version observed by the previous watch [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSSS
+------------------------------
+[sig-storage] Projected 
+  should provide container's memory request [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:11:54.320: INFO: >>> kubeConfig: /tmp/kubeconfig-411378559
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:858
+[It] should provide container's memory request [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating a pod to test downward API volume plugin
+Jul  2 13:11:54.440: INFO: Waiting up to 5m0s for pod "downwardapi-volume-7db81d5b-7df9-11e8-bae1-da96248f62d7" in namespace "e2e-tests-projected-ddgfg" to be "success or failure"
+Jul  2 13:11:54.444: INFO: Pod "downwardapi-volume-7db81d5b-7df9-11e8-bae1-da96248f62d7": Phase="Pending", Reason="", readiness=false. Elapsed: 3.293399ms
+Jul  2 13:11:56.447: INFO: Pod "downwardapi-volume-7db81d5b-7df9-11e8-bae1-da96248f62d7": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.007118262s
+STEP: Saw pod success
+Jul  2 13:11:56.447: INFO: Pod "downwardapi-volume-7db81d5b-7df9-11e8-bae1-da96248f62d7" satisfied condition "success or failure"
+Jul  2 13:11:56.450: INFO: Trying to get logs from node ip-10-250-24-1.ec2.internal pod downwardapi-volume-7db81d5b-7df9-11e8-bae1-da96248f62d7 container client-container: <nil>
+STEP: delete the pod
+Jul  2 13:11:56.568: INFO: Waiting for pod downwardapi-volume-7db81d5b-7df9-11e8-bae1-da96248f62d7 to disappear
+Jul  2 13:11:56.571: INFO: Pod downwardapi-volume-7db81d5b-7df9-11e8-bae1-da96248f62d7 no longer exists
+[AfterEach] [sig-storage] Projected
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:11:56.571: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-ddgfg" for this suite.
+Jul  2 13:12:02.585: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:12:02.653: INFO: namespace: e2e-tests-projected-ddgfg, resource: bindings, ignored listing per whitelist
+Jul  2 13:12:02.737: INFO: namespace e2e-tests-projected-ddgfg deletion completed in 6.16286226s
+
+• [SLOW TEST:8.418 seconds]
+[sig-storage] Projected
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:34
+  should provide container's memory request [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+S
+------------------------------
+[k8s.io] Pods 
+  should get a host IP [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [k8s.io] Pods
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:12:02.738: INFO: >>> kubeConfig: /tmp/kubeconfig-411378559
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [k8s.io] Pods
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/pods.go:127
+[It] should get a host IP [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: creating pod
+Jul  2 13:12:04.848: INFO: Pod pod-hostip-82b926a8-7df9-11e8-bae1-da96248f62d7 has hostIP: 10.250.24.1
+[AfterEach] [k8s.io] Pods
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:12:04.848: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-pods-ckpr2" for this suite.
+Jul  2 13:12:26.862: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:12:27.019: INFO: namespace: e2e-tests-pods-ckpr2, resource: bindings, ignored listing per whitelist
+Jul  2 13:12:27.042: INFO: namespace e2e-tests-pods-ckpr2 deletion completed in 22.190713026s
+
+• [SLOW TEST:24.304 seconds]
+[k8s.io] Pods
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:679
+  should get a host IP [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSSS
+------------------------------
+[sig-storage] Downward API volume 
+  should update labels on modification [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:12:27.042: INFO: >>> kubeConfig: /tmp/kubeconfig-411378559
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downwardapi_volume.go:38
+[It] should update labels on modification [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating the pod
+Jul  2 13:12:29.671: INFO: Successfully updated pod "labelsupdate91364fd7-7df9-11e8-bae1-da96248f62d7"
+[AfterEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:12:33.705: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-downward-api-c7lx9" for this suite.
+Jul  2 13:12:55.719: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:12:55.759: INFO: namespace: e2e-tests-downward-api-c7lx9, resource: bindings, ignored listing per whitelist
+Jul  2 13:12:55.826: INFO: namespace e2e-tests-downward-api-c7lx9 deletion completed in 22.117014641s
+
+• [SLOW TEST:28.784 seconds]
+[sig-storage] Downward API volume
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downwardapi_volume.go:33
+  should update labels on modification [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSS
+------------------------------
+[sig-apps] StatefulSet [k8s.io] Basic StatefulSet functionality [StatefulSetBasic] 
+  should perform rolling updates and roll backs of template modifications [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-apps] StatefulSet
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:12:55.826: INFO: >>> kubeConfig: /tmp/kubeconfig-411378559
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-apps] StatefulSet
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/statefulset.go:57
+[BeforeEach] [k8s.io] Basic StatefulSet functionality [StatefulSetBasic]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/statefulset.go:72
+STEP: Creating service test in namespace e2e-tests-statefulset-tbs6z
+[It] should perform rolling updates and roll backs of template modifications [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating a new StatefulSet
+Jul  2 13:12:55.932: INFO: Found 0 stateful pods, waiting for 3
+Jul  2 13:13:05.945: INFO: Waiting for pod ss2-0 to enter Running - Ready=true, currently Running - Ready=true
+Jul  2 13:13:05.945: INFO: Waiting for pod ss2-1 to enter Running - Ready=true, currently Running - Ready=true
+Jul  2 13:13:05.945: INFO: Waiting for pod ss2-2 to enter Running - Ready=true, currently Running - Ready=true
+Jul  2 13:13:05.956: INFO: Running '/usr/local/bin/kubectl --kubeconfig=/tmp/kubeconfig-411378559 exec --namespace=e2e-tests-statefulset-tbs6z ss2-1 -- /bin/sh -c mv -v /usr/share/nginx/html/index.html /tmp/ || true'
+Jul  2 13:13:06.443: INFO: stderr: ""
+Jul  2 13:13:06.443: INFO: stdout: "'/usr/share/nginx/html/index.html' -> '/tmp/index.html'\n"
+Jul  2 13:13:06.443: INFO: stdout of mv -v /usr/share/nginx/html/index.html /tmp/ || true on ss2-1: '/usr/share/nginx/html/index.html' -> '/tmp/index.html'
+
+STEP: Updating StatefulSet template: update image from k8s.gcr.io/nginx-slim-amd64:0.20 to k8s.gcr.io/nginx-slim-amd64:0.21
+Jul  2 13:13:16.554: INFO: Updating stateful set ss2
+STEP: Creating a new revision
+STEP: Updating Pods in reverse ordinal order
+Jul  2 13:13:26.650: INFO: Running '/usr/local/bin/kubectl --kubeconfig=/tmp/kubeconfig-411378559 exec --namespace=e2e-tests-statefulset-tbs6z ss2-1 -- /bin/sh -c mv -v /tmp/index.html /usr/share/nginx/html/ || true'
+Jul  2 13:13:27.093: INFO: stderr: ""
+Jul  2 13:13:27.094: INFO: stdout: "'/tmp/index.html' -> '/usr/share/nginx/html/index.html'\n"
+Jul  2 13:13:27.094: INFO: stdout of mv -v /tmp/index.html /usr/share/nginx/html/ || true on ss2-1: '/tmp/index.html' -> '/usr/share/nginx/html/index.html'
+
+Jul  2 13:13:37.162: INFO: Waiting for StatefulSet e2e-tests-statefulset-tbs6z/ss2 to complete update
+Jul  2 13:13:37.162: INFO: Waiting for Pod e2e-tests-statefulset-tbs6z/ss2-0 to have revision ss2-56dd5fb9c4 update revision ss2-76cb68b6ff
+Jul  2 13:13:37.163: INFO: Waiting for Pod e2e-tests-statefulset-tbs6z/ss2-1 to have revision ss2-56dd5fb9c4 update revision ss2-76cb68b6ff
+Jul  2 13:13:37.163: INFO: Waiting for Pod e2e-tests-statefulset-tbs6z/ss2-2 to have revision ss2-56dd5fb9c4 update revision ss2-76cb68b6ff
+Jul  2 13:13:47.244: INFO: Waiting for StatefulSet e2e-tests-statefulset-tbs6z/ss2 to complete update
+Jul  2 13:13:47.244: INFO: Waiting for Pod e2e-tests-statefulset-tbs6z/ss2-0 to have revision ss2-56dd5fb9c4 update revision ss2-76cb68b6ff
+Jul  2 13:13:47.244: INFO: Waiting for Pod e2e-tests-statefulset-tbs6z/ss2-1 to have revision ss2-56dd5fb9c4 update revision ss2-76cb68b6ff
+Jul  2 13:13:57.170: INFO: Waiting for StatefulSet e2e-tests-statefulset-tbs6z/ss2 to complete update
+Jul  2 13:13:57.170: INFO: Waiting for Pod e2e-tests-statefulset-tbs6z/ss2-0 to have revision ss2-56dd5fb9c4 update revision ss2-76cb68b6ff
+STEP: Rolling back to a previous revision
+Jul  2 13:14:07.170: INFO: Running '/usr/local/bin/kubectl --kubeconfig=/tmp/kubeconfig-411378559 exec --namespace=e2e-tests-statefulset-tbs6z ss2-1 -- /bin/sh -c mv -v /usr/share/nginx/html/index.html /tmp/ || true'
+Jul  2 13:14:07.623: INFO: stderr: ""
+Jul  2 13:14:07.623: INFO: stdout: "'/usr/share/nginx/html/index.html' -> '/tmp/index.html'\n"
+Jul  2 13:14:07.623: INFO: stdout of mv -v /usr/share/nginx/html/index.html /tmp/ || true on ss2-1: '/usr/share/nginx/html/index.html' -> '/tmp/index.html'
+
+Jul  2 13:14:07.671: INFO: Updating stateful set ss2
+STEP: Rolling back update in reverse ordinal order
+Jul  2 13:14:17.690: INFO: Running '/usr/local/bin/kubectl --kubeconfig=/tmp/kubeconfig-411378559 exec --namespace=e2e-tests-statefulset-tbs6z ss2-1 -- /bin/sh -c mv -v /tmp/index.html /usr/share/nginx/html/ || true'
+Jul  2 13:14:18.151: INFO: stderr: ""
+Jul  2 13:14:18.151: INFO: stdout: "'/tmp/index.html' -> '/usr/share/nginx/html/index.html'\n"
+Jul  2 13:14:18.151: INFO: stdout of mv -v /tmp/index.html /usr/share/nginx/html/ || true on ss2-1: '/tmp/index.html' -> '/usr/share/nginx/html/index.html'
+
+Jul  2 13:14:28.253: INFO: Waiting for StatefulSet e2e-tests-statefulset-tbs6z/ss2 to complete update
+Jul  2 13:14:28.253: INFO: Waiting for Pod e2e-tests-statefulset-tbs6z/ss2-0 to have revision ss2-76cb68b6ff update revision ss2-56dd5fb9c4
+Jul  2 13:14:28.253: INFO: Waiting for Pod e2e-tests-statefulset-tbs6z/ss2-1 to have revision ss2-76cb68b6ff update revision ss2-56dd5fb9c4
+Jul  2 13:14:28.253: INFO: Waiting for Pod e2e-tests-statefulset-tbs6z/ss2-2 to have revision ss2-76cb68b6ff update revision ss2-56dd5fb9c4
+Jul  2 13:14:38.261: INFO: Waiting for StatefulSet e2e-tests-statefulset-tbs6z/ss2 to complete update
+Jul  2 13:14:38.261: INFO: Waiting for Pod e2e-tests-statefulset-tbs6z/ss2-0 to have revision ss2-76cb68b6ff update revision ss2-56dd5fb9c4
+Jul  2 13:14:48.345: INFO: Waiting for StatefulSet e2e-tests-statefulset-tbs6z/ss2 to complete update
+Jul  2 13:14:48.345: INFO: Waiting for Pod e2e-tests-statefulset-tbs6z/ss2-0 to have revision ss2-76cb68b6ff update revision ss2-56dd5fb9c4
+[AfterEach] [k8s.io] Basic StatefulSet functionality [StatefulSetBasic]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/statefulset.go:83
+Jul  2 13:14:58.260: INFO: Deleting all statefulset in ns e2e-tests-statefulset-tbs6z
+Jul  2 13:14:58.263: INFO: Scaling statefulset ss2 to 0
+Jul  2 13:15:38.357: INFO: Waiting for statefulset status.replicas updated to 0
+Jul  2 13:15:38.360: INFO: Deleting statefulset ss2
+[AfterEach] [sig-apps] StatefulSet
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:15:38.458: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-statefulset-tbs6z" for this suite.
+Jul  2 13:15:44.474: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:15:44.610: INFO: namespace: e2e-tests-statefulset-tbs6z, resource: bindings, ignored listing per whitelist
+Jul  2 13:15:44.639: INFO: namespace e2e-tests-statefulset-tbs6z deletion completed in 6.17636792s
+
+• [SLOW TEST:168.813 seconds]
+[sig-apps] StatefulSet
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/framework.go:22
+  [k8s.io] Basic StatefulSet functionality [StatefulSetBasic]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:679
+    should perform rolling updates and roll backs of template modifications [Conformance]
+    /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSS
+------------------------------
+[sig-storage] EmptyDir volumes 
+  should support (non-root,0777,tmpfs) [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-storage] EmptyDir volumes
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:15:44.639: INFO: >>> kubeConfig: /tmp/kubeconfig-411378559
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should support (non-root,0777,tmpfs) [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating a pod to test emptydir 0777 on tmpfs
+Jul  2 13:15:44.733: INFO: Waiting up to 5m0s for pod "pod-06fc235e-7dfa-11e8-bae1-da96248f62d7" in namespace "e2e-tests-emptydir-sltbc" to be "success or failure"
+Jul  2 13:15:44.738: INFO: Pod "pod-06fc235e-7dfa-11e8-bae1-da96248f62d7": Phase="Pending", Reason="", readiness=false. Elapsed: 5.348203ms
+Jul  2 13:15:46.750: INFO: Pod "pod-06fc235e-7dfa-11e8-bae1-da96248f62d7": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.017001265s
+STEP: Saw pod success
+Jul  2 13:15:46.750: INFO: Pod "pod-06fc235e-7dfa-11e8-bae1-da96248f62d7" satisfied condition "success or failure"
+Jul  2 13:15:46.753: INFO: Trying to get logs from node ip-10-250-24-1.ec2.internal pod pod-06fc235e-7dfa-11e8-bae1-da96248f62d7 container test-container: <nil>
+STEP: delete the pod
+Jul  2 13:15:46.771: INFO: Waiting for pod pod-06fc235e-7dfa-11e8-bae1-da96248f62d7 to disappear
+Jul  2 13:15:46.784: INFO: Pod pod-06fc235e-7dfa-11e8-bae1-da96248f62d7 no longer exists
+[AfterEach] [sig-storage] EmptyDir volumes
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:15:46.784: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-emptydir-sltbc" for this suite.
+Jul  2 13:15:52.807: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:15:52.884: INFO: namespace: e2e-tests-emptydir-sltbc, resource: bindings, ignored listing per whitelist
+Jul  2 13:15:52.939: INFO: namespace e2e-tests-emptydir-sltbc deletion completed in 6.144804288s
+
+• [SLOW TEST:8.300 seconds]
+[sig-storage] EmptyDir volumes
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/empty_dir.go:40
+  should support (non-root,0777,tmpfs) [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+[sig-storage] ConfigMap 
+  optional updates should be reflected in volume [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-storage] ConfigMap
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:15:52.940: INFO: >>> kubeConfig: /tmp/kubeconfig-411378559
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] optional updates should be reflected in volume [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating configMap with name cm-test-opt-del-0bef9d99-7dfa-11e8-bae1-da96248f62d7
+STEP: Creating configMap with name cm-test-opt-upd-0bef9de4-7dfa-11e8-bae1-da96248f62d7
+STEP: Creating the pod
+STEP: Deleting configmap cm-test-opt-del-0bef9d99-7dfa-11e8-bae1-da96248f62d7
+STEP: Updating configmap cm-test-opt-upd-0bef9de4-7dfa-11e8-bae1-da96248f62d7
+STEP: Creating configMap with name cm-test-opt-create-0bef9e0c-7dfa-11e8-bae1-da96248f62d7
+STEP: waiting to observe update in volume
+[AfterEach] [sig-storage] ConfigMap
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:17:26.077: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-configmap-9lvl4" for this suite.
+Jul  2 13:17:48.092: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:17:48.112: INFO: namespace: e2e-tests-configmap-9lvl4, resource: bindings, ignored listing per whitelist
+Jul  2 13:17:48.190: INFO: namespace e2e-tests-configmap-9lvl4 deletion completed in 22.108391106s
+
+• [SLOW TEST:115.250 seconds]
+[sig-storage] ConfigMap
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/configmap_volume.go:32
+  optional updates should be reflected in volume [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSSSS
+------------------------------
+[sig-api-machinery] Downward API 
+  should provide default limits.cpu/memory from node allocatable [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-api-machinery] Downward API
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:17:48.190: INFO: >>> kubeConfig: /tmp/kubeconfig-411378559
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should provide default limits.cpu/memory from node allocatable [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating a pod to test downward api env vars
+Jul  2 13:17:48.289: INFO: Waiting up to 5m0s for pod "downward-api-50a14539-7dfa-11e8-bae1-da96248f62d7" in namespace "e2e-tests-downward-api-sl6vr" to be "success or failure"
+Jul  2 13:17:48.293: INFO: Pod "downward-api-50a14539-7dfa-11e8-bae1-da96248f62d7": Phase="Pending", Reason="", readiness=false. Elapsed: 3.918808ms
+Jul  2 13:17:50.297: INFO: Pod "downward-api-50a14539-7dfa-11e8-bae1-da96248f62d7": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.008112121s
+STEP: Saw pod success
+Jul  2 13:17:50.297: INFO: Pod "downward-api-50a14539-7dfa-11e8-bae1-da96248f62d7" satisfied condition "success or failure"
+Jul  2 13:17:50.302: INFO: Trying to get logs from node ip-10-250-24-1.ec2.internal pod downward-api-50a14539-7dfa-11e8-bae1-da96248f62d7 container dapi-container: <nil>
+STEP: delete the pod
+Jul  2 13:17:50.324: INFO: Waiting for pod downward-api-50a14539-7dfa-11e8-bae1-da96248f62d7 to disappear
+Jul  2 13:17:50.329: INFO: Pod downward-api-50a14539-7dfa-11e8-bae1-da96248f62d7 no longer exists
+[AfterEach] [sig-api-machinery] Downward API
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:17:50.329: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-downward-api-sl6vr" for this suite.
+Jul  2 13:17:56.445: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:17:56.480: INFO: namespace: e2e-tests-downward-api-sl6vr, resource: bindings, ignored listing per whitelist
+Jul  2 13:17:56.544: INFO: namespace e2e-tests-downward-api-sl6vr deletion completed in 6.209316641s
+
+• [SLOW TEST:8.354 seconds]
+[sig-api-machinery] Downward API
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downward_api.go:37
+  should provide default limits.cpu/memory from node allocatable [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+[sig-api-machinery] Secrets 
+  should be consumable via the environment [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-api-machinery] Secrets
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:17:56.544: INFO: >>> kubeConfig: /tmp/kubeconfig-411378559
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should be consumable via the environment [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: creating secret e2e-tests-secrets-hc29h/secret-test-559aea4a-7dfa-11e8-bae1-da96248f62d7
+STEP: Creating a pod to test consume secrets
+Jul  2 13:17:56.640: INFO: Waiting up to 5m0s for pod "pod-configmaps-559b7e2c-7dfa-11e8-bae1-da96248f62d7" in namespace "e2e-tests-secrets-hc29h" to be "success or failure"
+Jul  2 13:17:56.645: INFO: Pod "pod-configmaps-559b7e2c-7dfa-11e8-bae1-da96248f62d7": Phase="Pending", Reason="", readiness=false. Elapsed: 5.330752ms
+Jul  2 13:17:58.649: INFO: Pod "pod-configmaps-559b7e2c-7dfa-11e8-bae1-da96248f62d7": Phase="Pending", Reason="", readiness=false. Elapsed: 2.009030163s
+Jul  2 13:18:00.653: INFO: Pod "pod-configmaps-559b7e2c-7dfa-11e8-bae1-da96248f62d7": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.01260709s
+STEP: Saw pod success
+Jul  2 13:18:00.653: INFO: Pod "pod-configmaps-559b7e2c-7dfa-11e8-bae1-da96248f62d7" satisfied condition "success or failure"
+Jul  2 13:18:00.656: INFO: Trying to get logs from node ip-10-250-24-1.ec2.internal pod pod-configmaps-559b7e2c-7dfa-11e8-bae1-da96248f62d7 container env-test: <nil>
+STEP: delete the pod
+Jul  2 13:18:00.732: INFO: Waiting for pod pod-configmaps-559b7e2c-7dfa-11e8-bae1-da96248f62d7 to disappear
+Jul  2 13:18:00.736: INFO: Pod pod-configmaps-559b7e2c-7dfa-11e8-bae1-da96248f62d7 no longer exists
+[AfterEach] [sig-api-machinery] Secrets
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:18:00.736: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-secrets-hc29h" for this suite.
+Jul  2 13:18:06.765: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:18:06.793: INFO: namespace: e2e-tests-secrets-hc29h, resource: bindings, ignored listing per whitelist
+Jul  2 13:18:06.864: INFO: namespace e2e-tests-secrets-hc29h deletion completed in 6.115770011s
+
+• [SLOW TEST:10.321 seconds]
+[sig-api-machinery] Secrets
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/secrets.go:30
+  should be consumable via the environment [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+[sig-api-machinery] Garbage collector 
+  should delete pods created by rc when not orphaning [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-api-machinery] Garbage collector
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:18:06.865: INFO: >>> kubeConfig: /tmp/kubeconfig-411378559
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should delete pods created by rc when not orphaning [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: create the rc
+STEP: delete the rc
+STEP: wait for all pods to be garbage collected
+STEP: Gathering metrics
+W0702 13:18:17.062322      14 metrics_grabber.go:81] Master node is not registered. Grabbing metrics from Scheduler, ControllerManager and ClusterAutoscaler is disabled.
+Jul  2 13:18:17.062: INFO: For apiserver_request_count:
+For apiserver_request_latencies_summary:
+For etcd_helper_cache_entry_count:
+For etcd_helper_cache_hit_count:
+For etcd_helper_cache_miss_count:
+For etcd_request_cache_add_latencies_summary:
+For etcd_request_cache_get_latencies_summary:
+For etcd_request_latencies_summary:
+For garbage_collector_attempt_to_delete_queue_latency:
+For garbage_collector_attempt_to_delete_work_duration:
+For garbage_collector_attempt_to_orphan_queue_latency:
+For garbage_collector_attempt_to_orphan_work_duration:
+For garbage_collector_dirty_processing_latency_microseconds:
+For garbage_collector_event_processing_latency_microseconds:
+For garbage_collector_graph_changes_queue_latency:
+For garbage_collector_graph_changes_work_duration:
+For garbage_collector_orphan_processing_latency_microseconds:
+For namespace_queue_latency:
+For namespace_queue_latency_sum:
+For namespace_queue_latency_count:
+For namespace_retries:
+For namespace_work_duration:
+For namespace_work_duration_sum:
+For namespace_work_duration_count:
+For function_duration_seconds:
+For errors_total:
+For evicted_pods_total:
+
+[AfterEach] [sig-api-machinery] Garbage collector
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:18:17.062: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-gc-r7gj4" for this suite.
+Jul  2 13:18:23.079: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:18:23.175: INFO: namespace: e2e-tests-gc-r7gj4, resource: bindings, ignored listing per whitelist
+Jul  2 13:18:23.175: INFO: namespace e2e-tests-gc-r7gj4 deletion completed in 6.109386939s
+
+• [SLOW TEST:16.310 seconds]
+[sig-api-machinery] Garbage collector
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apimachinery/framework.go:22
+  should delete pods created by rc when not orphaning [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+S
+------------------------------
+[sig-storage] Projected 
+  should be consumable in multiple volumes in the same pod [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:18:23.175: INFO: >>> kubeConfig: /tmp/kubeconfig-411378559
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:858
+[It] should be consumable in multiple volumes in the same pod [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating configMap with name projected-configmap-test-volume-657ac9f5-7dfa-11e8-bae1-da96248f62d7
+STEP: Creating a pod to test consume configMaps
+Jul  2 13:18:23.274: INFO: Waiting up to 5m0s for pod "pod-projected-configmaps-657ba09d-7dfa-11e8-bae1-da96248f62d7" in namespace "e2e-tests-projected-rlvbr" to be "success or failure"
+Jul  2 13:18:23.279: INFO: Pod "pod-projected-configmaps-657ba09d-7dfa-11e8-bae1-da96248f62d7": Phase="Pending", Reason="", readiness=false. Elapsed: 5.262019ms
+Jul  2 13:18:25.283: INFO: Pod "pod-projected-configmaps-657ba09d-7dfa-11e8-bae1-da96248f62d7": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.00908757s
+STEP: Saw pod success
+Jul  2 13:18:25.283: INFO: Pod "pod-projected-configmaps-657ba09d-7dfa-11e8-bae1-da96248f62d7" satisfied condition "success or failure"
+Jul  2 13:18:25.350: INFO: Trying to get logs from node ip-10-250-24-1.ec2.internal pod pod-projected-configmaps-657ba09d-7dfa-11e8-bae1-da96248f62d7 container projected-configmap-volume-test: <nil>
+STEP: delete the pod
+Jul  2 13:18:25.370: INFO: Waiting for pod pod-projected-configmaps-657ba09d-7dfa-11e8-bae1-da96248f62d7 to disappear
+Jul  2 13:18:25.374: INFO: Pod pod-projected-configmaps-657ba09d-7dfa-11e8-bae1-da96248f62d7 no longer exists
+[AfterEach] [sig-storage] Projected
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:18:25.374: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-rlvbr" for this suite.
+Jul  2 13:18:31.392: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:18:31.532: INFO: namespace: e2e-tests-projected-rlvbr, resource: bindings, ignored listing per whitelist
+Jul  2 13:18:31.548: INFO: namespace e2e-tests-projected-rlvbr deletion completed in 6.169676153s
+
+• [SLOW TEST:8.373 seconds]
+[sig-storage] Projected
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:34
+  should be consumable in multiple volumes in the same pod [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSSSSSSSSS
+------------------------------
+[sig-storage] Downward API volume 
+  should update annotations on modification [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:18:31.548: INFO: >>> kubeConfig: /tmp/kubeconfig-411378559
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downwardapi_volume.go:38
+[It] should update annotations on modification [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating the pod
+Jul  2 13:18:34.351: INFO: Successfully updated pod "annotationupdate6a786a4a-7dfa-11e8-bae1-da96248f62d7"
+[AfterEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:18:38.465: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-downward-api-z59vp" for this suite.
+Jul  2 13:19:00.551: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:19:00.600: INFO: namespace: e2e-tests-downward-api-z59vp, resource: bindings, ignored listing per whitelist
+Jul  2 13:19:00.653: INFO: namespace e2e-tests-downward-api-z59vp deletion completed in 22.184229866s
+
+• [SLOW TEST:29.106 seconds]
+[sig-storage] Downward API volume
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downwardapi_volume.go:33
+  should update annotations on modification [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSSSSSS
+------------------------------
+[sig-apps] StatefulSet [k8s.io] Basic StatefulSet functionality [StatefulSetBasic] 
+  Should recreate evicted statefulset [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-apps] StatefulSet
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:19:00.654: INFO: >>> kubeConfig: /tmp/kubeconfig-411378559
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-apps] StatefulSet
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/statefulset.go:57
+[BeforeEach] [k8s.io] Basic StatefulSet functionality [StatefulSetBasic]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/statefulset.go:72
+STEP: Creating service test in namespace e2e-tests-statefulset-7kfk5
+[It] Should recreate evicted statefulset [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Looking for a node to schedule stateful set and pod
+STEP: Creating pod with conflicting port in namespace e2e-tests-statefulset-7kfk5
+STEP: Creating statefulset with conflicting port in namespace e2e-tests-statefulset-7kfk5
+STEP: Waiting until pod test-pod will start running in namespace e2e-tests-statefulset-7kfk5
+STEP: Waiting until stateful pod ss-0 will be recreated and deleted at least once in namespace e2e-tests-statefulset-7kfk5
+Jul  2 13:19:08.772: INFO: Observed stateful pod in namespace: e2e-tests-statefulset-7kfk5, name: ss-0, uid: 80025bce-7dfa-11e8-9deb-8e4c5ec544fb, status phase: Pending. Waiting for statefulset controller to delete.
+Jul  2 13:19:09.169: INFO: Observed stateful pod in namespace: e2e-tests-statefulset-7kfk5, name: ss-0, uid: 80025bce-7dfa-11e8-9deb-8e4c5ec544fb, status phase: Failed. Waiting for statefulset controller to delete.
+Jul  2 13:19:09.250: INFO: Observed stateful pod in namespace: e2e-tests-statefulset-7kfk5, name: ss-0, uid: 80025bce-7dfa-11e8-9deb-8e4c5ec544fb, status phase: Failed. Waiting for statefulset controller to delete.
+Jul  2 13:19:09.251: INFO: Observed delete event for stateful pod ss-0 in namespace e2e-tests-statefulset-7kfk5
+STEP: Removing pod with conflicting port in namespace e2e-tests-statefulset-7kfk5
+STEP: Waiting when stateful pod ss-0 will be recreated in namespace e2e-tests-statefulset-7kfk5 and will be in running state
+[AfterEach] [k8s.io] Basic StatefulSet functionality [StatefulSetBasic]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/statefulset.go:83
+Jul  2 13:19:13.269: INFO: Deleting all statefulset in ns e2e-tests-statefulset-7kfk5
+Jul  2 13:19:13.352: INFO: Scaling statefulset ss to 0
+Jul  2 13:19:23.368: INFO: Waiting for statefulset status.replicas updated to 0
+Jul  2 13:19:23.371: INFO: Deleting statefulset ss
+[AfterEach] [sig-apps] StatefulSet
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:19:23.457: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-statefulset-7kfk5" for this suite.
+Jul  2 13:19:29.470: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:19:29.596: INFO: namespace: e2e-tests-statefulset-7kfk5, resource: bindings, ignored listing per whitelist
+Jul  2 13:19:29.635: INFO: namespace e2e-tests-statefulset-7kfk5 deletion completed in 6.17505701s
+
+• [SLOW TEST:28.981 seconds]
+[sig-apps] StatefulSet
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/framework.go:22
+  [k8s.io] Basic StatefulSet functionality [StatefulSetBasic]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:679
+    Should recreate evicted statefulset [Conformance]
+    /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+[sig-api-machinery] ConfigMap 
+  should be consumable via the environment [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-api-machinery] ConfigMap
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:19:29.635: INFO: >>> kubeConfig: /tmp/kubeconfig-411378559
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should be consumable via the environment [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating configMap e2e-tests-configmap-l9bvh/configmap-test-8d193ba8-7dfa-11e8-bae1-da96248f62d7
+STEP: Creating a pod to test consume configMaps
+Jul  2 13:19:29.741: INFO: Waiting up to 5m0s for pod "pod-configmaps-8d19bb0e-7dfa-11e8-bae1-da96248f62d7" in namespace "e2e-tests-configmap-l9bvh" to be "success or failure"
+Jul  2 13:19:29.745: INFO: Pod "pod-configmaps-8d19bb0e-7dfa-11e8-bae1-da96248f62d7": Phase="Pending", Reason="", readiness=false. Elapsed: 3.756399ms
+Jul  2 13:19:31.753: INFO: Pod "pod-configmaps-8d19bb0e-7dfa-11e8-bae1-da96248f62d7": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.011525255s
+STEP: Saw pod success
+Jul  2 13:19:31.753: INFO: Pod "pod-configmaps-8d19bb0e-7dfa-11e8-bae1-da96248f62d7" satisfied condition "success or failure"
+Jul  2 13:19:31.756: INFO: Trying to get logs from node ip-10-250-24-1.ec2.internal pod pod-configmaps-8d19bb0e-7dfa-11e8-bae1-da96248f62d7 container env-test: <nil>
+STEP: delete the pod
+Jul  2 13:19:31.787: INFO: Waiting for pod pod-configmaps-8d19bb0e-7dfa-11e8-bae1-da96248f62d7 to disappear
+Jul  2 13:19:31.794: INFO: Pod pod-configmaps-8d19bb0e-7dfa-11e8-bae1-da96248f62d7 no longer exists
+[AfterEach] [sig-api-machinery] ConfigMap
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:19:31.803: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-configmap-l9bvh" for this suite.
+Jul  2 13:19:37.823: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:19:37.834: INFO: namespace: e2e-tests-configmap-l9bvh, resource: bindings, ignored listing per whitelist
+Jul  2 13:19:37.921: INFO: namespace e2e-tests-configmap-l9bvh deletion completed in 6.112653875s
+
+• [SLOW TEST:8.285 seconds]
+[sig-api-machinery] ConfigMap
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/configmap.go:29
+  should be consumable via the environment [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSS
+------------------------------
+[sig-storage] ConfigMap 
+  should be consumable from pods in volume with defaultMode set [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-storage] ConfigMap
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:19:37.921: INFO: >>> kubeConfig: /tmp/kubeconfig-411378559
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should be consumable from pods in volume with defaultMode set [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating configMap with name configmap-test-volume-9207edd8-7dfa-11e8-bae1-da96248f62d7
+STEP: Creating a pod to test consume configMaps
+Jul  2 13:19:38.017: INFO: Waiting up to 5m0s for pod "pod-configmaps-92086f58-7dfa-11e8-bae1-da96248f62d7" in namespace "e2e-tests-configmap-lldns" to be "success or failure"
+Jul  2 13:19:38.022: INFO: Pod "pod-configmaps-92086f58-7dfa-11e8-bae1-da96248f62d7": Phase="Pending", Reason="", readiness=false. Elapsed: 5.076038ms
+Jul  2 13:19:40.026: INFO: Pod "pod-configmaps-92086f58-7dfa-11e8-bae1-da96248f62d7": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.008722672s
+STEP: Saw pod success
+Jul  2 13:19:40.026: INFO: Pod "pod-configmaps-92086f58-7dfa-11e8-bae1-da96248f62d7" satisfied condition "success or failure"
+Jul  2 13:19:40.029: INFO: Trying to get logs from node ip-10-250-24-1.ec2.internal pod pod-configmaps-92086f58-7dfa-11e8-bae1-da96248f62d7 container configmap-volume-test: <nil>
+STEP: delete the pod
+Jul  2 13:19:40.048: INFO: Waiting for pod pod-configmaps-92086f58-7dfa-11e8-bae1-da96248f62d7 to disappear
+Jul  2 13:19:40.051: INFO: Pod pod-configmaps-92086f58-7dfa-11e8-bae1-da96248f62d7 no longer exists
+[AfterEach] [sig-storage] ConfigMap
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:19:40.064: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-configmap-lldns" for this suite.
+Jul  2 13:19:46.080: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:19:46.204: INFO: namespace: e2e-tests-configmap-lldns, resource: bindings, ignored listing per whitelist
+Jul  2 13:19:46.236: INFO: namespace e2e-tests-configmap-lldns deletion completed in 6.167659691s
+
+• [SLOW TEST:8.315 seconds]
+[sig-storage] ConfigMap
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/configmap_volume.go:32
+  should be consumable from pods in volume with defaultMode set [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSSSSSSSSSSS
+------------------------------
+[sig-network] Networking Granular Checks: Pods 
+  should function for intra-pod communication: http [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-network] Networking
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:19:46.237: INFO: >>> kubeConfig: /tmp/kubeconfig-411378559
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should function for intra-pod communication: http [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Performing setup for networking test in namespace e2e-tests-pod-network-test-cqt2h
+STEP: creating a selector
+STEP: Creating the service pods in kubernetes
+Jul  2 13:19:46.327: INFO: Waiting up to 10m0s for all (but 0) nodes to be schedulable
+STEP: Creating test pods
+Jul  2 13:20:08.478: INFO: ExecWithOptions {Command:[/bin/sh -c curl -g -q -s 'http://100.96.1.72:8080/dial?request=hostName&protocol=http&host=100.96.0.15&port=8080&tries=1'] Namespace:e2e-tests-pod-network-test-cqt2h PodName:host-test-container-pod ContainerName:hostexec Stdin:<nil> CaptureStdout:true CaptureStderr:true PreserveWhitespace:false}
+Jul  2 13:20:08.478: INFO: >>> kubeConfig: /tmp/kubeconfig-411378559
+Jul  2 13:20:08.845: INFO: Waiting for endpoints: map[]
+Jul  2 13:20:08.848: INFO: ExecWithOptions {Command:[/bin/sh -c curl -g -q -s 'http://100.96.1.72:8080/dial?request=hostName&protocol=http&host=100.96.1.71&port=8080&tries=1'] Namespace:e2e-tests-pod-network-test-cqt2h PodName:host-test-container-pod ContainerName:hostexec Stdin:<nil> CaptureStdout:true CaptureStderr:true PreserveWhitespace:false}
+Jul  2 13:20:08.848: INFO: >>> kubeConfig: /tmp/kubeconfig-411378559
+Jul  2 13:20:09.313: INFO: Waiting for endpoints: map[]
+[AfterEach] [sig-network] Networking
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:20:09.313: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-pod-network-test-cqt2h" for this suite.
+Jul  2 13:20:31.355: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:20:31.458: INFO: namespace: e2e-tests-pod-network-test-cqt2h, resource: bindings, ignored listing per whitelist
+Jul  2 13:20:31.555: INFO: namespace e2e-tests-pod-network-test-cqt2h deletion completed in 22.231851721s
+
+• [SLOW TEST:45.318 seconds]
+[sig-network] Networking
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/networking.go:25
+  Granular Checks: Pods
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/networking.go:28
+    should function for intra-pod communication: http [NodeConformance] [Conformance]
+    /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+[sig-storage] EmptyDir volumes 
+  should support (root,0777,default) [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-storage] EmptyDir volumes
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:20:31.555: INFO: >>> kubeConfig: /tmp/kubeconfig-411378559
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should support (root,0777,default) [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating a pod to test emptydir 0777 on node default medium
+Jul  2 13:20:31.650: INFO: Waiting up to 5m0s for pod "pod-b2001bf9-7dfa-11e8-bae1-da96248f62d7" in namespace "e2e-tests-emptydir-6jj9f" to be "success or failure"
+Jul  2 13:20:31.653: INFO: Pod "pod-b2001bf9-7dfa-11e8-bae1-da96248f62d7": Phase="Pending", Reason="", readiness=false. Elapsed: 3.572961ms
+Jul  2 13:20:33.657: INFO: Pod "pod-b2001bf9-7dfa-11e8-bae1-da96248f62d7": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.007349268s
+STEP: Saw pod success
+Jul  2 13:20:33.657: INFO: Pod "pod-b2001bf9-7dfa-11e8-bae1-da96248f62d7" satisfied condition "success or failure"
+Jul  2 13:20:33.660: INFO: Trying to get logs from node ip-10-250-24-1.ec2.internal pod pod-b2001bf9-7dfa-11e8-bae1-da96248f62d7 container test-container: <nil>
+STEP: delete the pod
+Jul  2 13:20:33.755: INFO: Waiting for pod pod-b2001bf9-7dfa-11e8-bae1-da96248f62d7 to disappear
+Jul  2 13:20:33.763: INFO: Pod pod-b2001bf9-7dfa-11e8-bae1-da96248f62d7 no longer exists
+[AfterEach] [sig-storage] EmptyDir volumes
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:20:33.763: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-emptydir-6jj9f" for this suite.
+Jul  2 13:20:39.780: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:20:39.789: INFO: namespace: e2e-tests-emptydir-6jj9f, resource: bindings, ignored listing per whitelist
+Jul  2 13:20:39.883: INFO: namespace e2e-tests-emptydir-6jj9f deletion completed in 6.116054585s
+
+• [SLOW TEST:8.328 seconds]
+[sig-storage] EmptyDir volumes
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/empty_dir.go:40
+  should support (root,0777,default) [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+[sig-network] Proxy version v1 
+  should proxy logs on node with explicit kubelet port using proxy subresource  [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] version v1
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:20:39.884: INFO: >>> kubeConfig: /tmp/kubeconfig-411378559
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should proxy logs on node with explicit kubelet port using proxy subresource  [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+Jul  2 13:20:40.069: INFO: (0) /api/v1/nodes/ip-10-250-20-212.ec2.internal:10250/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 95.061922ms)
+Jul  2 13:20:40.074: INFO: (1) /api/v1/nodes/ip-10-250-20-212.ec2.internal:10250/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 4.622082ms)
+Jul  2 13:20:40.078: INFO: (2) /api/v1/nodes/ip-10-250-20-212.ec2.internal:10250/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 4.578531ms)
+Jul  2 13:20:40.083: INFO: (3) /api/v1/nodes/ip-10-250-20-212.ec2.internal:10250/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 4.370649ms)
+Jul  2 13:20:40.087: INFO: (4) /api/v1/nodes/ip-10-250-20-212.ec2.internal:10250/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 4.352137ms)
+Jul  2 13:20:40.092: INFO: (5) /api/v1/nodes/ip-10-250-20-212.ec2.internal:10250/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 4.402135ms)
+Jul  2 13:20:40.098: INFO: (6) /api/v1/nodes/ip-10-250-20-212.ec2.internal:10250/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 5.945623ms)
+Jul  2 13:20:40.102: INFO: (7) /api/v1/nodes/ip-10-250-20-212.ec2.internal:10250/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 4.386067ms)
+Jul  2 13:20:40.144: INFO: (8) /api/v1/nodes/ip-10-250-20-212.ec2.internal:10250/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 42.384342ms)
+Jul  2 13:20:40.149: INFO: (9) /api/v1/nodes/ip-10-250-20-212.ec2.internal:10250/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 4.653096ms)
+Jul  2 13:20:40.154: INFO: (10) /api/v1/nodes/ip-10-250-20-212.ec2.internal:10250/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 4.654488ms)
+Jul  2 13:20:40.158: INFO: (11) /api/v1/nodes/ip-10-250-20-212.ec2.internal:10250/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 4.373121ms)
+Jul  2 13:20:40.163: INFO: (12) /api/v1/nodes/ip-10-250-20-212.ec2.internal:10250/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 4.533419ms)
+Jul  2 13:20:40.167: INFO: (13) /api/v1/nodes/ip-10-250-20-212.ec2.internal:10250/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 4.528968ms)
+Jul  2 13:20:40.172: INFO: (14) /api/v1/nodes/ip-10-250-20-212.ec2.internal:10250/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 4.669648ms)
+Jul  2 13:20:40.177: INFO: (15) /api/v1/nodes/ip-10-250-20-212.ec2.internal:10250/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 4.779077ms)
+Jul  2 13:20:40.181: INFO: (16) /api/v1/nodes/ip-10-250-20-212.ec2.internal:10250/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 4.488912ms)
+Jul  2 13:20:40.186: INFO: (17) /api/v1/nodes/ip-10-250-20-212.ec2.internal:10250/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 4.391717ms)
+Jul  2 13:20:40.190: INFO: (18) /api/v1/nodes/ip-10-250-20-212.ec2.internal:10250/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 4.370188ms)
+Jul  2 13:20:40.194: INFO: (19) /api/v1/nodes/ip-10-250-20-212.ec2.internal:10250/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 4.248283ms)
+[AfterEach] version v1
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:20:40.194: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-proxy-q8ffl" for this suite.
+Jul  2 13:20:46.208: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:20:46.253: INFO: namespace: e2e-tests-proxy-q8ffl, resource: bindings, ignored listing per whitelist
+Jul  2 13:20:46.311: INFO: namespace e2e-tests-proxy-q8ffl deletion completed in 6.11298362s
+
+• [SLOW TEST:6.427 seconds]
+[sig-network] Proxy
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/network/framework.go:22
+  version v1
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/network/proxy.go:56
+    should proxy logs on node with explicit kubelet port using proxy subresource  [Conformance]
+    /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+[sig-storage] Downward API volume 
+  should provide node allocatable (memory) as default memory limit if the limit is not set [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:20:46.312: INFO: >>> kubeConfig: /tmp/kubeconfig-411378559
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downwardapi_volume.go:38
+[It] should provide node allocatable (memory) as default memory limit if the limit is not set [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating a pod to test downward API volume plugin
+Jul  2 13:20:46.406: INFO: Waiting up to 5m0s for pod "downwardapi-volume-bacbcd54-7dfa-11e8-bae1-da96248f62d7" in namespace "e2e-tests-downward-api-jz2gw" to be "success or failure"
+Jul  2 13:20:46.409: INFO: Pod "downwardapi-volume-bacbcd54-7dfa-11e8-bae1-da96248f62d7": Phase="Pending", Reason="", readiness=false. Elapsed: 3.029863ms
+Jul  2 13:20:48.413: INFO: Pod "downwardapi-volume-bacbcd54-7dfa-11e8-bae1-da96248f62d7": Phase="Pending", Reason="", readiness=false. Elapsed: 2.007144204s
+Jul  2 13:20:50.417: INFO: Pod "downwardapi-volume-bacbcd54-7dfa-11e8-bae1-da96248f62d7": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.01105677s
+STEP: Saw pod success
+Jul  2 13:20:50.417: INFO: Pod "downwardapi-volume-bacbcd54-7dfa-11e8-bae1-da96248f62d7" satisfied condition "success or failure"
+Jul  2 13:20:50.420: INFO: Trying to get logs from node ip-10-250-24-1.ec2.internal pod downwardapi-volume-bacbcd54-7dfa-11e8-bae1-da96248f62d7 container client-container: <nil>
+STEP: delete the pod
+Jul  2 13:20:50.439: INFO: Waiting for pod downwardapi-volume-bacbcd54-7dfa-11e8-bae1-da96248f62d7 to disappear
+Jul  2 13:20:50.442: INFO: Pod downwardapi-volume-bacbcd54-7dfa-11e8-bae1-da96248f62d7 no longer exists
+[AfterEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:20:50.442: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-downward-api-jz2gw" for this suite.
+Jul  2 13:20:56.546: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:20:56.627: INFO: namespace: e2e-tests-downward-api-jz2gw, resource: bindings, ignored listing per whitelist
+Jul  2 13:20:56.657: INFO: namespace e2e-tests-downward-api-jz2gw deletion completed in 6.211125324s
+
+• [SLOW TEST:10.345 seconds]
+[sig-storage] Downward API volume
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downwardapi_volume.go:33
+  should provide node allocatable (memory) as default memory limit if the limit is not set [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSSSSSSSSSSS
+------------------------------
+[k8s.io] [sig-node] Events 
+  should be sent by kubelets and the scheduler about pods scheduling and running  [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [k8s.io] [sig-node] Events
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:20:56.658: INFO: >>> kubeConfig: /tmp/kubeconfig-411378559
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should be sent by kubelets and the scheduler about pods scheduling and running  [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: creating the pod
+STEP: submitting the pod to kubernetes
+STEP: verifying the pod is in kubernetes
+STEP: retrieving the pod
+&Pod{ObjectMeta:k8s_io_apimachinery_pkg_apis_meta_v1.ObjectMeta{Name:send-events-c0f6c6a7-7dfa-11e8-bae1-da96248f62d7,GenerateName:,Namespace:e2e-tests-events-hzlrk,SelfLink:/api/v1/namespaces/e2e-tests-events-hzlrk/pods/send-events-c0f6c6a7-7dfa-11e8-bae1-da96248f62d7,UID:c0f6ae3f-7dfa-11e8-9deb-8e4c5ec544fb,ResourceVersion:6097,Generation:0,CreationTimestamp:2018-07-02 13:20:56 +0000 UTC,DeletionTimestamp:<nil>,DeletionGracePeriodSeconds:nil,Labels:map[string]string{name: foo,time: 749437790,},Annotations:map[string]string{cni.projectcalico.org/podIP: 100.96.1.76/32,},OwnerReferences:[],Finalizers:[],ClusterName:,Initializers:nil,},Spec:PodSpec{Volumes:[{default-token-bh69l {nil nil nil nil nil SecretVolumeSource{SecretName:default-token-bh69l,Items:[],DefaultMode:*420,Optional:nil,} nil nil nil nil nil nil nil nil nil nil nil nil nil nil nil nil nil nil nil nil nil}}],Containers:[{p gcr.io/kubernetes-e2e-test-images/serve-hostname-amd64:1.0 [] []  [{ 0 80 TCP }] [] [] {map[] map[]} [{default-token-bh69l true /var/run/secrets/kubernetes.io/serviceaccount  <nil>}] [] nil nil nil /dev/termination-log File IfNotPresent nil false false false}],RestartPolicy:Always,TerminationGracePeriodSeconds:*30,ActiveDeadlineSeconds:nil,DNSPolicy:ClusterFirst,NodeSelector:map[string]string{},ServiceAccountName:default,DeprecatedServiceAccount:default,NodeName:ip-10-250-24-1.ec2.internal,HostNetwork:false,HostPID:false,HostIPC:false,SecurityContext:&PodSecurityContext{SELinuxOptions:nil,RunAsUser:nil,RunAsNonRoot:nil,SupplementalGroups:[],FSGroup:nil,RunAsGroup:nil,Sysctls:[],},ImagePullSecrets:[],Hostname:,Subdomain:,Affinity:nil,SchedulerName:default-scheduler,InitContainers:[],AutomountServiceAccountToken:nil,Tolerations:[{node.kubernetes.io/not-ready Exists  NoExecute 0xc4217069e0} {node.kubernetes.io/unreachable Exists  NoExecute 0xc421706a30}],HostAliases:[],PriorityClassName:,Priority:nil,DNSConfig:nil,ShareProcessNamespace:nil,ReadinessGates:[],},Status:PodStatus{Phase:Running,Conditions:[{Initialized True 0001-01-01 00:00:00 +0000 UTC 2018-07-02 13:20:56 +0000 UTC  } {Ready True 0001-01-01 00:00:00 +0000 UTC 2018-07-02 13:20:58 +0000 UTC  } {ContainersReady True 0001-01-01 00:00:00 +0000 UTC 0001-01-01 00:00:00 +0000 UTC  } {PodScheduled True 0001-01-01 00:00:00 +0000 UTC 2018-07-02 13:20:56 +0000 UTC  }],Message:,Reason:,HostIP:10.250.24.1,PodIP:100.96.1.76,StartTime:2018-07-02 13:20:56 +0000 UTC,ContainerStatuses:[{p {nil ContainerStateRunning{StartedAt:2018-07-02 13:20:57 +0000 UTC,} nil} {nil nil nil} true 0 gcr.io/kubernetes-e2e-test-images/serve-hostname-amd64:1.0 docker-pullable://gcr.io/kubernetes-e2e-test-images/serve-hostname-amd64@sha256:2dd4032e98a0450d95a0ac71a5e465f542a900812d8c41bc6ca635aed1a5fc91 docker://e310c89b33a9bb6ed5b693d500c206a64119d2c09b5c7a22d38e6f67941d50de}],QOSClass:BestEffort,InitContainerStatuses:[],NominatedNodeName:,},}
+STEP: checking for scheduler event about the pod
+Saw scheduler event for our pod.
+STEP: checking for kubelet event about the pod
+Saw kubelet event for our pod.
+STEP: deleting the pod
+[AfterEach] [k8s.io] [sig-node] Events
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:21:02.785: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-events-hzlrk" for this suite.
+Jul  2 13:21:24.808: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:21:24.831: INFO: namespace: e2e-tests-events-hzlrk, resource: bindings, ignored listing per whitelist
+Jul  2 13:21:24.917: INFO: namespace e2e-tests-events-hzlrk deletion completed in 22.125304032s
+
+• [SLOW TEST:28.259 seconds]
+[k8s.io] [sig-node] Events
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:679
+  should be sent by kubelets and the scheduler about pods scheduling and running  [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSSS
+------------------------------
+[sig-api-machinery] Garbage collector 
+  should orphan pods created by rc if delete options say so [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-api-machinery] Garbage collector
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:21:24.917: INFO: >>> kubeConfig: /tmp/kubeconfig-411378559
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should orphan pods created by rc if delete options say so [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: create the rc
+STEP: delete the rc
+STEP: wait for the rc to be deleted
+STEP: wait for 30 seconds to see if the garbage collector mistakenly deletes the pods
+STEP: Gathering metrics
+W0702 13:22:05.043364      14 metrics_grabber.go:81] Master node is not registered. Grabbing metrics from Scheduler, ControllerManager and ClusterAutoscaler is disabled.
+Jul  2 13:22:05.043: INFO: For apiserver_request_count:
+For apiserver_request_latencies_summary:
+For etcd_helper_cache_entry_count:
+For etcd_helper_cache_hit_count:
+For etcd_helper_cache_miss_count:
+For etcd_request_cache_add_latencies_summary:
+For etcd_request_cache_get_latencies_summary:
+For etcd_request_latencies_summary:
+For garbage_collector_attempt_to_delete_queue_latency:
+For garbage_collector_attempt_to_delete_work_duration:
+For garbage_collector_attempt_to_orphan_queue_latency:
+For garbage_collector_attempt_to_orphan_work_duration:
+For garbage_collector_dirty_processing_latency_microseconds:
+For garbage_collector_event_processing_latency_microseconds:
+For garbage_collector_graph_changes_queue_latency:
+For garbage_collector_graph_changes_work_duration:
+For garbage_collector_orphan_processing_latency_microseconds:
+For namespace_queue_latency:
+For namespace_queue_latency_sum:
+For namespace_queue_latency_count:
+For namespace_retries:
+For namespace_work_duration:
+For namespace_work_duration_sum:
+For namespace_work_duration_count:
+For function_duration_seconds:
+For errors_total:
+For evicted_pods_total:
+
+[AfterEach] [sig-api-machinery] Garbage collector
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:22:05.043: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-gc-xrpdf" for this suite.
+Jul  2 13:22:11.061: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:22:11.120: INFO: namespace: e2e-tests-gc-xrpdf, resource: bindings, ignored listing per whitelist
+Jul  2 13:22:11.202: INFO: namespace e2e-tests-gc-xrpdf deletion completed in 6.152341769s
+
+• [SLOW TEST:46.285 seconds]
+[sig-api-machinery] Garbage collector
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apimachinery/framework.go:22
+  should orphan pods created by rc if delete options say so [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSS
+------------------------------
+[sig-network] Networking Granular Checks: Pods 
+  should function for intra-pod communication: udp [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-network] Networking
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:22:11.203: INFO: >>> kubeConfig: /tmp/kubeconfig-411378559
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should function for intra-pod communication: udp [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Performing setup for networking test in namespace e2e-tests-pod-network-test-6vd4w
+STEP: creating a selector
+STEP: Creating the service pods in kubernetes
+Jul  2 13:22:11.319: INFO: Waiting up to 10m0s for all (but 0) nodes to be schedulable
+STEP: Creating test pods
+Jul  2 13:22:31.482: INFO: ExecWithOptions {Command:[/bin/sh -c curl -g -q -s 'http://100.96.1.85:8080/dial?request=hostName&protocol=udp&host=100.96.0.19&port=8081&tries=1'] Namespace:e2e-tests-pod-network-test-6vd4w PodName:host-test-container-pod ContainerName:hostexec Stdin:<nil> CaptureStdout:true CaptureStderr:true PreserveWhitespace:false}
+Jul  2 13:22:31.482: INFO: >>> kubeConfig: /tmp/kubeconfig-411378559
+Jul  2 13:22:31.891: INFO: Waiting for endpoints: map[]
+Jul  2 13:22:31.894: INFO: ExecWithOptions {Command:[/bin/sh -c curl -g -q -s 'http://100.96.1.85:8080/dial?request=hostName&protocol=udp&host=100.96.1.84&port=8081&tries=1'] Namespace:e2e-tests-pod-network-test-6vd4w PodName:host-test-container-pod ContainerName:hostexec Stdin:<nil> CaptureStdout:true CaptureStderr:true PreserveWhitespace:false}
+Jul  2 13:22:31.894: INFO: >>> kubeConfig: /tmp/kubeconfig-411378559
+Jul  2 13:22:32.351: INFO: Waiting for endpoints: map[]
+[AfterEach] [sig-network] Networking
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:22:32.351: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-pod-network-test-6vd4w" for this suite.
+Jul  2 13:22:54.370: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:22:54.383: INFO: namespace: e2e-tests-pod-network-test-6vd4w, resource: bindings, ignored listing per whitelist
+Jul  2 13:22:54.515: INFO: namespace e2e-tests-pod-network-test-6vd4w deletion completed in 22.156851499s
+
+• [SLOW TEST:43.313 seconds]
+[sig-network] Networking
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/networking.go:25
+  Granular Checks: Pods
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/networking.go:28
+    should function for intra-pod communication: udp [NodeConformance] [Conformance]
+    /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSSS
+------------------------------
+[sig-storage] Projected 
+  should be consumable from pods in volume with mappings and Item mode set [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:22:54.515: INFO: >>> kubeConfig: /tmp/kubeconfig-411378559
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:858
+[It] should be consumable from pods in volume with mappings and Item mode set [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating configMap with name projected-configmap-test-volume-map-0736480d-7dfb-11e8-bae1-da96248f62d7
+STEP: Creating a pod to test consume configMaps
+Jul  2 13:22:54.615: INFO: Waiting up to 5m0s for pod "pod-projected-configmaps-0736df07-7dfb-11e8-bae1-da96248f62d7" in namespace "e2e-tests-projected-4dszc" to be "success or failure"
+Jul  2 13:22:54.619: INFO: Pod "pod-projected-configmaps-0736df07-7dfb-11e8-bae1-da96248f62d7": Phase="Pending", Reason="", readiness=false. Elapsed: 3.698949ms
+Jul  2 13:22:56.623: INFO: Pod "pod-projected-configmaps-0736df07-7dfb-11e8-bae1-da96248f62d7": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.007675429s
+STEP: Saw pod success
+Jul  2 13:22:56.623: INFO: Pod "pod-projected-configmaps-0736df07-7dfb-11e8-bae1-da96248f62d7" satisfied condition "success or failure"
+Jul  2 13:22:56.625: INFO: Trying to get logs from node ip-10-250-24-1.ec2.internal pod pod-projected-configmaps-0736df07-7dfb-11e8-bae1-da96248f62d7 container projected-configmap-volume-test: <nil>
+STEP: delete the pod
+Jul  2 13:22:56.651: INFO: Waiting for pod pod-projected-configmaps-0736df07-7dfb-11e8-bae1-da96248f62d7 to disappear
+Jul  2 13:22:56.654: INFO: Pod pod-projected-configmaps-0736df07-7dfb-11e8-bae1-da96248f62d7 no longer exists
+[AfterEach] [sig-storage] Projected
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:22:56.654: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-4dszc" for this suite.
+Jul  2 13:23:02.676: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:23:02.793: INFO: namespace: e2e-tests-projected-4dszc, resource: bindings, ignored listing per whitelist
+Jul  2 13:23:02.838: INFO: namespace e2e-tests-projected-4dszc deletion completed in 6.180623103s
+
+• [SLOW TEST:8.323 seconds]
+[sig-storage] Projected
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:34
+  should be consumable from pods in volume with mappings and Item mode set [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+[sig-network] Service endpoints latency 
+  should not be very high  [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-network] Service endpoints latency
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:23:02.838: INFO: >>> kubeConfig: /tmp/kubeconfig-411378559
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should not be very high  [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: creating replication controller svc-latency-rc in namespace e2e-tests-svc-latency-422hm
+I0702 13:23:02.931417      14 runners.go:177] Created replication controller with name: svc-latency-rc, namespace: e2e-tests-svc-latency-422hm, replica count: 1
+I0702 13:23:03.983647      14 runners.go:177] svc-latency-rc Pods: 1 out of 1 created, 0 running, 1 pending, 0 waiting, 0 inactive, 0 terminating, 0 unknown, 0 runningButNotReady 
+I0702 13:23:04.983870      14 runners.go:177] svc-latency-rc Pods: 1 out of 1 created, 1 running, 0 pending, 0 waiting, 0 inactive, 0 terminating, 0 unknown, 0 runningButNotReady 
+Jul  2 13:23:05.158: INFO: Created: latency-svc-2w8zp
+Jul  2 13:23:05.165: INFO: Got endpoints: latency-svc-2w8zp [80.835248ms]
+Jul  2 13:23:05.175: INFO: Created: latency-svc-gp2gj
+Jul  2 13:23:05.180: INFO: Got endpoints: latency-svc-gp2gj [15.212164ms]
+Jul  2 13:23:05.181: INFO: Created: latency-svc-rw5p2
+Jul  2 13:23:05.186: INFO: Created: latency-svc-vjj6h
+Jul  2 13:23:05.186: INFO: Got endpoints: latency-svc-rw5p2 [18.791532ms]
+Jul  2 13:23:05.191: INFO: Got endpoints: latency-svc-vjj6h [25.923737ms]
+Jul  2 13:23:05.192: INFO: Created: latency-svc-g2g4g
+Jul  2 13:23:05.198: INFO: Got endpoints: latency-svc-g2g4g [32.655575ms]
+Jul  2 13:23:05.198: INFO: Created: latency-svc-lt65n
+Jul  2 13:23:05.203: INFO: Got endpoints: latency-svc-lt65n [37.804884ms]
+Jul  2 13:23:05.204: INFO: Created: latency-svc-s65sn
+Jul  2 13:23:05.210: INFO: Got endpoints: latency-svc-s65sn [44.376517ms]
+Jul  2 13:23:05.210: INFO: Created: latency-svc-wwlwj
+Jul  2 13:23:05.212: INFO: Got endpoints: latency-svc-wwlwj [46.517415ms]
+Jul  2 13:23:05.228: INFO: Created: latency-svc-tnzcr
+Jul  2 13:23:05.232: INFO: Created: latency-svc-hpq98
+Jul  2 13:23:05.232: INFO: Got endpoints: latency-svc-tnzcr [65.253471ms]
+Jul  2 13:23:05.232: INFO: Created: latency-svc-wq975
+Jul  2 13:23:05.232: INFO: Got endpoints: latency-svc-wq975 [66.477352ms]
+Jul  2 13:23:05.241: INFO: Got endpoints: latency-svc-hpq98 [73.929358ms]
+Jul  2 13:23:05.247: INFO: Created: latency-svc-z6kxl
+Jul  2 13:23:05.251: INFO: Got endpoints: latency-svc-z6kxl [84.896084ms]
+Jul  2 13:23:05.262: INFO: Created: latency-svc-4tq5x
+Jul  2 13:23:05.268: INFO: Got endpoints: latency-svc-4tq5x [101.352696ms]
+Jul  2 13:23:05.269: INFO: Created: latency-svc-g2ffv
+Jul  2 13:23:05.277: INFO: Created: latency-svc-ttqnq
+Jul  2 13:23:05.279: INFO: Got endpoints: latency-svc-g2ffv [112.541225ms]
+Jul  2 13:23:05.284: INFO: Got endpoints: latency-svc-ttqnq [117.329159ms]
+Jul  2 13:23:05.284: INFO: Created: latency-svc-cwlmc
+Jul  2 13:23:05.290: INFO: Got endpoints: latency-svc-cwlmc [122.689911ms]
+Jul  2 13:23:05.290: INFO: Created: latency-svc-4hrjx
+Jul  2 13:23:05.345: INFO: Got endpoints: latency-svc-4hrjx [165.155519ms]
+Jul  2 13:23:05.353: INFO: Created: latency-svc-pl4gl
+Jul  2 13:23:05.356: INFO: Got endpoints: latency-svc-pl4gl [170.232383ms]
+Jul  2 13:23:05.366: INFO: Created: latency-svc-npp9x
+Jul  2 13:23:05.369: INFO: Got endpoints: latency-svc-npp9x [177.561702ms]
+Jul  2 13:23:05.375: INFO: Created: latency-svc-9pzv7
+Jul  2 13:23:05.377: INFO: Got endpoints: latency-svc-9pzv7 [179.180113ms]
+Jul  2 13:23:05.382: INFO: Created: latency-svc-hkllx
+Jul  2 13:23:05.387: INFO: Got endpoints: latency-svc-hkllx [183.75808ms]
+Jul  2 13:23:05.392: INFO: Created: latency-svc-87mmb
+Jul  2 13:23:05.395: INFO: Got endpoints: latency-svc-87mmb [185.266551ms]
+Jul  2 13:23:05.399: INFO: Created: latency-svc-4md9n
+Jul  2 13:23:05.405: INFO: Created: latency-svc-dzz99
+Jul  2 13:23:05.405: INFO: Got endpoints: latency-svc-4md9n [192.917186ms]
+Jul  2 13:23:05.407: INFO: Got endpoints: latency-svc-dzz99 [175.736602ms]
+Jul  2 13:23:05.412: INFO: Created: latency-svc-pjbxb
+Jul  2 13:23:05.418: INFO: Got endpoints: latency-svc-pjbxb [185.046312ms]
+Jul  2 13:23:05.418: INFO: Created: latency-svc-q2xq8
+Jul  2 13:23:05.425: INFO: Created: latency-svc-f2kpx
+Jul  2 13:23:05.425: INFO: Got endpoints: latency-svc-q2xq8 [184.608451ms]
+Jul  2 13:23:05.431: INFO: Got endpoints: latency-svc-f2kpx [179.610223ms]
+Jul  2 13:23:05.431: INFO: Created: latency-svc-cnm49
+Jul  2 13:23:05.436: INFO: Created: latency-svc-gmwjc
+Jul  2 13:23:05.436: INFO: Got endpoints: latency-svc-cnm49 [168.186884ms]
+Jul  2 13:23:05.449: INFO: Got endpoints: latency-svc-gmwjc [169.719495ms]
+Jul  2 13:23:05.454: INFO: Created: latency-svc-dznps
+Jul  2 13:23:05.456: INFO: Got endpoints: latency-svc-dznps [172.026135ms]
+Jul  2 13:23:05.460: INFO: Created: latency-svc-s646s
+Jul  2 13:23:05.462: INFO: Got endpoints: latency-svc-s646s [172.696152ms]
+Jul  2 13:23:05.473: INFO: Created: latency-svc-4jffc
+Jul  2 13:23:05.475: INFO: Got endpoints: latency-svc-4jffc [129.95284ms]
+Jul  2 13:23:05.479: INFO: Created: latency-svc-9t7wg
+Jul  2 13:23:05.482: INFO: Got endpoints: latency-svc-9t7wg [125.792908ms]
+Jul  2 13:23:05.487: INFO: Created: latency-svc-5mf6r
+Jul  2 13:23:05.489: INFO: Got endpoints: latency-svc-5mf6r [120.105267ms]
+Jul  2 13:23:05.494: INFO: Created: latency-svc-cbzwz
+Jul  2 13:23:05.497: INFO: Got endpoints: latency-svc-cbzwz [119.739228ms]
+Jul  2 13:23:05.501: INFO: Created: latency-svc-l9bns
+Jul  2 13:23:05.504: INFO: Got endpoints: latency-svc-l9bns [116.80392ms]
+Jul  2 13:23:05.508: INFO: Created: latency-svc-25tcp
+Jul  2 13:23:05.511: INFO: Got endpoints: latency-svc-25tcp [115.399515ms]
+Jul  2 13:23:05.515: INFO: Created: latency-svc-wmrrm
+Jul  2 13:23:05.522: INFO: Created: latency-svc-8ldkr
+Jul  2 13:23:05.530: INFO: Created: latency-svc-vg5ck
+Jul  2 13:23:05.535: INFO: Created: latency-svc-7km2z
+Jul  2 13:23:05.542: INFO: Created: latency-svc-gtz9q
+Jul  2 13:23:05.549: INFO: Created: latency-svc-28lbk
+Jul  2 13:23:05.555: INFO: Created: latency-svc-k4bwk
+Jul  2 13:23:05.562: INFO: Got endpoints: latency-svc-wmrrm [157.189841ms]
+Jul  2 13:23:05.564: INFO: Created: latency-svc-dqlcl
+Jul  2 13:23:05.571: INFO: Created: latency-svc-7d46j
+Jul  2 13:23:05.582: INFO: Created: latency-svc-zgcsl
+Jul  2 13:23:05.589: INFO: Created: latency-svc-9xnrs
+Jul  2 13:23:05.595: INFO: Created: latency-svc-sddfg
+Jul  2 13:23:05.601: INFO: Created: latency-svc-t2pxv
+Jul  2 13:23:05.609: INFO: Created: latency-svc-x625c
+Jul  2 13:23:05.611: INFO: Got endpoints: latency-svc-8ldkr [203.386623ms]
+Jul  2 13:23:05.615: INFO: Created: latency-svc-rqkvz
+Jul  2 13:23:05.626: INFO: Created: latency-svc-78fns
+Jul  2 13:23:05.629: INFO: Created: latency-svc-ns85v
+Jul  2 13:23:05.660: INFO: Got endpoints: latency-svc-vg5ck [242.319566ms]
+Jul  2 13:23:05.670: INFO: Created: latency-svc-hlvzg
+Jul  2 13:23:05.710: INFO: Got endpoints: latency-svc-7km2z [284.960935ms]
+Jul  2 13:23:05.720: INFO: Created: latency-svc-hthfm
+Jul  2 13:23:05.761: INFO: Got endpoints: latency-svc-gtz9q [329.847727ms]
+Jul  2 13:23:05.770: INFO: Created: latency-svc-6mbjl
+Jul  2 13:23:05.810: INFO: Got endpoints: latency-svc-28lbk [373.80999ms]
+Jul  2 13:23:05.820: INFO: Created: latency-svc-vglkc
+Jul  2 13:23:05.860: INFO: Got endpoints: latency-svc-k4bwk [410.969514ms]
+Jul  2 13:23:05.870: INFO: Created: latency-svc-5fbjv
+Jul  2 13:23:05.911: INFO: Got endpoints: latency-svc-dqlcl [454.769697ms]
+Jul  2 13:23:05.920: INFO: Created: latency-svc-pzzb4
+Jul  2 13:23:05.960: INFO: Got endpoints: latency-svc-7d46j [497.874244ms]
+Jul  2 13:23:05.970: INFO: Created: latency-svc-pbfrn
+Jul  2 13:23:06.010: INFO: Got endpoints: latency-svc-zgcsl [534.956499ms]
+Jul  2 13:23:06.020: INFO: Created: latency-svc-nxwr8
+Jul  2 13:23:06.061: INFO: Got endpoints: latency-svc-9xnrs [578.785154ms]
+Jul  2 13:23:06.071: INFO: Created: latency-svc-mtvdb
+Jul  2 13:23:06.111: INFO: Got endpoints: latency-svc-sddfg [621.585787ms]
+Jul  2 13:23:06.121: INFO: Created: latency-svc-ctvth
+Jul  2 13:23:06.161: INFO: Got endpoints: latency-svc-t2pxv [664.226771ms]
+Jul  2 13:23:06.173: INFO: Created: latency-svc-gb4zl
+Jul  2 13:23:06.216: INFO: Got endpoints: latency-svc-x625c [711.879699ms]
+Jul  2 13:23:06.228: INFO: Created: latency-svc-fblvs
+Jul  2 13:23:06.260: INFO: Got endpoints: latency-svc-rqkvz [749.651845ms]
+Jul  2 13:23:06.272: INFO: Created: latency-svc-hbxw4
+Jul  2 13:23:06.311: INFO: Got endpoints: latency-svc-78fns [747.99773ms]
+Jul  2 13:23:06.326: INFO: Created: latency-svc-xdhvs
+Jul  2 13:23:06.361: INFO: Got endpoints: latency-svc-ns85v [749.758519ms]
+Jul  2 13:23:06.370: INFO: Created: latency-svc-bvmbc
+Jul  2 13:23:06.411: INFO: Got endpoints: latency-svc-hlvzg [750.707627ms]
+Jul  2 13:23:06.423: INFO: Created: latency-svc-c8wmf
+Jul  2 13:23:06.461: INFO: Got endpoints: latency-svc-hthfm [750.217449ms]
+Jul  2 13:23:06.471: INFO: Created: latency-svc-dqjns
+Jul  2 13:23:06.510: INFO: Got endpoints: latency-svc-6mbjl [749.874922ms]
+Jul  2 13:23:06.520: INFO: Created: latency-svc-zxvkc
+Jul  2 13:23:06.560: INFO: Got endpoints: latency-svc-vglkc [749.555197ms]
+Jul  2 13:23:06.570: INFO: Created: latency-svc-jq7ph
+Jul  2 13:23:06.611: INFO: Got endpoints: latency-svc-5fbjv [750.187407ms]
+Jul  2 13:23:06.620: INFO: Created: latency-svc-wqqwx
+Jul  2 13:23:06.660: INFO: Got endpoints: latency-svc-pzzb4 [749.639386ms]
+Jul  2 13:23:06.671: INFO: Created: latency-svc-5njxl
+Jul  2 13:23:06.710: INFO: Got endpoints: latency-svc-pbfrn [749.854932ms]
+Jul  2 13:23:06.720: INFO: Created: latency-svc-2xl89
+Jul  2 13:23:06.760: INFO: Got endpoints: latency-svc-nxwr8 [749.684839ms]
+Jul  2 13:23:06.770: INFO: Created: latency-svc-btpl7
+Jul  2 13:23:06.810: INFO: Got endpoints: latency-svc-mtvdb [749.412266ms]
+Jul  2 13:23:06.820: INFO: Created: latency-svc-k5p59
+Jul  2 13:23:06.865: INFO: Got endpoints: latency-svc-ctvth [754.506829ms]
+Jul  2 13:23:06.875: INFO: Created: latency-svc-c2fx2
+Jul  2 13:23:06.910: INFO: Got endpoints: latency-svc-gb4zl [749.111937ms]
+Jul  2 13:23:06.926: INFO: Created: latency-svc-47tkd
+Jul  2 13:23:06.963: INFO: Got endpoints: latency-svc-fblvs [747.517861ms]
+Jul  2 13:23:06.973: INFO: Created: latency-svc-2gmzh
+Jul  2 13:23:07.010: INFO: Got endpoints: latency-svc-hbxw4 [749.77468ms]
+Jul  2 13:23:07.022: INFO: Created: latency-svc-8zwb5
+Jul  2 13:23:07.060: INFO: Got endpoints: latency-svc-xdhvs [749.506901ms]
+Jul  2 13:23:07.070: INFO: Created: latency-svc-kzcqt
+Jul  2 13:23:07.110: INFO: Got endpoints: latency-svc-bvmbc [749.299866ms]
+Jul  2 13:23:07.120: INFO: Created: latency-svc-rzpqw
+Jul  2 13:23:07.164: INFO: Got endpoints: latency-svc-c8wmf [752.649378ms]
+Jul  2 13:23:07.173: INFO: Created: latency-svc-q9g5x
+Jul  2 13:23:07.210: INFO: Got endpoints: latency-svc-dqjns [749.56156ms]
+Jul  2 13:23:07.222: INFO: Created: latency-svc-sgtwr
+Jul  2 13:23:07.260: INFO: Got endpoints: latency-svc-zxvkc [749.614054ms]
+Jul  2 13:23:07.272: INFO: Created: latency-svc-cnp7m
+Jul  2 13:23:07.311: INFO: Got endpoints: latency-svc-jq7ph [751.002329ms]
+Jul  2 13:23:07.328: INFO: Created: latency-svc-g9jnm
+Jul  2 13:23:07.361: INFO: Got endpoints: latency-svc-wqqwx [750.214665ms]
+Jul  2 13:23:07.370: INFO: Created: latency-svc-xwkqd
+Jul  2 13:23:07.410: INFO: Got endpoints: latency-svc-5njxl [749.455074ms]
+Jul  2 13:23:07.423: INFO: Created: latency-svc-8m588
+Jul  2 13:23:07.461: INFO: Got endpoints: latency-svc-2xl89 [750.192008ms]
+Jul  2 13:23:07.471: INFO: Created: latency-svc-ncpbq
+Jul  2 13:23:07.511: INFO: Got endpoints: latency-svc-btpl7 [750.6994ms]
+Jul  2 13:23:07.525: INFO: Created: latency-svc-ptx25
+Jul  2 13:23:07.560: INFO: Got endpoints: latency-svc-k5p59 [749.802247ms]
+Jul  2 13:23:07.570: INFO: Created: latency-svc-zpmcb
+Jul  2 13:23:07.610: INFO: Got endpoints: latency-svc-c2fx2 [745.203437ms]
+Jul  2 13:23:07.620: INFO: Created: latency-svc-lbljs
+Jul  2 13:23:07.661: INFO: Got endpoints: latency-svc-47tkd [750.391404ms]
+Jul  2 13:23:07.671: INFO: Created: latency-svc-st8mq
+Jul  2 13:23:07.710: INFO: Got endpoints: latency-svc-2gmzh [746.71436ms]
+Jul  2 13:23:07.723: INFO: Created: latency-svc-c7qjj
+Jul  2 13:23:07.760: INFO: Got endpoints: latency-svc-8zwb5 [749.690037ms]
+Jul  2 13:23:07.770: INFO: Created: latency-svc-sf44f
+Jul  2 13:23:07.810: INFO: Got endpoints: latency-svc-kzcqt [749.744538ms]
+Jul  2 13:23:07.823: INFO: Created: latency-svc-5r7fk
+Jul  2 13:23:07.860: INFO: Got endpoints: latency-svc-rzpqw [749.837419ms]
+Jul  2 13:23:07.870: INFO: Created: latency-svc-wfzmd
+Jul  2 13:23:07.910: INFO: Got endpoints: latency-svc-q9g5x [746.434873ms]
+Jul  2 13:23:07.920: INFO: Created: latency-svc-67h5h
+Jul  2 13:23:07.960: INFO: Got endpoints: latency-svc-sgtwr [750.152493ms]
+Jul  2 13:23:07.970: INFO: Created: latency-svc-p2kkb
+Jul  2 13:23:08.010: INFO: Got endpoints: latency-svc-cnp7m [749.85509ms]
+Jul  2 13:23:08.020: INFO: Created: latency-svc-fxmj9
+Jul  2 13:23:08.060: INFO: Got endpoints: latency-svc-g9jnm [749.152715ms]
+Jul  2 13:23:08.070: INFO: Created: latency-svc-wt7dz
+Jul  2 13:23:08.112: INFO: Got endpoints: latency-svc-xwkqd [751.240553ms]
+Jul  2 13:23:08.122: INFO: Created: latency-svc-n4fwn
+Jul  2 13:23:08.160: INFO: Got endpoints: latency-svc-8m588 [750.334896ms]
+Jul  2 13:23:08.169: INFO: Created: latency-svc-hrth9
+Jul  2 13:23:08.210: INFO: Got endpoints: latency-svc-ncpbq [749.572796ms]
+Jul  2 13:23:08.225: INFO: Created: latency-svc-lbjh2
+Jul  2 13:23:08.260: INFO: Got endpoints: latency-svc-ptx25 [749.502052ms]
+Jul  2 13:23:08.270: INFO: Created: latency-svc-r4d6n
+Jul  2 13:23:08.310: INFO: Got endpoints: latency-svc-zpmcb [749.913932ms]
+Jul  2 13:23:08.323: INFO: Created: latency-svc-mvstc
+Jul  2 13:23:08.360: INFO: Got endpoints: latency-svc-lbljs [749.842911ms]
+Jul  2 13:23:08.372: INFO: Created: latency-svc-mcb6s
+Jul  2 13:23:08.410: INFO: Got endpoints: latency-svc-st8mq [749.55677ms]
+Jul  2 13:23:08.420: INFO: Created: latency-svc-tx7fq
+Jul  2 13:23:08.461: INFO: Got endpoints: latency-svc-c7qjj [750.583075ms]
+Jul  2 13:23:08.471: INFO: Created: latency-svc-rblp8
+Jul  2 13:23:08.511: INFO: Got endpoints: latency-svc-sf44f [750.839422ms]
+Jul  2 13:23:08.522: INFO: Created: latency-svc-8ts8w
+Jul  2 13:23:08.560: INFO: Got endpoints: latency-svc-5r7fk [750.392976ms]
+Jul  2 13:23:08.574: INFO: Created: latency-svc-8qj5c
+Jul  2 13:23:08.610: INFO: Got endpoints: latency-svc-wfzmd [750.397555ms]
+Jul  2 13:23:08.621: INFO: Created: latency-svc-q94nj
+Jul  2 13:23:08.661: INFO: Got endpoints: latency-svc-67h5h [750.451971ms]
+Jul  2 13:23:08.670: INFO: Created: latency-svc-ljdrn
+Jul  2 13:23:08.711: INFO: Got endpoints: latency-svc-p2kkb [750.710457ms]
+Jul  2 13:23:08.720: INFO: Created: latency-svc-4hgmx
+Jul  2 13:23:08.760: INFO: Got endpoints: latency-svc-fxmj9 [750.068737ms]
+Jul  2 13:23:08.774: INFO: Created: latency-svc-wtp72
+Jul  2 13:23:08.810: INFO: Got endpoints: latency-svc-wt7dz [749.914409ms]
+Jul  2 13:23:08.821: INFO: Created: latency-svc-bntg5
+Jul  2 13:23:08.861: INFO: Got endpoints: latency-svc-n4fwn [748.845298ms]
+Jul  2 13:23:08.872: INFO: Created: latency-svc-rsw28
+Jul  2 13:23:08.910: INFO: Got endpoints: latency-svc-hrth9 [749.779177ms]
+Jul  2 13:23:08.919: INFO: Created: latency-svc-6pxlz
+Jul  2 13:23:08.960: INFO: Got endpoints: latency-svc-lbjh2 [750.256106ms]
+Jul  2 13:23:08.971: INFO: Created: latency-svc-qlb9h
+Jul  2 13:23:09.010: INFO: Got endpoints: latency-svc-r4d6n [749.617946ms]
+Jul  2 13:23:09.020: INFO: Created: latency-svc-9mkjm
+Jul  2 13:23:09.060: INFO: Got endpoints: latency-svc-mvstc [750.13253ms]
+Jul  2 13:23:09.070: INFO: Created: latency-svc-gsp42
+Jul  2 13:23:09.110: INFO: Got endpoints: latency-svc-mcb6s [749.776202ms]
+Jul  2 13:23:09.120: INFO: Created: latency-svc-gbjtt
+Jul  2 13:23:09.160: INFO: Got endpoints: latency-svc-tx7fq [750.03444ms]
+Jul  2 13:23:09.173: INFO: Created: latency-svc-mzcwv
+Jul  2 13:23:09.210: INFO: Got endpoints: latency-svc-rblp8 [749.135421ms]
+Jul  2 13:23:09.220: INFO: Created: latency-svc-49wpl
+Jul  2 13:23:09.260: INFO: Got endpoints: latency-svc-8ts8w [749.459001ms]
+Jul  2 13:23:09.273: INFO: Created: latency-svc-kw9vh
+Jul  2 13:23:09.310: INFO: Got endpoints: latency-svc-8qj5c [749.919228ms]
+Jul  2 13:23:09.330: INFO: Created: latency-svc-lr4zw
+Jul  2 13:23:09.360: INFO: Got endpoints: latency-svc-q94nj [749.614135ms]
+Jul  2 13:23:09.370: INFO: Created: latency-svc-dbk5m
+Jul  2 13:23:09.411: INFO: Got endpoints: latency-svc-ljdrn [749.88881ms]
+Jul  2 13:23:09.421: INFO: Created: latency-svc-tfk9t
+Jul  2 13:23:09.461: INFO: Got endpoints: latency-svc-4hgmx [749.792242ms]
+Jul  2 13:23:09.471: INFO: Created: latency-svc-wcwnn
+Jul  2 13:23:09.511: INFO: Got endpoints: latency-svc-wtp72 [750.360181ms]
+Jul  2 13:23:09.523: INFO: Created: latency-svc-z8qkx
+Jul  2 13:23:09.561: INFO: Got endpoints: latency-svc-bntg5 [750.13168ms]
+Jul  2 13:23:09.574: INFO: Created: latency-svc-qhqpz
+Jul  2 13:23:09.611: INFO: Got endpoints: latency-svc-rsw28 [749.68755ms]
+Jul  2 13:23:09.620: INFO: Created: latency-svc-kjnpv
+Jul  2 13:23:09.661: INFO: Got endpoints: latency-svc-6pxlz [750.928254ms]
+Jul  2 13:23:09.671: INFO: Created: latency-svc-x45px
+Jul  2 13:23:09.711: INFO: Got endpoints: latency-svc-qlb9h [750.034184ms]
+Jul  2 13:23:09.720: INFO: Created: latency-svc-dlv2l
+Jul  2 13:23:09.761: INFO: Got endpoints: latency-svc-9mkjm [750.59449ms]
+Jul  2 13:23:09.771: INFO: Created: latency-svc-8gg8q
+Jul  2 13:23:09.810: INFO: Got endpoints: latency-svc-gsp42 [750.014532ms]
+Jul  2 13:23:09.820: INFO: Created: latency-svc-fmjdc
+Jul  2 13:23:09.860: INFO: Got endpoints: latency-svc-gbjtt [750.140353ms]
+Jul  2 13:23:09.869: INFO: Created: latency-svc-wb4b7
+Jul  2 13:23:09.910: INFO: Got endpoints: latency-svc-mzcwv [750.000567ms]
+Jul  2 13:23:09.920: INFO: Created: latency-svc-8btb8
+Jul  2 13:23:09.960: INFO: Got endpoints: latency-svc-49wpl [750.135488ms]
+Jul  2 13:23:09.970: INFO: Created: latency-svc-zgx2f
+Jul  2 13:23:10.010: INFO: Got endpoints: latency-svc-kw9vh [749.784162ms]
+Jul  2 13:23:10.020: INFO: Created: latency-svc-pwlmf
+Jul  2 13:23:10.060: INFO: Got endpoints: latency-svc-lr4zw [749.527335ms]
+Jul  2 13:23:10.070: INFO: Created: latency-svc-r9clt
+Jul  2 13:23:10.114: INFO: Got endpoints: latency-svc-dbk5m [753.760464ms]
+Jul  2 13:23:10.128: INFO: Created: latency-svc-6v792
+Jul  2 13:23:10.160: INFO: Got endpoints: latency-svc-tfk9t [749.515411ms]
+Jul  2 13:23:10.170: INFO: Created: latency-svc-6dzwt
+Jul  2 13:23:10.210: INFO: Got endpoints: latency-svc-wcwnn [749.308871ms]
+Jul  2 13:23:10.221: INFO: Created: latency-svc-6dp7q
+Jul  2 13:23:10.260: INFO: Got endpoints: latency-svc-z8qkx [749.351882ms]
+Jul  2 13:23:10.270: INFO: Created: latency-svc-jfkhq
+Jul  2 13:23:10.310: INFO: Got endpoints: latency-svc-qhqpz [749.302015ms]
+Jul  2 13:23:10.325: INFO: Created: latency-svc-dr7v7
+Jul  2 13:23:10.360: INFO: Got endpoints: latency-svc-kjnpv [749.241257ms]
+Jul  2 13:23:10.370: INFO: Created: latency-svc-87b76
+Jul  2 13:23:10.410: INFO: Got endpoints: latency-svc-x45px [748.997211ms]
+Jul  2 13:23:10.420: INFO: Created: latency-svc-ctktr
+Jul  2 13:23:10.460: INFO: Got endpoints: latency-svc-dlv2l [749.401428ms]
+Jul  2 13:23:10.477: INFO: Created: latency-svc-x6qkq
+Jul  2 13:23:10.547: INFO: Got endpoints: latency-svc-8gg8q [786.105424ms]
+Jul  2 13:23:10.557: INFO: Created: latency-svc-crg7l
+Jul  2 13:23:10.560: INFO: Got endpoints: latency-svc-fmjdc [749.714076ms]
+Jul  2 13:23:10.571: INFO: Created: latency-svc-htdkl
+Jul  2 13:23:10.610: INFO: Got endpoints: latency-svc-wb4b7 [749.905453ms]
+Jul  2 13:23:10.619: INFO: Created: latency-svc-qljgc
+Jul  2 13:23:10.660: INFO: Got endpoints: latency-svc-8btb8 [749.356611ms]
+Jul  2 13:23:10.669: INFO: Created: latency-svc-fp56g
+Jul  2 13:23:10.711: INFO: Got endpoints: latency-svc-zgx2f [750.35764ms]
+Jul  2 13:23:10.720: INFO: Created: latency-svc-dplks
+Jul  2 13:23:10.761: INFO: Got endpoints: latency-svc-pwlmf [750.648911ms]
+Jul  2 13:23:10.771: INFO: Created: latency-svc-gqbbw
+Jul  2 13:23:10.810: INFO: Got endpoints: latency-svc-r9clt [750.238259ms]
+Jul  2 13:23:10.820: INFO: Created: latency-svc-stlz2
+Jul  2 13:23:10.861: INFO: Got endpoints: latency-svc-6v792 [746.779963ms]
+Jul  2 13:23:10.871: INFO: Created: latency-svc-kg5r9
+Jul  2 13:23:10.910: INFO: Got endpoints: latency-svc-6dzwt [750.209969ms]
+Jul  2 13:23:10.920: INFO: Created: latency-svc-jc2ls
+Jul  2 13:23:10.961: INFO: Got endpoints: latency-svc-6dp7q [750.404541ms]
+Jul  2 13:23:10.971: INFO: Created: latency-svc-f9sc8
+Jul  2 13:23:11.010: INFO: Got endpoints: latency-svc-jfkhq [750.158922ms]
+Jul  2 13:23:11.020: INFO: Created: latency-svc-vttnv
+Jul  2 13:23:11.061: INFO: Got endpoints: latency-svc-dr7v7 [750.843123ms]
+Jul  2 13:23:11.071: INFO: Created: latency-svc-sq8dn
+Jul  2 13:23:11.110: INFO: Got endpoints: latency-svc-87b76 [749.914431ms]
+Jul  2 13:23:11.120: INFO: Created: latency-svc-bj55m
+Jul  2 13:23:11.161: INFO: Got endpoints: latency-svc-ctktr [750.661178ms]
+Jul  2 13:23:11.172: INFO: Created: latency-svc-nmd58
+Jul  2 13:23:11.212: INFO: Got endpoints: latency-svc-x6qkq [752.00108ms]
+Jul  2 13:23:11.223: INFO: Created: latency-svc-fctrv
+Jul  2 13:23:11.261: INFO: Got endpoints: latency-svc-crg7l [713.744038ms]
+Jul  2 13:23:11.272: INFO: Created: latency-svc-6fqww
+Jul  2 13:23:11.310: INFO: Got endpoints: latency-svc-htdkl [749.974845ms]
+Jul  2 13:23:11.319: INFO: Created: latency-svc-c2zrq
+Jul  2 13:23:11.360: INFO: Got endpoints: latency-svc-qljgc [749.805906ms]
+Jul  2 13:23:11.371: INFO: Created: latency-svc-lntr5
+Jul  2 13:23:11.411: INFO: Got endpoints: latency-svc-fp56g [750.509214ms]
+Jul  2 13:23:11.420: INFO: Created: latency-svc-glfcx
+Jul  2 13:23:11.462: INFO: Got endpoints: latency-svc-dplks [751.130636ms]
+Jul  2 13:23:11.471: INFO: Created: latency-svc-v79qk
+Jul  2 13:23:11.510: INFO: Got endpoints: latency-svc-gqbbw [749.206207ms]
+Jul  2 13:23:11.520: INFO: Created: latency-svc-8szpv
+Jul  2 13:23:11.560: INFO: Got endpoints: latency-svc-stlz2 [749.708002ms]
+Jul  2 13:23:11.572: INFO: Created: latency-svc-v4v79
+Jul  2 13:23:11.610: INFO: Got endpoints: latency-svc-kg5r9 [749.231651ms]
+Jul  2 13:23:11.619: INFO: Created: latency-svc-7zgk6
+Jul  2 13:23:11.660: INFO: Got endpoints: latency-svc-jc2ls [749.527886ms]
+Jul  2 13:23:11.669: INFO: Created: latency-svc-nttz6
+Jul  2 13:23:11.710: INFO: Got endpoints: latency-svc-f9sc8 [749.161836ms]
+Jul  2 13:23:11.719: INFO: Created: latency-svc-c9ftd
+Jul  2 13:23:11.761: INFO: Got endpoints: latency-svc-vttnv [750.126361ms]
+Jul  2 13:23:11.770: INFO: Created: latency-svc-lf2vr
+Jul  2 13:23:11.811: INFO: Got endpoints: latency-svc-sq8dn [749.401663ms]
+Jul  2 13:23:11.821: INFO: Created: latency-svc-5zpnz
+Jul  2 13:23:11.861: INFO: Got endpoints: latency-svc-bj55m [750.473274ms]
+Jul  2 13:23:11.870: INFO: Created: latency-svc-6rp9d
+Jul  2 13:23:11.947: INFO: Got endpoints: latency-svc-nmd58 [786.108308ms]
+Jul  2 13:23:11.957: INFO: Created: latency-svc-d77vk
+Jul  2 13:23:11.962: INFO: Got endpoints: latency-svc-fctrv [750.399405ms]
+Jul  2 13:23:11.972: INFO: Created: latency-svc-l2mkv
+Jul  2 13:23:12.052: INFO: Got endpoints: latency-svc-6fqww [790.799838ms]
+Jul  2 13:23:12.062: INFO: Got endpoints: latency-svc-c2zrq [751.42332ms]
+Jul  2 13:23:12.063: INFO: Created: latency-svc-9kzxt
+Jul  2 13:23:12.072: INFO: Created: latency-svc-62t4g
+Jul  2 13:23:12.147: INFO: Got endpoints: latency-svc-lntr5 [786.706806ms]
+Jul  2 13:23:12.157: INFO: Created: latency-svc-p5pj7
+Jul  2 13:23:12.160: INFO: Got endpoints: latency-svc-glfcx [749.114194ms]
+Jul  2 13:23:12.170: INFO: Created: latency-svc-4pd9s
+Jul  2 13:23:12.210: INFO: Got endpoints: latency-svc-v79qk [748.008205ms]
+Jul  2 13:23:12.221: INFO: Created: latency-svc-q5c9z
+Jul  2 13:23:12.261: INFO: Got endpoints: latency-svc-8szpv [750.933464ms]
+Jul  2 13:23:12.270: INFO: Created: latency-svc-n9qhq
+Jul  2 13:23:12.311: INFO: Got endpoints: latency-svc-v4v79 [750.363906ms]
+Jul  2 13:23:12.320: INFO: Created: latency-svc-tsv98
+Jul  2 13:23:12.361: INFO: Got endpoints: latency-svc-7zgk6 [750.806567ms]
+Jul  2 13:23:12.371: INFO: Created: latency-svc-6kt2c
+Jul  2 13:23:12.446: INFO: Got endpoints: latency-svc-nttz6 [786.405605ms]
+Jul  2 13:23:12.457: INFO: Created: latency-svc-qfgt6
+Jul  2 13:23:12.460: INFO: Got endpoints: latency-svc-c9ftd [749.867314ms]
+Jul  2 13:23:12.469: INFO: Created: latency-svc-g8rbn
+Jul  2 13:23:12.510: INFO: Got endpoints: latency-svc-lf2vr [749.67024ms]
+Jul  2 13:23:12.521: INFO: Created: latency-svc-dgqhk
+Jul  2 13:23:12.561: INFO: Got endpoints: latency-svc-5zpnz [750.071979ms]
+Jul  2 13:23:12.571: INFO: Created: latency-svc-fmsmw
+Jul  2 13:23:12.610: INFO: Got endpoints: latency-svc-6rp9d [749.362535ms]
+Jul  2 13:23:12.619: INFO: Created: latency-svc-d9h9p
+Jul  2 13:23:12.660: INFO: Got endpoints: latency-svc-d77vk [713.221247ms]
+Jul  2 13:23:12.670: INFO: Created: latency-svc-9rhr9
+Jul  2 13:23:12.710: INFO: Got endpoints: latency-svc-l2mkv [747.624289ms]
+Jul  2 13:23:12.720: INFO: Created: latency-svc-2bgfs
+Jul  2 13:23:12.760: INFO: Got endpoints: latency-svc-9kzxt [708.488423ms]
+Jul  2 13:23:12.770: INFO: Created: latency-svc-qd7n2
+Jul  2 13:23:12.810: INFO: Got endpoints: latency-svc-62t4g [748.441137ms]
+Jul  2 13:23:12.820: INFO: Created: latency-svc-277ks
+Jul  2 13:23:12.861: INFO: Got endpoints: latency-svc-p5pj7 [714.011536ms]
+Jul  2 13:23:12.871: INFO: Created: latency-svc-wc6zt
+Jul  2 13:23:12.911: INFO: Got endpoints: latency-svc-4pd9s [750.79791ms]
+Jul  2 13:23:12.920: INFO: Created: latency-svc-vs264
+Jul  2 13:23:12.960: INFO: Got endpoints: latency-svc-q5c9z [750.456719ms]
+Jul  2 13:23:12.970: INFO: Created: latency-svc-tdfgt
+Jul  2 13:23:13.011: INFO: Got endpoints: latency-svc-n9qhq [749.414176ms]
+Jul  2 13:23:13.062: INFO: Got endpoints: latency-svc-tsv98 [750.993653ms]
+Jul  2 13:23:13.110: INFO: Got endpoints: latency-svc-6kt2c [749.373499ms]
+Jul  2 13:23:13.161: INFO: Got endpoints: latency-svc-qfgt6 [714.057054ms]
+Jul  2 13:23:13.210: INFO: Got endpoints: latency-svc-g8rbn [750.519837ms]
+Jul  2 13:23:13.260: INFO: Got endpoints: latency-svc-dgqhk [749.729947ms]
+Jul  2 13:23:13.311: INFO: Got endpoints: latency-svc-fmsmw [749.76358ms]
+Jul  2 13:23:13.360: INFO: Got endpoints: latency-svc-d9h9p [750.403038ms]
+Jul  2 13:23:13.411: INFO: Got endpoints: latency-svc-9rhr9 [750.283379ms]
+Jul  2 13:23:13.460: INFO: Got endpoints: latency-svc-2bgfs [749.787691ms]
+Jul  2 13:23:13.510: INFO: Got endpoints: latency-svc-qd7n2 [749.857109ms]
+Jul  2 13:23:13.560: INFO: Got endpoints: latency-svc-277ks [750.001041ms]
+Jul  2 13:23:13.610: INFO: Got endpoints: latency-svc-wc6zt [748.928015ms]
+Jul  2 13:23:13.660: INFO: Got endpoints: latency-svc-vs264 [749.610951ms]
+Jul  2 13:23:13.710: INFO: Got endpoints: latency-svc-tdfgt [749.703422ms]
+Jul  2 13:23:13.710: INFO: Latencies: [15.212164ms 18.791532ms 25.923737ms 32.655575ms 37.804884ms 44.376517ms 46.517415ms 65.253471ms 66.477352ms 73.929358ms 84.896084ms 101.352696ms 112.541225ms 115.399515ms 116.80392ms 117.329159ms 119.739228ms 120.105267ms 122.689911ms 125.792908ms 129.95284ms 157.189841ms 165.155519ms 168.186884ms 169.719495ms 170.232383ms 172.026135ms 172.696152ms 175.736602ms 177.561702ms 179.180113ms 179.610223ms 183.75808ms 184.608451ms 185.046312ms 185.266551ms 192.917186ms 203.386623ms 242.319566ms 284.960935ms 329.847727ms 373.80999ms 410.969514ms 454.769697ms 497.874244ms 534.956499ms 578.785154ms 621.585787ms 664.226771ms 708.488423ms 711.879699ms 713.221247ms 713.744038ms 714.011536ms 714.057054ms 745.203437ms 746.434873ms 746.71436ms 746.779963ms 747.517861ms 747.624289ms 747.99773ms 748.008205ms 748.441137ms 748.845298ms 748.928015ms 748.997211ms 749.111937ms 749.114194ms 749.135421ms 749.152715ms 749.161836ms 749.206207ms 749.231651ms 749.241257ms 749.299866ms 749.302015ms 749.308871ms 749.351882ms 749.356611ms 749.362535ms 749.373499ms 749.401428ms 749.401663ms 749.412266ms 749.414176ms 749.455074ms 749.459001ms 749.502052ms 749.506901ms 749.515411ms 749.527335ms 749.527886ms 749.555197ms 749.55677ms 749.56156ms 749.572796ms 749.610951ms 749.614054ms 749.614135ms 749.617946ms 749.639386ms 749.651845ms 749.67024ms 749.684839ms 749.68755ms 749.690037ms 749.703422ms 749.708002ms 749.714076ms 749.729947ms 749.744538ms 749.758519ms 749.76358ms 749.77468ms 749.776202ms 749.779177ms 749.784162ms 749.787691ms 749.792242ms 749.802247ms 749.805906ms 749.837419ms 749.842911ms 749.854932ms 749.85509ms 749.857109ms 749.867314ms 749.874922ms 749.88881ms 749.905453ms 749.913932ms 749.914409ms 749.914431ms 749.919228ms 749.974845ms 750.000567ms 750.001041ms 750.014532ms 750.034184ms 750.03444ms 750.068737ms 750.071979ms 750.126361ms 750.13168ms 750.13253ms 750.135488ms 750.140353ms 750.152493ms 750.158922ms 750.187407ms 750.192008ms 750.209969ms 750.214665ms 750.217449ms 750.238259ms 750.256106ms 750.283379ms 750.334896ms 750.35764ms 750.360181ms 750.363906ms 750.391404ms 750.392976ms 750.397555ms 750.399405ms 750.403038ms 750.404541ms 750.451971ms 750.456719ms 750.473274ms 750.509214ms 750.519837ms 750.583075ms 750.59449ms 750.648911ms 750.661178ms 750.6994ms 750.707627ms 750.710457ms 750.79791ms 750.806567ms 750.839422ms 750.843123ms 750.928254ms 750.933464ms 750.993653ms 751.002329ms 751.130636ms 751.240553ms 751.42332ms 752.00108ms 752.649378ms 753.760464ms 754.506829ms 786.105424ms 786.108308ms 786.405605ms 786.706806ms 790.799838ms]
+Jul  2 13:23:13.710: INFO: 50 %ile: 749.617946ms
+Jul  2 13:23:13.710: INFO: 90 %ile: 750.79791ms
+Jul  2 13:23:13.710: INFO: 99 %ile: 786.706806ms
+Jul  2 13:23:13.710: INFO: Total sample count: 200
+[AfterEach] [sig-network] Service endpoints latency
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:23:13.710: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-svc-latency-422hm" for this suite.
+Jul  2 13:23:35.731: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:23:35.823: INFO: namespace: e2e-tests-svc-latency-422hm, resource: bindings, ignored listing per whitelist
+Jul  2 13:23:35.863: INFO: namespace e2e-tests-svc-latency-422hm deletion completed in 22.14754318s
+
+• [SLOW TEST:33.025 seconds]
+[sig-network] Service endpoints latency
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/network/framework.go:22
+  should not be very high  [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+[sig-network] Proxy version v1 
+  should proxy logs on node using proxy subresource  [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] version v1
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:23:35.863: INFO: >>> kubeConfig: /tmp/kubeconfig-411378559
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should proxy logs on node using proxy subresource  [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+Jul  2 13:23:35.960: INFO: (0) /api/v1/nodes/ip-10-250-20-212.ec2.internal/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 4.940381ms)
+Jul  2 13:23:36.000: INFO: (1) /api/v1/nodes/ip-10-250-20-212.ec2.internal/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 39.527648ms)
+Jul  2 13:23:36.005: INFO: (2) /api/v1/nodes/ip-10-250-20-212.ec2.internal/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 4.926419ms)
+Jul  2 13:23:36.009: INFO: (3) /api/v1/nodes/ip-10-250-20-212.ec2.internal/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 4.378844ms)
+Jul  2 13:23:36.014: INFO: (4) /api/v1/nodes/ip-10-250-20-212.ec2.internal/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 4.511534ms)
+Jul  2 13:23:36.019: INFO: (5) /api/v1/nodes/ip-10-250-20-212.ec2.internal/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 5.446357ms)
+Jul  2 13:23:36.046: INFO: (6) /api/v1/nodes/ip-10-250-20-212.ec2.internal/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 26.648608ms)
+Jul  2 13:23:36.051: INFO: (7) /api/v1/nodes/ip-10-250-20-212.ec2.internal/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 4.80163ms)
+Jul  2 13:23:36.056: INFO: (8) /api/v1/nodes/ip-10-250-20-212.ec2.internal/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 4.640854ms)
+Jul  2 13:23:36.060: INFO: (9) /api/v1/nodes/ip-10-250-20-212.ec2.internal/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 4.748009ms)
+Jul  2 13:23:36.065: INFO: (10) /api/v1/nodes/ip-10-250-20-212.ec2.internal/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 4.307188ms)
+Jul  2 13:23:36.069: INFO: (11) /api/v1/nodes/ip-10-250-20-212.ec2.internal/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 4.443307ms)
+Jul  2 13:23:36.074: INFO: (12) /api/v1/nodes/ip-10-250-20-212.ec2.internal/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 4.377961ms)
+Jul  2 13:23:36.078: INFO: (13) /api/v1/nodes/ip-10-250-20-212.ec2.internal/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 4.500081ms)
+Jul  2 13:23:36.083: INFO: (14) /api/v1/nodes/ip-10-250-20-212.ec2.internal/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 4.341759ms)
+Jul  2 13:23:36.087: INFO: (15) /api/v1/nodes/ip-10-250-20-212.ec2.internal/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 4.297686ms)
+Jul  2 13:23:36.091: INFO: (16) /api/v1/nodes/ip-10-250-20-212.ec2.internal/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 4.294524ms)
+Jul  2 13:23:36.096: INFO: (17) /api/v1/nodes/ip-10-250-20-212.ec2.internal/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 4.441484ms)
+Jul  2 13:23:36.100: INFO: (18) /api/v1/nodes/ip-10-250-20-212.ec2.internal/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 4.199897ms)
+Jul  2 13:23:36.104: INFO: (19) /api/v1/nodes/ip-10-250-20-212.ec2.internal/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 4.315644ms)
+[AfterEach] version v1
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:23:36.104: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-proxy-2tgk7" for this suite.
+Jul  2 13:23:42.118: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:23:42.127: INFO: namespace: e2e-tests-proxy-2tgk7, resource: bindings, ignored listing per whitelist
+Jul  2 13:23:42.285: INFO: namespace e2e-tests-proxy-2tgk7 deletion completed in 6.17751778s
+
+• [SLOW TEST:6.422 seconds]
+[sig-network] Proxy
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/network/framework.go:22
+  version v1
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/network/proxy.go:56
+    should proxy logs on node using proxy subresource  [Conformance]
+    /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSSSSSSSSSSSSS
+------------------------------
+[sig-storage] ConfigMap 
+  should be consumable from pods in volume with mappings and Item mode set [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-storage] ConfigMap
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:23:42.285: INFO: >>> kubeConfig: /tmp/kubeconfig-411378559
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should be consumable from pods in volume with mappings and Item mode set [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating configMap with name configmap-test-volume-map-23af0fec-7dfb-11e8-bae1-da96248f62d7
+STEP: Creating a pod to test consume configMaps
+Jul  2 13:23:42.382: INFO: Waiting up to 5m0s for pod "pod-configmaps-23af9e2e-7dfb-11e8-bae1-da96248f62d7" in namespace "e2e-tests-configmap-2v828" to be "success or failure"
+Jul  2 13:23:42.387: INFO: Pod "pod-configmaps-23af9e2e-7dfb-11e8-bae1-da96248f62d7": Phase="Pending", Reason="", readiness=false. Elapsed: 4.955145ms
+Jul  2 13:23:44.391: INFO: Pod "pod-configmaps-23af9e2e-7dfb-11e8-bae1-da96248f62d7": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.008739785s
+STEP: Saw pod success
+Jul  2 13:23:44.391: INFO: Pod "pod-configmaps-23af9e2e-7dfb-11e8-bae1-da96248f62d7" satisfied condition "success or failure"
+Jul  2 13:23:44.394: INFO: Trying to get logs from node ip-10-250-24-1.ec2.internal pod pod-configmaps-23af9e2e-7dfb-11e8-bae1-da96248f62d7 container configmap-volume-test: <nil>
+STEP: delete the pod
+Jul  2 13:23:44.411: INFO: Waiting for pod pod-configmaps-23af9e2e-7dfb-11e8-bae1-da96248f62d7 to disappear
+Jul  2 13:23:44.417: INFO: Pod pod-configmaps-23af9e2e-7dfb-11e8-bae1-da96248f62d7 no longer exists
+[AfterEach] [sig-storage] ConfigMap
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:23:44.418: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-configmap-2v828" for this suite.
+Jul  2 13:23:50.441: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:23:50.472: INFO: namespace: e2e-tests-configmap-2v828, resource: bindings, ignored listing per whitelist
+Jul  2 13:23:50.545: INFO: namespace e2e-tests-configmap-2v828 deletion completed in 6.116035483s
+
+• [SLOW TEST:8.260 seconds]
+[sig-storage] ConfigMap
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/configmap_volume.go:32
+  should be consumable from pods in volume with mappings and Item mode set [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+S
+------------------------------
+[sig-storage] EmptyDir volumes 
+  should support (root,0666,default) [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-storage] EmptyDir volumes
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:23:50.545: INFO: >>> kubeConfig: /tmp/kubeconfig-411378559
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should support (root,0666,default) [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating a pod to test emptydir 0666 on node default medium
+Jul  2 13:23:50.640: INFO: Waiting up to 5m0s for pod "pod-289bb609-7dfb-11e8-bae1-da96248f62d7" in namespace "e2e-tests-emptydir-df7mr" to be "success or failure"
+Jul  2 13:23:50.643: INFO: Pod "pod-289bb609-7dfb-11e8-bae1-da96248f62d7": Phase="Pending", Reason="", readiness=false. Elapsed: 2.754877ms
+Jul  2 13:23:52.647: INFO: Pod "pod-289bb609-7dfb-11e8-bae1-da96248f62d7": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.006599722s
+STEP: Saw pod success
+Jul  2 13:23:52.647: INFO: Pod "pod-289bb609-7dfb-11e8-bae1-da96248f62d7" satisfied condition "success or failure"
+Jul  2 13:23:52.649: INFO: Trying to get logs from node ip-10-250-24-1.ec2.internal pod pod-289bb609-7dfb-11e8-bae1-da96248f62d7 container test-container: <nil>
+STEP: delete the pod
+Jul  2 13:23:52.669: INFO: Waiting for pod pod-289bb609-7dfb-11e8-bae1-da96248f62d7 to disappear
+Jul  2 13:23:52.673: INFO: Pod pod-289bb609-7dfb-11e8-bae1-da96248f62d7 no longer exists
+[AfterEach] [sig-storage] EmptyDir volumes
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:23:52.673: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-emptydir-df7mr" for this suite.
+Jul  2 13:23:58.749: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:23:58.827: INFO: namespace: e2e-tests-emptydir-df7mr, resource: bindings, ignored listing per whitelist
+Jul  2 13:23:58.852: INFO: namespace e2e-tests-emptydir-df7mr deletion completed in 6.170781564s
+
+• [SLOW TEST:8.307 seconds]
+[sig-storage] EmptyDir volumes
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/empty_dir.go:40
+  should support (root,0666,default) [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSSSSSSSSSS
+------------------------------
+[sig-storage] Secrets 
+  should be consumable from pods in volume with mappings [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-storage] Secrets
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:23:58.852: INFO: >>> kubeConfig: /tmp/kubeconfig-411378559
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should be consumable from pods in volume with mappings [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating secret with name secret-test-map-2d8f6f40-7dfb-11e8-bae1-da96248f62d7
+STEP: Creating a pod to test consume secrets
+Jul  2 13:23:58.952: INFO: Waiting up to 5m0s for pod "pod-secrets-2d8ffdca-7dfb-11e8-bae1-da96248f62d7" in namespace "e2e-tests-secrets-k9vnt" to be "success or failure"
+Jul  2 13:23:58.960: INFO: Pod "pod-secrets-2d8ffdca-7dfb-11e8-bae1-da96248f62d7": Phase="Pending", Reason="", readiness=false. Elapsed: 7.603144ms
+Jul  2 13:24:00.964: INFO: Pod "pod-secrets-2d8ffdca-7dfb-11e8-bae1-da96248f62d7": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.012029009s
+STEP: Saw pod success
+Jul  2 13:24:00.964: INFO: Pod "pod-secrets-2d8ffdca-7dfb-11e8-bae1-da96248f62d7" satisfied condition "success or failure"
+Jul  2 13:24:00.967: INFO: Trying to get logs from node ip-10-250-24-1.ec2.internal pod pod-secrets-2d8ffdca-7dfb-11e8-bae1-da96248f62d7 container secret-volume-test: <nil>
+STEP: delete the pod
+Jul  2 13:24:01.065: INFO: Waiting for pod pod-secrets-2d8ffdca-7dfb-11e8-bae1-da96248f62d7 to disappear
+Jul  2 13:24:01.070: INFO: Pod pod-secrets-2d8ffdca-7dfb-11e8-bae1-da96248f62d7 no longer exists
+[AfterEach] [sig-storage] Secrets
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:24:01.070: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-secrets-k9vnt" for this suite.
+Jul  2 13:24:07.145: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:24:07.237: INFO: namespace: e2e-tests-secrets-k9vnt, resource: bindings, ignored listing per whitelist
+Jul  2 13:24:07.243: INFO: namespace e2e-tests-secrets-k9vnt deletion completed in 6.169279476s
+
+• [SLOW TEST:8.391 seconds]
+[sig-storage] Secrets
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/secrets_volume.go:33
+  should be consumable from pods in volume with mappings [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSS
+------------------------------
+[sig-network] Services 
+  should serve a basic endpoint from pods  [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-network] Services
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:24:07.243: INFO: >>> kubeConfig: /tmp/kubeconfig-411378559
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-network] Services
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/network/service.go:83
+[It] should serve a basic endpoint from pods  [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: creating service endpoint-test2 in namespace e2e-tests-services-d6xwx
+STEP: waiting up to 3m0s for service endpoint-test2 in namespace e2e-tests-services-d6xwx to expose endpoints map[]
+Jul  2 13:24:07.346: INFO: Get endpoints failed (2.953921ms elapsed, ignoring for 5s): endpoints "endpoint-test2" not found
+Jul  2 13:24:08.349: INFO: successfully validated that service endpoint-test2 in namespace e2e-tests-services-d6xwx exposes endpoints map[] (1.006430181s elapsed)
+STEP: Creating pod pod1 in namespace e2e-tests-services-d6xwx
+STEP: waiting up to 3m0s for service endpoint-test2 in namespace e2e-tests-services-d6xwx to expose endpoints map[pod1:[80]]
+Jul  2 13:24:10.374: INFO: successfully validated that service endpoint-test2 in namespace e2e-tests-services-d6xwx exposes endpoints map[pod1:[80]] (2.018926739s elapsed)
+STEP: Creating pod pod2 in namespace e2e-tests-services-d6xwx
+STEP: waiting up to 3m0s for service endpoint-test2 in namespace e2e-tests-services-d6xwx to expose endpoints map[pod1:[80] pod2:[80]]
+Jul  2 13:24:12.407: INFO: successfully validated that service endpoint-test2 in namespace e2e-tests-services-d6xwx exposes endpoints map[pod1:[80] pod2:[80]] (2.029432865s elapsed)
+STEP: Deleting pod pod1 in namespace e2e-tests-services-d6xwx
+STEP: waiting up to 3m0s for service endpoint-test2 in namespace e2e-tests-services-d6xwx to expose endpoints map[pod2:[80]]
+Jul  2 13:24:12.421: INFO: successfully validated that service endpoint-test2 in namespace e2e-tests-services-d6xwx exposes endpoints map[pod2:[80]] (9.130339ms elapsed)
+STEP: Deleting pod pod2 in namespace e2e-tests-services-d6xwx
+STEP: waiting up to 3m0s for service endpoint-test2 in namespace e2e-tests-services-d6xwx to expose endpoints map[]
+Jul  2 13:24:12.438: INFO: successfully validated that service endpoint-test2 in namespace e2e-tests-services-d6xwx exposes endpoints map[] (2.780335ms elapsed)
+[AfterEach] [sig-network] Services
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:24:12.450: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-services-d6xwx" for this suite.
+Jul  2 13:24:34.471: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:24:34.553: INFO: namespace: e2e-tests-services-d6xwx, resource: bindings, ignored listing per whitelist
+Jul  2 13:24:34.572: INFO: namespace e2e-tests-services-d6xwx deletion completed in 22.112794207s
+[AfterEach] [sig-network] Services
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/network/service.go:88
+
+• [SLOW TEST:27.329 seconds]
+[sig-network] Services
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/network/framework.go:22
+  should serve a basic endpoint from pods  [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+S
+------------------------------
+[sig-api-machinery] Garbage collector 
+  should not be blocked by dependency circle [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-api-machinery] Garbage collector
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:24:34.572: INFO: >>> kubeConfig: /tmp/kubeconfig-411378559
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should not be blocked by dependency circle [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+Jul  2 13:24:34.688: INFO: pod1.ObjectMeta.OwnerReferences=[]v1.OwnerReference{v1.OwnerReference{APIVersion:"v1", Kind:"Pod", Name:"pod3", UID:"42db0e49-7dfb-11e8-9deb-8e4c5ec544fb", Controller:(*bool)(0xc420ea3176), BlockOwnerDeletion:(*bool)(0xc420ea3177)}}
+Jul  2 13:24:34.693: INFO: pod2.ObjectMeta.OwnerReferences=[]v1.OwnerReference{v1.OwnerReference{APIVersion:"v1", Kind:"Pod", Name:"pod1", UID:"42d9a1f8-7dfb-11e8-9deb-8e4c5ec544fb", Controller:(*bool)(0xc421b3b7b6), BlockOwnerDeletion:(*bool)(0xc421b3b7b7)}}
+Jul  2 13:24:34.701: INFO: pod3.ObjectMeta.OwnerReferences=[]v1.OwnerReference{v1.OwnerReference{APIVersion:"v1", Kind:"Pod", Name:"pod2", UID:"42da36da-7dfb-11e8-9deb-8e4c5ec544fb", Controller:(*bool)(0xc421b3bbae), BlockOwnerDeletion:(*bool)(0xc421b3bbaf)}}
+[AfterEach] [sig-api-machinery] Garbage collector
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:24:39.714: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-gc-wvrg4" for this suite.
+Jul  2 13:24:45.758: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:24:45.909: INFO: namespace: e2e-tests-gc-wvrg4, resource: bindings, ignored listing per whitelist
+Jul  2 13:24:45.932: INFO: namespace e2e-tests-gc-wvrg4 deletion completed in 6.214951248s
+
+• [SLOW TEST:11.360 seconds]
+[sig-api-machinery] Garbage collector
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apimachinery/framework.go:22
+  should not be blocked by dependency circle [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSS
+------------------------------
+[sig-storage] Projected 
+  should be consumable from pods in volume with defaultMode set [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:24:45.932: INFO: >>> kubeConfig: /tmp/kubeconfig-411378559
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:858
+[It] should be consumable from pods in volume with defaultMode set [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating projection with secret that has name projected-secret-test-499f0306-7dfb-11e8-bae1-da96248f62d7
+STEP: Creating a pod to test consume secrets
+Jul  2 13:24:46.030: INFO: Waiting up to 5m0s for pod "pod-projected-secrets-499f935a-7dfb-11e8-bae1-da96248f62d7" in namespace "e2e-tests-projected-d59k4" to be "success or failure"
+Jul  2 13:24:46.033: INFO: Pod "pod-projected-secrets-499f935a-7dfb-11e8-bae1-da96248f62d7": Phase="Pending", Reason="", readiness=false. Elapsed: 2.653208ms
+Jul  2 13:24:48.051: INFO: Pod "pod-projected-secrets-499f935a-7dfb-11e8-bae1-da96248f62d7": Phase="Running", Reason="", readiness=true. Elapsed: 2.020036529s
+Jul  2 13:24:50.055: INFO: Pod "pod-projected-secrets-499f935a-7dfb-11e8-bae1-da96248f62d7": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.024651467s
+STEP: Saw pod success
+Jul  2 13:24:50.055: INFO: Pod "pod-projected-secrets-499f935a-7dfb-11e8-bae1-da96248f62d7" satisfied condition "success or failure"
+Jul  2 13:24:50.058: INFO: Trying to get logs from node ip-10-250-24-1.ec2.internal pod pod-projected-secrets-499f935a-7dfb-11e8-bae1-da96248f62d7 container projected-secret-volume-test: <nil>
+STEP: delete the pod
+Jul  2 13:24:50.081: INFO: Waiting for pod pod-projected-secrets-499f935a-7dfb-11e8-bae1-da96248f62d7 to disappear
+Jul  2 13:24:50.086: INFO: Pod pod-projected-secrets-499f935a-7dfb-11e8-bae1-da96248f62d7 no longer exists
+[AfterEach] [sig-storage] Projected
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:24:50.086: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-d59k4" for this suite.
+Jul  2 13:24:56.145: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:24:56.233: INFO: namespace: e2e-tests-projected-d59k4, resource: bindings, ignored listing per whitelist
+Jul  2 13:24:56.248: INFO: namespace e2e-tests-projected-d59k4 deletion completed in 6.149406317s
+
+• [SLOW TEST:10.316 seconds]
+[sig-storage] Projected
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:34
+  should be consumable from pods in volume with defaultMode set [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSS
+------------------------------
+[k8s.io] Pods 
+  should be submitted and removed [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [k8s.io] Pods
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:24:56.249: INFO: >>> kubeConfig: /tmp/kubeconfig-411378559
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [k8s.io] Pods
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/pods.go:127
+[It] should be submitted and removed [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: creating the pod
+STEP: setting up watch
+STEP: submitting the pod to kubernetes
+STEP: verifying the pod is in kubernetes
+STEP: verifying pod creation was observed
+Jul  2 13:24:58.446: INFO: running pod: &v1.Pod{TypeMeta:v1.TypeMeta{Kind:"", APIVersion:""}, ObjectMeta:v1.ObjectMeta{Name:"pod-submit-remove-4fc7d73c-7dfb-11e8-bae1-da96248f62d7", GenerateName:"", Namespace:"e2e-tests-pods-ffxxc", SelfLink:"/api/v1/namespaces/e2e-tests-pods-ffxxc/pods/pod-submit-remove-4fc7d73c-7dfb-11e8-bae1-da96248f62d7", UID:"4fc87ab8-7dfb-11e8-9deb-8e4c5ec544fb", ResourceVersion:"8183", Generation:0, CreationTimestamp:v1.Time{Time:time.Time{wall:0x0, ext:63666134696, loc:(*time.Location)(0x642c9a0)}}, DeletionTimestamp:(*v1.Time)(nil), DeletionGracePeriodSeconds:(*int64)(nil), Labels:map[string]string{"name":"foo", "time":"356032701"}, Annotations:map[string]string{"cni.projectcalico.org/podIP":"100.96.1.95/32"}, OwnerReferences:[]v1.OwnerReference(nil), Initializers:(*v1.Initializers)(nil), Finalizers:[]string(nil), ClusterName:""}, Spec:v1.PodSpec{Volumes:[]v1.Volume{v1.Volume{Name:"default-token-4c6w5", VolumeSource:v1.VolumeSource{HostPath:(*v1.HostPathVolumeSource)(nil), EmptyDir:(*v1.EmptyDirVolumeSource)(nil), GCEPersistentDisk:(*v1.GCEPersistentDiskVolumeSource)(nil), AWSElasticBlockStore:(*v1.AWSElasticBlockStoreVolumeSource)(nil), GitRepo:(*v1.GitRepoVolumeSource)(nil), Secret:(*v1.SecretVolumeSource)(0xc4222d0e40), NFS:(*v1.NFSVolumeSource)(nil), ISCSI:(*v1.ISCSIVolumeSource)(nil), Glusterfs:(*v1.GlusterfsVolumeSource)(nil), PersistentVolumeClaim:(*v1.PersistentVolumeClaimVolumeSource)(nil), RBD:(*v1.RBDVolumeSource)(nil), FlexVolume:(*v1.FlexVolumeSource)(nil), Cinder:(*v1.CinderVolumeSource)(nil), CephFS:(*v1.CephFSVolumeSource)(nil), Flocker:(*v1.FlockerVolumeSource)(nil), DownwardAPI:(*v1.DownwardAPIVolumeSource)(nil), FC:(*v1.FCVolumeSource)(nil), AzureFile:(*v1.AzureFileVolumeSource)(nil), ConfigMap:(*v1.ConfigMapVolumeSource)(nil), VsphereVolume:(*v1.VsphereVirtualDiskVolumeSource)(nil), Quobyte:(*v1.QuobyteVolumeSource)(nil), AzureDisk:(*v1.AzureDiskVolumeSource)(nil), PhotonPersistentDisk:(*v1.PhotonPersistentDiskVolumeSource)(nil), Projected:(*v1.ProjectedVolumeSource)(nil), PortworxVolume:(*v1.PortworxVolumeSource)(nil), ScaleIO:(*v1.ScaleIOVolumeSource)(nil), StorageOS:(*v1.StorageOSVolumeSource)(nil)}}}, InitContainers:[]v1.Container(nil), Containers:[]v1.Container{v1.Container{Name:"nginx", Image:"k8s.gcr.io/nginx-slim-amd64:0.20", Command:[]string(nil), Args:[]string(nil), WorkingDir:"", Ports:[]v1.ContainerPort(nil), EnvFrom:[]v1.EnvFromSource(nil), Env:[]v1.EnvVar(nil), Resources:v1.ResourceRequirements{Limits:v1.ResourceList(nil), Requests:v1.ResourceList(nil)}, VolumeMounts:[]v1.VolumeMount{v1.VolumeMount{Name:"default-token-4c6w5", ReadOnly:true, MountPath:"/var/run/secrets/kubernetes.io/serviceaccount", SubPath:"", MountPropagation:(*v1.MountPropagationMode)(nil)}}, VolumeDevices:[]v1.VolumeDevice(nil), LivenessProbe:(*v1.Probe)(nil), ReadinessProbe:(*v1.Probe)(nil), Lifecycle:(*v1.Lifecycle)(nil), TerminationMessagePath:"/dev/termination-log", TerminationMessagePolicy:"File", ImagePullPolicy:"IfNotPresent", SecurityContext:(*v1.SecurityContext)(nil), Stdin:false, StdinOnce:false, TTY:false}}, RestartPolicy:"Always", TerminationGracePeriodSeconds:(*int64)(0xc42213f2c8), ActiveDeadlineSeconds:(*int64)(nil), DNSPolicy:"ClusterFirst", NodeSelector:map[string]string(nil), ServiceAccountName:"default", DeprecatedServiceAccount:"default", AutomountServiceAccountToken:(*bool)(nil), NodeName:"ip-10-250-24-1.ec2.internal", HostNetwork:false, HostPID:false, HostIPC:false, ShareProcessNamespace:(*bool)(nil), SecurityContext:(*v1.PodSecurityContext)(0xc421e49e00), ImagePullSecrets:[]v1.LocalObjectReference(nil), Hostname:"", Subdomain:"", Affinity:(*v1.Affinity)(nil), SchedulerName:"default-scheduler", Tolerations:[]v1.Toleration{v1.Toleration{Key:"node.kubernetes.io/not-ready", Operator:"Exists", Value:"", Effect:"NoExecute", TolerationSeconds:(*int64)(0xc42213f300)}, v1.Toleration{Key:"node.kubernetes.io/unreachable", Operator:"Exists", Value:"", Effect:"NoExecute", TolerationSeconds:(*int64)(0xc42213f320)}}, HostAliases:[]v1.HostAlias(nil), PriorityClassName:"", Priority:(*int32)(nil), DNSConfig:(*v1.PodDNSConfig)(nil), ReadinessGates:[]v1.PodReadinessGate(nil)}, Status:v1.PodStatus{Phase:"Running", Conditions:[]v1.PodCondition{v1.PodCondition{Type:"Initialized", Status:"True", LastProbeTime:v1.Time{Time:time.Time{wall:0x0, ext:0, loc:(*time.Location)(nil)}}, LastTransitionTime:v1.Time{Time:time.Time{wall:0x0, ext:63666134696, loc:(*time.Location)(0x642c9a0)}}, Reason:"", Message:""}, v1.PodCondition{Type:"Ready", Status:"True", LastProbeTime:v1.Time{Time:time.Time{wall:0x0, ext:0, loc:(*time.Location)(nil)}}, LastTransitionTime:v1.Time{Time:time.Time{wall:0x0, ext:63666134698, loc:(*time.Location)(0x642c9a0)}}, Reason:"", Message:""}, v1.PodCondition{Type:"ContainersReady", Status:"True", LastProbeTime:v1.Time{Time:time.Time{wall:0x0, ext:0, loc:(*time.Location)(nil)}}, LastTransitionTime:v1.Time{Time:time.Time{wall:0x0, ext:0, loc:(*time.Location)(nil)}}, Reason:"", Message:""}, v1.PodCondition{Type:"PodScheduled", Status:"True", LastProbeTime:v1.Time{Time:time.Time{wall:0x0, ext:0, loc:(*time.Location)(nil)}}, LastTransitionTime:v1.Time{Time:time.Time{wall:0x0, ext:63666134696, loc:(*time.Location)(0x642c9a0)}}, Reason:"", Message:""}}, Message:"", Reason:"", NominatedNodeName:"", HostIP:"10.250.24.1", PodIP:"100.96.1.95", StartTime:(*v1.Time)(0xc4221507c0), InitContainerStatuses:[]v1.ContainerStatus(nil), ContainerStatuses:[]v1.ContainerStatus{v1.ContainerStatus{Name:"nginx", State:v1.ContainerState{Waiting:(*v1.ContainerStateWaiting)(nil), Running:(*v1.ContainerStateRunning)(0xc4221507e0), Terminated:(*v1.ContainerStateTerminated)(nil)}, LastTerminationState:v1.ContainerState{Waiting:(*v1.ContainerStateWaiting)(nil), Running:(*v1.ContainerStateRunning)(nil), Terminated:(*v1.ContainerStateTerminated)(nil)}, Ready:true, RestartCount:0, Image:"k8s.gcr.io/nginx-slim-amd64:0.20", ImageID:"docker-pullable://k8s.gcr.io/nginx-slim-amd64@sha256:6654db6d4028756062edac466454ee5c9cf9b20ef79e35a81e3c840031eb1e2b", ContainerID:"docker://7e27947b5bf25f95b59728743583da60c290b35d25667eb1620f97aa9a042279"}}, QOSClass:"BestEffort"}}
+STEP: deleting the pod gracefully
+STEP: verifying the kubelet observed the termination notice
+Jul  2 13:25:03.468: INFO: no pod exists with the name we were looking for, assuming the termination request was observed and completed
+STEP: verifying pod deletion was observed
+[AfterEach] [k8s.io] Pods
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:25:03.545: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-pods-ffxxc" for this suite.
+Jul  2 13:25:09.560: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:25:09.673: INFO: namespace: e2e-tests-pods-ffxxc, resource: bindings, ignored listing per whitelist
+Jul  2 13:25:09.734: INFO: namespace e2e-tests-pods-ffxxc deletion completed in 6.185898564s
+
+• [SLOW TEST:13.485 seconds]
+[k8s.io] Pods
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:679
+  should be submitted and removed [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSSSSSSS
+------------------------------
+[sig-storage] Projected 
+  should be consumable from pods in volume with mappings and Item Mode set [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:25:09.735: INFO: >>> kubeConfig: /tmp/kubeconfig-411378559
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:858
+[It] should be consumable from pods in volume with mappings and Item Mode set [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating projection with secret that has name projected-secret-test-map-57cee9e5-7dfb-11e8-bae1-da96248f62d7
+STEP: Creating a pod to test consume secrets
+Jul  2 13:25:09.832: INFO: Waiting up to 5m0s for pod "pod-projected-secrets-57cf74f5-7dfb-11e8-bae1-da96248f62d7" in namespace "e2e-tests-projected-jwv2t" to be "success or failure"
+Jul  2 13:25:09.838: INFO: Pod "pod-projected-secrets-57cf74f5-7dfb-11e8-bae1-da96248f62d7": Phase="Pending", Reason="", readiness=false. Elapsed: 5.453526ms
+Jul  2 13:25:11.842: INFO: Pod "pod-projected-secrets-57cf74f5-7dfb-11e8-bae1-da96248f62d7": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.009353492s
+STEP: Saw pod success
+Jul  2 13:25:11.842: INFO: Pod "pod-projected-secrets-57cf74f5-7dfb-11e8-bae1-da96248f62d7" satisfied condition "success or failure"
+Jul  2 13:25:11.845: INFO: Trying to get logs from node ip-10-250-24-1.ec2.internal pod pod-projected-secrets-57cf74f5-7dfb-11e8-bae1-da96248f62d7 container projected-secret-volume-test: <nil>
+STEP: delete the pod
+Jul  2 13:25:11.864: INFO: Waiting for pod pod-projected-secrets-57cf74f5-7dfb-11e8-bae1-da96248f62d7 to disappear
+Jul  2 13:25:11.877: INFO: Pod pod-projected-secrets-57cf74f5-7dfb-11e8-bae1-da96248f62d7 no longer exists
+[AfterEach] [sig-storage] Projected
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:25:11.877: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-jwv2t" for this suite.
+Jul  2 13:25:17.893: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:25:17.935: INFO: namespace: e2e-tests-projected-jwv2t, resource: bindings, ignored listing per whitelist
+Jul  2 13:25:18.011: INFO: namespace e2e-tests-projected-jwv2t deletion completed in 6.129790396s
+
+• [SLOW TEST:8.277 seconds]
+[sig-storage] Projected
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:34
+  should be consumable from pods in volume with mappings and Item Mode set [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SS
+------------------------------
+[sig-storage] Projected 
+  should provide container's cpu request [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:25:18.012: INFO: >>> kubeConfig: /tmp/kubeconfig-411378559
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:858
+[It] should provide container's cpu request [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating a pod to test downward API volume plugin
+Jul  2 13:25:18.118: INFO: Waiting up to 5m0s for pod "downwardapi-volume-5cbf9fc7-7dfb-11e8-bae1-da96248f62d7" in namespace "e2e-tests-projected-rxv5j" to be "success or failure"
+Jul  2 13:25:18.122: INFO: Pod "downwardapi-volume-5cbf9fc7-7dfb-11e8-bae1-da96248f62d7": Phase="Pending", Reason="", readiness=false. Elapsed: 4.204988ms
+Jul  2 13:25:20.126: INFO: Pod "downwardapi-volume-5cbf9fc7-7dfb-11e8-bae1-da96248f62d7": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.008218983s
+STEP: Saw pod success
+Jul  2 13:25:20.126: INFO: Pod "downwardapi-volume-5cbf9fc7-7dfb-11e8-bae1-da96248f62d7" satisfied condition "success or failure"
+Jul  2 13:25:20.150: INFO: Trying to get logs from node ip-10-250-24-1.ec2.internal pod downwardapi-volume-5cbf9fc7-7dfb-11e8-bae1-da96248f62d7 container client-container: <nil>
+STEP: delete the pod
+Jul  2 13:25:20.168: INFO: Waiting for pod downwardapi-volume-5cbf9fc7-7dfb-11e8-bae1-da96248f62d7 to disappear
+Jul  2 13:25:20.171: INFO: Pod downwardapi-volume-5cbf9fc7-7dfb-11e8-bae1-da96248f62d7 no longer exists
+[AfterEach] [sig-storage] Projected
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:25:20.171: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-rxv5j" for this suite.
+Jul  2 13:25:26.186: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:25:26.210: INFO: namespace: e2e-tests-projected-rxv5j, resource: bindings, ignored listing per whitelist
+Jul  2 13:25:26.336: INFO: namespace e2e-tests-projected-rxv5j deletion completed in 6.161066512s
+
+• [SLOW TEST:8.324 seconds]
+[sig-storage] Projected
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:34
+  should provide container's cpu request [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SS
+------------------------------
+[k8s.io] Docker Containers 
+  should be able to override the image's default arguments (docker cmd) [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [k8s.io] Docker Containers
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:25:26.336: INFO: >>> kubeConfig: /tmp/kubeconfig-411378559
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should be able to override the image's default arguments (docker cmd) [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating a pod to test override arguments
+Jul  2 13:25:26.438: INFO: Waiting up to 5m0s for pod "client-containers-61b529f3-7dfb-11e8-bae1-da96248f62d7" in namespace "e2e-tests-containers-dprfl" to be "success or failure"
+Jul  2 13:25:26.441: INFO: Pod "client-containers-61b529f3-7dfb-11e8-bae1-da96248f62d7": Phase="Pending", Reason="", readiness=false. Elapsed: 3.243046ms
+Jul  2 13:25:28.445: INFO: Pod "client-containers-61b529f3-7dfb-11e8-bae1-da96248f62d7": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.00727721s
+STEP: Saw pod success
+Jul  2 13:25:28.445: INFO: Pod "client-containers-61b529f3-7dfb-11e8-bae1-da96248f62d7" satisfied condition "success or failure"
+Jul  2 13:25:28.448: INFO: Trying to get logs from node ip-10-250-24-1.ec2.internal pod client-containers-61b529f3-7dfb-11e8-bae1-da96248f62d7 container test-container: <nil>
+STEP: delete the pod
+Jul  2 13:25:28.469: INFO: Waiting for pod client-containers-61b529f3-7dfb-11e8-bae1-da96248f62d7 to disappear
+Jul  2 13:25:28.481: INFO: Pod client-containers-61b529f3-7dfb-11e8-bae1-da96248f62d7 no longer exists
+[AfterEach] [k8s.io] Docker Containers
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:25:28.481: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-containers-dprfl" for this suite.
+Jul  2 13:25:34.497: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:25:34.618: INFO: namespace: e2e-tests-containers-dprfl, resource: bindings, ignored listing per whitelist
+Jul  2 13:25:34.635: INFO: namespace e2e-tests-containers-dprfl deletion completed in 6.14965915s
+
+• [SLOW TEST:8.299 seconds]
+[k8s.io] Docker Containers
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:679
+  should be able to override the image's default arguments (docker cmd) [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+S
+------------------------------
+[sig-storage] Downward API volume 
+  should provide container's memory limit [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:25:34.636: INFO: >>> kubeConfig: /tmp/kubeconfig-411378559
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downwardapi_volume.go:38
+[It] should provide container's memory limit [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating a pod to test downward API volume plugin
+Jul  2 13:25:34.727: INFO: Waiting up to 5m0s for pod "downwardapi-volume-66a5fd14-7dfb-11e8-bae1-da96248f62d7" in namespace "e2e-tests-downward-api-kskzc" to be "success or failure"
+Jul  2 13:25:34.732: INFO: Pod "downwardapi-volume-66a5fd14-7dfb-11e8-bae1-da96248f62d7": Phase="Pending", Reason="", readiness=false. Elapsed: 5.175757ms
+Jul  2 13:25:36.747: INFO: Pod "downwardapi-volume-66a5fd14-7dfb-11e8-bae1-da96248f62d7": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.020343874s
+STEP: Saw pod success
+Jul  2 13:25:36.747: INFO: Pod "downwardapi-volume-66a5fd14-7dfb-11e8-bae1-da96248f62d7" satisfied condition "success or failure"
+Jul  2 13:25:36.750: INFO: Trying to get logs from node ip-10-250-24-1.ec2.internal pod downwardapi-volume-66a5fd14-7dfb-11e8-bae1-da96248f62d7 container client-container: <nil>
+STEP: delete the pod
+Jul  2 13:25:36.773: INFO: Waiting for pod downwardapi-volume-66a5fd14-7dfb-11e8-bae1-da96248f62d7 to disappear
+Jul  2 13:25:36.778: INFO: Pod downwardapi-volume-66a5fd14-7dfb-11e8-bae1-da96248f62d7 no longer exists
+[AfterEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:25:36.778: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-downward-api-kskzc" for this suite.
+Jul  2 13:25:42.797: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:25:42.868: INFO: namespace: e2e-tests-downward-api-kskzc, resource: bindings, ignored listing per whitelist
+Jul  2 13:25:42.896: INFO: namespace e2e-tests-downward-api-kskzc deletion completed in 6.113710963s
+
+• [SLOW TEST:8.260 seconds]
+[sig-storage] Downward API volume
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downwardapi_volume.go:33
+  should provide container's memory limit [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSS
+------------------------------
+[sig-storage] ConfigMap 
+  should be consumable from pods in volume with mappings as non-root [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-storage] ConfigMap
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:25:42.896: INFO: >>> kubeConfig: /tmp/kubeconfig-411378559
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should be consumable from pods in volume with mappings as non-root [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating configMap with name configmap-test-volume-map-6b9391a6-7dfb-11e8-bae1-da96248f62d7
+STEP: Creating a pod to test consume configMaps
+Jul  2 13:25:42.998: INFO: Waiting up to 5m0s for pod "pod-configmaps-6b941e03-7dfb-11e8-bae1-da96248f62d7" in namespace "e2e-tests-configmap-xcmb4" to be "success or failure"
+Jul  2 13:25:43.001: INFO: Pod "pod-configmaps-6b941e03-7dfb-11e8-bae1-da96248f62d7": Phase="Pending", Reason="", readiness=false. Elapsed: 2.701456ms
+Jul  2 13:25:45.004: INFO: Pod "pod-configmaps-6b941e03-7dfb-11e8-bae1-da96248f62d7": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.006300782s
+STEP: Saw pod success
+Jul  2 13:25:45.004: INFO: Pod "pod-configmaps-6b941e03-7dfb-11e8-bae1-da96248f62d7" satisfied condition "success or failure"
+Jul  2 13:25:45.007: INFO: Trying to get logs from node ip-10-250-24-1.ec2.internal pod pod-configmaps-6b941e03-7dfb-11e8-bae1-da96248f62d7 container configmap-volume-test: <nil>
+STEP: delete the pod
+Jul  2 13:25:45.029: INFO: Waiting for pod pod-configmaps-6b941e03-7dfb-11e8-bae1-da96248f62d7 to disappear
+Jul  2 13:25:45.048: INFO: Pod pod-configmaps-6b941e03-7dfb-11e8-bae1-da96248f62d7 no longer exists
+[AfterEach] [sig-storage] ConfigMap
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:25:45.053: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-configmap-xcmb4" for this suite.
+Jul  2 13:25:51.068: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:25:51.224: INFO: namespace: e2e-tests-configmap-xcmb4, resource: bindings, ignored listing per whitelist
+Jul  2 13:25:51.240: INFO: namespace e2e-tests-configmap-xcmb4 deletion completed in 6.182848881s
+
+• [SLOW TEST:8.344 seconds]
+[sig-storage] ConfigMap
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/configmap_volume.go:32
+  should be consumable from pods in volume with mappings as non-root [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSS
+------------------------------
+[sig-api-machinery] Downward API 
+  should provide pod UID as env vars [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-api-machinery] Downward API
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:25:51.240: INFO: >>> kubeConfig: /tmp/kubeconfig-411378559
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should provide pod UID as env vars [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating a pod to test downward api env vars
+Jul  2 13:25:51.337: INFO: Waiting up to 5m0s for pod "downward-api-708c9995-7dfb-11e8-bae1-da96248f62d7" in namespace "e2e-tests-downward-api-l6cnz" to be "success or failure"
+Jul  2 13:25:51.342: INFO: Pod "downward-api-708c9995-7dfb-11e8-bae1-da96248f62d7": Phase="Pending", Reason="", readiness=false. Elapsed: 4.969674ms
+Jul  2 13:25:53.346: INFO: Pod "downward-api-708c9995-7dfb-11e8-bae1-da96248f62d7": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.00874763s
+STEP: Saw pod success
+Jul  2 13:25:53.346: INFO: Pod "downward-api-708c9995-7dfb-11e8-bae1-da96248f62d7" satisfied condition "success or failure"
+Jul  2 13:25:53.349: INFO: Trying to get logs from node ip-10-250-24-1.ec2.internal pod downward-api-708c9995-7dfb-11e8-bae1-da96248f62d7 container dapi-container: <nil>
+STEP: delete the pod
+Jul  2 13:25:53.429: INFO: Waiting for pod downward-api-708c9995-7dfb-11e8-bae1-da96248f62d7 to disappear
+Jul  2 13:25:53.436: INFO: Pod downward-api-708c9995-7dfb-11e8-bae1-da96248f62d7 no longer exists
+[AfterEach] [sig-api-machinery] Downward API
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:25:53.437: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-downward-api-l6cnz" for this suite.
+Jul  2 13:25:59.453: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:25:59.506: INFO: namespace: e2e-tests-downward-api-l6cnz, resource: bindings, ignored listing per whitelist
+Jul  2 13:25:59.597: INFO: namespace e2e-tests-downward-api-l6cnz deletion completed in 6.155053295s
+
+• [SLOW TEST:8.357 seconds]
+[sig-api-machinery] Downward API
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downward_api.go:37
+  should provide pod UID as env vars [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSSSS
+------------------------------
+[sig-storage] ConfigMap 
+  updates should be reflected in volume [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-storage] ConfigMap
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:25:59.598: INFO: >>> kubeConfig: /tmp/kubeconfig-411378559
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] updates should be reflected in volume [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating configMap with name configmap-test-upd-7589c660-7dfb-11e8-bae1-da96248f62d7
+STEP: Creating the pod
+STEP: Updating configmap configmap-test-upd-7589c660-7dfb-11e8-bae1-da96248f62d7
+STEP: waiting to observe update in volume
+[AfterEach] [sig-storage] ConfigMap
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:26:03.846: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-configmap-mfp4d" for this suite.
+Jul  2 13:26:25.860: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:26:25.956: INFO: namespace: e2e-tests-configmap-mfp4d, resource: bindings, ignored listing per whitelist
+Jul  2 13:26:25.962: INFO: namespace e2e-tests-configmap-mfp4d deletion completed in 22.111924785s
+
+• [SLOW TEST:26.364 seconds]
+[sig-storage] ConfigMap
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/configmap_volume.go:32
+  updates should be reflected in volume [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSSSSS
+------------------------------
+[sig-api-machinery] Garbage collector 
+  should keep the rc around until all its pods are deleted if the deleteOptions says so [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-api-machinery] Garbage collector
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:26:25.962: INFO: >>> kubeConfig: /tmp/kubeconfig-411378559
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should keep the rc around until all its pods are deleted if the deleteOptions says so [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: create the rc
+STEP: delete the rc
+STEP: wait for the rc to be deleted
+STEP: Gathering metrics
+W0702 13:26:32.173866      14 metrics_grabber.go:81] Master node is not registered. Grabbing metrics from Scheduler, ControllerManager and ClusterAutoscaler is disabled.
+Jul  2 13:26:32.173: INFO: For apiserver_request_count:
+For apiserver_request_latencies_summary:
+For etcd_helper_cache_entry_count:
+For etcd_helper_cache_hit_count:
+For etcd_helper_cache_miss_count:
+For etcd_request_cache_add_latencies_summary:
+For etcd_request_cache_get_latencies_summary:
+For etcd_request_latencies_summary:
+For garbage_collector_attempt_to_delete_queue_latency:
+For garbage_collector_attempt_to_delete_work_duration:
+For garbage_collector_attempt_to_orphan_queue_latency:
+For garbage_collector_attempt_to_orphan_work_duration:
+For garbage_collector_dirty_processing_latency_microseconds:
+For garbage_collector_event_processing_latency_microseconds:
+For garbage_collector_graph_changes_queue_latency:
+For garbage_collector_graph_changes_work_duration:
+For garbage_collector_orphan_processing_latency_microseconds:
+For namespace_queue_latency:
+For namespace_queue_latency_sum:
+For namespace_queue_latency_count:
+For namespace_retries:
+For namespace_work_duration:
+For namespace_work_duration_sum:
+For namespace_work_duration_count:
+For function_duration_seconds:
+For errors_total:
+For evicted_pods_total:
+
+[AfterEach] [sig-api-machinery] Garbage collector
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:26:32.173: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-gc-kclw8" for this suite.
+Jul  2 13:26:38.250: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:26:38.411: INFO: namespace: e2e-tests-gc-kclw8, resource: bindings, ignored listing per whitelist
+Jul  2 13:26:38.430: INFO: namespace e2e-tests-gc-kclw8 deletion completed in 6.252951446s
+
+• [SLOW TEST:12.468 seconds]
+[sig-api-machinery] Garbage collector
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apimachinery/framework.go:22
+  should keep the rc around until all its pods are deleted if the deleteOptions says so [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSSSSSSSSSS
+------------------------------
+[sig-api-machinery] Watchers 
+  should be able to start watching from a specific resource version [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-api-machinery] Watchers
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:26:38.431: INFO: >>> kubeConfig: /tmp/kubeconfig-411378559
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should be able to start watching from a specific resource version [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: creating a new configmap
+STEP: modifying the configmap once
+STEP: modifying the configmap a second time
+STEP: deleting the configmap
+STEP: creating a watch on configmaps from the resource version returned by the first update
+STEP: Expecting to observe notifications for all changes to the configmap after the first update
+Jul  2 13:26:38.544: INFO: Got : MODIFIED &ConfigMap{ObjectMeta:k8s_io_apimachinery_pkg_apis_meta_v1.ObjectMeta{Name:e2e-watch-test-resource-version,GenerateName:,Namespace:e2e-tests-watch-wwhm9,SelfLink:/api/v1/namespaces/e2e-tests-watch-wwhm9/configmaps/e2e-watch-test-resource-version,UID:8cacb312-7dfb-11e8-9deb-8e4c5ec544fb,ResourceVersion:8624,Generation:0,CreationTimestamp:2018-07-02 13:26:38 +0000 UTC,DeletionTimestamp:<nil>,DeletionGracePeriodSeconds:nil,Labels:map[string]string{watch-this-configmap: from-resource-version,},Annotations:map[string]string{},OwnerReferences:[],Finalizers:[],ClusterName:,Initializers:nil,},Data:map[string]string{mutation: 2,},BinaryData:map[string][]byte{},}
+Jul  2 13:26:38.544: INFO: Got : DELETED &ConfigMap{ObjectMeta:k8s_io_apimachinery_pkg_apis_meta_v1.ObjectMeta{Name:e2e-watch-test-resource-version,GenerateName:,Namespace:e2e-tests-watch-wwhm9,SelfLink:/api/v1/namespaces/e2e-tests-watch-wwhm9/configmaps/e2e-watch-test-resource-version,UID:8cacb312-7dfb-11e8-9deb-8e4c5ec544fb,ResourceVersion:8625,Generation:0,CreationTimestamp:2018-07-02 13:26:38 +0000 UTC,DeletionTimestamp:<nil>,DeletionGracePeriodSeconds:nil,Labels:map[string]string{watch-this-configmap: from-resource-version,},Annotations:map[string]string{},OwnerReferences:[],Finalizers:[],ClusterName:,Initializers:nil,},Data:map[string]string{mutation: 2,},BinaryData:map[string][]byte{},}
+[AfterEach] [sig-api-machinery] Watchers
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:26:38.544: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-watch-wwhm9" for this suite.
+Jul  2 13:26:44.651: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:26:44.760: INFO: namespace: e2e-tests-watch-wwhm9, resource: bindings, ignored listing per whitelist
+Jul  2 13:26:44.772: INFO: namespace e2e-tests-watch-wwhm9 deletion completed in 6.223925637s
+
+• [SLOW TEST:6.342 seconds]
+[sig-api-machinery] Watchers
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apimachinery/framework.go:22
+  should be able to start watching from a specific resource version [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSSSSS
+------------------------------
+[sig-storage] ConfigMap 
+  should be consumable in multiple volumes in the same pod [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-storage] ConfigMap
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:26:44.773: INFO: >>> kubeConfig: /tmp/kubeconfig-411378559
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should be consumable in multiple volumes in the same pod [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating configMap with name configmap-test-volume-90756cb4-7dfb-11e8-bae1-da96248f62d7
+STEP: Creating a pod to test consume configMaps
+Jul  2 13:26:44.876: INFO: Waiting up to 5m0s for pod "pod-configmaps-9075f4ef-7dfb-11e8-bae1-da96248f62d7" in namespace "e2e-tests-configmap-h6vqq" to be "success or failure"
+Jul  2 13:26:44.879: INFO: Pod "pod-configmaps-9075f4ef-7dfb-11e8-bae1-da96248f62d7": Phase="Pending", Reason="", readiness=false. Elapsed: 2.721335ms
+Jul  2 13:26:46.882: INFO: Pod "pod-configmaps-9075f4ef-7dfb-11e8-bae1-da96248f62d7": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.006421284s
+STEP: Saw pod success
+Jul  2 13:26:46.882: INFO: Pod "pod-configmaps-9075f4ef-7dfb-11e8-bae1-da96248f62d7" satisfied condition "success or failure"
+Jul  2 13:26:46.885: INFO: Trying to get logs from node ip-10-250-24-1.ec2.internal pod pod-configmaps-9075f4ef-7dfb-11e8-bae1-da96248f62d7 container configmap-volume-test: <nil>
+STEP: delete the pod
+Jul  2 13:26:46.905: INFO: Waiting for pod pod-configmaps-9075f4ef-7dfb-11e8-bae1-da96248f62d7 to disappear
+Jul  2 13:26:46.908: INFO: Pod pod-configmaps-9075f4ef-7dfb-11e8-bae1-da96248f62d7 no longer exists
+[AfterEach] [sig-storage] ConfigMap
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:26:46.909: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-configmap-h6vqq" for this suite.
+Jul  2 13:26:52.924: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:26:52.966: INFO: namespace: e2e-tests-configmap-h6vqq, resource: bindings, ignored listing per whitelist
+Jul  2 13:26:53.024: INFO: namespace e2e-tests-configmap-h6vqq deletion completed in 6.111750817s
+
+• [SLOW TEST:8.251 seconds]
+[sig-storage] ConfigMap
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/configmap_volume.go:32
+  should be consumable in multiple volumes in the same pod [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSS
+------------------------------
+[sig-storage] Projected 
+  should be consumable from pods in volume with mappings [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:26:53.024: INFO: >>> kubeConfig: /tmp/kubeconfig-411378559
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:858
+[It] should be consumable from pods in volume with mappings [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating projection with secret that has name projected-secret-test-map-955fd7d6-7dfb-11e8-bae1-da96248f62d7
+STEP: Creating a pod to test consume secrets
+Jul  2 13:26:53.123: INFO: Waiting up to 5m0s for pod "pod-projected-secrets-9560635a-7dfb-11e8-bae1-da96248f62d7" in namespace "e2e-tests-projected-zzj24" to be "success or failure"
+Jul  2 13:26:53.126: INFO: Pod "pod-projected-secrets-9560635a-7dfb-11e8-bae1-da96248f62d7": Phase="Pending", Reason="", readiness=false. Elapsed: 2.851677ms
+Jul  2 13:26:55.152: INFO: Pod "pod-projected-secrets-9560635a-7dfb-11e8-bae1-da96248f62d7": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.02857515s
+STEP: Saw pod success
+Jul  2 13:26:55.152: INFO: Pod "pod-projected-secrets-9560635a-7dfb-11e8-bae1-da96248f62d7" satisfied condition "success or failure"
+Jul  2 13:26:55.155: INFO: Trying to get logs from node ip-10-250-24-1.ec2.internal pod pod-projected-secrets-9560635a-7dfb-11e8-bae1-da96248f62d7 container projected-secret-volume-test: <nil>
+STEP: delete the pod
+Jul  2 13:26:55.182: INFO: Waiting for pod pod-projected-secrets-9560635a-7dfb-11e8-bae1-da96248f62d7 to disappear
+Jul  2 13:26:55.214: INFO: Pod pod-projected-secrets-9560635a-7dfb-11e8-bae1-da96248f62d7 no longer exists
+[AfterEach] [sig-storage] Projected
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:26:55.214: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-zzj24" for this suite.
+Jul  2 13:27:01.249: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:27:01.439: INFO: namespace: e2e-tests-projected-zzj24, resource: bindings, ignored listing per whitelist
+Jul  2 13:27:01.448: INFO: namespace e2e-tests-projected-zzj24 deletion completed in 6.229007586s
+
+• [SLOW TEST:8.424 seconds]
+[sig-storage] Projected
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:34
+  should be consumable from pods in volume with mappings [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SS
+------------------------------
+[sig-storage] Projected 
+  should update labels on modification [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:27:01.448: INFO: >>> kubeConfig: /tmp/kubeconfig-411378559
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:858
+[It] should update labels on modification [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating the pod
+Jul  2 13:27:04.156: INFO: Successfully updated pod "labelsupdate9a66bbf1-7dfb-11e8-bae1-da96248f62d7"
+[AfterEach] [sig-storage] Projected
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:27:06.255: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-hsj2t" for this suite.
+Jul  2 13:27:28.273: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:27:28.282: INFO: namespace: e2e-tests-projected-hsj2t, resource: bindings, ignored listing per whitelist
+Jul  2 13:27:28.434: INFO: namespace e2e-tests-projected-hsj2t deletion completed in 22.174814435s
+
+• [SLOW TEST:26.986 seconds]
+[sig-storage] Projected
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:34
+  should update labels on modification [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SS
+------------------------------
+[sig-auth] ServiceAccounts 
+  should allow opting out of API token automount  [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-auth] ServiceAccounts
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:27:28.434: INFO: >>> kubeConfig: /tmp/kubeconfig-411378559
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should allow opting out of API token automount  [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: getting the auto-created API token
+Jul  2 13:27:29.042: INFO: created pod pod-service-account-defaultsa
+Jul  2 13:27:29.042: INFO: pod pod-service-account-defaultsa service account token volume mount: true
+Jul  2 13:27:29.046: INFO: created pod pod-service-account-mountsa
+Jul  2 13:27:29.046: INFO: pod pod-service-account-mountsa service account token volume mount: true
+Jul  2 13:27:29.050: INFO: created pod pod-service-account-nomountsa
+Jul  2 13:27:29.050: INFO: pod pod-service-account-nomountsa service account token volume mount: false
+Jul  2 13:27:29.054: INFO: created pod pod-service-account-defaultsa-mountspec
+Jul  2 13:27:29.054: INFO: pod pod-service-account-defaultsa-mountspec service account token volume mount: true
+Jul  2 13:27:29.060: INFO: created pod pod-service-account-mountsa-mountspec
+Jul  2 13:27:29.060: INFO: pod pod-service-account-mountsa-mountspec service account token volume mount: true
+Jul  2 13:27:29.065: INFO: created pod pod-service-account-nomountsa-mountspec
+Jul  2 13:27:29.065: INFO: pod pod-service-account-nomountsa-mountspec service account token volume mount: true
+Jul  2 13:27:29.070: INFO: created pod pod-service-account-defaultsa-nomountspec
+Jul  2 13:27:29.070: INFO: pod pod-service-account-defaultsa-nomountspec service account token volume mount: false
+Jul  2 13:27:29.074: INFO: created pod pod-service-account-mountsa-nomountspec
+Jul  2 13:27:29.074: INFO: pod pod-service-account-mountsa-nomountspec service account token volume mount: false
+Jul  2 13:27:29.078: INFO: created pod pod-service-account-nomountsa-nomountspec
+Jul  2 13:27:29.078: INFO: pod pod-service-account-nomountsa-nomountspec service account token volume mount: false
+[AfterEach] [sig-auth] ServiceAccounts
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:27:29.078: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-svcaccounts-p74rw" for this suite.
+Jul  2 13:27:51.094: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:27:51.180: INFO: namespace: e2e-tests-svcaccounts-p74rw, resource: bindings, ignored listing per whitelist
+Jul  2 13:27:51.231: INFO: namespace e2e-tests-svcaccounts-p74rw deletion completed in 22.149220462s
+
+• [SLOW TEST:22.797 seconds]
+[sig-auth] ServiceAccounts
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/auth/framework.go:22
+  should allow opting out of API token automount  [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SS
+------------------------------
+[sig-api-machinery] Garbage collector 
+  should not delete dependents that have both valid owner and owner that's waiting for dependents to be deleted [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-api-machinery] Garbage collector
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:27:51.231: INFO: >>> kubeConfig: /tmp/kubeconfig-411378559
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should not delete dependents that have both valid owner and owner that's waiting for dependents to be deleted [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: create the rc1
+STEP: create the rc2
+STEP: set half of pods created by rc simpletest-rc-to-be-deleted to have rc simpletest-rc-to-stay as owner as well
+STEP: delete the rc simpletest-rc-to-be-deleted
+STEP: wait for the rc to be deleted
+STEP: Gathering metrics
+W0702 13:28:01.393793      14 metrics_grabber.go:81] Master node is not registered. Grabbing metrics from Scheduler, ControllerManager and ClusterAutoscaler is disabled.
+Jul  2 13:28:01.394: INFO: For apiserver_request_count:
+For apiserver_request_latencies_summary:
+For etcd_helper_cache_entry_count:
+For etcd_helper_cache_hit_count:
+For etcd_helper_cache_miss_count:
+For etcd_request_cache_add_latencies_summary:
+For etcd_request_cache_get_latencies_summary:
+For etcd_request_latencies_summary:
+For garbage_collector_attempt_to_delete_queue_latency:
+For garbage_collector_attempt_to_delete_work_duration:
+For garbage_collector_attempt_to_orphan_queue_latency:
+For garbage_collector_attempt_to_orphan_work_duration:
+For garbage_collector_dirty_processing_latency_microseconds:
+For garbage_collector_event_processing_latency_microseconds:
+For garbage_collector_graph_changes_queue_latency:
+For garbage_collector_graph_changes_work_duration:
+For garbage_collector_orphan_processing_latency_microseconds:
+For namespace_queue_latency:
+For namespace_queue_latency_sum:
+For namespace_queue_latency_count:
+For namespace_retries:
+For namespace_work_duration:
+For namespace_work_duration_sum:
+For namespace_work_duration_count:
+For function_duration_seconds:
+For errors_total:
+For evicted_pods_total:
+
+[AfterEach] [sig-api-machinery] Garbage collector
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:28:01.394: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-gc-pffdz" for this suite.
+Jul  2 13:28:07.412: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:28:07.485: INFO: namespace: e2e-tests-gc-pffdz, resource: bindings, ignored listing per whitelist
+Jul  2 13:28:07.533: INFO: namespace e2e-tests-gc-pffdz deletion completed in 6.136147118s
+
+• [SLOW TEST:16.302 seconds]
+[sig-api-machinery] Garbage collector
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apimachinery/framework.go:22
+  should not delete dependents that have both valid owner and owner that's waiting for dependents to be deleted [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+S
+------------------------------
+[sig-storage] Downward API volume 
+  should provide node allocatable (cpu) as default cpu limit if the limit is not set [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:28:07.534: INFO: >>> kubeConfig: /tmp/kubeconfig-411378559
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downwardapi_volume.go:38
+[It] should provide node allocatable (cpu) as default cpu limit if the limit is not set [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating a pod to test downward API volume plugin
+Jul  2 13:28:07.630: INFO: Waiting up to 5m0s for pod "downwardapi-volume-c1c92096-7dfb-11e8-bae1-da96248f62d7" in namespace "e2e-tests-downward-api-h4h9r" to be "success or failure"
+Jul  2 13:28:07.636: INFO: Pod "downwardapi-volume-c1c92096-7dfb-11e8-bae1-da96248f62d7": Phase="Pending", Reason="", readiness=false. Elapsed: 5.763716ms
+Jul  2 13:28:09.639: INFO: Pod "downwardapi-volume-c1c92096-7dfb-11e8-bae1-da96248f62d7": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.008972984s
+STEP: Saw pod success
+Jul  2 13:28:09.639: INFO: Pod "downwardapi-volume-c1c92096-7dfb-11e8-bae1-da96248f62d7" satisfied condition "success or failure"
+Jul  2 13:28:09.642: INFO: Trying to get logs from node ip-10-250-24-1.ec2.internal pod downwardapi-volume-c1c92096-7dfb-11e8-bae1-da96248f62d7 container client-container: <nil>
+STEP: delete the pod
+Jul  2 13:28:09.662: INFO: Waiting for pod downwardapi-volume-c1c92096-7dfb-11e8-bae1-da96248f62d7 to disappear
+Jul  2 13:28:09.672: INFO: Pod downwardapi-volume-c1c92096-7dfb-11e8-bae1-da96248f62d7 no longer exists
+[AfterEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:28:09.672: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-downward-api-h4h9r" for this suite.
+Jul  2 13:28:15.693: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:28:15.782: INFO: namespace: e2e-tests-downward-api-h4h9r, resource: bindings, ignored listing per whitelist
+Jul  2 13:28:15.796: INFO: namespace e2e-tests-downward-api-h4h9r deletion completed in 6.120393305s
+
+• [SLOW TEST:8.263 seconds]
+[sig-storage] Downward API volume
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downwardapi_volume.go:33
+  should provide node allocatable (cpu) as default cpu limit if the limit is not set [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSSSSSSSSSSSS
+------------------------------
+[sig-storage] Projected 
+  should set mode on item file [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:28:15.797: INFO: >>> kubeConfig: /tmp/kubeconfig-411378559
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:858
+[It] should set mode on item file [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating a pod to test downward API volume plugin
+Jul  2 13:28:15.894: INFO: Waiting up to 5m0s for pod "downwardapi-volume-c6b623be-7dfb-11e8-bae1-da96248f62d7" in namespace "e2e-tests-projected-jnl9x" to be "success or failure"
+Jul  2 13:28:15.899: INFO: Pod "downwardapi-volume-c6b623be-7dfb-11e8-bae1-da96248f62d7": Phase="Pending", Reason="", readiness=false. Elapsed: 5.837016ms
+Jul  2 13:28:17.903: INFO: Pod "downwardapi-volume-c6b623be-7dfb-11e8-bae1-da96248f62d7": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.009746304s
+STEP: Saw pod success
+Jul  2 13:28:17.903: INFO: Pod "downwardapi-volume-c6b623be-7dfb-11e8-bae1-da96248f62d7" satisfied condition "success or failure"
+Jul  2 13:28:17.911: INFO: Trying to get logs from node ip-10-250-24-1.ec2.internal pod downwardapi-volume-c6b623be-7dfb-11e8-bae1-da96248f62d7 container client-container: <nil>
+STEP: delete the pod
+Jul  2 13:28:17.936: INFO: Waiting for pod downwardapi-volume-c6b623be-7dfb-11e8-bae1-da96248f62d7 to disappear
+Jul  2 13:28:17.940: INFO: Pod downwardapi-volume-c6b623be-7dfb-11e8-bae1-da96248f62d7 no longer exists
+[AfterEach] [sig-storage] Projected
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:28:17.941: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-jnl9x" for this suite.
+Jul  2 13:28:23.966: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:28:24.133: INFO: namespace: e2e-tests-projected-jnl9x, resource: bindings, ignored listing per whitelist
+Jul  2 13:28:24.141: INFO: namespace e2e-tests-projected-jnl9x deletion completed in 6.194894548s
+
+• [SLOW TEST:8.344 seconds]
+[sig-storage] Projected
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:34
+  should set mode on item file [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSSSSSSSSSSSSSSSSSSSS
+------------------------------
+[sig-storage] EmptyDir volumes 
+  should support (root,0777,tmpfs) [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-storage] EmptyDir volumes
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:28:24.142: INFO: >>> kubeConfig: /tmp/kubeconfig-411378559
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should support (root,0777,tmpfs) [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating a pod to test emptydir 0777 on tmpfs
+Jul  2 13:28:24.237: INFO: Waiting up to 5m0s for pod "pod-cbaf3008-7dfb-11e8-bae1-da96248f62d7" in namespace "e2e-tests-emptydir-rdpt5" to be "success or failure"
+Jul  2 13:28:24.240: INFO: Pod "pod-cbaf3008-7dfb-11e8-bae1-da96248f62d7": Phase="Pending", Reason="", readiness=false. Elapsed: 3.366085ms
+Jul  2 13:28:26.244: INFO: Pod "pod-cbaf3008-7dfb-11e8-bae1-da96248f62d7": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.007486807s
+STEP: Saw pod success
+Jul  2 13:28:26.244: INFO: Pod "pod-cbaf3008-7dfb-11e8-bae1-da96248f62d7" satisfied condition "success or failure"
+Jul  2 13:28:26.247: INFO: Trying to get logs from node ip-10-250-24-1.ec2.internal pod pod-cbaf3008-7dfb-11e8-bae1-da96248f62d7 container test-container: <nil>
+STEP: delete the pod
+Jul  2 13:28:26.329: INFO: Waiting for pod pod-cbaf3008-7dfb-11e8-bae1-da96248f62d7 to disappear
+Jul  2 13:28:26.332: INFO: Pod pod-cbaf3008-7dfb-11e8-bae1-da96248f62d7 no longer exists
+[AfterEach] [sig-storage] EmptyDir volumes
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:28:26.332: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-emptydir-rdpt5" for this suite.
+Jul  2 13:28:32.346: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:28:32.439: INFO: namespace: e2e-tests-emptydir-rdpt5, resource: bindings, ignored listing per whitelist
+Jul  2 13:28:32.463: INFO: namespace e2e-tests-emptydir-rdpt5 deletion completed in 6.127512855s
+
+• [SLOW TEST:8.321 seconds]
+[sig-storage] EmptyDir volumes
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/empty_dir.go:40
+  should support (root,0777,tmpfs) [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSSSSSSSSSSSS
+------------------------------
+[k8s.io] Docker Containers 
+  should use the image defaults if command and args are blank [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [k8s.io] Docker Containers
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:28:32.463: INFO: >>> kubeConfig: /tmp/kubeconfig-411378559
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should use the image defaults if command and args are blank [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating a pod to test use defaults
+Jul  2 13:28:32.566: INFO: Waiting up to 5m0s for pod "client-containers-d0a631bd-7dfb-11e8-bae1-da96248f62d7" in namespace "e2e-tests-containers-4trvp" to be "success or failure"
+Jul  2 13:28:32.569: INFO: Pod "client-containers-d0a631bd-7dfb-11e8-bae1-da96248f62d7": Phase="Pending", Reason="", readiness=false. Elapsed: 2.858526ms
+Jul  2 13:28:34.573: INFO: Pod "client-containers-d0a631bd-7dfb-11e8-bae1-da96248f62d7": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.006237044s
+STEP: Saw pod success
+Jul  2 13:28:34.573: INFO: Pod "client-containers-d0a631bd-7dfb-11e8-bae1-da96248f62d7" satisfied condition "success or failure"
+Jul  2 13:28:34.576: INFO: Trying to get logs from node ip-10-250-24-1.ec2.internal pod client-containers-d0a631bd-7dfb-11e8-bae1-da96248f62d7 container test-container: <nil>
+STEP: delete the pod
+Jul  2 13:28:34.595: INFO: Waiting for pod client-containers-d0a631bd-7dfb-11e8-bae1-da96248f62d7 to disappear
+Jul  2 13:28:34.598: INFO: Pod client-containers-d0a631bd-7dfb-11e8-bae1-da96248f62d7 no longer exists
+[AfterEach] [k8s.io] Docker Containers
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:28:34.598: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-containers-4trvp" for this suite.
+Jul  2 13:28:40.615: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:28:40.817: INFO: namespace: e2e-tests-containers-4trvp, resource: bindings, ignored listing per whitelist
+Jul  2 13:28:40.832: INFO: namespace e2e-tests-containers-4trvp deletion completed in 6.229507301s
+
+• [SLOW TEST:8.369 seconds]
+[k8s.io] Docker Containers
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:679
+  should use the image defaults if command and args are blank [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSS
+------------------------------
+[sig-storage] EmptyDir volumes 
+  should support (non-root,0666,tmpfs) [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-storage] EmptyDir volumes
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:28:40.832: INFO: >>> kubeConfig: /tmp/kubeconfig-411378559
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should support (non-root,0666,tmpfs) [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating a pod to test emptydir 0666 on tmpfs
+Jul  2 13:28:40.943: INFO: Waiting up to 5m0s for pod "pod-d5a434f9-7dfb-11e8-bae1-da96248f62d7" in namespace "e2e-tests-emptydir-ktkf5" to be "success or failure"
+Jul  2 13:28:40.946: INFO: Pod "pod-d5a434f9-7dfb-11e8-bae1-da96248f62d7": Phase="Pending", Reason="", readiness=false. Elapsed: 2.845535ms
+Jul  2 13:28:42.950: INFO: Pod "pod-d5a434f9-7dfb-11e8-bae1-da96248f62d7": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.007351529s
+STEP: Saw pod success
+Jul  2 13:28:42.950: INFO: Pod "pod-d5a434f9-7dfb-11e8-bae1-da96248f62d7" satisfied condition "success or failure"
+Jul  2 13:28:43.044: INFO: Trying to get logs from node ip-10-250-24-1.ec2.internal pod pod-d5a434f9-7dfb-11e8-bae1-da96248f62d7 container test-container: <nil>
+STEP: delete the pod
+Jul  2 13:28:43.085: INFO: Waiting for pod pod-d5a434f9-7dfb-11e8-bae1-da96248f62d7 to disappear
+Jul  2 13:28:43.090: INFO: Pod pod-d5a434f9-7dfb-11e8-bae1-da96248f62d7 no longer exists
+[AfterEach] [sig-storage] EmptyDir volumes
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:28:43.090: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-emptydir-ktkf5" for this suite.
+Jul  2 13:28:49.148: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:28:49.266: INFO: namespace: e2e-tests-emptydir-ktkf5, resource: bindings, ignored listing per whitelist
+Jul  2 13:28:49.348: INFO: namespace e2e-tests-emptydir-ktkf5 deletion completed in 6.254410663s
+
+• [SLOW TEST:8.516 seconds]
+[sig-storage] EmptyDir volumes
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/empty_dir.go:40
+  should support (non-root,0666,tmpfs) [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSS
+------------------------------
+[sig-api-machinery] Garbage collector 
+  should orphan RS created by deployment when deleteOptions.PropagationPolicy is Orphan [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-api-machinery] Garbage collector
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:28:49.348: INFO: >>> kubeConfig: /tmp/kubeconfig-411378559
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should orphan RS created by deployment when deleteOptions.PropagationPolicy is Orphan [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: create the deployment
+STEP: Wait for the Deployment to create new ReplicaSet
+STEP: delete the deployment
+STEP: wait for 30 seconds to see if the garbage collector mistakenly deletes the rs
+STEP: Gathering metrics
+W0702 13:29:19.967420      14 metrics_grabber.go:81] Master node is not registered. Grabbing metrics from Scheduler, ControllerManager and ClusterAutoscaler is disabled.
+Jul  2 13:29:19.967: INFO: For apiserver_request_count:
+For apiserver_request_latencies_summary:
+For etcd_helper_cache_entry_count:
+For etcd_helper_cache_hit_count:
+For etcd_helper_cache_miss_count:
+For etcd_request_cache_add_latencies_summary:
+For etcd_request_cache_get_latencies_summary:
+For etcd_request_latencies_summary:
+For garbage_collector_attempt_to_delete_queue_latency:
+For garbage_collector_attempt_to_delete_work_duration:
+For garbage_collector_attempt_to_orphan_queue_latency:
+For garbage_collector_attempt_to_orphan_work_duration:
+For garbage_collector_dirty_processing_latency_microseconds:
+For garbage_collector_event_processing_latency_microseconds:
+For garbage_collector_graph_changes_queue_latency:
+For garbage_collector_graph_changes_work_duration:
+For garbage_collector_orphan_processing_latency_microseconds:
+For namespace_queue_latency:
+For namespace_queue_latency_sum:
+For namespace_queue_latency_count:
+For namespace_retries:
+For namespace_work_duration:
+For namespace_work_duration_sum:
+For namespace_work_duration_count:
+For function_duration_seconds:
+For errors_total:
+For evicted_pods_total:
+
+[AfterEach] [sig-api-machinery] Garbage collector
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:29:19.967: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-gc-x6pvz" for this suite.
+Jul  2 13:29:25.981: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:29:26.054: INFO: namespace: e2e-tests-gc-x6pvz, resource: bindings, ignored listing per whitelist
+Jul  2 13:29:26.078: INFO: namespace e2e-tests-gc-x6pvz deletion completed in 6.107323647s
+
+• [SLOW TEST:36.729 seconds]
+[sig-api-machinery] Garbage collector
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apimachinery/framework.go:22
+  should orphan RS created by deployment when deleteOptions.PropagationPolicy is Orphan [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+[k8s.io] Variable Expansion 
+  should allow substituting values in a container's command [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [k8s.io] Variable Expansion
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:29:26.078: INFO: >>> kubeConfig: /tmp/kubeconfig-411378559
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should allow substituting values in a container's command [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating a pod to test substitution in container's command
+Jul  2 13:29:26.177: INFO: Waiting up to 5m0s for pod "var-expansion-f09a30ba-7dfb-11e8-bae1-da96248f62d7" in namespace "e2e-tests-var-expansion-dwfbp" to be "success or failure"
+Jul  2 13:29:26.181: INFO: Pod "var-expansion-f09a30ba-7dfb-11e8-bae1-da96248f62d7": Phase="Pending", Reason="", readiness=false. Elapsed: 3.907841ms
+Jul  2 13:29:28.185: INFO: Pod "var-expansion-f09a30ba-7dfb-11e8-bae1-da96248f62d7": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.007648717s
+STEP: Saw pod success
+Jul  2 13:29:28.185: INFO: Pod "var-expansion-f09a30ba-7dfb-11e8-bae1-da96248f62d7" satisfied condition "success or failure"
+Jul  2 13:29:28.188: INFO: Trying to get logs from node ip-10-250-24-1.ec2.internal pod var-expansion-f09a30ba-7dfb-11e8-bae1-da96248f62d7 container dapi-container: <nil>
+STEP: delete the pod
+Jul  2 13:29:28.208: INFO: Waiting for pod var-expansion-f09a30ba-7dfb-11e8-bae1-da96248f62d7 to disappear
+Jul  2 13:29:28.211: INFO: Pod var-expansion-f09a30ba-7dfb-11e8-bae1-da96248f62d7 no longer exists
+[AfterEach] [k8s.io] Variable Expansion
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:29:28.211: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-var-expansion-dwfbp" for this suite.
+Jul  2 13:29:34.250: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:29:34.324: INFO: namespace: e2e-tests-var-expansion-dwfbp, resource: bindings, ignored listing per whitelist
+Jul  2 13:29:34.350: INFO: namespace e2e-tests-var-expansion-dwfbp deletion completed in 6.120093318s
+
+• [SLOW TEST:8.272 seconds]
+[k8s.io] Variable Expansion
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:679
+  should allow substituting values in a container's command [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSSSSSSSSSSSSSS
+------------------------------
+[k8s.io] Pods 
+  should allow activeDeadlineSeconds to be updated [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [k8s.io] Pods
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:29:34.350: INFO: >>> kubeConfig: /tmp/kubeconfig-411378559
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [k8s.io] Pods
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/pods.go:127
+[It] should allow activeDeadlineSeconds to be updated [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: creating the pod
+STEP: submitting the pod to kubernetes
+STEP: verifying the pod is in kubernetes
+STEP: updating the pod
+Jul  2 13:29:37.054: INFO: Successfully updated pod "pod-update-activedeadlineseconds-f587b46b-7dfb-11e8-bae1-da96248f62d7"
+Jul  2 13:29:37.054: INFO: Waiting up to 5m0s for pod "pod-update-activedeadlineseconds-f587b46b-7dfb-11e8-bae1-da96248f62d7" in namespace "e2e-tests-pods-krpd6" to be "terminated due to deadline exceeded"
+Jul  2 13:29:37.057: INFO: Pod "pod-update-activedeadlineseconds-f587b46b-7dfb-11e8-bae1-da96248f62d7": Phase="Running", Reason="", readiness=true. Elapsed: 2.946018ms
+Jul  2 13:29:39.061: INFO: Pod "pod-update-activedeadlineseconds-f587b46b-7dfb-11e8-bae1-da96248f62d7": Phase="Running", Reason="", readiness=true. Elapsed: 2.006801077s
+Jul  2 13:29:41.064: INFO: Pod "pod-update-activedeadlineseconds-f587b46b-7dfb-11e8-bae1-da96248f62d7": Phase="Failed", Reason="DeadlineExceeded", readiness=false. Elapsed: 4.010366101s
+Jul  2 13:29:41.064: INFO: Pod "pod-update-activedeadlineseconds-f587b46b-7dfb-11e8-bae1-da96248f62d7" satisfied condition "terminated due to deadline exceeded"
+[AfterEach] [k8s.io] Pods
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:29:41.064: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-pods-krpd6" for this suite.
+Jul  2 13:29:47.158: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:29:47.301: INFO: namespace: e2e-tests-pods-krpd6, resource: bindings, ignored listing per whitelist
+Jul  2 13:29:47.336: INFO: namespace e2e-tests-pods-krpd6 deletion completed in 6.267931473s
+
+• [SLOW TEST:12.985 seconds]
+[k8s.io] Pods
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:679
+  should allow activeDeadlineSeconds to be updated [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSS
+------------------------------
+[sig-storage] EmptyDir volumes 
+  should support (root,0666,tmpfs) [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-storage] EmptyDir volumes
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:29:47.336: INFO: >>> kubeConfig: /tmp/kubeconfig-411378559
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should support (root,0666,tmpfs) [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating a pod to test emptydir 0666 on tmpfs
+Jul  2 13:29:47.436: INFO: Waiting up to 5m0s for pod "pod-fd465d20-7dfb-11e8-bae1-da96248f62d7" in namespace "e2e-tests-emptydir-vgxv9" to be "success or failure"
+Jul  2 13:29:47.439: INFO: Pod "pod-fd465d20-7dfb-11e8-bae1-da96248f62d7": Phase="Pending", Reason="", readiness=false. Elapsed: 3.326458ms
+Jul  2 13:29:49.442: INFO: Pod "pod-fd465d20-7dfb-11e8-bae1-da96248f62d7": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.006669493s
+STEP: Saw pod success
+Jul  2 13:29:49.443: INFO: Pod "pod-fd465d20-7dfb-11e8-bae1-da96248f62d7" satisfied condition "success or failure"
+Jul  2 13:29:49.445: INFO: Trying to get logs from node ip-10-250-24-1.ec2.internal pod pod-fd465d20-7dfb-11e8-bae1-da96248f62d7 container test-container: <nil>
+STEP: delete the pod
+Jul  2 13:29:49.563: INFO: Waiting for pod pod-fd465d20-7dfb-11e8-bae1-da96248f62d7 to disappear
+Jul  2 13:29:49.572: INFO: Pod pod-fd465d20-7dfb-11e8-bae1-da96248f62d7 no longer exists
+[AfterEach] [sig-storage] EmptyDir volumes
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:29:49.572: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-emptydir-vgxv9" for this suite.
+Jul  2 13:29:55.599: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:29:55.707: INFO: namespace: e2e-tests-emptydir-vgxv9, resource: bindings, ignored listing per whitelist
+Jul  2 13:29:55.730: INFO: namespace e2e-tests-emptydir-vgxv9 deletion completed in 6.149867313s
+
+• [SLOW TEST:8.395 seconds]
+[sig-storage] EmptyDir volumes
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/empty_dir.go:40
+  should support (root,0666,tmpfs) [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSS
+------------------------------
+[sig-storage] EmptyDir volumes 
+  volume on default medium should have the correct mode [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-storage] EmptyDir volumes
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:29:55.731: INFO: >>> kubeConfig: /tmp/kubeconfig-411378559
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] volume on default medium should have the correct mode [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating a pod to test emptydir volume type on node default medium
+Jul  2 13:29:55.821: INFO: Waiting up to 5m0s for pod "pod-0245ce1a-7dfc-11e8-bae1-da96248f62d7" in namespace "e2e-tests-emptydir-qk26c" to be "success or failure"
+Jul  2 13:29:55.823: INFO: Pod "pod-0245ce1a-7dfc-11e8-bae1-da96248f62d7": Phase="Pending", Reason="", readiness=false. Elapsed: 2.533341ms
+Jul  2 13:29:57.827: INFO: Pod "pod-0245ce1a-7dfc-11e8-bae1-da96248f62d7": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.006059831s
+STEP: Saw pod success
+Jul  2 13:29:57.827: INFO: Pod "pod-0245ce1a-7dfc-11e8-bae1-da96248f62d7" satisfied condition "success or failure"
+Jul  2 13:29:57.829: INFO: Trying to get logs from node ip-10-250-24-1.ec2.internal pod pod-0245ce1a-7dfc-11e8-bae1-da96248f62d7 container test-container: <nil>
+STEP: delete the pod
+Jul  2 13:29:57.846: INFO: Waiting for pod pod-0245ce1a-7dfc-11e8-bae1-da96248f62d7 to disappear
+Jul  2 13:29:57.850: INFO: Pod pod-0245ce1a-7dfc-11e8-bae1-da96248f62d7 no longer exists
+[AfterEach] [sig-storage] EmptyDir volumes
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:29:57.850: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-emptydir-qk26c" for this suite.
+Jul  2 13:30:03.950: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:30:04.015: INFO: namespace: e2e-tests-emptydir-qk26c, resource: bindings, ignored listing per whitelist
+Jul  2 13:30:04.185: INFO: namespace e2e-tests-emptydir-qk26c deletion completed in 6.331297068s
+
+• [SLOW TEST:8.454 seconds]
+[sig-storage] EmptyDir volumes
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/empty_dir.go:40
+  volume on default medium should have the correct mode [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+S
+------------------------------
+[sig-apps] Daemon set [Serial] 
+  should update pod when spec was updated and update strategy is RollingUpdate [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-apps] Daemon set [Serial]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:30:04.185: INFO: >>> kubeConfig: /tmp/kubeconfig-411378559
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-apps] Daemon set [Serial]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/daemon_set.go:99
+[It] should update pod when spec was updated and update strategy is RollingUpdate [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+Jul  2 13:30:04.314: INFO: Creating simple daemon set daemon-set
+STEP: Check that daemon pods launch on every node of the cluster.
+Jul  2 13:30:04.326: INFO: Number of nodes with available pods: 0
+Jul  2 13:30:04.326: INFO: Node ip-10-250-20-212.ec2.internal is running more than one daemon pod
+Jul  2 13:30:05.334: INFO: Number of nodes with available pods: 0
+Jul  2 13:30:05.334: INFO: Node ip-10-250-20-212.ec2.internal is running more than one daemon pod
+Jul  2 13:30:06.334: INFO: Number of nodes with available pods: 2
+Jul  2 13:30:06.334: INFO: Number of running nodes: 2, number of available pods: 2
+STEP: Update daemon pods image.
+STEP: Check that daemon pods images are updated.
+Jul  2 13:30:06.364: INFO: Wrong image for pod: daemon-set-ch4hz. Expected: gcr.io/kubernetes-e2e-test-images/redis-amd64:1.0, got: gcr.io/kubernetes-e2e-test-images/serve-hostname-amd64:1.0.
+Jul  2 13:30:06.364: INFO: Wrong image for pod: daemon-set-m86lt. Expected: gcr.io/kubernetes-e2e-test-images/redis-amd64:1.0, got: gcr.io/kubernetes-e2e-test-images/serve-hostname-amd64:1.0.
+Jul  2 13:30:07.372: INFO: Wrong image for pod: daemon-set-ch4hz. Expected: gcr.io/kubernetes-e2e-test-images/redis-amd64:1.0, got: gcr.io/kubernetes-e2e-test-images/serve-hostname-amd64:1.0.
+Jul  2 13:30:07.372: INFO: Wrong image for pod: daemon-set-m86lt. Expected: gcr.io/kubernetes-e2e-test-images/redis-amd64:1.0, got: gcr.io/kubernetes-e2e-test-images/serve-hostname-amd64:1.0.
+Jul  2 13:30:08.449: INFO: Wrong image for pod: daemon-set-ch4hz. Expected: gcr.io/kubernetes-e2e-test-images/redis-amd64:1.0, got: gcr.io/kubernetes-e2e-test-images/serve-hostname-amd64:1.0.
+Jul  2 13:30:08.449: INFO: Wrong image for pod: daemon-set-m86lt. Expected: gcr.io/kubernetes-e2e-test-images/redis-amd64:1.0, got: gcr.io/kubernetes-e2e-test-images/serve-hostname-amd64:1.0.
+Jul  2 13:30:09.372: INFO: Wrong image for pod: daemon-set-ch4hz. Expected: gcr.io/kubernetes-e2e-test-images/redis-amd64:1.0, got: gcr.io/kubernetes-e2e-test-images/serve-hostname-amd64:1.0.
+Jul  2 13:30:09.372: INFO: Pod daemon-set-ch4hz is not available
+Jul  2 13:30:09.372: INFO: Wrong image for pod: daemon-set-m86lt. Expected: gcr.io/kubernetes-e2e-test-images/redis-amd64:1.0, got: gcr.io/kubernetes-e2e-test-images/serve-hostname-amd64:1.0.
+Jul  2 13:30:10.372: INFO: Wrong image for pod: daemon-set-ch4hz. Expected: gcr.io/kubernetes-e2e-test-images/redis-amd64:1.0, got: gcr.io/kubernetes-e2e-test-images/serve-hostname-amd64:1.0.
+Jul  2 13:30:10.372: INFO: Pod daemon-set-ch4hz is not available
+Jul  2 13:30:10.372: INFO: Wrong image for pod: daemon-set-m86lt. Expected: gcr.io/kubernetes-e2e-test-images/redis-amd64:1.0, got: gcr.io/kubernetes-e2e-test-images/serve-hostname-amd64:1.0.
+Jul  2 13:30:11.372: INFO: Wrong image for pod: daemon-set-ch4hz. Expected: gcr.io/kubernetes-e2e-test-images/redis-amd64:1.0, got: gcr.io/kubernetes-e2e-test-images/serve-hostname-amd64:1.0.
+Jul  2 13:30:11.372: INFO: Pod daemon-set-ch4hz is not available
+Jul  2 13:30:11.372: INFO: Wrong image for pod: daemon-set-m86lt. Expected: gcr.io/kubernetes-e2e-test-images/redis-amd64:1.0, got: gcr.io/kubernetes-e2e-test-images/serve-hostname-amd64:1.0.
+Jul  2 13:30:12.373: INFO: Wrong image for pod: daemon-set-ch4hz. Expected: gcr.io/kubernetes-e2e-test-images/redis-amd64:1.0, got: gcr.io/kubernetes-e2e-test-images/serve-hostname-amd64:1.0.
+Jul  2 13:30:12.374: INFO: Pod daemon-set-ch4hz is not available
+Jul  2 13:30:12.374: INFO: Wrong image for pod: daemon-set-m86lt. Expected: gcr.io/kubernetes-e2e-test-images/redis-amd64:1.0, got: gcr.io/kubernetes-e2e-test-images/serve-hostname-amd64:1.0.
+Jul  2 13:30:13.372: INFO: Wrong image for pod: daemon-set-ch4hz. Expected: gcr.io/kubernetes-e2e-test-images/redis-amd64:1.0, got: gcr.io/kubernetes-e2e-test-images/serve-hostname-amd64:1.0.
+Jul  2 13:30:13.372: INFO: Pod daemon-set-ch4hz is not available
+Jul  2 13:30:13.372: INFO: Wrong image for pod: daemon-set-m86lt. Expected: gcr.io/kubernetes-e2e-test-images/redis-amd64:1.0, got: gcr.io/kubernetes-e2e-test-images/serve-hostname-amd64:1.0.
+Jul  2 13:30:14.372: INFO: Wrong image for pod: daemon-set-ch4hz. Expected: gcr.io/kubernetes-e2e-test-images/redis-amd64:1.0, got: gcr.io/kubernetes-e2e-test-images/serve-hostname-amd64:1.0.
+Jul  2 13:30:14.372: INFO: Pod daemon-set-ch4hz is not available
+Jul  2 13:30:14.372: INFO: Wrong image for pod: daemon-set-m86lt. Expected: gcr.io/kubernetes-e2e-test-images/redis-amd64:1.0, got: gcr.io/kubernetes-e2e-test-images/serve-hostname-amd64:1.0.
+Jul  2 13:30:15.372: INFO: Wrong image for pod: daemon-set-ch4hz. Expected: gcr.io/kubernetes-e2e-test-images/redis-amd64:1.0, got: gcr.io/kubernetes-e2e-test-images/serve-hostname-amd64:1.0.
+Jul  2 13:30:15.372: INFO: Pod daemon-set-ch4hz is not available
+Jul  2 13:30:15.372: INFO: Wrong image for pod: daemon-set-m86lt. Expected: gcr.io/kubernetes-e2e-test-images/redis-amd64:1.0, got: gcr.io/kubernetes-e2e-test-images/serve-hostname-amd64:1.0.
+Jul  2 13:30:16.372: INFO: Wrong image for pod: daemon-set-ch4hz. Expected: gcr.io/kubernetes-e2e-test-images/redis-amd64:1.0, got: gcr.io/kubernetes-e2e-test-images/serve-hostname-amd64:1.0.
+Jul  2 13:30:16.372: INFO: Pod daemon-set-ch4hz is not available
+Jul  2 13:30:16.372: INFO: Wrong image for pod: daemon-set-m86lt. Expected: gcr.io/kubernetes-e2e-test-images/redis-amd64:1.0, got: gcr.io/kubernetes-e2e-test-images/serve-hostname-amd64:1.0.
+Jul  2 13:30:17.372: INFO: Wrong image for pod: daemon-set-ch4hz. Expected: gcr.io/kubernetes-e2e-test-images/redis-amd64:1.0, got: gcr.io/kubernetes-e2e-test-images/serve-hostname-amd64:1.0.
+Jul  2 13:30:17.372: INFO: Pod daemon-set-ch4hz is not available
+Jul  2 13:30:17.372: INFO: Wrong image for pod: daemon-set-m86lt. Expected: gcr.io/kubernetes-e2e-test-images/redis-amd64:1.0, got: gcr.io/kubernetes-e2e-test-images/serve-hostname-amd64:1.0.
+Jul  2 13:30:18.372: INFO: Wrong image for pod: daemon-set-ch4hz. Expected: gcr.io/kubernetes-e2e-test-images/redis-amd64:1.0, got: gcr.io/kubernetes-e2e-test-images/serve-hostname-amd64:1.0.
+Jul  2 13:30:18.372: INFO: Pod daemon-set-ch4hz is not available
+Jul  2 13:30:18.372: INFO: Wrong image for pod: daemon-set-m86lt. Expected: gcr.io/kubernetes-e2e-test-images/redis-amd64:1.0, got: gcr.io/kubernetes-e2e-test-images/serve-hostname-amd64:1.0.
+Jul  2 13:30:19.372: INFO: Wrong image for pod: daemon-set-ch4hz. Expected: gcr.io/kubernetes-e2e-test-images/redis-amd64:1.0, got: gcr.io/kubernetes-e2e-test-images/serve-hostname-amd64:1.0.
+Jul  2 13:30:19.372: INFO: Pod daemon-set-ch4hz is not available
+Jul  2 13:30:19.372: INFO: Wrong image for pod: daemon-set-m86lt. Expected: gcr.io/kubernetes-e2e-test-images/redis-amd64:1.0, got: gcr.io/kubernetes-e2e-test-images/serve-hostname-amd64:1.0.
+Jul  2 13:30:20.371: INFO: Pod daemon-set-66smt is not available
+Jul  2 13:30:20.371: INFO: Wrong image for pod: daemon-set-m86lt. Expected: gcr.io/kubernetes-e2e-test-images/redis-amd64:1.0, got: gcr.io/kubernetes-e2e-test-images/serve-hostname-amd64:1.0.
+Jul  2 13:30:21.372: INFO: Pod daemon-set-66smt is not available
+Jul  2 13:30:21.372: INFO: Wrong image for pod: daemon-set-m86lt. Expected: gcr.io/kubernetes-e2e-test-images/redis-amd64:1.0, got: gcr.io/kubernetes-e2e-test-images/serve-hostname-amd64:1.0.
+Jul  2 13:30:22.372: INFO: Pod daemon-set-66smt is not available
+Jul  2 13:30:22.372: INFO: Wrong image for pod: daemon-set-m86lt. Expected: gcr.io/kubernetes-e2e-test-images/redis-amd64:1.0, got: gcr.io/kubernetes-e2e-test-images/serve-hostname-amd64:1.0.
+Jul  2 13:30:23.373: INFO: Wrong image for pod: daemon-set-m86lt. Expected: gcr.io/kubernetes-e2e-test-images/redis-amd64:1.0, got: gcr.io/kubernetes-e2e-test-images/serve-hostname-amd64:1.0.
+Jul  2 13:30:24.372: INFO: Wrong image for pod: daemon-set-m86lt. Expected: gcr.io/kubernetes-e2e-test-images/redis-amd64:1.0, got: gcr.io/kubernetes-e2e-test-images/serve-hostname-amd64:1.0.
+Jul  2 13:30:24.372: INFO: Pod daemon-set-m86lt is not available
+Jul  2 13:30:25.372: INFO: Wrong image for pod: daemon-set-m86lt. Expected: gcr.io/kubernetes-e2e-test-images/redis-amd64:1.0, got: gcr.io/kubernetes-e2e-test-images/serve-hostname-amd64:1.0.
+Jul  2 13:30:25.372: INFO: Pod daemon-set-m86lt is not available
+Jul  2 13:30:26.372: INFO: Wrong image for pod: daemon-set-m86lt. Expected: gcr.io/kubernetes-e2e-test-images/redis-amd64:1.0, got: gcr.io/kubernetes-e2e-test-images/serve-hostname-amd64:1.0.
+Jul  2 13:30:26.372: INFO: Pod daemon-set-m86lt is not available
+Jul  2 13:30:27.372: INFO: Wrong image for pod: daemon-set-m86lt. Expected: gcr.io/kubernetes-e2e-test-images/redis-amd64:1.0, got: gcr.io/kubernetes-e2e-test-images/serve-hostname-amd64:1.0.
+Jul  2 13:30:27.372: INFO: Pod daemon-set-m86lt is not available
+Jul  2 13:30:28.372: INFO: Wrong image for pod: daemon-set-m86lt. Expected: gcr.io/kubernetes-e2e-test-images/redis-amd64:1.0, got: gcr.io/kubernetes-e2e-test-images/serve-hostname-amd64:1.0.
+Jul  2 13:30:28.372: INFO: Pod daemon-set-m86lt is not available
+Jul  2 13:30:29.373: INFO: Pod daemon-set-q6ltp is not available
+STEP: Check that daemon pods are still running on every node of the cluster.
+Jul  2 13:30:29.383: INFO: Number of nodes with available pods: 1
+Jul  2 13:30:29.383: INFO: Node ip-10-250-24-1.ec2.internal is running more than one daemon pod
+Jul  2 13:30:30.455: INFO: Number of nodes with available pods: 1
+Jul  2 13:30:30.455: INFO: Node ip-10-250-24-1.ec2.internal is running more than one daemon pod
+Jul  2 13:30:31.391: INFO: Number of nodes with available pods: 2
+Jul  2 13:30:31.391: INFO: Number of running nodes: 2, number of available pods: 2
+[AfterEach] [sig-apps] Daemon set [Serial]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/daemon_set.go:65
+STEP: Deleting DaemonSet "daemon-set"
+STEP: deleting {extensions DaemonSet} daemon-set in namespace e2e-tests-daemonsets-zjpc4, will wait for the garbage collector to delete the pods
+Jul  2 13:30:31.466: INFO: Deleting {extensions DaemonSet} daemon-set took: 5.812605ms
+Jul  2 13:30:31.566: INFO: Terminating {extensions DaemonSet} daemon-set pods took: 100.223286ms
+Jul  2 13:30:40.270: INFO: Number of nodes with available pods: 0
+Jul  2 13:30:40.270: INFO: Number of running nodes: 0, number of available pods: 0
+Jul  2 13:30:40.273: INFO: daemonset: {"kind":"DaemonSetList","apiVersion":"apps/v1","metadata":{"selfLink":"/apis/apps/v1/namespaces/e2e-tests-daemonsets-zjpc4/daemonsets","resourceVersion":"9622"},"items":null}
+
+Jul  2 13:30:40.276: INFO: pods: {"kind":"PodList","apiVersion":"v1","metadata":{"selfLink":"/api/v1/namespaces/e2e-tests-daemonsets-zjpc4/pods","resourceVersion":"9622"},"items":null}
+
+[AfterEach] [sig-apps] Daemon set [Serial]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:30:40.285: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-daemonsets-zjpc4" for this suite.
+Jul  2 13:30:46.299: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:30:46.350: INFO: namespace: e2e-tests-daemonsets-zjpc4, resource: bindings, ignored listing per whitelist
+Jul  2 13:30:46.398: INFO: namespace e2e-tests-daemonsets-zjpc4 deletion completed in 6.109457247s
+
+• [SLOW TEST:42.213 seconds]
+[sig-apps] Daemon set [Serial]
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/framework.go:22
+  should update pod when spec was updated and update strategy is RollingUpdate [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSSSSSSSSSSS
+------------------------------
+[sig-storage] Downward API volume 
+  should provide container's memory request [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:30:46.398: INFO: >>> kubeConfig: /tmp/kubeconfig-411378559
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downwardapi_volume.go:38
+[It] should provide container's memory request [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating a pod to test downward API volume plugin
+Jul  2 13:30:46.493: INFO: Waiting up to 5m0s for pod "downwardapi-volume-2079ceec-7dfc-11e8-bae1-da96248f62d7" in namespace "e2e-tests-downward-api-bk4zr" to be "success or failure"
+Jul  2 13:30:46.496: INFO: Pod "downwardapi-volume-2079ceec-7dfc-11e8-bae1-da96248f62d7": Phase="Pending", Reason="", readiness=false. Elapsed: 2.852113ms
+Jul  2 13:30:48.500: INFO: Pod "downwardapi-volume-2079ceec-7dfc-11e8-bae1-da96248f62d7": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.006783705s
+STEP: Saw pod success
+Jul  2 13:30:48.500: INFO: Pod "downwardapi-volume-2079ceec-7dfc-11e8-bae1-da96248f62d7" satisfied condition "success or failure"
+Jul  2 13:30:48.503: INFO: Trying to get logs from node ip-10-250-24-1.ec2.internal pod downwardapi-volume-2079ceec-7dfc-11e8-bae1-da96248f62d7 container client-container: <nil>
+STEP: delete the pod
+Jul  2 13:30:48.520: INFO: Waiting for pod downwardapi-volume-2079ceec-7dfc-11e8-bae1-da96248f62d7 to disappear
+Jul  2 13:30:48.524: INFO: Pod downwardapi-volume-2079ceec-7dfc-11e8-bae1-da96248f62d7 no longer exists
+[AfterEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:30:48.524: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-downward-api-bk4zr" for this suite.
+Jul  2 13:30:54.548: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:30:54.690: INFO: namespace: e2e-tests-downward-api-bk4zr, resource: bindings, ignored listing per whitelist
+Jul  2 13:30:54.738: INFO: namespace e2e-tests-downward-api-bk4zr deletion completed in 6.210511442s
+
+• [SLOW TEST:8.340 seconds]
+[sig-storage] Downward API volume
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downwardapi_volume.go:33
+  should provide container's memory request [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSSSSSSSSSSS
+------------------------------
+[sig-storage] EmptyDir volumes 
+  should support (root,0644,default) [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-storage] EmptyDir volumes
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:30:54.738: INFO: >>> kubeConfig: /tmp/kubeconfig-411378559
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should support (root,0644,default) [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating a pod to test emptydir 0644 on node default medium
+Jul  2 13:30:54.829: INFO: Waiting up to 5m0s for pod "pod-2571d756-7dfc-11e8-bae1-da96248f62d7" in namespace "e2e-tests-emptydir-f2f5g" to be "success or failure"
+Jul  2 13:30:54.832: INFO: Pod "pod-2571d756-7dfc-11e8-bae1-da96248f62d7": Phase="Pending", Reason="", readiness=false. Elapsed: 2.737991ms
+Jul  2 13:30:56.836: INFO: Pod "pod-2571d756-7dfc-11e8-bae1-da96248f62d7": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.006469973s
+STEP: Saw pod success
+Jul  2 13:30:56.836: INFO: Pod "pod-2571d756-7dfc-11e8-bae1-da96248f62d7" satisfied condition "success or failure"
+Jul  2 13:30:56.839: INFO: Trying to get logs from node ip-10-250-24-1.ec2.internal pod pod-2571d756-7dfc-11e8-bae1-da96248f62d7 container test-container: <nil>
+STEP: delete the pod
+Jul  2 13:30:56.863: INFO: Waiting for pod pod-2571d756-7dfc-11e8-bae1-da96248f62d7 to disappear
+Jul  2 13:30:56.866: INFO: Pod pod-2571d756-7dfc-11e8-bae1-da96248f62d7 no longer exists
+[AfterEach] [sig-storage] EmptyDir volumes
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:30:56.866: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-emptydir-f2f5g" for this suite.
+Jul  2 13:31:02.890: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:31:02.928: INFO: namespace: e2e-tests-emptydir-f2f5g, resource: bindings, ignored listing per whitelist
+Jul  2 13:31:03.003: INFO: namespace e2e-tests-emptydir-f2f5g deletion completed in 6.125121751s
+
+• [SLOW TEST:8.265 seconds]
+[sig-storage] EmptyDir volumes
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/empty_dir.go:40
+  should support (root,0644,default) [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSS
+------------------------------
+[sig-storage] Downward API volume 
+  should provide podname only [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:31:03.003: INFO: >>> kubeConfig: /tmp/kubeconfig-411378559
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downwardapi_volume.go:38
+[It] should provide podname only [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating a pod to test downward API volume plugin
+Jul  2 13:31:03.103: INFO: Waiting up to 5m0s for pod "downwardapi-volume-2a60205b-7dfc-11e8-bae1-da96248f62d7" in namespace "e2e-tests-downward-api-2s7v9" to be "success or failure"
+Jul  2 13:31:03.107: INFO: Pod "downwardapi-volume-2a60205b-7dfc-11e8-bae1-da96248f62d7": Phase="Pending", Reason="", readiness=false. Elapsed: 3.744499ms
+Jul  2 13:31:05.110: INFO: Pod "downwardapi-volume-2a60205b-7dfc-11e8-bae1-da96248f62d7": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.007662557s
+STEP: Saw pod success
+Jul  2 13:31:05.110: INFO: Pod "downwardapi-volume-2a60205b-7dfc-11e8-bae1-da96248f62d7" satisfied condition "success or failure"
+Jul  2 13:31:05.113: INFO: Trying to get logs from node ip-10-250-24-1.ec2.internal pod downwardapi-volume-2a60205b-7dfc-11e8-bae1-da96248f62d7 container client-container: <nil>
+STEP: delete the pod
+Jul  2 13:31:05.164: INFO: Waiting for pod downwardapi-volume-2a60205b-7dfc-11e8-bae1-da96248f62d7 to disappear
+Jul  2 13:31:05.169: INFO: Pod downwardapi-volume-2a60205b-7dfc-11e8-bae1-da96248f62d7 no longer exists
+[AfterEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:31:05.169: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-downward-api-2s7v9" for this suite.
+Jul  2 13:31:11.187: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:31:11.256: INFO: namespace: e2e-tests-downward-api-2s7v9, resource: bindings, ignored listing per whitelist
+Jul  2 13:31:11.341: INFO: namespace e2e-tests-downward-api-2s7v9 deletion completed in 6.168879946s
+
+• [SLOW TEST:8.338 seconds]
+[sig-storage] Downward API volume
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downwardapi_volume.go:33
+  should provide podname only [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSS
+------------------------------
+[sig-storage] Projected 
+  should set DefaultMode on files [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:31:11.342: INFO: >>> kubeConfig: /tmp/kubeconfig-411378559
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:858
+[It] should set DefaultMode on files [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating a pod to test downward API volume plugin
+Jul  2 13:31:11.439: INFO: Waiting up to 5m0s for pod "downwardapi-volume-2f57998f-7dfc-11e8-bae1-da96248f62d7" in namespace "e2e-tests-projected-cj826" to be "success or failure"
+Jul  2 13:31:11.448: INFO: Pod "downwardapi-volume-2f57998f-7dfc-11e8-bae1-da96248f62d7": Phase="Pending", Reason="", readiness=false. Elapsed: 9.195347ms
+Jul  2 13:31:13.452: INFO: Pod "downwardapi-volume-2f57998f-7dfc-11e8-bae1-da96248f62d7": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.013053403s
+STEP: Saw pod success
+Jul  2 13:31:13.452: INFO: Pod "downwardapi-volume-2f57998f-7dfc-11e8-bae1-da96248f62d7" satisfied condition "success or failure"
+Jul  2 13:31:13.455: INFO: Trying to get logs from node ip-10-250-24-1.ec2.internal pod downwardapi-volume-2f57998f-7dfc-11e8-bae1-da96248f62d7 container client-container: <nil>
+STEP: delete the pod
+Jul  2 13:31:13.475: INFO: Waiting for pod downwardapi-volume-2f57998f-7dfc-11e8-bae1-da96248f62d7 to disappear
+Jul  2 13:31:13.478: INFO: Pod downwardapi-volume-2f57998f-7dfc-11e8-bae1-da96248f62d7 no longer exists
+[AfterEach] [sig-storage] Projected
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:31:13.478: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-cj826" for this suite.
+Jul  2 13:31:19.547: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:31:19.604: INFO: namespace: e2e-tests-projected-cj826, resource: bindings, ignored listing per whitelist
+Jul  2 13:31:19.646: INFO: namespace e2e-tests-projected-cj826 deletion completed in 6.135737071s
+
+• [SLOW TEST:8.304 seconds]
+[sig-storage] Projected
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:34
+  should set DefaultMode on files [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+S
+------------------------------
+[sig-storage] EmptyDir volumes 
+  should support (non-root,0777,default) [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-storage] EmptyDir volumes
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:31:19.646: INFO: >>> kubeConfig: /tmp/kubeconfig-411378559
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should support (non-root,0777,default) [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating a pod to test emptydir 0777 on node default medium
+Jul  2 13:31:19.750: INFO: Waiting up to 5m0s for pod "pod-344c521c-7dfc-11e8-bae1-da96248f62d7" in namespace "e2e-tests-emptydir-mjl85" to be "success or failure"
+Jul  2 13:31:19.753: INFO: Pod "pod-344c521c-7dfc-11e8-bae1-da96248f62d7": Phase="Pending", Reason="", readiness=false. Elapsed: 3.549308ms
+Jul  2 13:31:21.757: INFO: Pod "pod-344c521c-7dfc-11e8-bae1-da96248f62d7": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.007299627s
+STEP: Saw pod success
+Jul  2 13:31:21.757: INFO: Pod "pod-344c521c-7dfc-11e8-bae1-da96248f62d7" satisfied condition "success or failure"
+Jul  2 13:31:21.844: INFO: Trying to get logs from node ip-10-250-24-1.ec2.internal pod pod-344c521c-7dfc-11e8-bae1-da96248f62d7 container test-container: <nil>
+STEP: delete the pod
+Jul  2 13:31:21.865: INFO: Waiting for pod pod-344c521c-7dfc-11e8-bae1-da96248f62d7 to disappear
+Jul  2 13:31:21.868: INFO: Pod pod-344c521c-7dfc-11e8-bae1-da96248f62d7 no longer exists
+[AfterEach] [sig-storage] EmptyDir volumes
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:31:21.868: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-emptydir-mjl85" for this suite.
+Jul  2 13:31:27.882: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:31:27.894: INFO: namespace: e2e-tests-emptydir-mjl85, resource: bindings, ignored listing per whitelist
+Jul  2 13:31:28.053: INFO: namespace e2e-tests-emptydir-mjl85 deletion completed in 6.1812143s
+
+• [SLOW TEST:8.407 seconds]
+[sig-storage] EmptyDir volumes
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/empty_dir.go:40
+  should support (non-root,0777,default) [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSSSS
+------------------------------
+[k8s.io] Probing container 
+  should have monotonically increasing restart count [Slow][NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [k8s.io] Probing container
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:31:28.053: INFO: >>> kubeConfig: /tmp/kubeconfig-411378559
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [k8s.io] Probing container
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/container_probe.go:48
+[It] should have monotonically increasing restart count [Slow][NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating pod liveness-http in namespace e2e-tests-container-probe-bj2wv
+Jul  2 13:31:30.160: INFO: Started pod liveness-http in namespace e2e-tests-container-probe-bj2wv
+STEP: checking the pod's current state and verifying that restartCount is present
+Jul  2 13:31:30.163: INFO: Initial restart count of pod liveness-http is 0
+Jul  2 13:31:48.253: INFO: Restart count of pod e2e-tests-container-probe-bj2wv/liveness-http is now 1 (18.090059676s elapsed)
+Jul  2 13:32:08.454: INFO: Restart count of pod e2e-tests-container-probe-bj2wv/liveness-http is now 2 (38.290908686s elapsed)
+Jul  2 13:32:28.651: INFO: Restart count of pod e2e-tests-container-probe-bj2wv/liveness-http is now 3 (58.487917014s elapsed)
+Jul  2 13:32:48.770: INFO: Restart count of pod e2e-tests-container-probe-bj2wv/liveness-http is now 4 (1m18.606561729s elapsed)
+Jul  2 13:33:59.151: INFO: Restart count of pod e2e-tests-container-probe-bj2wv/liveness-http is now 5 (2m28.987438801s elapsed)
+STEP: deleting the pod
+[AfterEach] [k8s.io] Probing container
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:33:59.162: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-container-probe-bj2wv" for this suite.
+Jul  2 13:34:05.249: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:34:05.310: INFO: namespace: e2e-tests-container-probe-bj2wv, resource: bindings, ignored listing per whitelist
+Jul  2 13:34:05.355: INFO: namespace e2e-tests-container-probe-bj2wv deletion completed in 6.188802369s
+
+• [SLOW TEST:157.302 seconds]
+[k8s.io] Probing container
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:679
+  should have monotonically increasing restart count [Slow][NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSSSSSSSSS
+------------------------------
+[sig-storage] Secrets 
+  should be consumable from pods in volume with defaultMode set [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-storage] Secrets
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:34:05.355: INFO: >>> kubeConfig: /tmp/kubeconfig-411378559
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should be consumable from pods in volume with defaultMode set [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating secret with name secret-test-9710df56-7dfc-11e8-bae1-da96248f62d7
+STEP: Creating a pod to test consume secrets
+Jul  2 13:34:05.458: INFO: Waiting up to 5m0s for pod "pod-secrets-9711703e-7dfc-11e8-bae1-da96248f62d7" in namespace "e2e-tests-secrets-xf8dc" to be "success or failure"
+Jul  2 13:34:05.461: INFO: Pod "pod-secrets-9711703e-7dfc-11e8-bae1-da96248f62d7": Phase="Pending", Reason="", readiness=false. Elapsed: 3.150661ms
+Jul  2 13:34:07.465: INFO: Pod "pod-secrets-9711703e-7dfc-11e8-bae1-da96248f62d7": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.006857046s
+STEP: Saw pod success
+Jul  2 13:34:07.465: INFO: Pod "pod-secrets-9711703e-7dfc-11e8-bae1-da96248f62d7" satisfied condition "success or failure"
+Jul  2 13:34:07.468: INFO: Trying to get logs from node ip-10-250-24-1.ec2.internal pod pod-secrets-9711703e-7dfc-11e8-bae1-da96248f62d7 container secret-volume-test: <nil>
+STEP: delete the pod
+Jul  2 13:34:07.555: INFO: Waiting for pod pod-secrets-9711703e-7dfc-11e8-bae1-da96248f62d7 to disappear
+Jul  2 13:34:07.568: INFO: Pod pod-secrets-9711703e-7dfc-11e8-bae1-da96248f62d7 no longer exists
+[AfterEach] [sig-storage] Secrets
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:34:07.568: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-secrets-xf8dc" for this suite.
+Jul  2 13:34:13.647: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:34:13.723: INFO: namespace: e2e-tests-secrets-xf8dc, resource: bindings, ignored listing per whitelist
+Jul  2 13:34:13.747: INFO: namespace e2e-tests-secrets-xf8dc deletion completed in 6.173754793s
+
+• [SLOW TEST:8.392 seconds]
+[sig-storage] Secrets
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/secrets_volume.go:33
+  should be consumable from pods in volume with defaultMode set [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSSSSSSSSSSSSSSSS
+------------------------------
+[sig-storage] Projected 
+  optional updates should be reflected in volume [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:34:13.747: INFO: >>> kubeConfig: /tmp/kubeconfig-411378559
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:858
+[It] optional updates should be reflected in volume [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating secret with name s-test-opt-del-9c114b03-7dfc-11e8-bae1-da96248f62d7
+STEP: Creating secret with name s-test-opt-upd-9c114b45-7dfc-11e8-bae1-da96248f62d7
+STEP: Creating the pod
+STEP: Deleting secret s-test-opt-del-9c114b03-7dfc-11e8-bae1-da96248f62d7
+STEP: Updating secret s-test-opt-upd-9c114b45-7dfc-11e8-bae1-da96248f62d7
+STEP: Creating secret with name s-test-opt-create-9c114b67-7dfc-11e8-bae1-da96248f62d7
+STEP: waiting to observe update in volume
+[AfterEach] [sig-storage] Projected
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:34:18.337: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-sgchv" for this suite.
+Jul  2 13:34:40.353: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:34:40.478: INFO: namespace: e2e-tests-projected-sgchv, resource: bindings, ignored listing per whitelist
+Jul  2 13:34:40.543: INFO: namespace e2e-tests-projected-sgchv deletion completed in 22.201666867s
+
+• [SLOW TEST:26.795 seconds]
+[sig-storage] Projected
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:34
+  optional updates should be reflected in volume [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSSSSSS
+------------------------------
+[sig-storage] Projected 
+  should be consumable from pods in volume as non-root [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:34:40.543: INFO: >>> kubeConfig: /tmp/kubeconfig-411378559
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:858
+[It] should be consumable from pods in volume as non-root [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating configMap with name projected-configmap-test-volume-ac096653-7dfc-11e8-bae1-da96248f62d7
+STEP: Creating a pod to test consume configMaps
+Jul  2 13:34:40.641: INFO: Waiting up to 5m0s for pod "pod-projected-configmaps-ac09eb50-7dfc-11e8-bae1-da96248f62d7" in namespace "e2e-tests-projected-pbk44" to be "success or failure"
+Jul  2 13:34:40.645: INFO: Pod "pod-projected-configmaps-ac09eb50-7dfc-11e8-bae1-da96248f62d7": Phase="Pending", Reason="", readiness=false. Elapsed: 3.815549ms
+Jul  2 13:34:42.649: INFO: Pod "pod-projected-configmaps-ac09eb50-7dfc-11e8-bae1-da96248f62d7": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.008223442s
+STEP: Saw pod success
+Jul  2 13:34:42.649: INFO: Pod "pod-projected-configmaps-ac09eb50-7dfc-11e8-bae1-da96248f62d7" satisfied condition "success or failure"
+Jul  2 13:34:42.655: INFO: Trying to get logs from node ip-10-250-24-1.ec2.internal pod pod-projected-configmaps-ac09eb50-7dfc-11e8-bae1-da96248f62d7 container projected-configmap-volume-test: <nil>
+STEP: delete the pod
+Jul  2 13:34:42.711: INFO: Waiting for pod pod-projected-configmaps-ac09eb50-7dfc-11e8-bae1-da96248f62d7 to disappear
+Jul  2 13:34:42.727: INFO: Pod pod-projected-configmaps-ac09eb50-7dfc-11e8-bae1-da96248f62d7 no longer exists
+[AfterEach] [sig-storage] Projected
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:34:42.729: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-pbk44" for this suite.
+Jul  2 13:34:48.751: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:34:48.790: INFO: namespace: e2e-tests-projected-pbk44, resource: bindings, ignored listing per whitelist
+Jul  2 13:34:48.849: INFO: namespace e2e-tests-projected-pbk44 deletion completed in 6.110643998s
+
+• [SLOW TEST:8.306 seconds]
+[sig-storage] Projected
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:34
+  should be consumable from pods in volume as non-root [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+[sig-apps] ReplicationController 
+  should serve a basic image on each replica with a public image  [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-apps] ReplicationController
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:34:48.849: INFO: >>> kubeConfig: /tmp/kubeconfig-411378559
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should serve a basic image on each replica with a public image  [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating replication controller my-hostname-basic-b0fc6021-7dfc-11e8-bae1-da96248f62d7
+Jul  2 13:34:48.942: INFO: Pod name my-hostname-basic-b0fc6021-7dfc-11e8-bae1-da96248f62d7: Found 0 pods out of 1
+Jul  2 13:34:53.947: INFO: Pod name my-hostname-basic-b0fc6021-7dfc-11e8-bae1-da96248f62d7: Found 1 pods out of 1
+Jul  2 13:34:53.947: INFO: Ensuring all pods for ReplicationController "my-hostname-basic-b0fc6021-7dfc-11e8-bae1-da96248f62d7" are running
+Jul  2 13:34:53.950: INFO: Pod "my-hostname-basic-b0fc6021-7dfc-11e8-bae1-da96248f62d7-tkbmg" is running (conditions: [{Type:Initialized Status:True LastProbeTime:0001-01-01 00:00:00 +0000 UTC LastTransitionTime:2018-07-02 13:34:48 +0000 UTC Reason: Message:} {Type:Ready Status:True LastProbeTime:0001-01-01 00:00:00 +0000 UTC LastTransitionTime:2018-07-02 13:34:50 +0000 UTC Reason: Message:} {Type:ContainersReady Status:True LastProbeTime:0001-01-01 00:00:00 +0000 UTC LastTransitionTime:0001-01-01 00:00:00 +0000 UTC Reason: Message:} {Type:PodScheduled Status:True LastProbeTime:0001-01-01 00:00:00 +0000 UTC LastTransitionTime:2018-07-02 13:34:48 +0000 UTC Reason: Message:}])
+Jul  2 13:34:53.950: INFO: Trying to dial the pod
+Jul  2 13:34:59.133: INFO: Controller my-hostname-basic-b0fc6021-7dfc-11e8-bae1-da96248f62d7: Got expected result from replica 1 [my-hostname-basic-b0fc6021-7dfc-11e8-bae1-da96248f62d7-tkbmg]: "my-hostname-basic-b0fc6021-7dfc-11e8-bae1-da96248f62d7-tkbmg", 1 of 1 required successes so far
+[AfterEach] [sig-apps] ReplicationController
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:34:59.133: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-replication-controller-5xrfp" for this suite.
+Jul  2 13:35:05.249: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:35:05.271: INFO: namespace: e2e-tests-replication-controller-5xrfp, resource: bindings, ignored listing per whitelist
+Jul  2 13:35:05.354: INFO: namespace e2e-tests-replication-controller-5xrfp deletion completed in 6.216588568s
+
+• [SLOW TEST:16.504 seconds]
+[sig-apps] ReplicationController
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/framework.go:22
+  should serve a basic image on each replica with a public image  [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSS
+------------------------------
+[sig-api-machinery] Downward API 
+  should provide pod name, namespace and IP address as env vars [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-api-machinery] Downward API
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:35:05.354: INFO: >>> kubeConfig: /tmp/kubeconfig-411378559
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should provide pod name, namespace and IP address as env vars [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating a pod to test downward api env vars
+Jul  2 13:35:05.454: INFO: Waiting up to 5m0s for pod "downward-api-bad3e914-7dfc-11e8-bae1-da96248f62d7" in namespace "e2e-tests-downward-api-cctt2" to be "success or failure"
+Jul  2 13:35:05.459: INFO: Pod "downward-api-bad3e914-7dfc-11e8-bae1-da96248f62d7": Phase="Pending", Reason="", readiness=false. Elapsed: 5.0079ms
+Jul  2 13:35:07.463: INFO: Pod "downward-api-bad3e914-7dfc-11e8-bae1-da96248f62d7": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.008893055s
+STEP: Saw pod success
+Jul  2 13:35:07.463: INFO: Pod "downward-api-bad3e914-7dfc-11e8-bae1-da96248f62d7" satisfied condition "success or failure"
+Jul  2 13:35:07.466: INFO: Trying to get logs from node ip-10-250-24-1.ec2.internal pod downward-api-bad3e914-7dfc-11e8-bae1-da96248f62d7 container dapi-container: <nil>
+STEP: delete the pod
+Jul  2 13:35:07.482: INFO: Waiting for pod downward-api-bad3e914-7dfc-11e8-bae1-da96248f62d7 to disappear
+Jul  2 13:35:07.488: INFO: Pod downward-api-bad3e914-7dfc-11e8-bae1-da96248f62d7 no longer exists
+[AfterEach] [sig-api-machinery] Downward API
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:35:07.488: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-downward-api-cctt2" for this suite.
+Jul  2 13:35:13.509: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:35:13.544: INFO: namespace: e2e-tests-downward-api-cctt2, resource: bindings, ignored listing per whitelist
+Jul  2 13:35:13.611: INFO: namespace e2e-tests-downward-api-cctt2 deletion completed in 6.115883115s
+
+• [SLOW TEST:8.257 seconds]
+[sig-api-machinery] Downward API
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downward_api.go:37
+  should provide pod name, namespace and IP address as env vars [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSSSSSSSSSSSSSSSSSSS
+------------------------------
+[sig-network] Networking Granular Checks: Pods 
+  should function for node-pod communication: http [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-network] Networking
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:35:13.612: INFO: >>> kubeConfig: /tmp/kubeconfig-411378559
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should function for node-pod communication: http [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Performing setup for networking test in namespace e2e-tests-pod-network-test-8ccpz
+STEP: creating a selector
+STEP: Creating the service pods in kubernetes
+Jul  2 13:35:13.701: INFO: Waiting up to 10m0s for all (but 0) nodes to be schedulable
+STEP: Creating test pods
+Jul  2 13:35:31.767: INFO: ExecWithOptions {Command:[/bin/sh -c timeout -t 15 curl -g -q -s --connect-timeout 1 http://100.96.0.29:8080/hostName | grep -v '^\s*$'] Namespace:e2e-tests-pod-network-test-8ccpz PodName:host-test-container-pod ContainerName:hostexec Stdin:<nil> CaptureStdout:true CaptureStderr:true PreserveWhitespace:false}
+Jul  2 13:35:31.767: INFO: >>> kubeConfig: /tmp/kubeconfig-411378559
+Jul  2 13:35:32.141: INFO: Found all expected endpoints: [netserver-0]
+Jul  2 13:35:32.146: INFO: ExecWithOptions {Command:[/bin/sh -c timeout -t 15 curl -g -q -s --connect-timeout 1 http://100.96.1.154:8080/hostName | grep -v '^\s*$'] Namespace:e2e-tests-pod-network-test-8ccpz PodName:host-test-container-pod ContainerName:hostexec Stdin:<nil> CaptureStdout:true CaptureStderr:true PreserveWhitespace:false}
+Jul  2 13:35:32.146: INFO: >>> kubeConfig: /tmp/kubeconfig-411378559
+Jul  2 13:35:32.523: INFO: Found all expected endpoints: [netserver-1]
+[AfterEach] [sig-network] Networking
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:35:32.523: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-pod-network-test-8ccpz" for this suite.
+Jul  2 13:35:54.556: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:35:54.697: INFO: namespace: e2e-tests-pod-network-test-8ccpz, resource: bindings, ignored listing per whitelist
+Jul  2 13:35:54.735: INFO: namespace e2e-tests-pod-network-test-8ccpz deletion completed in 22.207470955s
+
+• [SLOW TEST:41.123 seconds]
+[sig-network] Networking
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/networking.go:25
+  Granular Checks: Pods
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/networking.go:28
+    should function for node-pod communication: http [NodeConformance] [Conformance]
+    /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+S
+------------------------------
+[sig-storage] Secrets 
+  should be consumable from pods in volume as non-root with defaultMode and fsGroup set [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-storage] Secrets
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:35:54.735: INFO: >>> kubeConfig: /tmp/kubeconfig-411378559
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should be consumable from pods in volume as non-root with defaultMode and fsGroup set [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating secret with name secret-test-d842e3fa-7dfc-11e8-bae1-da96248f62d7
+STEP: Creating a pod to test consume secrets
+Jul  2 13:35:54.837: INFO: Waiting up to 5m0s for pod "pod-secrets-d8436ff1-7dfc-11e8-bae1-da96248f62d7" in namespace "e2e-tests-secrets-bzw75" to be "success or failure"
+Jul  2 13:35:54.841: INFO: Pod "pod-secrets-d8436ff1-7dfc-11e8-bae1-da96248f62d7": Phase="Pending", Reason="", readiness=false. Elapsed: 3.666723ms
+Jul  2 13:35:56.845: INFO: Pod "pod-secrets-d8436ff1-7dfc-11e8-bae1-da96248f62d7": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.007486719s
+STEP: Saw pod success
+Jul  2 13:35:56.845: INFO: Pod "pod-secrets-d8436ff1-7dfc-11e8-bae1-da96248f62d7" satisfied condition "success or failure"
+Jul  2 13:35:56.848: INFO: Trying to get logs from node ip-10-250-24-1.ec2.internal pod pod-secrets-d8436ff1-7dfc-11e8-bae1-da96248f62d7 container secret-volume-test: <nil>
+STEP: delete the pod
+Jul  2 13:35:56.874: INFO: Waiting for pod pod-secrets-d8436ff1-7dfc-11e8-bae1-da96248f62d7 to disappear
+Jul  2 13:35:56.878: INFO: Pod pod-secrets-d8436ff1-7dfc-11e8-bae1-da96248f62d7 no longer exists
+[AfterEach] [sig-storage] Secrets
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:35:56.878: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-secrets-bzw75" for this suite.
+Jul  2 13:36:02.947: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:36:03.017: INFO: namespace: e2e-tests-secrets-bzw75, resource: bindings, ignored listing per whitelist
+Jul  2 13:36:03.056: INFO: namespace e2e-tests-secrets-bzw75 deletion completed in 6.173784588s
+
+• [SLOW TEST:8.321 seconds]
+[sig-storage] Secrets
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/secrets_volume.go:33
+  should be consumable from pods in volume as non-root with defaultMode and fsGroup set [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSSSSSSS
+------------------------------
+[sig-storage] Projected 
+  should be consumable from pods in volume [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:36:03.056: INFO: >>> kubeConfig: /tmp/kubeconfig-411378559
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:858
+[It] should be consumable from pods in volume [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating configMap with name projected-configmap-test-volume-dd37c47d-7dfc-11e8-bae1-da96248f62d7
+STEP: Creating a pod to test consume configMaps
+Jul  2 13:36:03.153: INFO: Waiting up to 5m0s for pod "pod-projected-configmaps-dd384667-7dfc-11e8-bae1-da96248f62d7" in namespace "e2e-tests-projected-bp599" to be "success or failure"
+Jul  2 13:36:03.156: INFO: Pod "pod-projected-configmaps-dd384667-7dfc-11e8-bae1-da96248f62d7": Phase="Pending", Reason="", readiness=false. Elapsed: 2.968055ms
+Jul  2 13:36:05.160: INFO: Pod "pod-projected-configmaps-dd384667-7dfc-11e8-bae1-da96248f62d7": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.006642496s
+STEP: Saw pod success
+Jul  2 13:36:05.160: INFO: Pod "pod-projected-configmaps-dd384667-7dfc-11e8-bae1-da96248f62d7" satisfied condition "success or failure"
+Jul  2 13:36:05.163: INFO: Trying to get logs from node ip-10-250-24-1.ec2.internal pod pod-projected-configmaps-dd384667-7dfc-11e8-bae1-da96248f62d7 container projected-configmap-volume-test: <nil>
+STEP: delete the pod
+Jul  2 13:36:05.181: INFO: Waiting for pod pod-projected-configmaps-dd384667-7dfc-11e8-bae1-da96248f62d7 to disappear
+Jul  2 13:36:05.185: INFO: Pod pod-projected-configmaps-dd384667-7dfc-11e8-bae1-da96248f62d7 no longer exists
+[AfterEach] [sig-storage] Projected
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:36:05.193: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-bp599" for this suite.
+Jul  2 13:36:11.246: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:36:11.302: INFO: namespace: e2e-tests-projected-bp599, resource: bindings, ignored listing per whitelist
+Jul  2 13:36:11.349: INFO: namespace e2e-tests-projected-bp599 deletion completed in 6.152117872s
+
+• [SLOW TEST:8.293 seconds]
+[sig-storage] Projected
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:34
+  should be consumable from pods in volume [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+S
+------------------------------
+[k8s.io] KubeletManagedEtcHosts 
+  should test kubelet managed /etc/hosts file [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [k8s.io] KubeletManagedEtcHosts
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:36:11.349: INFO: >>> kubeConfig: /tmp/kubeconfig-411378559
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should test kubelet managed /etc/hosts file [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Setting up the test
+STEP: Creating hostNetwork=false pod
+STEP: Creating hostNetwork=true pod
+STEP: Running the test
+STEP: Verifying /etc/hosts of container is kubelet-managed for pod with hostNetwork=false
+Jul  2 13:36:15.656: INFO: ExecWithOptions {Command:[cat /etc/hosts] Namespace:e2e-tests-e2e-kubelet-etc-hosts-sl2qt PodName:test-pod ContainerName:busybox-1 Stdin:<nil> CaptureStdout:true CaptureStderr:true PreserveWhitespace:false}
+Jul  2 13:36:15.656: INFO: >>> kubeConfig: /tmp/kubeconfig-411378559
+Jul  2 13:36:16.009: INFO: Exec stderr: ""
+Jul  2 13:36:16.009: INFO: ExecWithOptions {Command:[cat /etc/hosts-original] Namespace:e2e-tests-e2e-kubelet-etc-hosts-sl2qt PodName:test-pod ContainerName:busybox-1 Stdin:<nil> CaptureStdout:true CaptureStderr:true PreserveWhitespace:false}
+Jul  2 13:36:16.009: INFO: >>> kubeConfig: /tmp/kubeconfig-411378559
+Jul  2 13:36:16.408: INFO: Exec stderr: ""
+Jul  2 13:36:16.408: INFO: ExecWithOptions {Command:[cat /etc/hosts] Namespace:e2e-tests-e2e-kubelet-etc-hosts-sl2qt PodName:test-pod ContainerName:busybox-2 Stdin:<nil> CaptureStdout:true CaptureStderr:true PreserveWhitespace:false}
+Jul  2 13:36:16.408: INFO: >>> kubeConfig: /tmp/kubeconfig-411378559
+Jul  2 13:36:16.807: INFO: Exec stderr: ""
+Jul  2 13:36:16.807: INFO: ExecWithOptions {Command:[cat /etc/hosts-original] Namespace:e2e-tests-e2e-kubelet-etc-hosts-sl2qt PodName:test-pod ContainerName:busybox-2 Stdin:<nil> CaptureStdout:true CaptureStderr:true PreserveWhitespace:false}
+Jul  2 13:36:16.807: INFO: >>> kubeConfig: /tmp/kubeconfig-411378559
+Jul  2 13:36:17.216: INFO: Exec stderr: ""
+STEP: Verifying /etc/hosts of container is not kubelet-managed since container specifies /etc/hosts mount
+Jul  2 13:36:17.216: INFO: ExecWithOptions {Command:[cat /etc/hosts] Namespace:e2e-tests-e2e-kubelet-etc-hosts-sl2qt PodName:test-pod ContainerName:busybox-3 Stdin:<nil> CaptureStdout:true CaptureStderr:true PreserveWhitespace:false}
+Jul  2 13:36:17.217: INFO: >>> kubeConfig: /tmp/kubeconfig-411378559
+Jul  2 13:36:17.642: INFO: Exec stderr: ""
+Jul  2 13:36:17.643: INFO: ExecWithOptions {Command:[cat /etc/hosts-original] Namespace:e2e-tests-e2e-kubelet-etc-hosts-sl2qt PodName:test-pod ContainerName:busybox-3 Stdin:<nil> CaptureStdout:true CaptureStderr:true PreserveWhitespace:false}
+Jul  2 13:36:17.643: INFO: >>> kubeConfig: /tmp/kubeconfig-411378559
+Jul  2 13:36:18.038: INFO: Exec stderr: ""
+STEP: Verifying /etc/hosts content of container is not kubelet-managed for pod with hostNetwork=true
+Jul  2 13:36:18.039: INFO: ExecWithOptions {Command:[cat /etc/hosts] Namespace:e2e-tests-e2e-kubelet-etc-hosts-sl2qt PodName:test-host-network-pod ContainerName:busybox-1 Stdin:<nil> CaptureStdout:true CaptureStderr:true PreserveWhitespace:false}
+Jul  2 13:36:18.039: INFO: >>> kubeConfig: /tmp/kubeconfig-411378559
+Jul  2 13:36:18.485: INFO: Exec stderr: ""
+Jul  2 13:36:18.485: INFO: ExecWithOptions {Command:[cat /etc/hosts-original] Namespace:e2e-tests-e2e-kubelet-etc-hosts-sl2qt PodName:test-host-network-pod ContainerName:busybox-1 Stdin:<nil> CaptureStdout:true CaptureStderr:true PreserveWhitespace:false}
+Jul  2 13:36:18.485: INFO: >>> kubeConfig: /tmp/kubeconfig-411378559
+Jul  2 13:36:18.969: INFO: Exec stderr: ""
+Jul  2 13:36:18.969: INFO: ExecWithOptions {Command:[cat /etc/hosts] Namespace:e2e-tests-e2e-kubelet-etc-hosts-sl2qt PodName:test-host-network-pod ContainerName:busybox-2 Stdin:<nil> CaptureStdout:true CaptureStderr:true PreserveWhitespace:false}
+Jul  2 13:36:18.969: INFO: >>> kubeConfig: /tmp/kubeconfig-411378559
+Jul  2 13:36:19.410: INFO: Exec stderr: ""
+Jul  2 13:36:19.410: INFO: ExecWithOptions {Command:[cat /etc/hosts-original] Namespace:e2e-tests-e2e-kubelet-etc-hosts-sl2qt PodName:test-host-network-pod ContainerName:busybox-2 Stdin:<nil> CaptureStdout:true CaptureStderr:true PreserveWhitespace:false}
+Jul  2 13:36:19.410: INFO: >>> kubeConfig: /tmp/kubeconfig-411378559
+Jul  2 13:36:19.797: INFO: Exec stderr: ""
+[AfterEach] [k8s.io] KubeletManagedEtcHosts
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:36:19.797: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-e2e-kubelet-etc-hosts-sl2qt" for this suite.
+Jul  2 13:37:09.855: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:37:09.990: INFO: namespace: e2e-tests-e2e-kubelet-etc-hosts-sl2qt, resource: bindings, ignored listing per whitelist
+Jul  2 13:37:10.041: INFO: namespace e2e-tests-e2e-kubelet-etc-hosts-sl2qt deletion completed in 50.239774292s
+
+• [SLOW TEST:58.692 seconds]
+[k8s.io] KubeletManagedEtcHosts
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:679
+  should test kubelet managed /etc/hosts file [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SS
+------------------------------
+[sig-storage] Projected 
+  should update annotations on modification [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:37:10.041: INFO: >>> kubeConfig: /tmp/kubeconfig-411378559
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:858
+[It] should update annotations on modification [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating the pod
+Jul  2 13:37:12.739: INFO: Successfully updated pod "annotationupdate0526fbcf-7dfd-11e8-bae1-da96248f62d7"
+[AfterEach] [sig-storage] Projected
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:37:16.842: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-vpnqf" for this suite.
+Jul  2 13:37:38.857: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:37:38.883: INFO: namespace: e2e-tests-projected-vpnqf, resource: bindings, ignored listing per whitelist
+Jul  2 13:37:38.958: INFO: namespace e2e-tests-projected-vpnqf deletion completed in 22.112189029s
+
+• [SLOW TEST:28.917 seconds]
+[sig-storage] Projected
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:34
+  should update annotations on modification [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+[sig-storage] Projected 
+  should be consumable in multiple volumes in a pod [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:37:38.958: INFO: >>> kubeConfig: /tmp/kubeconfig-411378559
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:858
+[It] should be consumable in multiple volumes in a pod [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating secret with name projected-secret-test-16627b0b-7dfd-11e8-bae1-da96248f62d7
+STEP: Creating a pod to test consume secrets
+Jul  2 13:37:39.063: INFO: Waiting up to 5m0s for pod "pod-projected-secrets-166301d6-7dfd-11e8-bae1-da96248f62d7" in namespace "e2e-tests-projected-p7fdv" to be "success or failure"
+Jul  2 13:37:39.067: INFO: Pod "pod-projected-secrets-166301d6-7dfd-11e8-bae1-da96248f62d7": Phase="Pending", Reason="", readiness=false. Elapsed: 3.857889ms
+Jul  2 13:37:41.071: INFO: Pod "pod-projected-secrets-166301d6-7dfd-11e8-bae1-da96248f62d7": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.00715307s
+STEP: Saw pod success
+Jul  2 13:37:41.071: INFO: Pod "pod-projected-secrets-166301d6-7dfd-11e8-bae1-da96248f62d7" satisfied condition "success or failure"
+Jul  2 13:37:41.074: INFO: Trying to get logs from node ip-10-250-24-1.ec2.internal pod pod-projected-secrets-166301d6-7dfd-11e8-bae1-da96248f62d7 container secret-volume-test: <nil>
+STEP: delete the pod
+Jul  2 13:37:41.094: INFO: Waiting for pod pod-projected-secrets-166301d6-7dfd-11e8-bae1-da96248f62d7 to disappear
+Jul  2 13:37:41.103: INFO: Pod pod-projected-secrets-166301d6-7dfd-11e8-bae1-da96248f62d7 no longer exists
+[AfterEach] [sig-storage] Projected
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:37:41.109: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-p7fdv" for this suite.
+Jul  2 13:37:47.125: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:37:47.205: INFO: namespace: e2e-tests-projected-p7fdv, resource: bindings, ignored listing per whitelist
+Jul  2 13:37:47.236: INFO: namespace e2e-tests-projected-p7fdv deletion completed in 6.123038224s
+
+• [SLOW TEST:8.278 seconds]
+[sig-storage] Projected
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:34
+  should be consumable in multiple volumes in a pod [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSSSSSSS
+------------------------------
+[k8s.io] Variable Expansion 
+  should allow composing env vars into new env vars [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [k8s.io] Variable Expansion
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:37:47.236: INFO: >>> kubeConfig: /tmp/kubeconfig-411378559
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should allow composing env vars into new env vars [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating a pod to test env composition
+Jul  2 13:37:47.331: INFO: Waiting up to 5m0s for pod "var-expansion-1b508243-7dfd-11e8-bae1-da96248f62d7" in namespace "e2e-tests-var-expansion-8vw7c" to be "success or failure"
+Jul  2 13:37:47.335: INFO: Pod "var-expansion-1b508243-7dfd-11e8-bae1-da96248f62d7": Phase="Pending", Reason="", readiness=false. Elapsed: 3.954741ms
+Jul  2 13:37:49.339: INFO: Pod "var-expansion-1b508243-7dfd-11e8-bae1-da96248f62d7": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.007794538s
+STEP: Saw pod success
+Jul  2 13:37:49.339: INFO: Pod "var-expansion-1b508243-7dfd-11e8-bae1-da96248f62d7" satisfied condition "success or failure"
+Jul  2 13:37:49.341: INFO: Trying to get logs from node ip-10-250-24-1.ec2.internal pod var-expansion-1b508243-7dfd-11e8-bae1-da96248f62d7 container dapi-container: <nil>
+STEP: delete the pod
+Jul  2 13:37:49.359: INFO: Waiting for pod var-expansion-1b508243-7dfd-11e8-bae1-da96248f62d7 to disappear
+Jul  2 13:37:49.361: INFO: Pod var-expansion-1b508243-7dfd-11e8-bae1-da96248f62d7 no longer exists
+[AfterEach] [k8s.io] Variable Expansion
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:37:49.362: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-var-expansion-8vw7c" for this suite.
+Jul  2 13:37:55.446: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:37:55.523: INFO: namespace: e2e-tests-var-expansion-8vw7c, resource: bindings, ignored listing per whitelist
+Jul  2 13:37:55.548: INFO: namespace e2e-tests-var-expansion-8vw7c deletion completed in 6.182755226s
+
+• [SLOW TEST:8.312 seconds]
+[k8s.io] Variable Expansion
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:679
+  should allow composing env vars into new env vars [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSS
+------------------------------
+[sig-network] Services 
+  should serve multiport endpoints from pods  [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-network] Services
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:37:55.548: INFO: >>> kubeConfig: /tmp/kubeconfig-411378559
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-network] Services
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/network/service.go:83
+[It] should serve multiport endpoints from pods  [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: creating service multi-endpoint-test in namespace e2e-tests-services-6jfq2
+STEP: waiting up to 3m0s for service multi-endpoint-test in namespace e2e-tests-services-6jfq2 to expose endpoints map[]
+Jul  2 13:37:55.654: INFO: Get endpoints failed (3.953867ms elapsed, ignoring for 5s): endpoints "multi-endpoint-test" not found
+Jul  2 13:37:56.657: INFO: successfully validated that service multi-endpoint-test in namespace e2e-tests-services-6jfq2 exposes endpoints map[] (1.007392204s elapsed)
+STEP: Creating pod pod1 in namespace e2e-tests-services-6jfq2
+STEP: waiting up to 3m0s for service multi-endpoint-test in namespace e2e-tests-services-6jfq2 to expose endpoints map[pod1:[100]]
+Jul  2 13:37:58.683: INFO: successfully validated that service multi-endpoint-test in namespace e2e-tests-services-6jfq2 exposes endpoints map[pod1:[100]] (2.019405524s elapsed)
+STEP: Creating pod pod2 in namespace e2e-tests-services-6jfq2
+STEP: waiting up to 3m0s for service multi-endpoint-test in namespace e2e-tests-services-6jfq2 to expose endpoints map[pod1:[100] pod2:[101]]
+Jul  2 13:38:00.770: INFO: successfully validated that service multi-endpoint-test in namespace e2e-tests-services-6jfq2 exposes endpoints map[pod1:[100] pod2:[101]] (2.082193149s elapsed)
+STEP: Deleting pod pod1 in namespace e2e-tests-services-6jfq2
+STEP: waiting up to 3m0s for service multi-endpoint-test in namespace e2e-tests-services-6jfq2 to expose endpoints map[pod2:[101]]
+Jul  2 13:38:00.858: INFO: successfully validated that service multi-endpoint-test in namespace e2e-tests-services-6jfq2 exposes endpoints map[pod2:[101]] (9.319316ms elapsed)
+STEP: Deleting pod pod2 in namespace e2e-tests-services-6jfq2
+STEP: waiting up to 3m0s for service multi-endpoint-test in namespace e2e-tests-services-6jfq2 to expose endpoints map[]
+Jul  2 13:38:00.870: INFO: successfully validated that service multi-endpoint-test in namespace e2e-tests-services-6jfq2 exposes endpoints map[] (2.955422ms elapsed)
+[AfterEach] [sig-network] Services
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:38:00.881: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-services-6jfq2" for this suite.
+Jul  2 13:38:22.898: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:38:22.956: INFO: namespace: e2e-tests-services-6jfq2, resource: bindings, ignored listing per whitelist
+Jul  2 13:38:22.998: INFO: namespace e2e-tests-services-6jfq2 deletion completed in 22.113771283s
+[AfterEach] [sig-network] Services
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/network/service.go:88
+
+• [SLOW TEST:27.450 seconds]
+[sig-network] Services
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/network/framework.go:22
+  should serve multiport endpoints from pods  [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSS
+------------------------------
+[sig-api-machinery] ConfigMap 
+  should be consumable via environment variable [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-api-machinery] ConfigMap
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:38:22.998: INFO: >>> kubeConfig: /tmp/kubeconfig-411378559
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should be consumable via environment variable [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating configMap e2e-tests-configmap-jx95f/configmap-test-30a42881-7dfd-11e8-bae1-da96248f62d7
+STEP: Creating a pod to test consume configMaps
+Jul  2 13:38:23.114: INFO: Waiting up to 5m0s for pod "pod-configmaps-30a4b4dc-7dfd-11e8-bae1-da96248f62d7" in namespace "e2e-tests-configmap-jx95f" to be "success or failure"
+Jul  2 13:38:23.120: INFO: Pod "pod-configmaps-30a4b4dc-7dfd-11e8-bae1-da96248f62d7": Phase="Pending", Reason="", readiness=false. Elapsed: 5.177656ms
+Jul  2 13:38:25.149: INFO: Pod "pod-configmaps-30a4b4dc-7dfd-11e8-bae1-da96248f62d7": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.03456298s
+STEP: Saw pod success
+Jul  2 13:38:25.149: INFO: Pod "pod-configmaps-30a4b4dc-7dfd-11e8-bae1-da96248f62d7" satisfied condition "success or failure"
+Jul  2 13:38:25.153: INFO: Trying to get logs from node ip-10-250-24-1.ec2.internal pod pod-configmaps-30a4b4dc-7dfd-11e8-bae1-da96248f62d7 container env-test: <nil>
+STEP: delete the pod
+Jul  2 13:38:25.178: INFO: Waiting for pod pod-configmaps-30a4b4dc-7dfd-11e8-bae1-da96248f62d7 to disappear
+Jul  2 13:38:25.187: INFO: Pod pod-configmaps-30a4b4dc-7dfd-11e8-bae1-da96248f62d7 no longer exists
+[AfterEach] [sig-api-machinery] ConfigMap
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:38:25.190: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-configmap-jx95f" for this suite.
+Jul  2 13:38:31.241: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:38:31.312: INFO: namespace: e2e-tests-configmap-jx95f, resource: bindings, ignored listing per whitelist
+Jul  2 13:38:31.342: INFO: namespace e2e-tests-configmap-jx95f deletion completed in 6.144434786s
+
+• [SLOW TEST:8.344 seconds]
+[sig-api-machinery] ConfigMap
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/configmap.go:29
+  should be consumable via environment variable [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSSSSSS
+------------------------------
+[k8s.io] Probing container 
+  should be restarted with a exec "cat /tmp/health" liveness probe [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [k8s.io] Probing container
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:38:31.343: INFO: >>> kubeConfig: /tmp/kubeconfig-411378559
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [k8s.io] Probing container
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/container_probe.go:48
+[It] should be restarted with a exec "cat /tmp/health" liveness probe [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating pod liveness-exec in namespace e2e-tests-container-probe-dkhls
+Jul  2 13:38:33.469: INFO: Started pod liveness-exec in namespace e2e-tests-container-probe-dkhls
+STEP: checking the pod's current state and verifying that restartCount is present
+Jul  2 13:38:33.474: INFO: Initial restart count of pod liveness-exec is 0
+Jul  2 13:39:25.694: INFO: Restart count of pod e2e-tests-container-probe-dkhls/liveness-exec is now 1 (52.219536518s elapsed)
+STEP: deleting the pod
+[AfterEach] [k8s.io] Probing container
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:39:25.706: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-container-probe-dkhls" for this suite.
+Jul  2 13:39:31.734: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:39:31.818: INFO: namespace: e2e-tests-container-probe-dkhls, resource: bindings, ignored listing per whitelist
+Jul  2 13:39:31.832: INFO: namespace e2e-tests-container-probe-dkhls deletion completed in 6.112692296s
+
+• [SLOW TEST:60.489 seconds]
+[k8s.io] Probing container
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:679
+  should be restarted with a exec "cat /tmp/health" liveness probe [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSSSS
+------------------------------
+[sig-storage] Projected 
+  should be consumable from pods in volume [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:39:31.832: INFO: >>> kubeConfig: /tmp/kubeconfig-411378559
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:858
+[It] should be consumable from pods in volume [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating projection with secret that has name projected-secret-test-59a89141-7dfd-11e8-bae1-da96248f62d7
+STEP: Creating a pod to test consume secrets
+Jul  2 13:39:31.930: INFO: Waiting up to 5m0s for pod "pod-projected-secrets-59a915af-7dfd-11e8-bae1-da96248f62d7" in namespace "e2e-tests-projected-p4bxj" to be "success or failure"
+Jul  2 13:39:31.933: INFO: Pod "pod-projected-secrets-59a915af-7dfd-11e8-bae1-da96248f62d7": Phase="Pending", Reason="", readiness=false. Elapsed: 3.171756ms
+Jul  2 13:39:33.937: INFO: Pod "pod-projected-secrets-59a915af-7dfd-11e8-bae1-da96248f62d7": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.007143266s
+STEP: Saw pod success
+Jul  2 13:39:33.937: INFO: Pod "pod-projected-secrets-59a915af-7dfd-11e8-bae1-da96248f62d7" satisfied condition "success or failure"
+Jul  2 13:39:33.940: INFO: Trying to get logs from node ip-10-250-24-1.ec2.internal pod pod-projected-secrets-59a915af-7dfd-11e8-bae1-da96248f62d7 container projected-secret-volume-test: <nil>
+STEP: delete the pod
+Jul  2 13:39:33.970: INFO: Waiting for pod pod-projected-secrets-59a915af-7dfd-11e8-bae1-da96248f62d7 to disappear
+Jul  2 13:39:33.983: INFO: Pod pod-projected-secrets-59a915af-7dfd-11e8-bae1-da96248f62d7 no longer exists
+[AfterEach] [sig-storage] Projected
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:39:33.983: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-p4bxj" for this suite.
+Jul  2 13:39:39.997: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:39:40.062: INFO: namespace: e2e-tests-projected-p4bxj, resource: bindings, ignored listing per whitelist
+Jul  2 13:39:40.096: INFO: namespace e2e-tests-projected-p4bxj deletion completed in 6.109225024s
+
+• [SLOW TEST:8.264 seconds]
+[sig-storage] Projected
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:34
+  should be consumable from pods in volume [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSSSSSS
+------------------------------
+[sig-apps] StatefulSet [k8s.io] Basic StatefulSet functionality [StatefulSetBasic] 
+  Scaling should happen in predictable order and halt if any stateful pod is unhealthy [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-apps] StatefulSet
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:39:40.096: INFO: >>> kubeConfig: /tmp/kubeconfig-411378559
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-apps] StatefulSet
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/statefulset.go:57
+[BeforeEach] [k8s.io] Basic StatefulSet functionality [StatefulSetBasic]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/statefulset.go:72
+STEP: Creating service test in namespace e2e-tests-statefulset-nxr8c
+[It] Scaling should happen in predictable order and halt if any stateful pod is unhealthy [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Initializing watcher for selector baz=blah,foo=bar
+STEP: Creating stateful set ss in namespace e2e-tests-statefulset-nxr8c
+STEP: Waiting until all stateful set ss replicas will be running in namespace e2e-tests-statefulset-nxr8c
+Jul  2 13:39:40.198: INFO: Found 0 stateful pods, waiting for 1
+Jul  2 13:39:50.202: INFO: Waiting for pod ss-0 to enter Running - Ready=true, currently Running - Ready=true
+STEP: Confirming that stateful set scale up will halt with unhealthy stateful pod
+Jul  2 13:39:50.206: INFO: Running '/usr/local/bin/kubectl --kubeconfig=/tmp/kubeconfig-411378559 exec --namespace=e2e-tests-statefulset-nxr8c ss-0 -- /bin/sh -c mv -v /usr/share/nginx/html/index.html /tmp/ || true'
+Jul  2 13:39:50.647: INFO: stderr: ""
+Jul  2 13:39:50.647: INFO: stdout: "'/usr/share/nginx/html/index.html' -> '/tmp/index.html'\n"
+Jul  2 13:39:50.647: INFO: stdout of mv -v /usr/share/nginx/html/index.html /tmp/ || true on ss-0: '/usr/share/nginx/html/index.html' -> '/tmp/index.html'
+
+Jul  2 13:39:50.651: INFO: Waiting for pod ss-0 to enter Running - Ready=false, currently Running - Ready=true
+Jul  2 13:40:00.659: INFO: Waiting for pod ss-0 to enter Running - Ready=false, currently Running - Ready=false
+Jul  2 13:40:00.659: INFO: Waiting for statefulset status.replicas updated to 0
+Jul  2 13:40:00.675: INFO: Verifying statefulset ss doesn't scale past 1 for another 9.999999067s
+Jul  2 13:40:01.680: INFO: Verifying statefulset ss doesn't scale past 1 for another 8.996431313s
+Jul  2 13:40:02.684: INFO: Verifying statefulset ss doesn't scale past 1 for another 7.991427206s
+Jul  2 13:40:03.688: INFO: Verifying statefulset ss doesn't scale past 1 for another 6.986939403s
+Jul  2 13:40:04.692: INFO: Verifying statefulset ss doesn't scale past 1 for another 5.982764669s
+Jul  2 13:40:05.697: INFO: Verifying statefulset ss doesn't scale past 1 for another 4.978679183s
+Jul  2 13:40:06.749: INFO: Verifying statefulset ss doesn't scale past 1 for another 3.974364124s
+Jul  2 13:40:07.752: INFO: Verifying statefulset ss doesn't scale past 1 for another 2.922321882s
+Jul  2 13:40:08.757: INFO: Verifying statefulset ss doesn't scale past 1 for another 1.918797053s
+Jul  2 13:40:09.761: INFO: Verifying statefulset ss doesn't scale past 1 for another 914.388384ms
+STEP: Scaling up stateful set ss to 3 replicas and waiting until all of them will be running in namespace e2e-tests-statefulset-nxr8c
+Jul  2 13:40:10.765: INFO: Running '/usr/local/bin/kubectl --kubeconfig=/tmp/kubeconfig-411378559 exec --namespace=e2e-tests-statefulset-nxr8c ss-0 -- /bin/sh -c mv -v /tmp/index.html /usr/share/nginx/html/ || true'
+Jul  2 13:40:11.213: INFO: stderr: ""
+Jul  2 13:40:11.213: INFO: stdout: "'/tmp/index.html' -> '/usr/share/nginx/html/index.html'\n"
+Jul  2 13:40:11.213: INFO: stdout of mv -v /tmp/index.html /usr/share/nginx/html/ || true on ss-0: '/tmp/index.html' -> '/usr/share/nginx/html/index.html'
+
+Jul  2 13:40:11.221: INFO: Found 1 stateful pods, waiting for 3
+Jul  2 13:40:21.225: INFO: Waiting for pod ss-0 to enter Running - Ready=true, currently Running - Ready=true
+Jul  2 13:40:21.225: INFO: Waiting for pod ss-1 to enter Running - Ready=true, currently Running - Ready=true
+Jul  2 13:40:21.225: INFO: Waiting for pod ss-2 to enter Running - Ready=true, currently Running - Ready=true
+STEP: Verifying that stateful set ss was scaled up in order
+STEP: Scale down will halt with unhealthy stateful pod
+Jul  2 13:40:21.231: INFO: Running '/usr/local/bin/kubectl --kubeconfig=/tmp/kubeconfig-411378559 exec --namespace=e2e-tests-statefulset-nxr8c ss-0 -- /bin/sh -c mv -v /usr/share/nginx/html/index.html /tmp/ || true'
+Jul  2 13:40:21.678: INFO: stderr: ""
+Jul  2 13:40:21.678: INFO: stdout: "'/usr/share/nginx/html/index.html' -> '/tmp/index.html'\n"
+Jul  2 13:40:21.678: INFO: stdout of mv -v /usr/share/nginx/html/index.html /tmp/ || true on ss-0: '/usr/share/nginx/html/index.html' -> '/tmp/index.html'
+
+Jul  2 13:40:21.678: INFO: Running '/usr/local/bin/kubectl --kubeconfig=/tmp/kubeconfig-411378559 exec --namespace=e2e-tests-statefulset-nxr8c ss-1 -- /bin/sh -c mv -v /usr/share/nginx/html/index.html /tmp/ || true'
+Jul  2 13:40:22.265: INFO: stderr: ""
+Jul  2 13:40:22.265: INFO: stdout: "'/usr/share/nginx/html/index.html' -> '/tmp/index.html'\n"
+Jul  2 13:40:22.265: INFO: stdout of mv -v /usr/share/nginx/html/index.html /tmp/ || true on ss-1: '/usr/share/nginx/html/index.html' -> '/tmp/index.html'
+
+Jul  2 13:40:22.265: INFO: Running '/usr/local/bin/kubectl --kubeconfig=/tmp/kubeconfig-411378559 exec --namespace=e2e-tests-statefulset-nxr8c ss-2 -- /bin/sh -c mv -v /usr/share/nginx/html/index.html /tmp/ || true'
+Jul  2 13:40:22.709: INFO: stderr: ""
+Jul  2 13:40:22.710: INFO: stdout: "'/usr/share/nginx/html/index.html' -> '/tmp/index.html'\n"
+Jul  2 13:40:22.710: INFO: stdout of mv -v /usr/share/nginx/html/index.html /tmp/ || true on ss-2: '/usr/share/nginx/html/index.html' -> '/tmp/index.html'
+
+Jul  2 13:40:22.710: INFO: Waiting for statefulset status.replicas updated to 0
+Jul  2 13:40:22.713: INFO: Waiting for stateful set status.readyReplicas to become 0, currently 2
+Jul  2 13:40:32.720: INFO: Waiting for pod ss-0 to enter Running - Ready=false, currently Running - Ready=false
+Jul  2 13:40:32.720: INFO: Waiting for pod ss-1 to enter Running - Ready=false, currently Running - Ready=false
+Jul  2 13:40:32.720: INFO: Waiting for pod ss-2 to enter Running - Ready=false, currently Running - Ready=false
+Jul  2 13:40:32.731: INFO: Verifying statefulset ss doesn't scale past 3 for another 9.999999031s
+Jul  2 13:40:33.735: INFO: Verifying statefulset ss doesn't scale past 3 for another 8.996355711s
+Jul  2 13:40:34.739: INFO: Verifying statefulset ss doesn't scale past 3 for another 7.992064638s
+Jul  2 13:40:35.744: INFO: Verifying statefulset ss doesn't scale past 3 for another 6.987656251s
+Jul  2 13:40:36.748: INFO: Verifying statefulset ss doesn't scale past 3 for another 5.983375794s
+Jul  2 13:40:37.752: INFO: Verifying statefulset ss doesn't scale past 3 for another 4.978778501s
+Jul  2 13:40:38.756: INFO: Verifying statefulset ss doesn't scale past 3 for another 3.974915129s
+Jul  2 13:40:39.761: INFO: Verifying statefulset ss doesn't scale past 3 for another 2.970774796s
+Jul  2 13:40:40.765: INFO: Verifying statefulset ss doesn't scale past 3 for another 1.966460666s
+Jul  2 13:40:41.769: INFO: Verifying statefulset ss doesn't scale past 3 for another 961.928672ms
+STEP: Scaling down stateful set ss to 0 replicas and waiting until none of pods will run in namespacee2e-tests-statefulset-nxr8c
+Jul  2 13:40:42.774: INFO: Running '/usr/local/bin/kubectl --kubeconfig=/tmp/kubeconfig-411378559 exec --namespace=e2e-tests-statefulset-nxr8c ss-0 -- /bin/sh -c mv -v /tmp/index.html /usr/share/nginx/html/ || true'
+Jul  2 13:40:43.209: INFO: stderr: ""
+Jul  2 13:40:43.209: INFO: stdout: "'/tmp/index.html' -> '/usr/share/nginx/html/index.html'\n"
+Jul  2 13:40:43.209: INFO: stdout of mv -v /tmp/index.html /usr/share/nginx/html/ || true on ss-0: '/tmp/index.html' -> '/usr/share/nginx/html/index.html'
+
+Jul  2 13:40:43.209: INFO: Running '/usr/local/bin/kubectl --kubeconfig=/tmp/kubeconfig-411378559 exec --namespace=e2e-tests-statefulset-nxr8c ss-1 -- /bin/sh -c mv -v /tmp/index.html /usr/share/nginx/html/ || true'
+Jul  2 13:40:43.666: INFO: stderr: ""
+Jul  2 13:40:43.666: INFO: stdout: "'/tmp/index.html' -> '/usr/share/nginx/html/index.html'\n"
+Jul  2 13:40:43.666: INFO: stdout of mv -v /tmp/index.html /usr/share/nginx/html/ || true on ss-1: '/tmp/index.html' -> '/usr/share/nginx/html/index.html'
+
+Jul  2 13:40:43.666: INFO: Running '/usr/local/bin/kubectl --kubeconfig=/tmp/kubeconfig-411378559 exec --namespace=e2e-tests-statefulset-nxr8c ss-2 -- /bin/sh -c mv -v /tmp/index.html /usr/share/nginx/html/ || true'
+Jul  2 13:40:44.237: INFO: rc: 1
+Jul  2 13:40:44.237: INFO: Waiting 10s to retry failed RunHostCmd: error running &{/usr/local/bin/kubectl [kubectl --kubeconfig=/tmp/kubeconfig-411378559 exec --namespace=e2e-tests-statefulset-nxr8c ss-2 -- /bin/sh -c mv -v /tmp/index.html /usr/share/nginx/html/ || true] []  <nil>  error: Internal error occurred: error executing command in container: container not running (7b6d8c7999fc058ccf7b427d1664481caefe8c3582790a4a85c1eb01e01e7bf8)
+ [] <nil> 0xc42049d5f0 exit status 1 <nil> <nil> true [0xc4210306b8 0xc4210306f0 0xc421030728] [0xc4210306b8 0xc4210306f0 0xc421030728] [0xc4210306e8 0xc421030710] [0x8f98d0 0x8f98d0] 0xc4213bd560 <nil>}:
+Command stdout:
+
+stderr:
+error: Internal error occurred: error executing command in container: container not running (7b6d8c7999fc058ccf7b427d1664481caefe8c3582790a4a85c1eb01e01e7bf8)
+
+error:
+exit status 1
+
+Jul  2 13:40:54.237: INFO: Running '/usr/local/bin/kubectl --kubeconfig=/tmp/kubeconfig-411378559 exec --namespace=e2e-tests-statefulset-nxr8c ss-2 -- /bin/sh -c mv -v /tmp/index.html /usr/share/nginx/html/ || true'
+Jul  2 13:40:54.318: INFO: rc: 1
+Jul  2 13:40:54.318: INFO: Waiting 10s to retry failed RunHostCmd: error running &{/usr/local/bin/kubectl [kubectl --kubeconfig=/tmp/kubeconfig-411378559 exec --namespace=e2e-tests-statefulset-nxr8c ss-2 -- /bin/sh -c mv -v /tmp/index.html /usr/share/nginx/html/ || true] []  <nil>  Error from server (NotFound): pods "ss-2" not found
+ [] <nil> 0xc42095dcb0 exit status 1 <nil> <nil> true [0xc421206828 0xc421206840 0xc421206858] [0xc421206828 0xc421206840 0xc421206858] [0xc421206838 0xc421206850] [0x8f98d0 0x8f98d0] 0xc421385f80 <nil>}:
+Command stdout:
+
+stderr:
+Error from server (NotFound): pods "ss-2" not found
+
+error:
+exit status 1
+
+Jul  2 13:41:04.319: INFO: Running '/usr/local/bin/kubectl --kubeconfig=/tmp/kubeconfig-411378559 exec --namespace=e2e-tests-statefulset-nxr8c ss-2 -- /bin/sh -c mv -v /tmp/index.html /usr/share/nginx/html/ || true'
+Jul  2 13:41:04.400: INFO: rc: 1
+Jul  2 13:41:04.400: INFO: Waiting 10s to retry failed RunHostCmd: error running &{/usr/local/bin/kubectl [kubectl --kubeconfig=/tmp/kubeconfig-411378559 exec --namespace=e2e-tests-statefulset-nxr8c ss-2 -- /bin/sh -c mv -v /tmp/index.html /usr/share/nginx/html/ || true] []  <nil>  Error from server (NotFound): pods "ss-2" not found
+ [] <nil> 0xc42049daa0 exit status 1 <nil> <nil> true [0xc421030730 0xc421030768 0xc421030790] [0xc421030730 0xc421030768 0xc421030790] [0xc421030750 0xc421030778] [0x8f98d0 0x8f98d0] 0xc4213bd680 <nil>}:
+Command stdout:
+
+stderr:
+Error from server (NotFound): pods "ss-2" not found
+
+error:
+exit status 1
+
+Jul  2 13:41:14.400: INFO: Running '/usr/local/bin/kubectl --kubeconfig=/tmp/kubeconfig-411378559 exec --namespace=e2e-tests-statefulset-nxr8c ss-2 -- /bin/sh -c mv -v /tmp/index.html /usr/share/nginx/html/ || true'
+Jul  2 13:41:14.480: INFO: rc: 1
+Jul  2 13:41:14.481: INFO: Waiting 10s to retry failed RunHostCmd: error running &{/usr/local/bin/kubectl [kubectl --kubeconfig=/tmp/kubeconfig-411378559 exec --namespace=e2e-tests-statefulset-nxr8c ss-2 -- /bin/sh -c mv -v /tmp/index.html /usr/share/nginx/html/ || true] []  <nil>  Error from server (NotFound): pods "ss-2" not found
+ [] <nil> 0xc42034d650 exit status 1 <nil> <nil> true [0xc421206860 0xc421206878 0xc421206890] [0xc421206860 0xc421206878 0xc421206890] [0xc421206870 0xc421206888] [0x8f98d0 0x8f98d0] 0xc420b520c0 <nil>}:
+Command stdout:
+
+stderr:
+Error from server (NotFound): pods "ss-2" not found
+
+error:
+exit status 1
+
+Jul  2 13:41:24.481: INFO: Running '/usr/local/bin/kubectl --kubeconfig=/tmp/kubeconfig-411378559 exec --namespace=e2e-tests-statefulset-nxr8c ss-2 -- /bin/sh -c mv -v /tmp/index.html /usr/share/nginx/html/ || true'
+Jul  2 13:41:24.586: INFO: rc: 1
+Jul  2 13:41:24.586: INFO: Waiting 10s to retry failed RunHostCmd: error running &{/usr/local/bin/kubectl [kubectl --kubeconfig=/tmp/kubeconfig-411378559 exec --namespace=e2e-tests-statefulset-nxr8c ss-2 -- /bin/sh -c mv -v /tmp/index.html /usr/share/nginx/html/ || true] []  <nil>  Error from server (NotFound): pods "ss-2" not found
+ [] <nil> 0xc42049dec0 exit status 1 <nil> <nil> true [0xc4210307a8 0xc4210307d0 0xc421030820] [0xc4210307a8 0xc4210307d0 0xc421030820] [0xc4210307b8 0xc421030800] [0x8f98d0 0x8f98d0] 0xc4213bd7a0 <nil>}:
+Command stdout:
+
+stderr:
+Error from server (NotFound): pods "ss-2" not found
+
+error:
+exit status 1
+
+Jul  2 13:41:34.586: INFO: Running '/usr/local/bin/kubectl --kubeconfig=/tmp/kubeconfig-411378559 exec --namespace=e2e-tests-statefulset-nxr8c ss-2 -- /bin/sh -c mv -v /tmp/index.html /usr/share/nginx/html/ || true'
+Jul  2 13:41:34.670: INFO: rc: 1
+Jul  2 13:41:34.670: INFO: Waiting 10s to retry failed RunHostCmd: error running &{/usr/local/bin/kubectl [kubectl --kubeconfig=/tmp/kubeconfig-411378559 exec --namespace=e2e-tests-statefulset-nxr8c ss-2 -- /bin/sh -c mv -v /tmp/index.html /usr/share/nginx/html/ || true] []  <nil>  Error from server (NotFound): pods "ss-2" not found
+ [] <nil> 0xc4208e21e0 exit status 1 <nil> <nil> true [0xc421206898 0xc4212068b8 0xc4212068d0] [0xc421206898 0xc4212068b8 0xc4212068d0] [0xc4212068b0 0xc4212068c8] [0x8f98d0 0x8f98d0] 0xc420b521e0 <nil>}:
+Command stdout:
+
+stderr:
+Error from server (NotFound): pods "ss-2" not found
+
+error:
+exit status 1
+
+Jul  2 13:41:44.670: INFO: Running '/usr/local/bin/kubectl --kubeconfig=/tmp/kubeconfig-411378559 exec --namespace=e2e-tests-statefulset-nxr8c ss-2 -- /bin/sh -c mv -v /tmp/index.html /usr/share/nginx/html/ || true'
+Jul  2 13:41:44.751: INFO: rc: 1
+Jul  2 13:41:44.751: INFO: Waiting 10s to retry failed RunHostCmd: error running &{/usr/local/bin/kubectl [kubectl --kubeconfig=/tmp/kubeconfig-411378559 exec --namespace=e2e-tests-statefulset-nxr8c ss-2 -- /bin/sh -c mv -v /tmp/index.html /usr/share/nginx/html/ || true] []  <nil>  Error from server (NotFound): pods "ss-2" not found
+ [] <nil> 0xc4208e2a20 exit status 1 <nil> <nil> true [0xc4212068d8 0xc4212068f0 0xc421206918] [0xc4212068d8 0xc4212068f0 0xc421206918] [0xc4212068e8 0xc421206908] [0x8f98d0 0x8f98d0] 0xc420b52360 <nil>}:
+Command stdout:
+
+stderr:
+Error from server (NotFound): pods "ss-2" not found
+
+error:
+exit status 1
+
+Jul  2 13:41:54.751: INFO: Running '/usr/local/bin/kubectl --kubeconfig=/tmp/kubeconfig-411378559 exec --namespace=e2e-tests-statefulset-nxr8c ss-2 -- /bin/sh -c mv -v /tmp/index.html /usr/share/nginx/html/ || true'
+Jul  2 13:41:54.832: INFO: rc: 1
+Jul  2 13:41:54.832: INFO: Waiting 10s to retry failed RunHostCmd: error running &{/usr/local/bin/kubectl [kubectl --kubeconfig=/tmp/kubeconfig-411378559 exec --namespace=e2e-tests-statefulset-nxr8c ss-2 -- /bin/sh -c mv -v /tmp/index.html /usr/share/nginx/html/ || true] []  <nil>  Error from server (NotFound): pods "ss-2" not found
+ [] <nil> 0xc4208e2f30 exit status 1 <nil> <nil> true [0xc421206920 0xc421206938 0xc421206950] [0xc421206920 0xc421206938 0xc421206950] [0xc421206930 0xc421206948] [0x8f98d0 0x8f98d0] 0xc420b524e0 <nil>}:
+Command stdout:
+
+stderr:
+Error from server (NotFound): pods "ss-2" not found
+
+error:
+exit status 1
+
+Jul  2 13:42:04.833: INFO: Running '/usr/local/bin/kubectl --kubeconfig=/tmp/kubeconfig-411378559 exec --namespace=e2e-tests-statefulset-nxr8c ss-2 -- /bin/sh -c mv -v /tmp/index.html /usr/share/nginx/html/ || true'
+Jul  2 13:42:04.914: INFO: rc: 1
+Jul  2 13:42:04.914: INFO: Waiting 10s to retry failed RunHostCmd: error running &{/usr/local/bin/kubectl [kubectl --kubeconfig=/tmp/kubeconfig-411378559 exec --namespace=e2e-tests-statefulset-nxr8c ss-2 -- /bin/sh -c mv -v /tmp/index.html /usr/share/nginx/html/ || true] []  <nil>  Error from server (NotFound): pods "ss-2" not found
+ [] <nil> 0xc42034de00 exit status 1 <nil> <nil> true [0xc421030018 0xc421030030 0xc421030048] [0xc421030018 0xc421030030 0xc421030048] [0xc421030028 0xc421030040] [0x8f98d0 0x8f98d0] 0xc421384060 <nil>}:
+Command stdout:
+
+stderr:
+Error from server (NotFound): pods "ss-2" not found
+
+error:
+exit status 1
+
+Jul  2 13:42:14.914: INFO: Running '/usr/local/bin/kubectl --kubeconfig=/tmp/kubeconfig-411378559 exec --namespace=e2e-tests-statefulset-nxr8c ss-2 -- /bin/sh -c mv -v /tmp/index.html /usr/share/nginx/html/ || true'
+Jul  2 13:42:15.008: INFO: rc: 1
+Jul  2 13:42:15.009: INFO: Waiting 10s to retry failed RunHostCmd: error running &{/usr/local/bin/kubectl [kubectl --kubeconfig=/tmp/kubeconfig-411378559 exec --namespace=e2e-tests-statefulset-nxr8c ss-2 -- /bin/sh -c mv -v /tmp/index.html /usr/share/nginx/html/ || true] []  <nil>  Error from server (NotFound): pods "ss-2" not found
+ [] <nil> 0xc42095dec0 exit status 1 <nil> <nil> true [0xc421206040 0xc421206188 0xc421206260] [0xc421206040 0xc421206188 0xc421206260] [0xc4212060d0 0xc421206250] [0x8f98d0 0x8f98d0] 0xc421470060 <nil>}:
+Command stdout:
+
+stderr:
+Error from server (NotFound): pods "ss-2" not found
+
+error:
+exit status 1
+
+Jul  2 13:42:25.009: INFO: Running '/usr/local/bin/kubectl --kubeconfig=/tmp/kubeconfig-411378559 exec --namespace=e2e-tests-statefulset-nxr8c ss-2 -- /bin/sh -c mv -v /tmp/index.html /usr/share/nginx/html/ || true'
+Jul  2 13:42:25.143: INFO: rc: 1
+Jul  2 13:42:25.143: INFO: Waiting 10s to retry failed RunHostCmd: error running &{/usr/local/bin/kubectl [kubectl --kubeconfig=/tmp/kubeconfig-411378559 exec --namespace=e2e-tests-statefulset-nxr8c ss-2 -- /bin/sh -c mv -v /tmp/index.html /usr/share/nginx/html/ || true] []  <nil>  Error from server (NotFound): pods "ss-2" not found
+ [] <nil> 0xc42102e420 exit status 1 <nil> <nil> true [0xc421030050 0xc421030068 0xc421030098] [0xc421030050 0xc421030068 0xc421030098] [0xc421030060 0xc421030090] [0x8f98d0 0x8f98d0] 0xc421384180 <nil>}:
+Command stdout:
+
+stderr:
+Error from server (NotFound): pods "ss-2" not found
+
+error:
+exit status 1
+
+Jul  2 13:42:35.143: INFO: Running '/usr/local/bin/kubectl --kubeconfig=/tmp/kubeconfig-411378559 exec --namespace=e2e-tests-statefulset-nxr8c ss-2 -- /bin/sh -c mv -v /tmp/index.html /usr/share/nginx/html/ || true'
+Jul  2 13:42:35.228: INFO: rc: 1
+Jul  2 13:42:35.228: INFO: Waiting 10s to retry failed RunHostCmd: error running &{/usr/local/bin/kubectl [kubectl --kubeconfig=/tmp/kubeconfig-411378559 exec --namespace=e2e-tests-statefulset-nxr8c ss-2 -- /bin/sh -c mv -v /tmp/index.html /usr/share/nginx/html/ || true] []  <nil>  Error from server (NotFound): pods "ss-2" not found
+ [] <nil> 0xc42102e8d0 exit status 1 <nil> <nil> true [0xc4210300a0 0xc4210300b8 0xc4210300f0] [0xc4210300a0 0xc4210300b8 0xc4210300f0] [0xc4210300b0 0xc4210300e8] [0x8f98d0 0x8f98d0] 0xc4213842a0 <nil>}:
+Command stdout:
+
+stderr:
+Error from server (NotFound): pods "ss-2" not found
+
+error:
+exit status 1
+
+Jul  2 13:42:45.229: INFO: Running '/usr/local/bin/kubectl --kubeconfig=/tmp/kubeconfig-411378559 exec --namespace=e2e-tests-statefulset-nxr8c ss-2 -- /bin/sh -c mv -v /tmp/index.html /usr/share/nginx/html/ || true'
+Jul  2 13:42:45.316: INFO: rc: 1
+Jul  2 13:42:45.316: INFO: Waiting 10s to retry failed RunHostCmd: error running &{/usr/local/bin/kubectl [kubectl --kubeconfig=/tmp/kubeconfig-411378559 exec --namespace=e2e-tests-statefulset-nxr8c ss-2 -- /bin/sh -c mv -v /tmp/index.html /usr/share/nginx/html/ || true] []  <nil>  Error from server (NotFound): pods "ss-2" not found
+ [] <nil> 0xc4212b6330 exit status 1 <nil> <nil> true [0xc4212062a8 0xc421206328 0xc4212063f0] [0xc4212062a8 0xc421206328 0xc4212063f0] [0xc421206300 0xc421206368] [0x8f98d0 0x8f98d0] 0xc421470180 <nil>}:
+Command stdout:
+
+stderr:
+Error from server (NotFound): pods "ss-2" not found
+
+error:
+exit status 1
+
+Jul  2 13:42:55.316: INFO: Running '/usr/local/bin/kubectl --kubeconfig=/tmp/kubeconfig-411378559 exec --namespace=e2e-tests-statefulset-nxr8c ss-2 -- /bin/sh -c mv -v /tmp/index.html /usr/share/nginx/html/ || true'
+Jul  2 13:42:55.396: INFO: rc: 1
+Jul  2 13:42:55.396: INFO: Waiting 10s to retry failed RunHostCmd: error running &{/usr/local/bin/kubectl [kubectl --kubeconfig=/tmp/kubeconfig-411378559 exec --namespace=e2e-tests-statefulset-nxr8c ss-2 -- /bin/sh -c mv -v /tmp/index.html /usr/share/nginx/html/ || true] []  <nil>  Error from server (NotFound): pods "ss-2" not found
+ [] <nil> 0xc4212b6840 exit status 1 <nil> <nil> true [0xc421206408 0xc421206460 0xc4212064a8] [0xc421206408 0xc421206460 0xc4212064a8] [0xc421206448 0xc421206490] [0x8f98d0 0x8f98d0] 0xc4214702a0 <nil>}:
+Command stdout:
+
+stderr:
+Error from server (NotFound): pods "ss-2" not found
+
+error:
+exit status 1
+
+Jul  2 13:43:05.397: INFO: Running '/usr/local/bin/kubectl --kubeconfig=/tmp/kubeconfig-411378559 exec --namespace=e2e-tests-statefulset-nxr8c ss-2 -- /bin/sh -c mv -v /tmp/index.html /usr/share/nginx/html/ || true'
+Jul  2 13:43:05.476: INFO: rc: 1
+Jul  2 13:43:05.476: INFO: Waiting 10s to retry failed RunHostCmd: error running &{/usr/local/bin/kubectl [kubectl --kubeconfig=/tmp/kubeconfig-411378559 exec --namespace=e2e-tests-statefulset-nxr8c ss-2 -- /bin/sh -c mv -v /tmp/index.html /usr/share/nginx/html/ || true] []  <nil>  Error from server (NotFound): pods "ss-2" not found
+ [] <nil> 0xc4212b6de0 exit status 1 <nil> <nil> true [0xc4212064c8 0xc421206500 0xc421206550] [0xc4212064c8 0xc421206500 0xc421206550] [0xc4212064f0 0xc421206548] [0x8f98d0 0x8f98d0] 0xc421471980 <nil>}:
+Command stdout:
+
+stderr:
+Error from server (NotFound): pods "ss-2" not found
+
+error:
+exit status 1
+
+Jul  2 13:43:15.476: INFO: Running '/usr/local/bin/kubectl --kubeconfig=/tmp/kubeconfig-411378559 exec --namespace=e2e-tests-statefulset-nxr8c ss-2 -- /bin/sh -c mv -v /tmp/index.html /usr/share/nginx/html/ || true'
+Jul  2 13:43:15.555: INFO: rc: 1
+Jul  2 13:43:15.556: INFO: Waiting 10s to retry failed RunHostCmd: error running &{/usr/local/bin/kubectl [kubectl --kubeconfig=/tmp/kubeconfig-411378559 exec --namespace=e2e-tests-statefulset-nxr8c ss-2 -- /bin/sh -c mv -v /tmp/index.html /usr/share/nginx/html/ || true] []  <nil>  Error from server (NotFound): pods "ss-2" not found
+ [] <nil> 0xc4212b7620 exit status 1 <nil> <nil> true [0xc421206558 0xc421206570 0xc4212065a0] [0xc421206558 0xc421206570 0xc4212065a0] [0xc421206568 0xc421206590] [0x8f98d0 0x8f98d0] 0xc421471aa0 <nil>}:
+Command stdout:
+
+stderr:
+Error from server (NotFound): pods "ss-2" not found
+
+error:
+exit status 1
+
+Jul  2 13:43:25.556: INFO: Running '/usr/local/bin/kubectl --kubeconfig=/tmp/kubeconfig-411378559 exec --namespace=e2e-tests-statefulset-nxr8c ss-2 -- /bin/sh -c mv -v /tmp/index.html /usr/share/nginx/html/ || true'
+Jul  2 13:43:25.651: INFO: rc: 1
+Jul  2 13:43:25.651: INFO: Waiting 10s to retry failed RunHostCmd: error running &{/usr/local/bin/kubectl [kubectl --kubeconfig=/tmp/kubeconfig-411378559 exec --namespace=e2e-tests-statefulset-nxr8c ss-2 -- /bin/sh -c mv -v /tmp/index.html /usr/share/nginx/html/ || true] []  <nil>  Error from server (NotFound): pods "ss-2" not found
+ [] <nil> 0xc42102ecf0 exit status 1 <nil> <nil> true [0xc421030108 0xc421030120 0xc421030138] [0xc421030108 0xc421030120 0xc421030138] [0xc421030118 0xc421030130] [0x8f98d0 0x8f98d0] 0xc4213843c0 <nil>}:
+Command stdout:
+
+stderr:
+Error from server (NotFound): pods "ss-2" not found
+
+error:
+exit status 1
+
+Jul  2 13:43:35.651: INFO: Running '/usr/local/bin/kubectl --kubeconfig=/tmp/kubeconfig-411378559 exec --namespace=e2e-tests-statefulset-nxr8c ss-2 -- /bin/sh -c mv -v /tmp/index.html /usr/share/nginx/html/ || true'
+Jul  2 13:43:35.730: INFO: rc: 1
+Jul  2 13:43:35.731: INFO: Waiting 10s to retry failed RunHostCmd: error running &{/usr/local/bin/kubectl [kubectl --kubeconfig=/tmp/kubeconfig-411378559 exec --namespace=e2e-tests-statefulset-nxr8c ss-2 -- /bin/sh -c mv -v /tmp/index.html /usr/share/nginx/html/ || true] []  <nil>  Error from server (NotFound): pods "ss-2" not found
+ [] <nil> 0xc4212b7cb0 exit status 1 <nil> <nil> true [0xc4212065b0 0xc4212065e0 0xc421206620] [0xc4212065b0 0xc4212065e0 0xc421206620] [0xc4212065d0 0xc421206610] [0x8f98d0 0x8f98d0] 0xc421471bc0 <nil>}:
+Command stdout:
+
+stderr:
+Error from server (NotFound): pods "ss-2" not found
+
+error:
+exit status 1
+
+Jul  2 13:43:45.731: INFO: Running '/usr/local/bin/kubectl --kubeconfig=/tmp/kubeconfig-411378559 exec --namespace=e2e-tests-statefulset-nxr8c ss-2 -- /bin/sh -c mv -v /tmp/index.html /usr/share/nginx/html/ || true'
+Jul  2 13:43:45.814: INFO: rc: 1
+Jul  2 13:43:45.815: INFO: Waiting 10s to retry failed RunHostCmd: error running &{/usr/local/bin/kubectl [kubectl --kubeconfig=/tmp/kubeconfig-411378559 exec --namespace=e2e-tests-statefulset-nxr8c ss-2 -- /bin/sh -c mv -v /tmp/index.html /usr/share/nginx/html/ || true] []  <nil>  Error from server (NotFound): pods "ss-2" not found
+ [] <nil> 0xc42102f110 exit status 1 <nil> <nil> true [0xc421030140 0xc421030158 0xc421030170] [0xc421030140 0xc421030158 0xc421030170] [0xc421030150 0xc421030168] [0x8f98d0 0x8f98d0] 0xc4213846c0 <nil>}:
+Command stdout:
+
+stderr:
+Error from server (NotFound): pods "ss-2" not found
+
+error:
+exit status 1
+
+Jul  2 13:43:55.815: INFO: Running '/usr/local/bin/kubectl --kubeconfig=/tmp/kubeconfig-411378559 exec --namespace=e2e-tests-statefulset-nxr8c ss-2 -- /bin/sh -c mv -v /tmp/index.html /usr/share/nginx/html/ || true'
+Jul  2 13:43:55.895: INFO: rc: 1
+Jul  2 13:43:55.895: INFO: Waiting 10s to retry failed RunHostCmd: error running &{/usr/local/bin/kubectl [kubectl --kubeconfig=/tmp/kubeconfig-411378559 exec --namespace=e2e-tests-statefulset-nxr8c ss-2 -- /bin/sh -c mv -v /tmp/index.html /usr/share/nginx/html/ || true] []  <nil>  Error from server (NotFound): pods "ss-2" not found
+ [] <nil> 0xc42102f530 exit status 1 <nil> <nil> true [0xc421030178 0xc421030190 0xc4210301a8] [0xc421030178 0xc421030190 0xc4210301a8] [0xc421030188 0xc4210301a0] [0x8f98d0 0x8f98d0] 0xc4213847e0 <nil>}:
+Command stdout:
+
+stderr:
+Error from server (NotFound): pods "ss-2" not found
+
+error:
+exit status 1
+
+Jul  2 13:44:05.896: INFO: Running '/usr/local/bin/kubectl --kubeconfig=/tmp/kubeconfig-411378559 exec --namespace=e2e-tests-statefulset-nxr8c ss-2 -- /bin/sh -c mv -v /tmp/index.html /usr/share/nginx/html/ || true'
+Jul  2 13:44:05.989: INFO: rc: 1
+Jul  2 13:44:05.990: INFO: Waiting 10s to retry failed RunHostCmd: error running &{/usr/local/bin/kubectl [kubectl --kubeconfig=/tmp/kubeconfig-411378559 exec --namespace=e2e-tests-statefulset-nxr8c ss-2 -- /bin/sh -c mv -v /tmp/index.html /usr/share/nginx/html/ || true] []  <nil>  Error from server (NotFound): pods "ss-2" not found
+ [] <nil> 0xc42102fb60 exit status 1 <nil> <nil> true [0xc4210301b8 0xc4210301d0 0xc4210301e8] [0xc4210301b8 0xc4210301d0 0xc4210301e8] [0xc4210301c8 0xc4210301e0] [0x8f98d0 0x8f98d0] 0xc421384960 <nil>}:
+Command stdout:
+
+stderr:
+Error from server (NotFound): pods "ss-2" not found
+
+error:
+exit status 1
+
+Jul  2 13:44:15.990: INFO: Running '/usr/local/bin/kubectl --kubeconfig=/tmp/kubeconfig-411378559 exec --namespace=e2e-tests-statefulset-nxr8c ss-2 -- /bin/sh -c mv -v /tmp/index.html /usr/share/nginx/html/ || true'
+Jul  2 13:44:16.151: INFO: rc: 1
+Jul  2 13:44:16.151: INFO: Waiting 10s to retry failed RunHostCmd: error running &{/usr/local/bin/kubectl [kubectl --kubeconfig=/tmp/kubeconfig-411378559 exec --namespace=e2e-tests-statefulset-nxr8c ss-2 -- /bin/sh -c mv -v /tmp/index.html /usr/share/nginx/html/ || true] []  <nil>  Error from server (NotFound): pods "ss-2" not found
+ [] <nil> 0xc42095de90 exit status 1 <nil> <nil> true [0xc421030010 0xc421030028 0xc421030040] [0xc421030010 0xc421030028 0xc421030040] [0xc421030020 0xc421030038] [0x8f98d0 0x8f98d0] 0xc421384060 <nil>}:
+Command stdout:
+
+stderr:
+Error from server (NotFound): pods "ss-2" not found
+
+error:
+exit status 1
+
+Jul  2 13:44:26.152: INFO: Running '/usr/local/bin/kubectl --kubeconfig=/tmp/kubeconfig-411378559 exec --namespace=e2e-tests-statefulset-nxr8c ss-2 -- /bin/sh -c mv -v /tmp/index.html /usr/share/nginx/html/ || true'
+Jul  2 13:44:26.244: INFO: rc: 1
+Jul  2 13:44:26.245: INFO: Waiting 10s to retry failed RunHostCmd: error running &{/usr/local/bin/kubectl [kubectl --kubeconfig=/tmp/kubeconfig-411378559 exec --namespace=e2e-tests-statefulset-nxr8c ss-2 -- /bin/sh -c mv -v /tmp/index.html /usr/share/nginx/html/ || true] []  <nil>  Error from server (NotFound): pods "ss-2" not found
+ [] <nil> 0xc42034dda0 exit status 1 <nil> <nil> true [0xc421206040 0xc421206188 0xc421206260] [0xc421206040 0xc421206188 0xc421206260] [0xc4212060d0 0xc421206250] [0x8f98d0 0x8f98d0] 0xc421470060 <nil>}:
+Command stdout:
+
+stderr:
+Error from server (NotFound): pods "ss-2" not found
+
+error:
+exit status 1
+
+Jul  2 13:44:36.245: INFO: Running '/usr/local/bin/kubectl --kubeconfig=/tmp/kubeconfig-411378559 exec --namespace=e2e-tests-statefulset-nxr8c ss-2 -- /bin/sh -c mv -v /tmp/index.html /usr/share/nginx/html/ || true'
+Jul  2 13:44:36.325: INFO: rc: 1
+Jul  2 13:44:36.325: INFO: Waiting 10s to retry failed RunHostCmd: error running &{/usr/local/bin/kubectl [kubectl --kubeconfig=/tmp/kubeconfig-411378559 exec --namespace=e2e-tests-statefulset-nxr8c ss-2 -- /bin/sh -c mv -v /tmp/index.html /usr/share/nginx/html/ || true] []  <nil>  Error from server (NotFound): pods "ss-2" not found
+ [] <nil> 0xc42102e390 exit status 1 <nil> <nil> true [0xc4212062a8 0xc421206328 0xc4212063f0] [0xc4212062a8 0xc421206328 0xc4212063f0] [0xc421206300 0xc421206368] [0x8f98d0 0x8f98d0] 0xc421470180 <nil>}:
+Command stdout:
+
+stderr:
+Error from server (NotFound): pods "ss-2" not found
+
+error:
+exit status 1
+
+Jul  2 13:44:46.325: INFO: Running '/usr/local/bin/kubectl --kubeconfig=/tmp/kubeconfig-411378559 exec --namespace=e2e-tests-statefulset-nxr8c ss-2 -- /bin/sh -c mv -v /tmp/index.html /usr/share/nginx/html/ || true'
+Jul  2 13:44:46.408: INFO: rc: 1
+Jul  2 13:44:46.408: INFO: Waiting 10s to retry failed RunHostCmd: error running &{/usr/local/bin/kubectl [kubectl --kubeconfig=/tmp/kubeconfig-411378559 exec --namespace=e2e-tests-statefulset-nxr8c ss-2 -- /bin/sh -c mv -v /tmp/index.html /usr/share/nginx/html/ || true] []  <nil>  Error from server (NotFound): pods "ss-2" not found
+ [] <nil> 0xc4212b6390 exit status 1 <nil> <nil> true [0xc421030048 0xc421030060 0xc421030090] [0xc421030048 0xc421030060 0xc421030090] [0xc421030058 0xc421030070] [0x8f98d0 0x8f98d0] 0xc421384180 <nil>}:
+Command stdout:
+
+stderr:
+Error from server (NotFound): pods "ss-2" not found
+
+error:
+exit status 1
+
+Jul  2 13:44:56.408: INFO: Running '/usr/local/bin/kubectl --kubeconfig=/tmp/kubeconfig-411378559 exec --namespace=e2e-tests-statefulset-nxr8c ss-2 -- /bin/sh -c mv -v /tmp/index.html /usr/share/nginx/html/ || true'
+Jul  2 13:44:56.488: INFO: rc: 1
+Jul  2 13:44:56.488: INFO: Waiting 10s to retry failed RunHostCmd: error running &{/usr/local/bin/kubectl [kubectl --kubeconfig=/tmp/kubeconfig-411378559 exec --namespace=e2e-tests-statefulset-nxr8c ss-2 -- /bin/sh -c mv -v /tmp/index.html /usr/share/nginx/html/ || true] []  <nil>  Error from server (NotFound): pods "ss-2" not found
+ [] <nil> 0xc42102e8a0 exit status 1 <nil> <nil> true [0xc421206408 0xc421206460 0xc4212064a8] [0xc421206408 0xc421206460 0xc4212064a8] [0xc421206448 0xc421206490] [0x8f98d0 0x8f98d0] 0xc4214702a0 <nil>}:
+Command stdout:
+
+stderr:
+Error from server (NotFound): pods "ss-2" not found
+
+error:
+exit status 1
+
+Jul  2 13:45:06.488: INFO: Running '/usr/local/bin/kubectl --kubeconfig=/tmp/kubeconfig-411378559 exec --namespace=e2e-tests-statefulset-nxr8c ss-2 -- /bin/sh -c mv -v /tmp/index.html /usr/share/nginx/html/ || true'
+Jul  2 13:45:06.569: INFO: rc: 1
+Jul  2 13:45:06.569: INFO: Waiting 10s to retry failed RunHostCmd: error running &{/usr/local/bin/kubectl [kubectl --kubeconfig=/tmp/kubeconfig-411378559 exec --namespace=e2e-tests-statefulset-nxr8c ss-2 -- /bin/sh -c mv -v /tmp/index.html /usr/share/nginx/html/ || true] []  <nil>  Error from server (NotFound): pods "ss-2" not found
+ [] <nil> 0xc4212b69f0 exit status 1 <nil> <nil> true [0xc421030098 0xc4210300b0 0xc4210300e8] [0xc421030098 0xc4210300b0 0xc4210300e8] [0xc4210300a8 0xc4210300c8] [0x8f98d0 0x8f98d0] 0xc4213842a0 <nil>}:
+Command stdout:
+
+stderr:
+Error from server (NotFound): pods "ss-2" not found
+
+error:
+exit status 1
+
+Jul  2 13:45:16.569: INFO: Running '/usr/local/bin/kubectl --kubeconfig=/tmp/kubeconfig-411378559 exec --namespace=e2e-tests-statefulset-nxr8c ss-2 -- /bin/sh -c mv -v /tmp/index.html /usr/share/nginx/html/ || true'
+Jul  2 13:45:16.654: INFO: rc: 1
+Jul  2 13:45:16.654: INFO: Waiting 10s to retry failed RunHostCmd: error running &{/usr/local/bin/kubectl [kubectl --kubeconfig=/tmp/kubeconfig-411378559 exec --namespace=e2e-tests-statefulset-nxr8c ss-2 -- /bin/sh -c mv -v /tmp/index.html /usr/share/nginx/html/ || true] []  <nil>  Error from server (NotFound): pods "ss-2" not found
+ [] <nil> 0xc4212b6f00 exit status 1 <nil> <nil> true [0xc4210300f0 0xc421030118 0xc421030130] [0xc4210300f0 0xc421030118 0xc421030130] [0xc421030110 0xc421030128] [0x8f98d0 0x8f98d0] 0xc4213843c0 <nil>}:
+Command stdout:
+
+stderr:
+Error from server (NotFound): pods "ss-2" not found
+
+error:
+exit status 1
+
+Jul  2 13:45:26.654: INFO: Running '/usr/local/bin/kubectl --kubeconfig=/tmp/kubeconfig-411378559 exec --namespace=e2e-tests-statefulset-nxr8c ss-2 -- /bin/sh -c mv -v /tmp/index.html /usr/share/nginx/html/ || true'
+Jul  2 13:45:26.752: INFO: rc: 1
+Jul  2 13:45:26.752: INFO: Waiting 10s to retry failed RunHostCmd: error running &{/usr/local/bin/kubectl [kubectl --kubeconfig=/tmp/kubeconfig-411378559 exec --namespace=e2e-tests-statefulset-nxr8c ss-2 -- /bin/sh -c mv -v /tmp/index.html /usr/share/nginx/html/ || true] []  <nil>  Error from server (NotFound): pods "ss-2" not found
+ [] <nil> 0xc4212b7740 exit status 1 <nil> <nil> true [0xc421030138 0xc421030150 0xc421030168] [0xc421030138 0xc421030150 0xc421030168] [0xc421030148 0xc421030160] [0x8f98d0 0x8f98d0] 0xc4213846c0 <nil>}:
+Command stdout:
+
+stderr:
+Error from server (NotFound): pods "ss-2" not found
+
+error:
+exit status 1
+
+Jul  2 13:45:36.752: INFO: Running '/usr/local/bin/kubectl --kubeconfig=/tmp/kubeconfig-411378559 exec --namespace=e2e-tests-statefulset-nxr8c ss-2 -- /bin/sh -c mv -v /tmp/index.html /usr/share/nginx/html/ || true'
+Jul  2 13:45:36.833: INFO: rc: 1
+Jul  2 13:45:36.833: INFO: Waiting 10s to retry failed RunHostCmd: error running &{/usr/local/bin/kubectl [kubectl --kubeconfig=/tmp/kubeconfig-411378559 exec --namespace=e2e-tests-statefulset-nxr8c ss-2 -- /bin/sh -c mv -v /tmp/index.html /usr/share/nginx/html/ || true] []  <nil>  Error from server (NotFound): pods "ss-2" not found
+ [] <nil> 0xc4212b7e30 exit status 1 <nil> <nil> true [0xc421030170 0xc421030188 0xc4210301a0] [0xc421030170 0xc421030188 0xc4210301a0] [0xc421030180 0xc421030198] [0x8f98d0 0x8f98d0] 0xc4213847e0 <nil>}:
+Command stdout:
+
+stderr:
+Error from server (NotFound): pods "ss-2" not found
+
+error:
+exit status 1
+
+Jul  2 13:45:46.833: INFO: Running '/usr/local/bin/kubectl --kubeconfig=/tmp/kubeconfig-411378559 exec --namespace=e2e-tests-statefulset-nxr8c ss-2 -- /bin/sh -c mv -v /tmp/index.html /usr/share/nginx/html/ || true'
+Jul  2 13:45:46.915: INFO: rc: 1
+Jul  2 13:45:46.915: INFO: stdout of mv -v /tmp/index.html /usr/share/nginx/html/ || true on ss-2: 
+Jul  2 13:45:46.915: INFO: Scaling statefulset ss to 0
+STEP: Verifying that stateful set ss was scaled down in reverse order
+[AfterEach] [k8s.io] Basic StatefulSet functionality [StatefulSetBasic]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/statefulset.go:83
+Jul  2 13:45:46.926: INFO: Deleting all statefulset in ns e2e-tests-statefulset-nxr8c
+Jul  2 13:45:46.929: INFO: Scaling statefulset ss to 0
+Jul  2 13:45:46.939: INFO: Waiting for statefulset status.replicas updated to 0
+Jul  2 13:45:46.941: INFO: Deleting statefulset ss
+[AfterEach] [sig-apps] StatefulSet
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:45:46.952: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-statefulset-nxr8c" for this suite.
+Jul  2 13:45:52.966: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:45:53.015: INFO: namespace: e2e-tests-statefulset-nxr8c, resource: bindings, ignored listing per whitelist
+Jul  2 13:45:53.065: INFO: namespace e2e-tests-statefulset-nxr8c deletion completed in 6.109487978s
+
+• [SLOW TEST:372.969 seconds]
+[sig-apps] StatefulSet
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/framework.go:22
+  [k8s.io] Basic StatefulSet functionality [StatefulSetBasic]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:679
+    Scaling should happen in predictable order and halt if any stateful pod is unhealthy [Conformance]
+    /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSSSSSSS
+------------------------------
+[sig-storage] HostPath 
+  should give a volume the correct mode [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-storage] HostPath
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:45:53.066: INFO: >>> kubeConfig: /tmp/kubeconfig-411378559
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] HostPath
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/host_path.go:36
+[It] should give a volume the correct mode [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating a pod to test hostPath mode
+Jul  2 13:45:53.179: INFO: Waiting up to 5m0s for pod "pod-host-path-test" in namespace "e2e-tests-hostpath-f7xsr" to be "success or failure"
+Jul  2 13:45:53.184: INFO: Pod "pod-host-path-test": Phase="Pending", Reason="", readiness=false. Elapsed: 5.175665ms
+Jul  2 13:45:55.188: INFO: Pod "pod-host-path-test": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.009222741s
+STEP: Saw pod success
+Jul  2 13:45:55.188: INFO: Pod "pod-host-path-test" satisfied condition "success or failure"
+Jul  2 13:45:55.191: INFO: Trying to get logs from node ip-10-250-24-1.ec2.internal pod pod-host-path-test container test-container-1: <nil>
+STEP: delete the pod
+Jul  2 13:45:55.209: INFO: Waiting for pod pod-host-path-test to disappear
+Jul  2 13:45:55.212: INFO: Pod pod-host-path-test no longer exists
+[AfterEach] [sig-storage] HostPath
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:45:55.212: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-hostpath-f7xsr" for this suite.
+Jul  2 13:46:01.242: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:46:01.288: INFO: namespace: e2e-tests-hostpath-f7xsr, resource: bindings, ignored listing per whitelist
+Jul  2 13:46:01.347: INFO: namespace e2e-tests-hostpath-f7xsr deletion completed in 6.129543416s
+
+• [SLOW TEST:8.281 seconds]
+[sig-storage] HostPath
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/host_path.go:33
+  should give a volume the correct mode [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSSSSS
+------------------------------
+[k8s.io] [sig-node] PreStop 
+  should call prestop when killing a pod  [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [k8s.io] [sig-node] PreStop
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:46:01.347: INFO: >>> kubeConfig: /tmp/kubeconfig-411378559
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should call prestop when killing a pod  [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating server pod server in namespace e2e-tests-prestop-65qnw
+STEP: Waiting for pods to come up.
+STEP: Creating tester pod tester in namespace e2e-tests-prestop-65qnw
+STEP: Deleting pre-stop pod
+Jul  2 13:46:14.560: INFO: Saw: {
+	"Hostname": "server",
+	"Sent": null,
+	"Received": {
+		"prestop": 1
+	},
+	"Errors": null,
+	"Log": [
+		"default/nettest has 0 endpoints ([]), which is less than 8 as expected. Waiting for all endpoints to come up.",
+		"default/nettest has 0 endpoints ([]), which is less than 8 as expected. Waiting for all endpoints to come up.",
+		"default/nettest has 0 endpoints ([]), which is less than 8 as expected. Waiting for all endpoints to come up."
+	],
+	"StillContactingPeers": true
+}
+STEP: Deleting the server pod
+[AfterEach] [k8s.io] [sig-node] PreStop
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:46:14.566: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-prestop-65qnw" for this suite.
+Jul  2 13:46:52.665: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:46:52.685: INFO: namespace: e2e-tests-prestop-65qnw, resource: bindings, ignored listing per whitelist
+Jul  2 13:46:52.765: INFO: namespace e2e-tests-prestop-65qnw deletion completed in 38.116666427s
+
+• [SLOW TEST:51.419 seconds]
+[k8s.io] [sig-node] PreStop
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:679
+  should call prestop when killing a pod  [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SS
+------------------------------
+[k8s.io] Docker Containers 
+  should be able to override the image's default command and arguments [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [k8s.io] Docker Containers
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:46:52.766: INFO: >>> kubeConfig: /tmp/kubeconfig-411378559
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should be able to override the image's default command and arguments [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating a pod to test override all
+Jul  2 13:46:52.862: INFO: Waiting up to 5m0s for pod "client-containers-607a0d03-7dfe-11e8-bae1-da96248f62d7" in namespace "e2e-tests-containers-zsgvp" to be "success or failure"
+Jul  2 13:46:52.865: INFO: Pod "client-containers-607a0d03-7dfe-11e8-bae1-da96248f62d7": Phase="Pending", Reason="", readiness=false. Elapsed: 2.609801ms
+Jul  2 13:46:54.869: INFO: Pod "client-containers-607a0d03-7dfe-11e8-bae1-da96248f62d7": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.006280009s
+STEP: Saw pod success
+Jul  2 13:46:54.869: INFO: Pod "client-containers-607a0d03-7dfe-11e8-bae1-da96248f62d7" satisfied condition "success or failure"
+Jul  2 13:46:54.946: INFO: Trying to get logs from node ip-10-250-24-1.ec2.internal pod client-containers-607a0d03-7dfe-11e8-bae1-da96248f62d7 container test-container: <nil>
+STEP: delete the pod
+Jul  2 13:46:54.965: INFO: Waiting for pod client-containers-607a0d03-7dfe-11e8-bae1-da96248f62d7 to disappear
+Jul  2 13:46:54.970: INFO: Pod client-containers-607a0d03-7dfe-11e8-bae1-da96248f62d7 no longer exists
+[AfterEach] [k8s.io] Docker Containers
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:46:54.970: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-containers-zsgvp" for this suite.
+Jul  2 13:47:00.999: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:47:01.014: INFO: namespace: e2e-tests-containers-zsgvp, resource: bindings, ignored listing per whitelist
+Jul  2 13:47:01.100: INFO: namespace e2e-tests-containers-zsgvp deletion completed in 6.110996423s
+
+• [SLOW TEST:8.334 seconds]
+[k8s.io] Docker Containers
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:679
+  should be able to override the image's default command and arguments [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSS
+------------------------------
+[sig-api-machinery] Watchers 
+  should observe add, update, and delete watch notifications on configmaps [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-api-machinery] Watchers
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:47:01.100: INFO: >>> kubeConfig: /tmp/kubeconfig-411378559
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should observe add, update, and delete watch notifications on configmaps [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: creating a watch on configmaps with label A
+STEP: creating a watch on configmaps with label B
+STEP: creating a watch on configmaps with label A or B
+STEP: creating a configmap with label A and ensuring the correct watchers observe the notification
+Jul  2 13:47:01.203: INFO: Got : ADDED &ConfigMap{ObjectMeta:k8s_io_apimachinery_pkg_apis_meta_v1.ObjectMeta{Name:e2e-watch-test-configmap-a,GenerateName:,Namespace:e2e-tests-watch-vvw8k,SelfLink:/api/v1/namespaces/e2e-tests-watch-vvw8k/configmaps/e2e-watch-test-configmap-a,UID:6572f7da-7dfe-11e8-9deb-8e4c5ec544fb,ResourceVersion:12202,Generation:0,CreationTimestamp:2018-07-02 13:47:01 +0000 UTC,DeletionTimestamp:<nil>,DeletionGracePeriodSeconds:nil,Labels:map[string]string{watch-this-configmap: multiple-watchers-A,},Annotations:map[string]string{},OwnerReferences:[],Finalizers:[],ClusterName:,Initializers:nil,},Data:map[string]string{},BinaryData:map[string][]byte{},}
+Jul  2 13:47:01.203: INFO: Got : ADDED &ConfigMap{ObjectMeta:k8s_io_apimachinery_pkg_apis_meta_v1.ObjectMeta{Name:e2e-watch-test-configmap-a,GenerateName:,Namespace:e2e-tests-watch-vvw8k,SelfLink:/api/v1/namespaces/e2e-tests-watch-vvw8k/configmaps/e2e-watch-test-configmap-a,UID:6572f7da-7dfe-11e8-9deb-8e4c5ec544fb,ResourceVersion:12202,Generation:0,CreationTimestamp:2018-07-02 13:47:01 +0000 UTC,DeletionTimestamp:<nil>,DeletionGracePeriodSeconds:nil,Labels:map[string]string{watch-this-configmap: multiple-watchers-A,},Annotations:map[string]string{},OwnerReferences:[],Finalizers:[],ClusterName:,Initializers:nil,},Data:map[string]string{},BinaryData:map[string][]byte{},}
+STEP: modifying configmap A and ensuring the correct watchers observe the notification
+Jul  2 13:47:11.250: INFO: Got : MODIFIED &ConfigMap{ObjectMeta:k8s_io_apimachinery_pkg_apis_meta_v1.ObjectMeta{Name:e2e-watch-test-configmap-a,GenerateName:,Namespace:e2e-tests-watch-vvw8k,SelfLink:/api/v1/namespaces/e2e-tests-watch-vvw8k/configmaps/e2e-watch-test-configmap-a,UID:6572f7da-7dfe-11e8-9deb-8e4c5ec544fb,ResourceVersion:12221,Generation:0,CreationTimestamp:2018-07-02 13:47:01 +0000 UTC,DeletionTimestamp:<nil>,DeletionGracePeriodSeconds:nil,Labels:map[string]string{watch-this-configmap: multiple-watchers-A,},Annotations:map[string]string{},OwnerReferences:[],Finalizers:[],ClusterName:,Initializers:nil,},Data:map[string]string{mutation: 1,},BinaryData:map[string][]byte{},}
+Jul  2 13:47:11.250: INFO: Got : MODIFIED &ConfigMap{ObjectMeta:k8s_io_apimachinery_pkg_apis_meta_v1.ObjectMeta{Name:e2e-watch-test-configmap-a,GenerateName:,Namespace:e2e-tests-watch-vvw8k,SelfLink:/api/v1/namespaces/e2e-tests-watch-vvw8k/configmaps/e2e-watch-test-configmap-a,UID:6572f7da-7dfe-11e8-9deb-8e4c5ec544fb,ResourceVersion:12221,Generation:0,CreationTimestamp:2018-07-02 13:47:01 +0000 UTC,DeletionTimestamp:<nil>,DeletionGracePeriodSeconds:nil,Labels:map[string]string{watch-this-configmap: multiple-watchers-A,},Annotations:map[string]string{},OwnerReferences:[],Finalizers:[],ClusterName:,Initializers:nil,},Data:map[string]string{mutation: 1,},BinaryData:map[string][]byte{},}
+STEP: modifying configmap A again and ensuring the correct watchers observe the notification
+Jul  2 13:47:21.258: INFO: Got : MODIFIED &ConfigMap{ObjectMeta:k8s_io_apimachinery_pkg_apis_meta_v1.ObjectMeta{Name:e2e-watch-test-configmap-a,GenerateName:,Namespace:e2e-tests-watch-vvw8k,SelfLink:/api/v1/namespaces/e2e-tests-watch-vvw8k/configmaps/e2e-watch-test-configmap-a,UID:6572f7da-7dfe-11e8-9deb-8e4c5ec544fb,ResourceVersion:12241,Generation:0,CreationTimestamp:2018-07-02 13:47:01 +0000 UTC,DeletionTimestamp:<nil>,DeletionGracePeriodSeconds:nil,Labels:map[string]string{watch-this-configmap: multiple-watchers-A,},Annotations:map[string]string{},OwnerReferences:[],Finalizers:[],ClusterName:,Initializers:nil,},Data:map[string]string{mutation: 2,},BinaryData:map[string][]byte{},}
+Jul  2 13:47:21.258: INFO: Got : MODIFIED &ConfigMap{ObjectMeta:k8s_io_apimachinery_pkg_apis_meta_v1.ObjectMeta{Name:e2e-watch-test-configmap-a,GenerateName:,Namespace:e2e-tests-watch-vvw8k,SelfLink:/api/v1/namespaces/e2e-tests-watch-vvw8k/configmaps/e2e-watch-test-configmap-a,UID:6572f7da-7dfe-11e8-9deb-8e4c5ec544fb,ResourceVersion:12241,Generation:0,CreationTimestamp:2018-07-02 13:47:01 +0000 UTC,DeletionTimestamp:<nil>,DeletionGracePeriodSeconds:nil,Labels:map[string]string{watch-this-configmap: multiple-watchers-A,},Annotations:map[string]string{},OwnerReferences:[],Finalizers:[],ClusterName:,Initializers:nil,},Data:map[string]string{mutation: 2,},BinaryData:map[string][]byte{},}
+STEP: deleting configmap A and ensuring the correct watchers observe the notification
+Jul  2 13:47:31.265: INFO: Got : DELETED &ConfigMap{ObjectMeta:k8s_io_apimachinery_pkg_apis_meta_v1.ObjectMeta{Name:e2e-watch-test-configmap-a,GenerateName:,Namespace:e2e-tests-watch-vvw8k,SelfLink:/api/v1/namespaces/e2e-tests-watch-vvw8k/configmaps/e2e-watch-test-configmap-a,UID:6572f7da-7dfe-11e8-9deb-8e4c5ec544fb,ResourceVersion:12263,Generation:0,CreationTimestamp:2018-07-02 13:47:01 +0000 UTC,DeletionTimestamp:<nil>,DeletionGracePeriodSeconds:nil,Labels:map[string]string{watch-this-configmap: multiple-watchers-A,},Annotations:map[string]string{},OwnerReferences:[],Finalizers:[],ClusterName:,Initializers:nil,},Data:map[string]string{mutation: 2,},BinaryData:map[string][]byte{},}
+Jul  2 13:47:31.265: INFO: Got : DELETED &ConfigMap{ObjectMeta:k8s_io_apimachinery_pkg_apis_meta_v1.ObjectMeta{Name:e2e-watch-test-configmap-a,GenerateName:,Namespace:e2e-tests-watch-vvw8k,SelfLink:/api/v1/namespaces/e2e-tests-watch-vvw8k/configmaps/e2e-watch-test-configmap-a,UID:6572f7da-7dfe-11e8-9deb-8e4c5ec544fb,ResourceVersion:12263,Generation:0,CreationTimestamp:2018-07-02 13:47:01 +0000 UTC,DeletionTimestamp:<nil>,DeletionGracePeriodSeconds:nil,Labels:map[string]string{watch-this-configmap: multiple-watchers-A,},Annotations:map[string]string{},OwnerReferences:[],Finalizers:[],ClusterName:,Initializers:nil,},Data:map[string]string{mutation: 2,},BinaryData:map[string][]byte{},}
+STEP: creating a configmap with label B and ensuring the correct watchers observe the notification
+Jul  2 13:47:41.270: INFO: Got : ADDED &ConfigMap{ObjectMeta:k8s_io_apimachinery_pkg_apis_meta_v1.ObjectMeta{Name:e2e-watch-test-configmap-b,GenerateName:,Namespace:e2e-tests-watch-vvw8k,SelfLink:/api/v1/namespaces/e2e-tests-watch-vvw8k/configmaps/e2e-watch-test-configmap-b,UID:7d54abcf-7dfe-11e8-9deb-8e4c5ec544fb,ResourceVersion:12285,Generation:0,CreationTimestamp:2018-07-02 13:47:41 +0000 UTC,DeletionTimestamp:<nil>,DeletionGracePeriodSeconds:nil,Labels:map[string]string{watch-this-configmap: multiple-watchers-B,},Annotations:map[string]string{},OwnerReferences:[],Finalizers:[],ClusterName:,Initializers:nil,},Data:map[string]string{},BinaryData:map[string][]byte{},}
+Jul  2 13:47:41.271: INFO: Got : ADDED &ConfigMap{ObjectMeta:k8s_io_apimachinery_pkg_apis_meta_v1.ObjectMeta{Name:e2e-watch-test-configmap-b,GenerateName:,Namespace:e2e-tests-watch-vvw8k,SelfLink:/api/v1/namespaces/e2e-tests-watch-vvw8k/configmaps/e2e-watch-test-configmap-b,UID:7d54abcf-7dfe-11e8-9deb-8e4c5ec544fb,ResourceVersion:12285,Generation:0,CreationTimestamp:2018-07-02 13:47:41 +0000 UTC,DeletionTimestamp:<nil>,DeletionGracePeriodSeconds:nil,Labels:map[string]string{watch-this-configmap: multiple-watchers-B,},Annotations:map[string]string{},OwnerReferences:[],Finalizers:[],ClusterName:,Initializers:nil,},Data:map[string]string{},BinaryData:map[string][]byte{},}
+STEP: deleting configmap B and ensuring the correct watchers observe the notification
+Jul  2 13:47:51.277: INFO: Got : DELETED &ConfigMap{ObjectMeta:k8s_io_apimachinery_pkg_apis_meta_v1.ObjectMeta{Name:e2e-watch-test-configmap-b,GenerateName:,Namespace:e2e-tests-watch-vvw8k,SelfLink:/api/v1/namespaces/e2e-tests-watch-vvw8k/configmaps/e2e-watch-test-configmap-b,UID:7d54abcf-7dfe-11e8-9deb-8e4c5ec544fb,ResourceVersion:12306,Generation:0,CreationTimestamp:2018-07-02 13:47:41 +0000 UTC,DeletionTimestamp:<nil>,DeletionGracePeriodSeconds:nil,Labels:map[string]string{watch-this-configmap: multiple-watchers-B,},Annotations:map[string]string{},OwnerReferences:[],Finalizers:[],ClusterName:,Initializers:nil,},Data:map[string]string{},BinaryData:map[string][]byte{},}
+Jul  2 13:47:51.277: INFO: Got : DELETED &ConfigMap{ObjectMeta:k8s_io_apimachinery_pkg_apis_meta_v1.ObjectMeta{Name:e2e-watch-test-configmap-b,GenerateName:,Namespace:e2e-tests-watch-vvw8k,SelfLink:/api/v1/namespaces/e2e-tests-watch-vvw8k/configmaps/e2e-watch-test-configmap-b,UID:7d54abcf-7dfe-11e8-9deb-8e4c5ec544fb,ResourceVersion:12306,Generation:0,CreationTimestamp:2018-07-02 13:47:41 +0000 UTC,DeletionTimestamp:<nil>,DeletionGracePeriodSeconds:nil,Labels:map[string]string{watch-this-configmap: multiple-watchers-B,},Annotations:map[string]string{},OwnerReferences:[],Finalizers:[],ClusterName:,Initializers:nil,},Data:map[string]string{},BinaryData:map[string][]byte{},}
+[AfterEach] [sig-api-machinery] Watchers
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:48:01.277: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-watch-vvw8k" for this suite.
+Jul  2 13:48:07.292: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:48:07.510: INFO: namespace: e2e-tests-watch-vvw8k, resource: bindings, ignored listing per whitelist
+Jul  2 13:48:07.517: INFO: namespace e2e-tests-watch-vvw8k deletion completed in 6.236119585s
+
+• [SLOW TEST:66.417 seconds]
+[sig-api-machinery] Watchers
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apimachinery/framework.go:22
+  should observe add, update, and delete watch notifications on configmaps [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSS
+------------------------------
+[sig-storage] Projected 
+  should be consumable from pods in volume with mappings as non-root [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:48:07.517: INFO: >>> kubeConfig: /tmp/kubeconfig-411378559
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:858
+[It] should be consumable from pods in volume with mappings as non-root [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating configMap with name projected-configmap-test-volume-map-8d081100-7dfe-11e8-bae1-da96248f62d7
+STEP: Creating a pod to test consume configMaps
+Jul  2 13:48:07.617: INFO: Waiting up to 5m0s for pod "pod-projected-configmaps-8d08ab1b-7dfe-11e8-bae1-da96248f62d7" in namespace "e2e-tests-projected-x9nj7" to be "success or failure"
+Jul  2 13:48:07.622: INFO: Pod "pod-projected-configmaps-8d08ab1b-7dfe-11e8-bae1-da96248f62d7": Phase="Pending", Reason="", readiness=false. Elapsed: 4.587824ms
+Jul  2 13:48:09.643: INFO: Pod "pod-projected-configmaps-8d08ab1b-7dfe-11e8-bae1-da96248f62d7": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.026437433s
+STEP: Saw pod success
+Jul  2 13:48:09.643: INFO: Pod "pod-projected-configmaps-8d08ab1b-7dfe-11e8-bae1-da96248f62d7" satisfied condition "success or failure"
+Jul  2 13:48:09.651: INFO: Trying to get logs from node ip-10-250-24-1.ec2.internal pod pod-projected-configmaps-8d08ab1b-7dfe-11e8-bae1-da96248f62d7 container projected-configmap-volume-test: <nil>
+STEP: delete the pod
+Jul  2 13:48:09.693: INFO: Waiting for pod pod-projected-configmaps-8d08ab1b-7dfe-11e8-bae1-da96248f62d7 to disappear
+Jul  2 13:48:09.706: INFO: Pod pod-projected-configmaps-8d08ab1b-7dfe-11e8-bae1-da96248f62d7 no longer exists
+[AfterEach] [sig-storage] Projected
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:48:09.706: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-x9nj7" for this suite.
+Jul  2 13:48:15.728: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:48:15.768: INFO: namespace: e2e-tests-projected-x9nj7, resource: bindings, ignored listing per whitelist
+Jul  2 13:48:15.825: INFO: namespace e2e-tests-projected-x9nj7 deletion completed in 6.109174498s
+
+• [SLOW TEST:8.308 seconds]
+[sig-storage] Projected
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:34
+  should be consumable from pods in volume with mappings as non-root [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+S
+------------------------------
+[sig-apps] StatefulSet [k8s.io] Basic StatefulSet functionality [StatefulSetBasic] 
+  Burst scaling should run to completion even with unhealthy pods [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-apps] StatefulSet
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:48:15.826: INFO: >>> kubeConfig: /tmp/kubeconfig-411378559
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-apps] StatefulSet
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/statefulset.go:57
+[BeforeEach] [k8s.io] Basic StatefulSet functionality [StatefulSetBasic]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/statefulset.go:72
+STEP: Creating service test in namespace e2e-tests-statefulset-27xml
+[It] Burst scaling should run to completion even with unhealthy pods [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating stateful set ss in namespace e2e-tests-statefulset-27xml
+STEP: Waiting until all stateful set ss replicas will be running in namespace e2e-tests-statefulset-27xml
+Jul  2 13:48:15.934: INFO: Found 0 stateful pods, waiting for 1
+Jul  2 13:48:25.939: INFO: Waiting for pod ss-0 to enter Running - Ready=true, currently Running - Ready=true
+STEP: Confirming that stateful set scale up will not halt with unhealthy stateful pod
+Jul  2 13:48:25.942: INFO: Running '/usr/local/bin/kubectl --kubeconfig=/tmp/kubeconfig-411378559 exec --namespace=e2e-tests-statefulset-27xml ss-0 -- /bin/sh -c mv -v /usr/share/nginx/html/index.html /tmp/ || true'
+Jul  2 13:48:26.292: INFO: stderr: ""
+Jul  2 13:48:26.292: INFO: stdout: "'/usr/share/nginx/html/index.html' -> '/tmp/index.html'\n"
+Jul  2 13:48:26.292: INFO: stdout of mv -v /usr/share/nginx/html/index.html /tmp/ || true on ss-0: '/usr/share/nginx/html/index.html' -> '/tmp/index.html'
+
+Jul  2 13:48:26.295: INFO: Waiting for pod ss-0 to enter Running - Ready=false, currently Running - Ready=true
+Jul  2 13:48:36.299: INFO: Waiting for pod ss-0 to enter Running - Ready=false, currently Running - Ready=false
+Jul  2 13:48:36.300: INFO: Waiting for statefulset status.replicas updated to 0
+Jul  2 13:48:36.355: INFO: POD   NODE                         PHASE    GRACE  CONDITIONS
+Jul  2 13:48:36.355: INFO: ss-0  ip-10-250-24-1.ec2.internal  Running         [{Initialized True 0001-01-01 00:00:00 +0000 UTC 2018-07-02 13:48:15 +0000 UTC  } {Ready False 0001-01-01 00:00:00 +0000 UTC 2018-07-02 13:48:26 +0000 UTC ContainersNotReady containers with unready status: [nginx]} {ContainersReady False 0001-01-01 00:00:00 +0000 UTC 0001-01-01 00:00:00 +0000 UTC ContainersNotReady containers with unready status: [nginx]} {PodScheduled True 0001-01-01 00:00:00 +0000 UTC 2018-07-02 13:48:15 +0000 UTC  }]
+Jul  2 13:48:36.355: INFO: ss-1                               Pending         []
+Jul  2 13:48:36.355: INFO: 
+Jul  2 13:48:36.355: INFO: StatefulSet ss has not reached scale 3, at 2
+Jul  2 13:48:37.360: INFO: Verifying statefulset ss doesn't scale past 3 for another 8.994597543s
+Jul  2 13:48:38.364: INFO: Verifying statefulset ss doesn't scale past 3 for another 7.990513216s
+Jul  2 13:48:39.368: INFO: Verifying statefulset ss doesn't scale past 3 for another 6.986306095s
+Jul  2 13:48:40.374: INFO: Verifying statefulset ss doesn't scale past 3 for another 5.981624238s
+Jul  2 13:48:41.378: INFO: Verifying statefulset ss doesn't scale past 3 for another 4.976719797s
+Jul  2 13:48:42.383: INFO: Verifying statefulset ss doesn't scale past 3 for another 3.972458936s
+Jul  2 13:48:43.387: INFO: Verifying statefulset ss doesn't scale past 3 for another 2.967741257s
+Jul  2 13:48:44.391: INFO: Verifying statefulset ss doesn't scale past 3 for another 1.963257368s
+Jul  2 13:48:45.395: INFO: Verifying statefulset ss doesn't scale past 3 for another 959.261575ms
+STEP: Scaling up stateful set ss to 3 replicas and waiting until all of them will be running in namespace e2e-tests-statefulset-27xml
+Jul  2 13:48:46.444: INFO: Running '/usr/local/bin/kubectl --kubeconfig=/tmp/kubeconfig-411378559 exec --namespace=e2e-tests-statefulset-27xml ss-0 -- /bin/sh -c mv -v /tmp/index.html /usr/share/nginx/html/ || true'
+Jul  2 13:48:46.905: INFO: stderr: ""
+Jul  2 13:48:46.905: INFO: stdout: "'/tmp/index.html' -> '/usr/share/nginx/html/index.html'\n"
+Jul  2 13:48:46.905: INFO: stdout of mv -v /tmp/index.html /usr/share/nginx/html/ || true on ss-0: '/tmp/index.html' -> '/usr/share/nginx/html/index.html'
+
+Jul  2 13:48:46.906: INFO: Running '/usr/local/bin/kubectl --kubeconfig=/tmp/kubeconfig-411378559 exec --namespace=e2e-tests-statefulset-27xml ss-1 -- /bin/sh -c mv -v /tmp/index.html /usr/share/nginx/html/ || true'
+Jul  2 13:48:47.383: INFO: stderr: "mv: cannot stat '/tmp/index.html': No such file or directory\n"
+Jul  2 13:48:47.383: INFO: stdout: ""
+Jul  2 13:48:47.383: INFO: stdout of mv -v /tmp/index.html /usr/share/nginx/html/ || true on ss-1: 
+Jul  2 13:48:47.383: INFO: Running '/usr/local/bin/kubectl --kubeconfig=/tmp/kubeconfig-411378559 exec --namespace=e2e-tests-statefulset-27xml ss-2 -- /bin/sh -c mv -v /tmp/index.html /usr/share/nginx/html/ || true'
+Jul  2 13:48:47.885: INFO: stderr: "mv: cannot stat '/tmp/index.html': No such file or directory\n"
+Jul  2 13:48:47.885: INFO: stdout: ""
+Jul  2 13:48:47.885: INFO: stdout of mv -v /tmp/index.html /usr/share/nginx/html/ || true on ss-2: 
+Jul  2 13:48:47.889: INFO: Waiting for pod ss-0 to enter Running - Ready=true, currently Running - Ready=true
+Jul  2 13:48:47.889: INFO: Waiting for pod ss-1 to enter Running - Ready=true, currently Running - Ready=true
+Jul  2 13:48:47.889: INFO: Waiting for pod ss-2 to enter Running - Ready=true, currently Running - Ready=true
+STEP: Scale down will not halt with unhealthy stateful pod
+Jul  2 13:48:47.894: INFO: Running '/usr/local/bin/kubectl --kubeconfig=/tmp/kubeconfig-411378559 exec --namespace=e2e-tests-statefulset-27xml ss-0 -- /bin/sh -c mv -v /usr/share/nginx/html/index.html /tmp/ || true'
+Jul  2 13:48:48.369: INFO: stderr: ""
+Jul  2 13:48:48.369: INFO: stdout: "'/usr/share/nginx/html/index.html' -> '/tmp/index.html'\n"
+Jul  2 13:48:48.369: INFO: stdout of mv -v /usr/share/nginx/html/index.html /tmp/ || true on ss-0: '/usr/share/nginx/html/index.html' -> '/tmp/index.html'
+
+Jul  2 13:48:48.369: INFO: Running '/usr/local/bin/kubectl --kubeconfig=/tmp/kubeconfig-411378559 exec --namespace=e2e-tests-statefulset-27xml ss-1 -- /bin/sh -c mv -v /usr/share/nginx/html/index.html /tmp/ || true'
+Jul  2 13:48:48.939: INFO: stderr: ""
+Jul  2 13:48:48.939: INFO: stdout: "'/usr/share/nginx/html/index.html' -> '/tmp/index.html'\n"
+Jul  2 13:48:48.939: INFO: stdout of mv -v /usr/share/nginx/html/index.html /tmp/ || true on ss-1: '/usr/share/nginx/html/index.html' -> '/tmp/index.html'
+
+Jul  2 13:48:48.939: INFO: Running '/usr/local/bin/kubectl --kubeconfig=/tmp/kubeconfig-411378559 exec --namespace=e2e-tests-statefulset-27xml ss-2 -- /bin/sh -c mv -v /usr/share/nginx/html/index.html /tmp/ || true'
+Jul  2 13:48:49.466: INFO: stderr: ""
+Jul  2 13:48:49.466: INFO: stdout: "'/usr/share/nginx/html/index.html' -> '/tmp/index.html'\n"
+Jul  2 13:48:49.466: INFO: stdout of mv -v /usr/share/nginx/html/index.html /tmp/ || true on ss-2: '/usr/share/nginx/html/index.html' -> '/tmp/index.html'
+
+Jul  2 13:48:49.466: INFO: Waiting for statefulset status.replicas updated to 0
+Jul  2 13:48:49.470: INFO: Waiting for stateful set status.readyReplicas to become 0, currently 1
+Jul  2 13:48:59.477: INFO: Waiting for pod ss-0 to enter Running - Ready=false, currently Running - Ready=false
+Jul  2 13:48:59.477: INFO: Waiting for pod ss-1 to enter Running - Ready=false, currently Running - Ready=false
+Jul  2 13:48:59.477: INFO: Waiting for pod ss-2 to enter Running - Ready=false, currently Running - Ready=false
+Jul  2 13:48:59.553: INFO: POD   NODE                         PHASE    GRACE  CONDITIONS
+Jul  2 13:48:59.553: INFO: ss-0  ip-10-250-24-1.ec2.internal  Running         [{Initialized True 0001-01-01 00:00:00 +0000 UTC 2018-07-02 13:48:15 +0000 UTC  } {Ready False 0001-01-01 00:00:00 +0000 UTC 2018-07-02 13:48:48 +0000 UTC ContainersNotReady containers with unready status: [nginx]} {ContainersReady False 0001-01-01 00:00:00 +0000 UTC 0001-01-01 00:00:00 +0000 UTC ContainersNotReady containers with unready status: [nginx]} {PodScheduled True 0001-01-01 00:00:00 +0000 UTC 2018-07-02 13:48:15 +0000 UTC  }]
+Jul  2 13:48:59.553: INFO: ss-1  ip-10-250-24-1.ec2.internal  Running         [{Initialized True 0001-01-01 00:00:00 +0000 UTC 2018-07-02 13:48:36 +0000 UTC  } {Ready False 0001-01-01 00:00:00 +0000 UTC 2018-07-02 13:48:48 +0000 UTC ContainersNotReady containers with unready status: [nginx]} {ContainersReady False 0001-01-01 00:00:00 +0000 UTC 0001-01-01 00:00:00 +0000 UTC ContainersNotReady containers with unready status: [nginx]} {PodScheduled True 0001-01-01 00:00:00 +0000 UTC 2018-07-02 13:48:36 +0000 UTC  }]
+Jul  2 13:48:59.553: INFO: ss-2  ip-10-250-24-1.ec2.internal  Running         [{Initialized True 0001-01-01 00:00:00 +0000 UTC 2018-07-02 13:48:36 +0000 UTC  } {Ready False 0001-01-01 00:00:00 +0000 UTC 2018-07-02 13:48:50 +0000 UTC ContainersNotReady containers with unready status: [nginx]} {ContainersReady False 0001-01-01 00:00:00 +0000 UTC 0001-01-01 00:00:00 +0000 UTC ContainersNotReady containers with unready status: [nginx]} {PodScheduled True 0001-01-01 00:00:00 +0000 UTC 2018-07-02 13:48:36 +0000 UTC  }]
+Jul  2 13:48:59.553: INFO: 
+Jul  2 13:48:59.553: INFO: StatefulSet ss has not reached scale 0, at 3
+Jul  2 13:49:00.557: INFO: POD   NODE                         PHASE    GRACE  CONDITIONS
+Jul  2 13:49:00.557: INFO: ss-0  ip-10-250-24-1.ec2.internal  Running  30s    [{Initialized True 0001-01-01 00:00:00 +0000 UTC 2018-07-02 13:48:15 +0000 UTC  } {Ready False 0001-01-01 00:00:00 +0000 UTC 2018-07-02 13:48:48 +0000 UTC ContainersNotReady containers with unready status: [nginx]} {ContainersReady False 0001-01-01 00:00:00 +0000 UTC 0001-01-01 00:00:00 +0000 UTC ContainersNotReady containers with unready status: [nginx]} {PodScheduled True 0001-01-01 00:00:00 +0000 UTC 2018-07-02 13:48:15 +0000 UTC  }]
+Jul  2 13:49:00.557: INFO: ss-1  ip-10-250-24-1.ec2.internal  Running  30s    [{Initialized True 0001-01-01 00:00:00 +0000 UTC 2018-07-02 13:48:36 +0000 UTC  } {Ready False 0001-01-01 00:00:00 +0000 UTC 2018-07-02 13:48:48 +0000 UTC ContainersNotReady containers with unready status: [nginx]} {ContainersReady False 0001-01-01 00:00:00 +0000 UTC 0001-01-01 00:00:00 +0000 UTC ContainersNotReady containers with unready status: [nginx]} {PodScheduled True 0001-01-01 00:00:00 +0000 UTC 2018-07-02 13:48:36 +0000 UTC  }]
+Jul  2 13:49:00.558: INFO: ss-2  ip-10-250-24-1.ec2.internal  Running  30s    [{Initialized True 0001-01-01 00:00:00 +0000 UTC 2018-07-02 13:48:36 +0000 UTC  } {Ready False 0001-01-01 00:00:00 +0000 UTC 2018-07-02 13:48:50 +0000 UTC ContainersNotReady containers with unready status: [nginx]} {ContainersReady False 0001-01-01 00:00:00 +0000 UTC 0001-01-01 00:00:00 +0000 UTC ContainersNotReady containers with unready status: [nginx]} {PodScheduled True 0001-01-01 00:00:00 +0000 UTC 2018-07-02 13:48:36 +0000 UTC  }]
+Jul  2 13:49:00.558: INFO: 
+Jul  2 13:49:00.558: INFO: StatefulSet ss has not reached scale 0, at 3
+Jul  2 13:49:01.562: INFO: POD   NODE                         PHASE    GRACE  CONDITIONS
+Jul  2 13:49:01.562: INFO: ss-0  ip-10-250-24-1.ec2.internal  Running  30s    [{Initialized True 0001-01-01 00:00:00 +0000 UTC 2018-07-02 13:48:15 +0000 UTC  } {Ready False 0001-01-01 00:00:00 +0000 UTC 2018-07-02 13:48:48 +0000 UTC ContainersNotReady containers with unready status: [nginx]} {ContainersReady False 0001-01-01 00:00:00 +0000 UTC 0001-01-01 00:00:00 +0000 UTC ContainersNotReady containers with unready status: [nginx]} {PodScheduled True 0001-01-01 00:00:00 +0000 UTC 2018-07-02 13:48:15 +0000 UTC  }]
+Jul  2 13:49:01.562: INFO: ss-1  ip-10-250-24-1.ec2.internal  Running  30s    [{Initialized True 0001-01-01 00:00:00 +0000 UTC 2018-07-02 13:48:36 +0000 UTC  } {Ready False 0001-01-01 00:00:00 +0000 UTC 2018-07-02 13:48:48 +0000 UTC ContainersNotReady containers with unready status: [nginx]} {ContainersReady False 0001-01-01 00:00:00 +0000 UTC 0001-01-01 00:00:00 +0000 UTC ContainersNotReady containers with unready status: [nginx]} {PodScheduled True 0001-01-01 00:00:00 +0000 UTC 2018-07-02 13:48:36 +0000 UTC  }]
+Jul  2 13:49:01.562: INFO: ss-2  ip-10-250-24-1.ec2.internal  Running  30s    [{Initialized True 0001-01-01 00:00:00 +0000 UTC 2018-07-02 13:48:36 +0000 UTC  } {Ready False 0001-01-01 00:00:00 +0000 UTC 2018-07-02 13:48:50 +0000 UTC ContainersNotReady containers with unready status: [nginx]} {ContainersReady False 0001-01-01 00:00:00 +0000 UTC 0001-01-01 00:00:00 +0000 UTC ContainersNotReady containers with unready status: [nginx]} {PodScheduled True 0001-01-01 00:00:00 +0000 UTC 2018-07-02 13:48:36 +0000 UTC  }]
+Jul  2 13:49:01.562: INFO: 
+Jul  2 13:49:01.562: INFO: StatefulSet ss has not reached scale 0, at 3
+Jul  2 13:49:02.567: INFO: POD   NODE                         PHASE    GRACE  CONDITIONS
+Jul  2 13:49:02.567: INFO: ss-0  ip-10-250-24-1.ec2.internal  Running  30s    [{Initialized True 0001-01-01 00:00:00 +0000 UTC 2018-07-02 13:48:15 +0000 UTC  } {Ready False 0001-01-01 00:00:00 +0000 UTC 2018-07-02 13:48:48 +0000 UTC ContainersNotReady containers with unready status: [nginx]} {ContainersReady False 0001-01-01 00:00:00 +0000 UTC 0001-01-01 00:00:00 +0000 UTC ContainersNotReady containers with unready status: [nginx]} {PodScheduled True 0001-01-01 00:00:00 +0000 UTC 2018-07-02 13:48:15 +0000 UTC  }]
+Jul  2 13:49:02.567: INFO: ss-1  ip-10-250-24-1.ec2.internal  Pending  30s    [{Initialized True 0001-01-01 00:00:00 +0000 UTC 2018-07-02 13:48:36 +0000 UTC  } {Ready False 0001-01-01 00:00:00 +0000 UTC 2018-07-02 13:48:48 +0000 UTC ContainersNotReady containers with unready status: [nginx]} {ContainersReady False 0001-01-01 00:00:00 +0000 UTC 0001-01-01 00:00:00 +0000 UTC ContainersNotReady containers with unready status: [nginx]} {PodScheduled True 0001-01-01 00:00:00 +0000 UTC 2018-07-02 13:48:36 +0000 UTC  }]
+Jul  2 13:49:02.567: INFO: 
+Jul  2 13:49:02.567: INFO: StatefulSet ss has not reached scale 0, at 2
+Jul  2 13:49:03.571: INFO: POD   NODE                         PHASE    GRACE  CONDITIONS
+Jul  2 13:49:03.571: INFO: ss-0  ip-10-250-24-1.ec2.internal  Running  30s    [{Initialized True 0001-01-01 00:00:00 +0000 UTC 2018-07-02 13:48:15 +0000 UTC  } {Ready False 0001-01-01 00:00:00 +0000 UTC 2018-07-02 13:48:48 +0000 UTC ContainersNotReady containers with unready status: [nginx]} {ContainersReady False 0001-01-01 00:00:00 +0000 UTC 0001-01-01 00:00:00 +0000 UTC ContainersNotReady containers with unready status: [nginx]} {PodScheduled True 0001-01-01 00:00:00 +0000 UTC 2018-07-02 13:48:15 +0000 UTC  }]
+Jul  2 13:49:03.571: INFO: ss-1  ip-10-250-24-1.ec2.internal  Pending  30s    [{Initialized True 0001-01-01 00:00:00 +0000 UTC 2018-07-02 13:48:36 +0000 UTC  } {Ready False 0001-01-01 00:00:00 +0000 UTC 2018-07-02 13:48:48 +0000 UTC ContainersNotReady containers with unready status: [nginx]} {ContainersReady False 0001-01-01 00:00:00 +0000 UTC 0001-01-01 00:00:00 +0000 UTC ContainersNotReady containers with unready status: [nginx]} {PodScheduled True 0001-01-01 00:00:00 +0000 UTC 2018-07-02 13:48:36 +0000 UTC  }]
+Jul  2 13:49:03.571: INFO: 
+Jul  2 13:49:03.572: INFO: StatefulSet ss has not reached scale 0, at 2
+Jul  2 13:49:04.576: INFO: POD   NODE                         PHASE    GRACE  CONDITIONS
+Jul  2 13:49:04.576: INFO: ss-0  ip-10-250-24-1.ec2.internal  Running  30s    [{Initialized True 0001-01-01 00:00:00 +0000 UTC 2018-07-02 13:48:15 +0000 UTC  } {Ready False 0001-01-01 00:00:00 +0000 UTC 2018-07-02 13:48:48 +0000 UTC ContainersNotReady containers with unready status: [nginx]} {ContainersReady False 0001-01-01 00:00:00 +0000 UTC 0001-01-01 00:00:00 +0000 UTC ContainersNotReady containers with unready status: [nginx]} {PodScheduled True 0001-01-01 00:00:00 +0000 UTC 2018-07-02 13:48:15 +0000 UTC  }]
+Jul  2 13:49:04.576: INFO: ss-1  ip-10-250-24-1.ec2.internal  Pending  30s    [{Initialized True 0001-01-01 00:00:00 +0000 UTC 2018-07-02 13:48:36 +0000 UTC  } {Ready False 0001-01-01 00:00:00 +0000 UTC 2018-07-02 13:48:48 +0000 UTC ContainersNotReady containers with unready status: [nginx]} {ContainersReady False 0001-01-01 00:00:00 +0000 UTC 0001-01-01 00:00:00 +0000 UTC ContainersNotReady containers with unready status: [nginx]} {PodScheduled True 0001-01-01 00:00:00 +0000 UTC 2018-07-02 13:48:36 +0000 UTC  }]
+Jul  2 13:49:04.576: INFO: 
+Jul  2 13:49:04.576: INFO: StatefulSet ss has not reached scale 0, at 2
+Jul  2 13:49:05.581: INFO: POD   NODE                         PHASE    GRACE  CONDITIONS
+Jul  2 13:49:05.581: INFO: ss-0  ip-10-250-24-1.ec2.internal  Running  30s    [{Initialized True 0001-01-01 00:00:00 +0000 UTC 2018-07-02 13:48:15 +0000 UTC  } {Ready False 0001-01-01 00:00:00 +0000 UTC 2018-07-02 13:48:48 +0000 UTC ContainersNotReady containers with unready status: [nginx]} {ContainersReady False 0001-01-01 00:00:00 +0000 UTC 0001-01-01 00:00:00 +0000 UTC ContainersNotReady containers with unready status: [nginx]} {PodScheduled True 0001-01-01 00:00:00 +0000 UTC 2018-07-02 13:48:15 +0000 UTC  }]
+Jul  2 13:49:05.581: INFO: ss-1  ip-10-250-24-1.ec2.internal  Pending  30s    [{Initialized True 0001-01-01 00:00:00 +0000 UTC 2018-07-02 13:48:36 +0000 UTC  } {Ready False 0001-01-01 00:00:00 +0000 UTC 2018-07-02 13:48:48 +0000 UTC ContainersNotReady containers with unready status: [nginx]} {ContainersReady False 0001-01-01 00:00:00 +0000 UTC 0001-01-01 00:00:00 +0000 UTC ContainersNotReady containers with unready status: [nginx]} {PodScheduled True 0001-01-01 00:00:00 +0000 UTC 2018-07-02 13:48:36 +0000 UTC  }]
+Jul  2 13:49:05.581: INFO: 
+Jul  2 13:49:05.581: INFO: StatefulSet ss has not reached scale 0, at 2
+Jul  2 13:49:06.644: INFO: POD   NODE                         PHASE    GRACE  CONDITIONS
+Jul  2 13:49:06.644: INFO: ss-0  ip-10-250-24-1.ec2.internal  Running  30s    [{Initialized True 0001-01-01 00:00:00 +0000 UTC 2018-07-02 13:48:15 +0000 UTC  } {Ready False 0001-01-01 00:00:00 +0000 UTC 2018-07-02 13:48:48 +0000 UTC ContainersNotReady containers with unready status: [nginx]} {ContainersReady False 0001-01-01 00:00:00 +0000 UTC 0001-01-01 00:00:00 +0000 UTC ContainersNotReady containers with unready status: [nginx]} {PodScheduled True 0001-01-01 00:00:00 +0000 UTC 2018-07-02 13:48:15 +0000 UTC  }]
+Jul  2 13:49:06.644: INFO: ss-1  ip-10-250-24-1.ec2.internal  Pending  30s    [{Initialized True 0001-01-01 00:00:00 +0000 UTC 2018-07-02 13:48:36 +0000 UTC  } {Ready False 0001-01-01 00:00:00 +0000 UTC 2018-07-02 13:48:48 +0000 UTC ContainersNotReady containers with unready status: [nginx]} {ContainersReady False 0001-01-01 00:00:00 +0000 UTC 0001-01-01 00:00:00 +0000 UTC ContainersNotReady containers with unready status: [nginx]} {PodScheduled True 0001-01-01 00:00:00 +0000 UTC 2018-07-02 13:48:36 +0000 UTC  }]
+Jul  2 13:49:06.644: INFO: 
+Jul  2 13:49:06.644: INFO: StatefulSet ss has not reached scale 0, at 2
+Jul  2 13:49:07.649: INFO: POD   NODE                         PHASE    GRACE  CONDITIONS
+Jul  2 13:49:07.649: INFO: ss-0  ip-10-250-24-1.ec2.internal  Running  30s    [{Initialized True 0001-01-01 00:00:00 +0000 UTC 2018-07-02 13:48:15 +0000 UTC  } {Ready False 0001-01-01 00:00:00 +0000 UTC 2018-07-02 13:48:48 +0000 UTC ContainersNotReady containers with unready status: [nginx]} {ContainersReady False 0001-01-01 00:00:00 +0000 UTC 0001-01-01 00:00:00 +0000 UTC ContainersNotReady containers with unready status: [nginx]} {PodScheduled True 0001-01-01 00:00:00 +0000 UTC 2018-07-02 13:48:15 +0000 UTC  }]
+Jul  2 13:49:07.649: INFO: ss-1  ip-10-250-24-1.ec2.internal  Pending  30s    [{Initialized True 0001-01-01 00:00:00 +0000 UTC 2018-07-02 13:48:36 +0000 UTC  } {Ready False 0001-01-01 00:00:00 +0000 UTC 2018-07-02 13:48:48 +0000 UTC ContainersNotReady containers with unready status: [nginx]} {ContainersReady False 0001-01-01 00:00:00 +0000 UTC 0001-01-01 00:00:00 +0000 UTC ContainersNotReady containers with unready status: [nginx]} {PodScheduled True 0001-01-01 00:00:00 +0000 UTC 2018-07-02 13:48:36 +0000 UTC  }]
+Jul  2 13:49:07.649: INFO: 
+Jul  2 13:49:07.649: INFO: StatefulSet ss has not reached scale 0, at 2
+Jul  2 13:49:08.743: INFO: POD   NODE                         PHASE    GRACE  CONDITIONS
+Jul  2 13:49:08.743: INFO: ss-0  ip-10-250-24-1.ec2.internal  Running  30s    [{Initialized True 0001-01-01 00:00:00 +0000 UTC 2018-07-02 13:48:15 +0000 UTC  } {Ready False 0001-01-01 00:00:00 +0000 UTC 2018-07-02 13:48:48 +0000 UTC ContainersNotReady containers with unready status: [nginx]} {ContainersReady False 0001-01-01 00:00:00 +0000 UTC 0001-01-01 00:00:00 +0000 UTC ContainersNotReady containers with unready status: [nginx]} {PodScheduled True 0001-01-01 00:00:00 +0000 UTC 2018-07-02 13:48:15 +0000 UTC  }]
+Jul  2 13:49:08.743: INFO: ss-1  ip-10-250-24-1.ec2.internal  Pending  30s    [{Initialized True 0001-01-01 00:00:00 +0000 UTC 2018-07-02 13:48:36 +0000 UTC  } {Ready False 0001-01-01 00:00:00 +0000 UTC 2018-07-02 13:48:48 +0000 UTC ContainersNotReady containers with unready status: [nginx]} {ContainersReady False 0001-01-01 00:00:00 +0000 UTC 0001-01-01 00:00:00 +0000 UTC ContainersNotReady containers with unready status: [nginx]} {PodScheduled True 0001-01-01 00:00:00 +0000 UTC 2018-07-02 13:48:36 +0000 UTC  }]
+Jul  2 13:49:08.743: INFO: 
+Jul  2 13:49:08.743: INFO: StatefulSet ss has not reached scale 0, at 2
+STEP: Scaling down stateful set ss to 0 replicas and waiting until none of pods will run in namespacee2e-tests-statefulset-27xml
+Jul  2 13:49:09.747: INFO: Scaling statefulset ss to 0
+Jul  2 13:49:09.756: INFO: Waiting for statefulset status.replicas updated to 0
+[AfterEach] [k8s.io] Basic StatefulSet functionality [StatefulSetBasic]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/statefulset.go:83
+Jul  2 13:49:09.847: INFO: Deleting all statefulset in ns e2e-tests-statefulset-27xml
+Jul  2 13:49:09.850: INFO: Scaling statefulset ss to 0
+Jul  2 13:49:09.860: INFO: Waiting for statefulset status.replicas updated to 0
+Jul  2 13:49:09.862: INFO: Deleting statefulset ss
+[AfterEach] [sig-apps] StatefulSet
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:49:09.873: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-statefulset-27xml" for this suite.
+Jul  2 13:49:15.887: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:49:15.985: INFO: namespace: e2e-tests-statefulset-27xml, resource: bindings, ignored listing per whitelist
+Jul  2 13:49:16.033: INFO: namespace e2e-tests-statefulset-27xml deletion completed in 6.156427845s
+
+• [SLOW TEST:60.207 seconds]
+[sig-apps] StatefulSet
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/framework.go:22
+  [k8s.io] Basic StatefulSet functionality [StatefulSetBasic]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:679
+    Burst scaling should run to completion even with unhealthy pods [Conformance]
+    /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSSSSSSSSSS
+------------------------------
+[sig-storage] Projected 
+  should provide podname only [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:49:16.034: INFO: >>> kubeConfig: /tmp/kubeconfig-411378559
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:858
+[It] should provide podname only [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating a pod to test downward API volume plugin
+Jul  2 13:49:16.127: INFO: Waiting up to 5m0s for pod "downwardapi-volume-b5de958f-7dfe-11e8-bae1-da96248f62d7" in namespace "e2e-tests-projected-qq87k" to be "success or failure"
+Jul  2 13:49:16.130: INFO: Pod "downwardapi-volume-b5de958f-7dfe-11e8-bae1-da96248f62d7": Phase="Pending", Reason="", readiness=false. Elapsed: 2.742788ms
+Jul  2 13:49:18.148: INFO: Pod "downwardapi-volume-b5de958f-7dfe-11e8-bae1-da96248f62d7": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.020865414s
+STEP: Saw pod success
+Jul  2 13:49:18.148: INFO: Pod "downwardapi-volume-b5de958f-7dfe-11e8-bae1-da96248f62d7" satisfied condition "success or failure"
+Jul  2 13:49:18.152: INFO: Trying to get logs from node ip-10-250-24-1.ec2.internal pod downwardapi-volume-b5de958f-7dfe-11e8-bae1-da96248f62d7 container client-container: <nil>
+STEP: delete the pod
+Jul  2 13:49:18.171: INFO: Waiting for pod downwardapi-volume-b5de958f-7dfe-11e8-bae1-da96248f62d7 to disappear
+Jul  2 13:49:18.174: INFO: Pod downwardapi-volume-b5de958f-7dfe-11e8-bae1-da96248f62d7 no longer exists
+[AfterEach] [sig-storage] Projected
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:49:18.174: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-qq87k" for this suite.
+Jul  2 13:49:24.188: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:49:24.312: INFO: namespace: e2e-tests-projected-qq87k, resource: bindings, ignored listing per whitelist
+Jul  2 13:49:24.346: INFO: namespace e2e-tests-projected-qq87k deletion completed in 6.168458651s
+
+• [SLOW TEST:8.312 seconds]
+[sig-storage] Projected
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:34
+  should provide podname only [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SS
+------------------------------
+[sig-storage] Secrets 
+  should be consumable from pods in volume with mappings and Item Mode set [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-storage] Secrets
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:49:24.346: INFO: >>> kubeConfig: /tmp/kubeconfig-411378559
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should be consumable from pods in volume with mappings and Item Mode set [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating secret with name secret-test-map-bad2bbef-7dfe-11e8-bae1-da96248f62d7
+STEP: Creating a pod to test consume secrets
+Jul  2 13:49:24.442: INFO: Waiting up to 5m0s for pod "pod-secrets-bad3490a-7dfe-11e8-bae1-da96248f62d7" in namespace "e2e-tests-secrets-sh8gf" to be "success or failure"
+Jul  2 13:49:24.446: INFO: Pod "pod-secrets-bad3490a-7dfe-11e8-bae1-da96248f62d7": Phase="Pending", Reason="", readiness=false. Elapsed: 3.735506ms
+Jul  2 13:49:26.451: INFO: Pod "pod-secrets-bad3490a-7dfe-11e8-bae1-da96248f62d7": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.008195057s
+STEP: Saw pod success
+Jul  2 13:49:26.451: INFO: Pod "pod-secrets-bad3490a-7dfe-11e8-bae1-da96248f62d7" satisfied condition "success or failure"
+Jul  2 13:49:26.454: INFO: Trying to get logs from node ip-10-250-24-1.ec2.internal pod pod-secrets-bad3490a-7dfe-11e8-bae1-da96248f62d7 container secret-volume-test: <nil>
+STEP: delete the pod
+Jul  2 13:49:26.474: INFO: Waiting for pod pod-secrets-bad3490a-7dfe-11e8-bae1-da96248f62d7 to disappear
+Jul  2 13:49:26.477: INFO: Pod pod-secrets-bad3490a-7dfe-11e8-bae1-da96248f62d7 no longer exists
+[AfterEach] [sig-storage] Secrets
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:49:26.477: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-secrets-sh8gf" for this suite.
+Jul  2 13:49:32.491: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:49:32.519: INFO: namespace: e2e-tests-secrets-sh8gf, resource: bindings, ignored listing per whitelist
+Jul  2 13:49:32.657: INFO: namespace e2e-tests-secrets-sh8gf deletion completed in 6.176353179s
+
+• [SLOW TEST:8.311 seconds]
+[sig-storage] Secrets
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/secrets_volume.go:33
+  should be consumable from pods in volume with mappings and Item Mode set [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SS
+------------------------------
+[sig-storage] EmptyDir volumes 
+  should support (root,0644,tmpfs) [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-storage] EmptyDir volumes
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:49:32.658: INFO: >>> kubeConfig: /tmp/kubeconfig-411378559
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should support (root,0644,tmpfs) [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating a pod to test emptydir 0644 on tmpfs
+Jul  2 13:49:32.755: INFO: Waiting up to 5m0s for pod "pod-bfc7b526-7dfe-11e8-bae1-da96248f62d7" in namespace "e2e-tests-emptydir-gtblv" to be "success or failure"
+Jul  2 13:49:32.760: INFO: Pod "pod-bfc7b526-7dfe-11e8-bae1-da96248f62d7": Phase="Pending", Reason="", readiness=false. Elapsed: 5.037306ms
+Jul  2 13:49:34.766: INFO: Pod "pod-bfc7b526-7dfe-11e8-bae1-da96248f62d7": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.010854086s
+STEP: Saw pod success
+Jul  2 13:49:34.766: INFO: Pod "pod-bfc7b526-7dfe-11e8-bae1-da96248f62d7" satisfied condition "success or failure"
+Jul  2 13:49:34.768: INFO: Trying to get logs from node ip-10-250-24-1.ec2.internal pod pod-bfc7b526-7dfe-11e8-bae1-da96248f62d7 container test-container: <nil>
+STEP: delete the pod
+Jul  2 13:49:34.861: INFO: Waiting for pod pod-bfc7b526-7dfe-11e8-bae1-da96248f62d7 to disappear
+Jul  2 13:49:34.864: INFO: Pod pod-bfc7b526-7dfe-11e8-bae1-da96248f62d7 no longer exists
+[AfterEach] [sig-storage] EmptyDir volumes
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:49:34.864: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-emptydir-gtblv" for this suite.
+Jul  2 13:49:40.878: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:49:40.955: INFO: namespace: e2e-tests-emptydir-gtblv, resource: bindings, ignored listing per whitelist
+Jul  2 13:49:41.027: INFO: namespace e2e-tests-emptydir-gtblv deletion completed in 6.158579903s
+
+• [SLOW TEST:8.369 seconds]
+[sig-storage] EmptyDir volumes
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/empty_dir.go:40
+  should support (root,0644,tmpfs) [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSS
+------------------------------
+[sig-scheduling] SchedulerPredicates [Serial] 
+  validates resource limits of pods that are allowed to run  [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-scheduling] SchedulerPredicates [Serial]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:49:41.027: INFO: >>> kubeConfig: /tmp/kubeconfig-411378559
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-scheduling] SchedulerPredicates [Serial]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/scheduling/predicates.go:79
+Jul  2 13:49:41.115: INFO: Waiting up to 1m0s for all nodes to be ready
+Jul  2 13:50:41.141: INFO: Waiting for terminating namespaces to be deleted...
+Jul  2 13:50:41.146: INFO: Waiting up to 5m0s for all pods (need at least 0) in namespace 'kube-system' to be running and ready
+Jul  2 13:50:41.158: INFO: 14 / 14 pods in namespace 'kube-system' are running and ready (0 seconds elapsed)
+Jul  2 13:50:41.158: INFO: expected 8 pod replicas in namespace 'kube-system', 8 are Running and Ready.
+Jul  2 13:50:41.163: INFO: Waiting for pods to enter Success, but no pods in "kube-system" match label map[name:e2e-image-puller]
+Jul  2 13:50:41.163: INFO: 
+Logging pods the kubelet thinks is on node ip-10-250-20-212.ec2.internal before test
+Jul  2 13:50:41.245: INFO: addons-nginx-ingress-nginx-ingress-k8s-backend-7b5569797f-64wcj from kube-system started at 2018-07-02 12:48:00 +0000 UTC (1 container statuses recorded)
+Jul  2 13:50:41.245: INFO: 	Container nginx-ingress-nginx-ingress-k8s-backend ready: true, restart count 0
+Jul  2 13:50:41.245: INFO: node-exporter-zm2rg from kube-system started at 2018-07-02 12:47:40 +0000 UTC (1 container statuses recorded)
+Jul  2 13:50:41.245: INFO: 	Container node-exporter ready: true, restart count 0
+Jul  2 13:50:41.245: INFO: kube-dns-autoscaler-6dd4765967-gqbtv from kube-system started at 2018-07-02 12:48:00 +0000 UTC (1 container statuses recorded)
+Jul  2 13:50:41.245: INFO: 	Container autoscaler ready: true, restart count 0
+Jul  2 13:50:41.245: INFO: addons-heapster-e3b0c-64455ddddb-m2pxn from kube-system started at 2018-07-02 12:48:00 +0000 UTC (2 container statuses recorded)
+Jul  2 13:50:41.245: INFO: 	Container heapster ready: true, restart count 0
+Jul  2 13:50:41.245: INFO: 	Container heapster-nanny ready: true, restart count 0
+Jul  2 13:50:41.245: INFO: kube-dns-9c4dfc4fb-hk72g from kube-system started at 2018-07-02 12:48:00 +0000 UTC (3 container statuses recorded)
+Jul  2 13:50:41.246: INFO: 	Container dnsmasq ready: true, restart count 0
+Jul  2 13:50:41.246: INFO: 	Container kubedns ready: true, restart count 0
+Jul  2 13:50:41.246: INFO: 	Container sidecar ready: true, restart count 0
+Jul  2 13:50:41.246: INFO: calico-node-4lmw2 from kube-system started at 2018-07-02 12:47:40 +0000 UTC (2 container statuses recorded)
+Jul  2 13:50:41.246: INFO: 	Container calico-node ready: true, restart count 0
+Jul  2 13:50:41.246: INFO: 	Container install-cni ready: true, restart count 0
+Jul  2 13:50:41.246: INFO: addons-kubernetes-dashboard-5486b968b7-kgkrm from kube-system started at 2018-07-02 12:48:00 +0000 UTC (1 container statuses recorded)
+Jul  2 13:50:41.246: INFO: 	Container main ready: true, restart count 0
+Jul  2 13:50:41.246: INFO: vpn-shoot-77bdbf95b-zdv7s from kube-system started at 2018-07-02 12:48:00 +0000 UTC (1 container statuses recorded)
+Jul  2 13:50:41.246: INFO: 	Container vpn-shoot ready: true, restart count 0
+Jul  2 13:50:41.246: INFO: kube-proxy-r9nzr from kube-system started at 2018-07-02 12:47:40 +0000 UTC (1 container statuses recorded)
+Jul  2 13:50:41.246: INFO: 	Container kube-proxy ready: true, restart count 0
+Jul  2 13:50:41.246: INFO: addons-nginx-ingress-controller-77fffb78c6-rvwcv from kube-system started at 2018-07-02 12:48:00 +0000 UTC (1 container statuses recorded)
+Jul  2 13:50:41.246: INFO: 	Container nginx-ingress-controller ready: true, restart count 0
+Jul  2 13:50:41.246: INFO: kube-dns-9c4dfc4fb-8q2xj from kube-system started at 2018-07-02 12:49:17 +0000 UTC (3 container statuses recorded)
+Jul  2 13:50:41.246: INFO: 	Container dnsmasq ready: true, restart count 0
+Jul  2 13:50:41.246: INFO: 	Container kubedns ready: true, restart count 0
+Jul  2 13:50:41.246: INFO: 	Container sidecar ready: true, restart count 0
+Jul  2 13:50:41.246: INFO: 
+Logging pods the kubelet thinks is on node ip-10-250-24-1.ec2.internal before test
+Jul  2 13:50:41.290: INFO: kube-proxy-zj5gp from kube-system started at 2018-07-02 12:49:09 +0000 UTC (1 container statuses recorded)
+Jul  2 13:50:41.290: INFO: 	Container kube-proxy ready: true, restart count 0
+Jul  2 13:50:41.290: INFO: sonobuoy-e2e-job-28cb3bdc6acd48a9 from sonobuoy started at 2018-07-02 12:53:32 +0000 UTC (2 container statuses recorded)
+Jul  2 13:50:41.290: INFO: 	Container e2e ready: true, restart count 0
+Jul  2 13:50:41.290: INFO: 	Container sonobuoy-worker ready: true, restart count 0
+Jul  2 13:50:41.290: INFO: calico-node-sd5dt from kube-system started at 2018-07-02 12:49:09 +0000 UTC (2 container statuses recorded)
+Jul  2 13:50:41.290: INFO: 	Container calico-node ready: true, restart count 0
+Jul  2 13:50:41.290: INFO: 	Container install-cni ready: true, restart count 0
+Jul  2 13:50:41.290: INFO: node-exporter-mkl4n from kube-system started at 2018-07-02 12:49:09 +0000 UTC (1 container statuses recorded)
+Jul  2 13:50:41.290: INFO: 	Container node-exporter ready: true, restart count 0
+Jul  2 13:50:41.290: INFO: sonobuoy from sonobuoy started at 2018-07-02 12:53:17 +0000 UTC (1 container statuses recorded)
+Jul  2 13:50:41.290: INFO: 	Container kube-sonobuoy ready: true, restart count 0
+[It] validates resource limits of pods that are allowed to run  [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: verifying the node has the label node ip-10-250-20-212.ec2.internal
+STEP: verifying the node has the label node ip-10-250-24-1.ec2.internal
+Jul  2 13:50:41.326: INFO: Pod addons-heapster-e3b0c-64455ddddb-m2pxn requesting resource cpu=50m on Node ip-10-250-20-212.ec2.internal
+Jul  2 13:50:41.326: INFO: Pod addons-kubernetes-dashboard-5486b968b7-kgkrm requesting resource cpu=50m on Node ip-10-250-20-212.ec2.internal
+Jul  2 13:50:41.326: INFO: Pod addons-nginx-ingress-controller-77fffb78c6-rvwcv requesting resource cpu=100m on Node ip-10-250-20-212.ec2.internal
+Jul  2 13:50:41.326: INFO: Pod addons-nginx-ingress-nginx-ingress-k8s-backend-7b5569797f-64wcj requesting resource cpu=0m on Node ip-10-250-20-212.ec2.internal
+Jul  2 13:50:41.326: INFO: Pod calico-node-4lmw2 requesting resource cpu=250m on Node ip-10-250-20-212.ec2.internal
+Jul  2 13:50:41.326: INFO: Pod calico-node-sd5dt requesting resource cpu=250m on Node ip-10-250-24-1.ec2.internal
+Jul  2 13:50:41.326: INFO: Pod kube-dns-9c4dfc4fb-8q2xj requesting resource cpu=260m on Node ip-10-250-20-212.ec2.internal
+Jul  2 13:50:41.326: INFO: Pod kube-dns-9c4dfc4fb-hk72g requesting resource cpu=260m on Node ip-10-250-20-212.ec2.internal
+Jul  2 13:50:41.326: INFO: Pod kube-dns-autoscaler-6dd4765967-gqbtv requesting resource cpu=20m on Node ip-10-250-20-212.ec2.internal
+Jul  2 13:50:41.326: INFO: Pod kube-proxy-r9nzr requesting resource cpu=50m on Node ip-10-250-20-212.ec2.internal
+Jul  2 13:50:41.326: INFO: Pod kube-proxy-zj5gp requesting resource cpu=50m on Node ip-10-250-24-1.ec2.internal
+Jul  2 13:50:41.326: INFO: Pod node-exporter-mkl4n requesting resource cpu=10m on Node ip-10-250-24-1.ec2.internal
+Jul  2 13:50:41.326: INFO: Pod node-exporter-zm2rg requesting resource cpu=10m on Node ip-10-250-20-212.ec2.internal
+Jul  2 13:50:41.326: INFO: Pod vpn-shoot-77bdbf95b-zdv7s requesting resource cpu=100m on Node ip-10-250-20-212.ec2.internal
+Jul  2 13:50:41.326: INFO: Pod sonobuoy requesting resource cpu=0m on Node ip-10-250-24-1.ec2.internal
+Jul  2 13:50:41.326: INFO: Pod sonobuoy-e2e-job-28cb3bdc6acd48a9 requesting resource cpu=0m on Node ip-10-250-24-1.ec2.internal
+STEP: Starting Pods to consume most of the cluster CPU.
+STEP: Creating another pod that requires unavailable amount of CPU.
+STEP: Considering event: 
+Type = [Normal], Name = [filler-pod-e8a7ae36-7dfe-11e8-bae1-da96248f62d7.153d918343824b83], Reason = [Scheduled], Message = [Successfully assigned e2e-tests-sched-pred-nxn6d/filler-pod-e8a7ae36-7dfe-11e8-bae1-da96248f62d7 to ip-10-250-20-212.ec2.internal]
+STEP: Considering event: 
+Type = [Normal], Name = [filler-pod-e8a7ae36-7dfe-11e8-bae1-da96248f62d7.153d9183745ad6cf], Reason = [Pulled], Message = [Container image "k8s.gcr.io/pause:3.1" already present on machine]
+STEP: Considering event: 
+Type = [Normal], Name = [filler-pod-e8a7ae36-7dfe-11e8-bae1-da96248f62d7.153d918376c8af3c], Reason = [Created], Message = [Created container]
+STEP: Considering event: 
+Type = [Normal], Name = [filler-pod-e8a7ae36-7dfe-11e8-bae1-da96248f62d7.153d918381996262], Reason = [Started], Message = [Started container]
+STEP: Considering event: 
+Type = [Normal], Name = [filler-pod-e8a8a952-7dfe-11e8-bae1-da96248f62d7.153d918343d2029e], Reason = [Scheduled], Message = [Successfully assigned e2e-tests-sched-pred-nxn6d/filler-pod-e8a8a952-7dfe-11e8-bae1-da96248f62d7 to ip-10-250-24-1.ec2.internal]
+STEP: Considering event: 
+Type = [Normal], Name = [filler-pod-e8a8a952-7dfe-11e8-bae1-da96248f62d7.153d918373839252], Reason = [Pulled], Message = [Container image "k8s.gcr.io/pause:3.1" already present on machine]
+STEP: Considering event: 
+Type = [Normal], Name = [filler-pod-e8a8a952-7dfe-11e8-bae1-da96248f62d7.153d9183755f315b], Reason = [Created], Message = [Created container]
+STEP: Considering event: 
+Type = [Normal], Name = [filler-pod-e8a8a952-7dfe-11e8-bae1-da96248f62d7.153d91837bc9a2d6], Reason = [Started], Message = [Started container]
+STEP: Considering event: 
+Type = [Warning], Name = [additional-pod.153d9183c1626f0f], Reason = [FailedScheduling], Message = [0/2 nodes are available: 2 Insufficient cpu.]
+STEP: removing the label node off the node ip-10-250-20-212.ec2.internal
+STEP: verifying the node doesn't have the label node
+STEP: removing the label node off the node ip-10-250-24-1.ec2.internal
+STEP: verifying the node doesn't have the label node
+[AfterEach] [sig-scheduling] SchedulerPredicates [Serial]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:50:44.566: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-sched-pred-nxn6d" for this suite.
+Jul  2 13:51:06.580: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:51:06.623: INFO: namespace: e2e-tests-sched-pred-nxn6d, resource: bindings, ignored listing per whitelist
+Jul  2 13:51:06.705: INFO: namespace e2e-tests-sched-pred-nxn6d deletion completed in 22.135271115s
+[AfterEach] [sig-scheduling] SchedulerPredicates [Serial]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/scheduling/predicates.go:70
+
+• [SLOW TEST:85.678 seconds]
+[sig-scheduling] SchedulerPredicates [Serial]
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/scheduling/framework.go:22
+  validates resource limits of pods that are allowed to run  [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SS
+------------------------------
+[sig-storage] Projected 
+  optional updates should be reflected in volume [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:51:06.705: INFO: >>> kubeConfig: /tmp/kubeconfig-411378559
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:858
+[It] optional updates should be reflected in volume [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating configMap with name cm-test-opt-del-f7d6c8bb-7dfe-11e8-bae1-da96248f62d7
+STEP: Creating configMap with name cm-test-opt-upd-f7d6c904-7dfe-11e8-bae1-da96248f62d7
+STEP: Creating the pod
+STEP: Deleting configmap cm-test-opt-del-f7d6c8bb-7dfe-11e8-bae1-da96248f62d7
+STEP: Updating configmap cm-test-opt-upd-f7d6c904-7dfe-11e8-bae1-da96248f62d7
+STEP: Creating configMap with name cm-test-opt-create-f7d6c92c-7dfe-11e8-bae1-da96248f62d7
+STEP: waiting to observe update in volume
+[AfterEach] [sig-storage] Projected
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:51:11.229: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-9sdpt" for this suite.
+Jul  2 13:51:33.245: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:51:33.363: INFO: namespace: e2e-tests-projected-9sdpt, resource: bindings, ignored listing per whitelist
+Jul  2 13:51:33.430: INFO: namespace e2e-tests-projected-9sdpt deletion completed in 22.19696381s
+
+• [SLOW TEST:26.725 seconds]
+[sig-storage] Projected
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:34
+  optional updates should be reflected in volume [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+S
+------------------------------
+[sig-network] Proxy version v1 
+  should proxy through a service and a pod  [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] version v1
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:51:33.430: INFO: >>> kubeConfig: /tmp/kubeconfig-411378559
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should proxy through a service and a pod  [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: starting an echo server on multiple ports
+STEP: creating replication controller proxy-service-qsb8g in namespace e2e-tests-proxy-zfjzs
+I0702 13:51:33.533303      14 runners.go:177] Created replication controller with name: proxy-service-qsb8g, namespace: e2e-tests-proxy-zfjzs, replica count: 1
+I0702 13:51:34.583849      14 runners.go:177] proxy-service-qsb8g Pods: 1 out of 1 created, 0 running, 1 pending, 0 waiting, 0 inactive, 0 terminating, 0 unknown, 0 runningButNotReady 
+I0702 13:51:35.584069      14 runners.go:177] proxy-service-qsb8g Pods: 1 out of 1 created, 0 running, 1 pending, 0 waiting, 0 inactive, 0 terminating, 0 unknown, 0 runningButNotReady 
+I0702 13:51:36.584288      14 runners.go:177] proxy-service-qsb8g Pods: 1 out of 1 created, 1 running, 0 pending, 0 waiting, 0 inactive, 0 terminating, 0 unknown, 0 runningButNotReady 
+Jul  2 13:51:36.587: INFO: setup took 3.067659688s, starting test cases
+STEP: running 16 cases, 20 attempts per case, 320 total attempts
+Jul  2 13:51:36.625: INFO: (0) /api/v1/namespaces/e2e-tests-proxy-zfjzs/pods/proxy-service-qsb8g-rr7rx:162/proxy/: bar (200; 37.052634ms)
+Jul  2 13:51:36.631: INFO: (0) /api/v1/namespaces/e2e-tests-proxy-zfjzs/services/http:proxy-service-qsb8g:portname1/proxy/: foo (200; 43.113834ms)
+Jul  2 13:51:36.631: INFO: (0) /api/v1/namespaces/e2e-tests-proxy-zfjzs/services/proxy-service-qsb8g:portname2/proxy/: bar (200; 43.52202ms)
+Jul  2 13:51:36.631: INFO: (0) /api/v1/namespaces/e2e-tests-proxy-zfjzs/pods/http:proxy-service-qsb8g-rr7rx:160/proxy/: foo (200; 43.393939ms)
+Jul  2 13:51:36.631: INFO: (0) /api/v1/namespaces/e2e-tests-proxy-zfjzs/pods/proxy-service-qsb8g-rr7rx:160/proxy/: foo (200; 43.158045ms)
+Jul  2 13:51:36.645: INFO: (0) /api/v1/namespaces/e2e-tests-proxy-zfjzs/services/proxy-service-qsb8g:portname1/proxy/: foo (200; 57.559567ms)
+Jul  2 13:51:36.645: INFO: (0) /api/v1/namespaces/e2e-tests-proxy-zfjzs/services/http:proxy-service-qsb8g:portname2/proxy/: bar (200; 57.050319ms)
+Jul  2 13:51:36.645: INFO: (0) /api/v1/namespaces/e2e-tests-proxy-zfjzs/pods/proxy-service-qsb8g-rr7rx/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-zfjzs/pods/proxy-service-qsb8g-rr7rx/proxy/rewriteme"... (200; 57.158064ms)
+Jul  2 13:51:36.645: INFO: (0) /api/v1/namespaces/e2e-tests-proxy-zfjzs/pods/proxy-service-qsb8g-rr7rx:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-zfjzs/pods/proxy-service-qsb8g-rr7rx:1080/proxy/rewri... (200; 57.012057ms)
+Jul  2 13:51:36.645: INFO: (0) /api/v1/namespaces/e2e-tests-proxy-zfjzs/pods/http:proxy-service-qsb8g-rr7rx:162/proxy/: bar (200; 56.99789ms)
+Jul  2 13:51:36.645: INFO: (0) /api/v1/namespaces/e2e-tests-proxy-zfjzs/pods/http:proxy-service-qsb8g-rr7rx:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-zfjzs/pods/http:proxy-service-qsb8g-rr7rx:1080/proxy/... (200; 57.202338ms)
+Jul  2 13:51:36.657: INFO: (0) /api/v1/namespaces/e2e-tests-proxy-zfjzs/services/https:proxy-service-qsb8g:tlsportname2/proxy/: tls qux (200; 68.675013ms)
+Jul  2 13:51:36.659: INFO: (0) /api/v1/namespaces/e2e-tests-proxy-zfjzs/pods/https:proxy-service-qsb8g-rr7rx:462/proxy/: tls qux (200; 71.037526ms)
+Jul  2 13:51:36.660: INFO: (0) /api/v1/namespaces/e2e-tests-proxy-zfjzs/services/https:proxy-service-qsb8g:tlsportname1/proxy/: tls baz (200; 71.746789ms)
+Jul  2 13:51:36.661: INFO: (0) /api/v1/namespaces/e2e-tests-proxy-zfjzs/pods/https:proxy-service-qsb8g-rr7rx:443/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-zfjzs/pods/https:proxy-service-qsb8g-rr7rx:443/proxy/... (200; 72.543632ms)
+Jul  2 13:51:36.662: INFO: (0) /api/v1/namespaces/e2e-tests-proxy-zfjzs/pods/https:proxy-service-qsb8g-rr7rx:460/proxy/: tls baz (200; 73.837198ms)
+Jul  2 13:51:36.668: INFO: (1) /api/v1/namespaces/e2e-tests-proxy-zfjzs/pods/http:proxy-service-qsb8g-rr7rx:160/proxy/: foo (200; 6.334664ms)
+Jul  2 13:51:36.669: INFO: (1) /api/v1/namespaces/e2e-tests-proxy-zfjzs/pods/proxy-service-qsb8g-rr7rx:162/proxy/: bar (200; 6.963511ms)
+Jul  2 13:51:36.669: INFO: (1) /api/v1/namespaces/e2e-tests-proxy-zfjzs/services/https:proxy-service-qsb8g:tlsportname1/proxy/: tls baz (200; 7.333441ms)
+Jul  2 13:51:36.670: INFO: (1) /api/v1/namespaces/e2e-tests-proxy-zfjzs/pods/proxy-service-qsb8g-rr7rx/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-zfjzs/pods/proxy-service-qsb8g-rr7rx/proxy/rewriteme"... (200; 7.832622ms)
+Jul  2 13:51:36.670: INFO: (1) /api/v1/namespaces/e2e-tests-proxy-zfjzs/pods/http:proxy-service-qsb8g-rr7rx:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-zfjzs/pods/http:proxy-service-qsb8g-rr7rx:1080/proxy/... (200; 7.585827ms)
+Jul  2 13:51:36.670: INFO: (1) /api/v1/namespaces/e2e-tests-proxy-zfjzs/pods/https:proxy-service-qsb8g-rr7rx:462/proxy/: tls qux (200; 7.264301ms)
+Jul  2 13:51:36.670: INFO: (1) /api/v1/namespaces/e2e-tests-proxy-zfjzs/pods/https:proxy-service-qsb8g-rr7rx:443/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-zfjzs/pods/https:proxy-service-qsb8g-rr7rx:443/proxy/... (200; 7.396146ms)
+Jul  2 13:51:36.670: INFO: (1) /api/v1/namespaces/e2e-tests-proxy-zfjzs/pods/proxy-service-qsb8g-rr7rx:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-zfjzs/pods/proxy-service-qsb8g-rr7rx:1080/proxy/rewri... (200; 7.500489ms)
+Jul  2 13:51:36.670: INFO: (1) /api/v1/namespaces/e2e-tests-proxy-zfjzs/pods/https:proxy-service-qsb8g-rr7rx:460/proxy/: tls baz (200; 7.395426ms)
+Jul  2 13:51:36.670: INFO: (1) /api/v1/namespaces/e2e-tests-proxy-zfjzs/pods/http:proxy-service-qsb8g-rr7rx:162/proxy/: bar (200; 7.50903ms)
+Jul  2 13:51:36.670: INFO: (1) /api/v1/namespaces/e2e-tests-proxy-zfjzs/pods/proxy-service-qsb8g-rr7rx:160/proxy/: foo (200; 7.948832ms)
+Jul  2 13:51:36.671: INFO: (1) /api/v1/namespaces/e2e-tests-proxy-zfjzs/services/proxy-service-qsb8g:portname1/proxy/: foo (200; 8.674234ms)
+Jul  2 13:51:36.671: INFO: (1) /api/v1/namespaces/e2e-tests-proxy-zfjzs/services/https:proxy-service-qsb8g:tlsportname2/proxy/: tls qux (200; 8.259166ms)
+Jul  2 13:51:36.671: INFO: (1) /api/v1/namespaces/e2e-tests-proxy-zfjzs/services/http:proxy-service-qsb8g:portname2/proxy/: bar (200; 9.466143ms)
+Jul  2 13:51:36.673: INFO: (1) /api/v1/namespaces/e2e-tests-proxy-zfjzs/services/proxy-service-qsb8g:portname2/proxy/: bar (200; 10.217627ms)
+Jul  2 13:51:36.673: INFO: (1) /api/v1/namespaces/e2e-tests-proxy-zfjzs/services/http:proxy-service-qsb8g:portname1/proxy/: foo (200; 10.680335ms)
+Jul  2 13:51:36.680: INFO: (2) /api/v1/namespaces/e2e-tests-proxy-zfjzs/pods/http:proxy-service-qsb8g-rr7rx:160/proxy/: foo (200; 7.533785ms)
+Jul  2 13:51:36.681: INFO: (2) /api/v1/namespaces/e2e-tests-proxy-zfjzs/pods/proxy-service-qsb8g-rr7rx/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-zfjzs/pods/proxy-service-qsb8g-rr7rx/proxy/rewriteme"... (200; 7.217265ms)
+Jul  2 13:51:36.681: INFO: (2) /api/v1/namespaces/e2e-tests-proxy-zfjzs/pods/https:proxy-service-qsb8g-rr7rx:443/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-zfjzs/pods/https:proxy-service-qsb8g-rr7rx:443/proxy/... (200; 7.400243ms)
+Jul  2 13:51:36.681: INFO: (2) /api/v1/namespaces/e2e-tests-proxy-zfjzs/pods/proxy-service-qsb8g-rr7rx:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-zfjzs/pods/proxy-service-qsb8g-rr7rx:1080/proxy/rewri... (200; 7.326032ms)
+Jul  2 13:51:36.681: INFO: (2) /api/v1/namespaces/e2e-tests-proxy-zfjzs/pods/http:proxy-service-qsb8g-rr7rx:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-zfjzs/pods/http:proxy-service-qsb8g-rr7rx:1080/proxy/... (200; 7.700658ms)
+Jul  2 13:51:36.681: INFO: (2) /api/v1/namespaces/e2e-tests-proxy-zfjzs/pods/https:proxy-service-qsb8g-rr7rx:462/proxy/: tls qux (200; 7.87187ms)
+Jul  2 13:51:36.681: INFO: (2) /api/v1/namespaces/e2e-tests-proxy-zfjzs/pods/http:proxy-service-qsb8g-rr7rx:162/proxy/: bar (200; 7.793958ms)
+Jul  2 13:51:36.681: INFO: (2) /api/v1/namespaces/e2e-tests-proxy-zfjzs/services/http:proxy-service-qsb8g:portname1/proxy/: foo (200; 8.500953ms)
+Jul  2 13:51:36.682: INFO: (2) /api/v1/namespaces/e2e-tests-proxy-zfjzs/pods/proxy-service-qsb8g-rr7rx:162/proxy/: bar (200; 9.190343ms)
+Jul  2 13:51:36.682: INFO: (2) /api/v1/namespaces/e2e-tests-proxy-zfjzs/pods/https:proxy-service-qsb8g-rr7rx:460/proxy/: tls baz (200; 9.425931ms)
+Jul  2 13:51:36.682: INFO: (2) /api/v1/namespaces/e2e-tests-proxy-zfjzs/services/https:proxy-service-qsb8g:tlsportname2/proxy/: tls qux (200; 9.346091ms)
+Jul  2 13:51:36.682: INFO: (2) /api/v1/namespaces/e2e-tests-proxy-zfjzs/services/https:proxy-service-qsb8g:tlsportname1/proxy/: tls baz (200; 9.599656ms)
+Jul  2 13:51:36.683: INFO: (2) /api/v1/namespaces/e2e-tests-proxy-zfjzs/pods/proxy-service-qsb8g-rr7rx:160/proxy/: foo (200; 10.315039ms)
+Jul  2 13:51:36.684: INFO: (2) /api/v1/namespaces/e2e-tests-proxy-zfjzs/services/http:proxy-service-qsb8g:portname2/proxy/: bar (200; 10.991815ms)
+Jul  2 13:51:36.684: INFO: (2) /api/v1/namespaces/e2e-tests-proxy-zfjzs/services/proxy-service-qsb8g:portname1/proxy/: foo (200; 11.130823ms)
+Jul  2 13:51:36.685: INFO: (2) /api/v1/namespaces/e2e-tests-proxy-zfjzs/services/proxy-service-qsb8g:portname2/proxy/: bar (200; 11.731937ms)
+Jul  2 13:51:36.693: INFO: (3) /api/v1/namespaces/e2e-tests-proxy-zfjzs/pods/http:proxy-service-qsb8g-rr7rx:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-zfjzs/pods/http:proxy-service-qsb8g-rr7rx:1080/proxy/... (200; 7.881519ms)
+Jul  2 13:51:36.693: INFO: (3) /api/v1/namespaces/e2e-tests-proxy-zfjzs/pods/proxy-service-qsb8g-rr7rx:162/proxy/: bar (200; 7.709637ms)
+Jul  2 13:51:36.694: INFO: (3) /api/v1/namespaces/e2e-tests-proxy-zfjzs/pods/https:proxy-service-qsb8g-rr7rx:460/proxy/: tls baz (200; 8.239656ms)
+Jul  2 13:51:36.694: INFO: (3) /api/v1/namespaces/e2e-tests-proxy-zfjzs/pods/http:proxy-service-qsb8g-rr7rx:162/proxy/: bar (200; 8.014831ms)
+Jul  2 13:51:36.694: INFO: (3) /api/v1/namespaces/e2e-tests-proxy-zfjzs/pods/http:proxy-service-qsb8g-rr7rx:160/proxy/: foo (200; 7.75236ms)
+Jul  2 13:51:36.694: INFO: (3) /api/v1/namespaces/e2e-tests-proxy-zfjzs/pods/proxy-service-qsb8g-rr7rx:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-zfjzs/pods/proxy-service-qsb8g-rr7rx:1080/proxy/rewri... (200; 8.100905ms)
+Jul  2 13:51:36.694: INFO: (3) /api/v1/namespaces/e2e-tests-proxy-zfjzs/services/http:proxy-service-qsb8g:portname1/proxy/: foo (200; 8.783523ms)
+Jul  2 13:51:36.694: INFO: (3) /api/v1/namespaces/e2e-tests-proxy-zfjzs/pods/https:proxy-service-qsb8g-rr7rx:443/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-zfjzs/pods/https:proxy-service-qsb8g-rr7rx:443/proxy/... (200; 8.625598ms)
+Jul  2 13:51:36.694: INFO: (3) /api/v1/namespaces/e2e-tests-proxy-zfjzs/pods/proxy-service-qsb8g-rr7rx/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-zfjzs/pods/proxy-service-qsb8g-rr7rx/proxy/rewriteme"... (200; 8.829133ms)
+Jul  2 13:51:36.694: INFO: (3) /api/v1/namespaces/e2e-tests-proxy-zfjzs/services/https:proxy-service-qsb8g:tlsportname1/proxy/: tls baz (200; 9.132677ms)
+Jul  2 13:51:36.695: INFO: (3) /api/v1/namespaces/e2e-tests-proxy-zfjzs/services/https:proxy-service-qsb8g:tlsportname2/proxy/: tls qux (200; 8.829649ms)
+Jul  2 13:51:36.695: INFO: (3) /api/v1/namespaces/e2e-tests-proxy-zfjzs/pods/https:proxy-service-qsb8g-rr7rx:462/proxy/: tls qux (200; 9.218581ms)
+Jul  2 13:51:36.696: INFO: (3) /api/v1/namespaces/e2e-tests-proxy-zfjzs/services/proxy-service-qsb8g:portname2/proxy/: bar (200; 10.842177ms)
+Jul  2 13:51:36.698: INFO: (3) /api/v1/namespaces/e2e-tests-proxy-zfjzs/pods/proxy-service-qsb8g-rr7rx:160/proxy/: foo (200; 11.99192ms)
+Jul  2 13:51:36.698: INFO: (3) /api/v1/namespaces/e2e-tests-proxy-zfjzs/services/http:proxy-service-qsb8g:portname2/proxy/: bar (200; 12.278261ms)
+Jul  2 13:51:36.698: INFO: (3) /api/v1/namespaces/e2e-tests-proxy-zfjzs/services/proxy-service-qsb8g:portname1/proxy/: foo (200; 11.808203ms)
+Jul  2 13:51:36.704: INFO: (4) /api/v1/namespaces/e2e-tests-proxy-zfjzs/pods/http:proxy-service-qsb8g-rr7rx:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-zfjzs/pods/http:proxy-service-qsb8g-rr7rx:1080/proxy/... (200; 6.300401ms)
+Jul  2 13:51:36.705: INFO: (4) /api/v1/namespaces/e2e-tests-proxy-zfjzs/pods/http:proxy-service-qsb8g-rr7rx:160/proxy/: foo (200; 7.212805ms)
+Jul  2 13:51:36.705: INFO: (4) /api/v1/namespaces/e2e-tests-proxy-zfjzs/pods/https:proxy-service-qsb8g-rr7rx:460/proxy/: tls baz (200; 6.965474ms)
+Jul  2 13:51:36.705: INFO: (4) /api/v1/namespaces/e2e-tests-proxy-zfjzs/pods/proxy-service-qsb8g-rr7rx:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-zfjzs/pods/proxy-service-qsb8g-rr7rx:1080/proxy/rewri... (200; 7.256307ms)
+Jul  2 13:51:36.705: INFO: (4) /api/v1/namespaces/e2e-tests-proxy-zfjzs/pods/http:proxy-service-qsb8g-rr7rx:162/proxy/: bar (200; 7.243744ms)
+Jul  2 13:51:36.705: INFO: (4) /api/v1/namespaces/e2e-tests-proxy-zfjzs/pods/https:proxy-service-qsb8g-rr7rx:443/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-zfjzs/pods/https:proxy-service-qsb8g-rr7rx:443/proxy/... (200; 7.257557ms)
+Jul  2 13:51:36.706: INFO: (4) /api/v1/namespaces/e2e-tests-proxy-zfjzs/pods/proxy-service-qsb8g-rr7rx/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-zfjzs/pods/proxy-service-qsb8g-rr7rx/proxy/rewriteme"... (200; 7.516247ms)
+Jul  2 13:51:36.706: INFO: (4) /api/v1/namespaces/e2e-tests-proxy-zfjzs/pods/https:proxy-service-qsb8g-rr7rx:462/proxy/: tls qux (200; 7.923925ms)
+Jul  2 13:51:36.706: INFO: (4) /api/v1/namespaces/e2e-tests-proxy-zfjzs/pods/proxy-service-qsb8g-rr7rx:160/proxy/: foo (200; 7.665889ms)
+Jul  2 13:51:36.707: INFO: (4) /api/v1/namespaces/e2e-tests-proxy-zfjzs/services/https:proxy-service-qsb8g:tlsportname1/proxy/: tls baz (200; 8.515092ms)
+Jul  2 13:51:36.707: INFO: (4) /api/v1/namespaces/e2e-tests-proxy-zfjzs/pods/proxy-service-qsb8g-rr7rx:162/proxy/: bar (200; 8.136409ms)
+Jul  2 13:51:36.707: INFO: (4) /api/v1/namespaces/e2e-tests-proxy-zfjzs/services/https:proxy-service-qsb8g:tlsportname2/proxy/: tls qux (200; 8.462924ms)
+Jul  2 13:51:36.708: INFO: (4) /api/v1/namespaces/e2e-tests-proxy-zfjzs/services/http:proxy-service-qsb8g:portname1/proxy/: foo (200; 8.937368ms)
+Jul  2 13:51:36.709: INFO: (4) /api/v1/namespaces/e2e-tests-proxy-zfjzs/services/http:proxy-service-qsb8g:portname2/proxy/: bar (200; 9.896032ms)
+Jul  2 13:51:36.709: INFO: (4) /api/v1/namespaces/e2e-tests-proxy-zfjzs/services/proxy-service-qsb8g:portname1/proxy/: foo (200; 11.053532ms)
+Jul  2 13:51:36.710: INFO: (4) /api/v1/namespaces/e2e-tests-proxy-zfjzs/services/proxy-service-qsb8g:portname2/proxy/: bar (200; 11.5363ms)
+Jul  2 13:51:36.717: INFO: (5) /api/v1/namespaces/e2e-tests-proxy-zfjzs/pods/https:proxy-service-qsb8g-rr7rx:462/proxy/: tls qux (200; 6.543767ms)
+Jul  2 13:51:36.717: INFO: (5) /api/v1/namespaces/e2e-tests-proxy-zfjzs/pods/https:proxy-service-qsb8g-rr7rx:460/proxy/: tls baz (200; 6.752524ms)
+Jul  2 13:51:36.717: INFO: (5) /api/v1/namespaces/e2e-tests-proxy-zfjzs/pods/proxy-service-qsb8g-rr7rx/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-zfjzs/pods/proxy-service-qsb8g-rr7rx/proxy/rewriteme"... (200; 7.298706ms)
+Jul  2 13:51:36.717: INFO: (5) /api/v1/namespaces/e2e-tests-proxy-zfjzs/pods/proxy-service-qsb8g-rr7rx:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-zfjzs/pods/proxy-service-qsb8g-rr7rx:1080/proxy/rewri... (200; 7.072742ms)
+Jul  2 13:51:36.717: INFO: (5) /api/v1/namespaces/e2e-tests-proxy-zfjzs/pods/http:proxy-service-qsb8g-rr7rx:160/proxy/: foo (200; 6.826201ms)
+Jul  2 13:51:36.717: INFO: (5) /api/v1/namespaces/e2e-tests-proxy-zfjzs/pods/http:proxy-service-qsb8g-rr7rx:162/proxy/: bar (200; 7.053607ms)
+Jul  2 13:51:36.717: INFO: (5) /api/v1/namespaces/e2e-tests-proxy-zfjzs/pods/http:proxy-service-qsb8g-rr7rx:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-zfjzs/pods/http:proxy-service-qsb8g-rr7rx:1080/proxy/... (200; 7.352565ms)
+Jul  2 13:51:36.717: INFO: (5) /api/v1/namespaces/e2e-tests-proxy-zfjzs/pods/https:proxy-service-qsb8g-rr7rx:443/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-zfjzs/pods/https:proxy-service-qsb8g-rr7rx:443/proxy/... (200; 7.449006ms)
+Jul  2 13:51:36.717: INFO: (5) /api/v1/namespaces/e2e-tests-proxy-zfjzs/pods/proxy-service-qsb8g-rr7rx:160/proxy/: foo (200; 7.034666ms)
+Jul  2 13:51:36.717: INFO: (5) /api/v1/namespaces/e2e-tests-proxy-zfjzs/pods/proxy-service-qsb8g-rr7rx:162/proxy/: bar (200; 7.663867ms)
+Jul  2 13:51:36.718: INFO: (5) /api/v1/namespaces/e2e-tests-proxy-zfjzs/services/https:proxy-service-qsb8g:tlsportname1/proxy/: tls baz (200; 8.492842ms)
+Jul  2 13:51:36.719: INFO: (5) /api/v1/namespaces/e2e-tests-proxy-zfjzs/services/https:proxy-service-qsb8g:tlsportname2/proxy/: tls qux (200; 8.417178ms)
+Jul  2 13:51:36.719: INFO: (5) /api/v1/namespaces/e2e-tests-proxy-zfjzs/services/proxy-service-qsb8g:portname1/proxy/: foo (200; 9.135394ms)
+Jul  2 13:51:36.720: INFO: (5) /api/v1/namespaces/e2e-tests-proxy-zfjzs/services/proxy-service-qsb8g:portname2/proxy/: bar (200; 10.386688ms)
+Jul  2 13:51:36.720: INFO: (5) /api/v1/namespaces/e2e-tests-proxy-zfjzs/services/http:proxy-service-qsb8g:portname2/proxy/: bar (200; 10.643796ms)
+Jul  2 13:51:36.721: INFO: (5) /api/v1/namespaces/e2e-tests-proxy-zfjzs/services/http:proxy-service-qsb8g:portname1/proxy/: foo (200; 10.148327ms)
+Jul  2 13:51:36.731: INFO: (6) /api/v1/namespaces/e2e-tests-proxy-zfjzs/services/proxy-service-qsb8g:portname1/proxy/: foo (200; 10.272699ms)
+Jul  2 13:51:36.731: INFO: (6) /api/v1/namespaces/e2e-tests-proxy-zfjzs/pods/https:proxy-service-qsb8g-rr7rx:462/proxy/: tls qux (200; 10.437368ms)
+Jul  2 13:51:36.731: INFO: (6) /api/v1/namespaces/e2e-tests-proxy-zfjzs/services/http:proxy-service-qsb8g:portname2/proxy/: bar (200; 10.150458ms)
+Jul  2 13:51:36.731: INFO: (6) /api/v1/namespaces/e2e-tests-proxy-zfjzs/pods/proxy-service-qsb8g-rr7rx:162/proxy/: bar (200; 10.25166ms)
+Jul  2 13:51:36.731: INFO: (6) /api/v1/namespaces/e2e-tests-proxy-zfjzs/pods/proxy-service-qsb8g-rr7rx:160/proxy/: foo (200; 10.324229ms)
+Jul  2 13:51:36.732: INFO: (6) /api/v1/namespaces/e2e-tests-proxy-zfjzs/services/https:proxy-service-qsb8g:tlsportname2/proxy/: tls qux (200; 10.198892ms)
+Jul  2 13:51:36.732: INFO: (6) /api/v1/namespaces/e2e-tests-proxy-zfjzs/pods/proxy-service-qsb8g-rr7rx/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-zfjzs/pods/proxy-service-qsb8g-rr7rx/proxy/rewriteme"... (200; 10.537922ms)
+Jul  2 13:51:36.732: INFO: (6) /api/v1/namespaces/e2e-tests-proxy-zfjzs/pods/https:proxy-service-qsb8g-rr7rx:460/proxy/: tls baz (200; 10.327983ms)
+Jul  2 13:51:36.732: INFO: (6) /api/v1/namespaces/e2e-tests-proxy-zfjzs/pods/proxy-service-qsb8g-rr7rx:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-zfjzs/pods/proxy-service-qsb8g-rr7rx:1080/proxy/rewri... (200; 10.651566ms)
+Jul  2 13:51:36.732: INFO: (6) /api/v1/namespaces/e2e-tests-proxy-zfjzs/pods/https:proxy-service-qsb8g-rr7rx:443/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-zfjzs/pods/https:proxy-service-qsb8g-rr7rx:443/proxy/... (200; 10.868465ms)
+Jul  2 13:51:36.732: INFO: (6) /api/v1/namespaces/e2e-tests-proxy-zfjzs/services/https:proxy-service-qsb8g:tlsportname1/proxy/: tls baz (200; 10.850936ms)
+Jul  2 13:51:36.732: INFO: (6) /api/v1/namespaces/e2e-tests-proxy-zfjzs/pods/http:proxy-service-qsb8g-rr7rx:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-zfjzs/pods/http:proxy-service-qsb8g-rr7rx:1080/proxy/... (200; 11.126218ms)
+Jul  2 13:51:36.736: INFO: (6) /api/v1/namespaces/e2e-tests-proxy-zfjzs/services/proxy-service-qsb8g:portname2/proxy/: bar (200; 15.562785ms)
+Jul  2 13:51:36.736: INFO: (6) /api/v1/namespaces/e2e-tests-proxy-zfjzs/services/http:proxy-service-qsb8g:portname1/proxy/: foo (200; 15.545202ms)
+Jul  2 13:51:36.736: INFO: (6) /api/v1/namespaces/e2e-tests-proxy-zfjzs/pods/http:proxy-service-qsb8g-rr7rx:160/proxy/: foo (200; 15.082473ms)
+Jul  2 13:51:36.736: INFO: (6) /api/v1/namespaces/e2e-tests-proxy-zfjzs/pods/http:proxy-service-qsb8g-rr7rx:162/proxy/: bar (200; 15.170122ms)
+Jul  2 13:51:36.745: INFO: (7) /api/v1/namespaces/e2e-tests-proxy-zfjzs/pods/proxy-service-qsb8g-rr7rx:160/proxy/: foo (200; 7.81111ms)
+Jul  2 13:51:36.745: INFO: (7) /api/v1/namespaces/e2e-tests-proxy-zfjzs/pods/https:proxy-service-qsb8g-rr7rx:460/proxy/: tls baz (200; 8.171218ms)
+Jul  2 13:51:36.745: INFO: (7) /api/v1/namespaces/e2e-tests-proxy-zfjzs/pods/proxy-service-qsb8g-rr7rx:162/proxy/: bar (200; 7.777153ms)
+Jul  2 13:51:36.745: INFO: (7) /api/v1/namespaces/e2e-tests-proxy-zfjzs/services/https:proxy-service-qsb8g:tlsportname1/proxy/: tls baz (200; 8.955482ms)
+Jul  2 13:51:36.746: INFO: (7) /api/v1/namespaces/e2e-tests-proxy-zfjzs/pods/https:proxy-service-qsb8g-rr7rx:443/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-zfjzs/pods/https:proxy-service-qsb8g-rr7rx:443/proxy/... (200; 8.371555ms)
+Jul  2 13:51:36.746: INFO: (7) /api/v1/namespaces/e2e-tests-proxy-zfjzs/services/https:proxy-service-qsb8g:tlsportname2/proxy/: tls qux (200; 8.909104ms)
+Jul  2 13:51:36.746: INFO: (7) /api/v1/namespaces/e2e-tests-proxy-zfjzs/pods/http:proxy-service-qsb8g-rr7rx:162/proxy/: bar (200; 8.628476ms)
+Jul  2 13:51:36.746: INFO: (7) /api/v1/namespaces/e2e-tests-proxy-zfjzs/pods/proxy-service-qsb8g-rr7rx:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-zfjzs/pods/proxy-service-qsb8g-rr7rx:1080/proxy/rewri... (200; 8.710971ms)
+Jul  2 13:51:36.746: INFO: (7) /api/v1/namespaces/e2e-tests-proxy-zfjzs/pods/proxy-service-qsb8g-rr7rx/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-zfjzs/pods/proxy-service-qsb8g-rr7rx/proxy/rewriteme"... (200; 8.848788ms)
+Jul  2 13:51:36.746: INFO: (7) /api/v1/namespaces/e2e-tests-proxy-zfjzs/pods/http:proxy-service-qsb8g-rr7rx:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-zfjzs/pods/http:proxy-service-qsb8g-rr7rx:1080/proxy/... (200; 9.346453ms)
+Jul  2 13:51:36.746: INFO: (7) /api/v1/namespaces/e2e-tests-proxy-zfjzs/services/proxy-service-qsb8g:portname1/proxy/: foo (200; 9.576605ms)
+Jul  2 13:51:36.746: INFO: (7) /api/v1/namespaces/e2e-tests-proxy-zfjzs/pods/https:proxy-service-qsb8g-rr7rx:462/proxy/: tls qux (200; 9.326038ms)
+Jul  2 13:51:36.788: INFO: (7) /api/v1/namespaces/e2e-tests-proxy-zfjzs/services/http:proxy-service-qsb8g:portname2/proxy/: bar (200; 50.669627ms)
+Jul  2 13:51:36.788: INFO: (7) /api/v1/namespaces/e2e-tests-proxy-zfjzs/services/proxy-service-qsb8g:portname2/proxy/: bar (200; 50.232454ms)
+Jul  2 13:51:36.788: INFO: (7) /api/v1/namespaces/e2e-tests-proxy-zfjzs/services/http:proxy-service-qsb8g:portname1/proxy/: foo (200; 50.799885ms)
+Jul  2 13:51:36.788: INFO: (7) /api/v1/namespaces/e2e-tests-proxy-zfjzs/pods/http:proxy-service-qsb8g-rr7rx:160/proxy/: foo (200; 50.543402ms)
+Jul  2 13:51:36.795: INFO: (8) /api/v1/namespaces/e2e-tests-proxy-zfjzs/pods/https:proxy-service-qsb8g-rr7rx:462/proxy/: tls qux (200; 6.449442ms)
+Jul  2 13:51:36.796: INFO: (8) /api/v1/namespaces/e2e-tests-proxy-zfjzs/services/proxy-service-qsb8g:portname2/proxy/: bar (200; 8.059007ms)
+Jul  2 13:51:36.796: INFO: (8) /api/v1/namespaces/e2e-tests-proxy-zfjzs/pods/proxy-service-qsb8g-rr7rx:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-zfjzs/pods/proxy-service-qsb8g-rr7rx:1080/proxy/rewri... (200; 7.972512ms)
+Jul  2 13:51:36.796: INFO: (8) /api/v1/namespaces/e2e-tests-proxy-zfjzs/pods/https:proxy-service-qsb8g-rr7rx:443/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-zfjzs/pods/https:proxy-service-qsb8g-rr7rx:443/proxy/... (200; 8.059113ms)
+Jul  2 13:51:36.796: INFO: (8) /api/v1/namespaces/e2e-tests-proxy-zfjzs/pods/http:proxy-service-qsb8g-rr7rx:162/proxy/: bar (200; 7.973745ms)
+Jul  2 13:51:36.797: INFO: (8) /api/v1/namespaces/e2e-tests-proxy-zfjzs/services/https:proxy-service-qsb8g:tlsportname2/proxy/: tls qux (200; 8.552365ms)
+Jul  2 13:51:36.797: INFO: (8) /api/v1/namespaces/e2e-tests-proxy-zfjzs/pods/http:proxy-service-qsb8g-rr7rx:160/proxy/: foo (200; 8.65034ms)
+Jul  2 13:51:36.797: INFO: (8) /api/v1/namespaces/e2e-tests-proxy-zfjzs/services/proxy-service-qsb8g:portname1/proxy/: foo (200; 8.749881ms)
+Jul  2 13:51:36.798: INFO: (8) /api/v1/namespaces/e2e-tests-proxy-zfjzs/pods/https:proxy-service-qsb8g-rr7rx:460/proxy/: tls baz (200; 9.31861ms)
+Jul  2 13:51:36.798: INFO: (8) /api/v1/namespaces/e2e-tests-proxy-zfjzs/pods/http:proxy-service-qsb8g-rr7rx:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-zfjzs/pods/http:proxy-service-qsb8g-rr7rx:1080/proxy/... (200; 9.483093ms)
+Jul  2 13:51:36.798: INFO: (8) /api/v1/namespaces/e2e-tests-proxy-zfjzs/pods/proxy-service-qsb8g-rr7rx/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-zfjzs/pods/proxy-service-qsb8g-rr7rx/proxy/rewriteme"... (200; 9.606728ms)
+Jul  2 13:51:36.798: INFO: (8) /api/v1/namespaces/e2e-tests-proxy-zfjzs/services/https:proxy-service-qsb8g:tlsportname1/proxy/: tls baz (200; 9.812555ms)
+Jul  2 13:51:36.800: INFO: (8) /api/v1/namespaces/e2e-tests-proxy-zfjzs/services/http:proxy-service-qsb8g:portname2/proxy/: bar (200; 11.659306ms)
+Jul  2 13:51:36.800: INFO: (8) /api/v1/namespaces/e2e-tests-proxy-zfjzs/pods/proxy-service-qsb8g-rr7rx:162/proxy/: bar (200; 11.661979ms)
+Jul  2 13:51:36.801: INFO: (8) /api/v1/namespaces/e2e-tests-proxy-zfjzs/services/http:proxy-service-qsb8g:portname1/proxy/: foo (200; 12.598762ms)
+Jul  2 13:51:36.801: INFO: (8) /api/v1/namespaces/e2e-tests-proxy-zfjzs/pods/proxy-service-qsb8g-rr7rx:160/proxy/: foo (200; 12.574179ms)
+Jul  2 13:51:36.807: INFO: (9) /api/v1/namespaces/e2e-tests-proxy-zfjzs/pods/proxy-service-qsb8g-rr7rx:162/proxy/: bar (200; 5.917369ms)
+Jul  2 13:51:36.808: INFO: (9) /api/v1/namespaces/e2e-tests-proxy-zfjzs/pods/proxy-service-qsb8g-rr7rx:160/proxy/: foo (200; 7.108084ms)
+Jul  2 13:51:36.809: INFO: (9) /api/v1/namespaces/e2e-tests-proxy-zfjzs/pods/https:proxy-service-qsb8g-rr7rx:460/proxy/: tls baz (200; 6.424521ms)
+Jul  2 13:51:36.809: INFO: (9) /api/v1/namespaces/e2e-tests-proxy-zfjzs/pods/http:proxy-service-qsb8g-rr7rx:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-zfjzs/pods/http:proxy-service-qsb8g-rr7rx:1080/proxy/... (200; 7.033126ms)
+Jul  2 13:51:36.809: INFO: (9) /api/v1/namespaces/e2e-tests-proxy-zfjzs/pods/proxy-service-qsb8g-rr7rx/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-zfjzs/pods/proxy-service-qsb8g-rr7rx/proxy/rewriteme"... (200; 7.173546ms)
+Jul  2 13:51:36.809: INFO: (9) /api/v1/namespaces/e2e-tests-proxy-zfjzs/pods/proxy-service-qsb8g-rr7rx:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-zfjzs/pods/proxy-service-qsb8g-rr7rx:1080/proxy/rewri... (200; 6.932927ms)
+Jul  2 13:51:36.809: INFO: (9) /api/v1/namespaces/e2e-tests-proxy-zfjzs/pods/https:proxy-service-qsb8g-rr7rx:443/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-zfjzs/pods/https:proxy-service-qsb8g-rr7rx:443/proxy/... (200; 7.604171ms)
+Jul  2 13:51:36.809: INFO: (9) /api/v1/namespaces/e2e-tests-proxy-zfjzs/pods/http:proxy-service-qsb8g-rr7rx:162/proxy/: bar (200; 7.448701ms)
+Jul  2 13:51:36.809: INFO: (9) /api/v1/namespaces/e2e-tests-proxy-zfjzs/pods/https:proxy-service-qsb8g-rr7rx:462/proxy/: tls qux (200; 8.456562ms)
+Jul  2 13:51:36.810: INFO: (9) /api/v1/namespaces/e2e-tests-proxy-zfjzs/services/http:proxy-service-qsb8g:portname1/proxy/: foo (200; 8.276677ms)
+Jul  2 13:51:36.810: INFO: (9) /api/v1/namespaces/e2e-tests-proxy-zfjzs/services/https:proxy-service-qsb8g:tlsportname1/proxy/: tls baz (200; 8.4461ms)
+Jul  2 13:51:36.810: INFO: (9) /api/v1/namespaces/e2e-tests-proxy-zfjzs/services/proxy-service-qsb8g:portname2/proxy/: bar (200; 9.280035ms)
+Jul  2 13:51:36.811: INFO: (9) /api/v1/namespaces/e2e-tests-proxy-zfjzs/pods/http:proxy-service-qsb8g-rr7rx:160/proxy/: foo (200; 9.189163ms)
+Jul  2 13:51:36.811: INFO: (9) /api/v1/namespaces/e2e-tests-proxy-zfjzs/services/https:proxy-service-qsb8g:tlsportname2/proxy/: tls qux (200; 9.127711ms)
+Jul  2 13:51:36.812: INFO: (9) /api/v1/namespaces/e2e-tests-proxy-zfjzs/services/http:proxy-service-qsb8g:portname2/proxy/: bar (200; 10.707818ms)
+Jul  2 13:51:36.812: INFO: (9) /api/v1/namespaces/e2e-tests-proxy-zfjzs/services/proxy-service-qsb8g:portname1/proxy/: foo (200; 11.021226ms)
+Jul  2 13:51:36.819: INFO: (10) /api/v1/namespaces/e2e-tests-proxy-zfjzs/pods/proxy-service-qsb8g-rr7rx:162/proxy/: bar (200; 6.433528ms)
+Jul  2 13:51:36.820: INFO: (10) /api/v1/namespaces/e2e-tests-proxy-zfjzs/pods/http:proxy-service-qsb8g-rr7rx:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-zfjzs/pods/http:proxy-service-qsb8g-rr7rx:1080/proxy/... (200; 7.11291ms)
+Jul  2 13:51:36.820: INFO: (10) /api/v1/namespaces/e2e-tests-proxy-zfjzs/pods/proxy-service-qsb8g-rr7rx:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-zfjzs/pods/proxy-service-qsb8g-rr7rx:1080/proxy/rewri... (200; 6.973199ms)
+Jul  2 13:51:36.820: INFO: (10) /api/v1/namespaces/e2e-tests-proxy-zfjzs/pods/proxy-service-qsb8g-rr7rx/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-zfjzs/pods/proxy-service-qsb8g-rr7rx/proxy/rewriteme"... (200; 7.761152ms)
+Jul  2 13:51:36.820: INFO: (10) /api/v1/namespaces/e2e-tests-proxy-zfjzs/pods/proxy-service-qsb8g-rr7rx:160/proxy/: foo (200; 7.622343ms)
+Jul  2 13:51:36.820: INFO: (10) /api/v1/namespaces/e2e-tests-proxy-zfjzs/pods/http:proxy-service-qsb8g-rr7rx:162/proxy/: bar (200; 7.150931ms)
+Jul  2 13:51:36.821: INFO: (10) /api/v1/namespaces/e2e-tests-proxy-zfjzs/pods/https:proxy-service-qsb8g-rr7rx:443/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-zfjzs/pods/https:proxy-service-qsb8g-rr7rx:443/proxy/... (200; 7.72463ms)
+Jul  2 13:51:36.821: INFO: (10) /api/v1/namespaces/e2e-tests-proxy-zfjzs/services/http:proxy-service-qsb8g:portname1/proxy/: foo (200; 8.241028ms)
+Jul  2 13:51:36.821: INFO: (10) /api/v1/namespaces/e2e-tests-proxy-zfjzs/pods/https:proxy-service-qsb8g-rr7rx:462/proxy/: tls qux (200; 7.679822ms)
+Jul  2 13:51:36.821: INFO: (10) /api/v1/namespaces/e2e-tests-proxy-zfjzs/pods/https:proxy-service-qsb8g-rr7rx:460/proxy/: tls baz (200; 7.910166ms)
+Jul  2 13:51:36.822: INFO: (10) /api/v1/namespaces/e2e-tests-proxy-zfjzs/services/proxy-service-qsb8g:portname2/proxy/: bar (200; 8.957836ms)
+Jul  2 13:51:36.823: INFO: (10) /api/v1/namespaces/e2e-tests-proxy-zfjzs/services/https:proxy-service-qsb8g:tlsportname2/proxy/: tls qux (200; 9.377855ms)
+Jul  2 13:51:36.823: INFO: (10) /api/v1/namespaces/e2e-tests-proxy-zfjzs/services/https:proxy-service-qsb8g:tlsportname1/proxy/: tls baz (200; 9.551496ms)
+Jul  2 13:51:36.830: INFO: (10) /api/v1/namespaces/e2e-tests-proxy-zfjzs/services/http:proxy-service-qsb8g:portname2/proxy/: bar (200; 16.670991ms)
+Jul  2 13:51:36.830: INFO: (10) /api/v1/namespaces/e2e-tests-proxy-zfjzs/pods/http:proxy-service-qsb8g-rr7rx:160/proxy/: foo (200; 16.064226ms)
+Jul  2 13:51:36.830: INFO: (10) /api/v1/namespaces/e2e-tests-proxy-zfjzs/services/proxy-service-qsb8g:portname1/proxy/: foo (200; 17.091073ms)
+Jul  2 13:51:36.838: INFO: (11) /api/v1/namespaces/e2e-tests-proxy-zfjzs/pods/https:proxy-service-qsb8g-rr7rx:462/proxy/: tls qux (200; 8.539919ms)
+Jul  2 13:51:36.839: INFO: (11) /api/v1/namespaces/e2e-tests-proxy-zfjzs/pods/proxy-service-qsb8g-rr7rx:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-zfjzs/pods/proxy-service-qsb8g-rr7rx:1080/proxy/rewri... (200; 9.227965ms)
+Jul  2 13:51:36.847: INFO: (11) /api/v1/namespaces/e2e-tests-proxy-zfjzs/pods/proxy-service-qsb8g-rr7rx:162/proxy/: bar (200; 16.235992ms)
+Jul  2 13:51:36.847: INFO: (11) /api/v1/namespaces/e2e-tests-proxy-zfjzs/services/https:proxy-service-qsb8g:tlsportname2/proxy/: tls qux (200; 16.773919ms)
+Jul  2 13:51:36.847: INFO: (11) /api/v1/namespaces/e2e-tests-proxy-zfjzs/pods/https:proxy-service-qsb8g-rr7rx:460/proxy/: tls baz (200; 17.118962ms)
+Jul  2 13:51:36.848: INFO: (11) /api/v1/namespaces/e2e-tests-proxy-zfjzs/pods/proxy-service-qsb8g-rr7rx/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-zfjzs/pods/proxy-service-qsb8g-rr7rx/proxy/rewriteme"... (200; 16.979064ms)
+Jul  2 13:51:36.848: INFO: (11) /api/v1/namespaces/e2e-tests-proxy-zfjzs/pods/https:proxy-service-qsb8g-rr7rx:443/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-zfjzs/pods/https:proxy-service-qsb8g-rr7rx:443/proxy/... (200; 17.673102ms)
+Jul  2 13:51:36.848: INFO: (11) /api/v1/namespaces/e2e-tests-proxy-zfjzs/pods/http:proxy-service-qsb8g-rr7rx:162/proxy/: bar (200; 18.073323ms)
+Jul  2 13:51:36.849: INFO: (11) /api/v1/namespaces/e2e-tests-proxy-zfjzs/pods/proxy-service-qsb8g-rr7rx:160/proxy/: foo (200; 18.024833ms)
+Jul  2 13:51:36.849: INFO: (11) /api/v1/namespaces/e2e-tests-proxy-zfjzs/services/http:proxy-service-qsb8g:portname1/proxy/: foo (200; 18.301238ms)
+Jul  2 13:51:36.849: INFO: (11) /api/v1/namespaces/e2e-tests-proxy-zfjzs/services/https:proxy-service-qsb8g:tlsportname1/proxy/: tls baz (200; 19.147095ms)
+Jul  2 13:51:36.849: INFO: (11) /api/v1/namespaces/e2e-tests-proxy-zfjzs/pods/http:proxy-service-qsb8g-rr7rx:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-zfjzs/pods/http:proxy-service-qsb8g-rr7rx:1080/proxy/... (200; 18.614771ms)
+Jul  2 13:51:36.850: INFO: (11) /api/v1/namespaces/e2e-tests-proxy-zfjzs/pods/http:proxy-service-qsb8g-rr7rx:160/proxy/: foo (200; 20.058461ms)
+Jul  2 13:51:36.850: INFO: (11) /api/v1/namespaces/e2e-tests-proxy-zfjzs/services/proxy-service-qsb8g:portname2/proxy/: bar (200; 20.427521ms)
+Jul  2 13:51:36.853: INFO: (11) /api/v1/namespaces/e2e-tests-proxy-zfjzs/services/proxy-service-qsb8g:portname1/proxy/: foo (200; 23.03078ms)
+Jul  2 13:51:36.854: INFO: (11) /api/v1/namespaces/e2e-tests-proxy-zfjzs/services/http:proxy-service-qsb8g:portname2/proxy/: bar (200; 22.916066ms)
+Jul  2 13:51:36.865: INFO: (12) /api/v1/namespaces/e2e-tests-proxy-zfjzs/pods/proxy-service-qsb8g-rr7rx:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-zfjzs/pods/proxy-service-qsb8g-rr7rx:1080/proxy/rewri... (200; 11.029982ms)
+Jul  2 13:51:36.866: INFO: (12) /api/v1/namespaces/e2e-tests-proxy-zfjzs/services/https:proxy-service-qsb8g:tlsportname1/proxy/: tls baz (200; 11.820903ms)
+Jul  2 13:51:36.866: INFO: (12) /api/v1/namespaces/e2e-tests-proxy-zfjzs/pods/http:proxy-service-qsb8g-rr7rx:162/proxy/: bar (200; 11.749803ms)
+Jul  2 13:51:36.866: INFO: (12) /api/v1/namespaces/e2e-tests-proxy-zfjzs/pods/https:proxy-service-qsb8g-rr7rx:462/proxy/: tls qux (200; 12.197639ms)
+Jul  2 13:51:36.866: INFO: (12) /api/v1/namespaces/e2e-tests-proxy-zfjzs/pods/proxy-service-qsb8g-rr7rx:162/proxy/: bar (200; 11.694561ms)
+Jul  2 13:51:36.866: INFO: (12) /api/v1/namespaces/e2e-tests-proxy-zfjzs/pods/https:proxy-service-qsb8g-rr7rx:443/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-zfjzs/pods/https:proxy-service-qsb8g-rr7rx:443/proxy/... (200; 11.903765ms)
+Jul  2 13:51:36.866: INFO: (12) /api/v1/namespaces/e2e-tests-proxy-zfjzs/pods/https:proxy-service-qsb8g-rr7rx:460/proxy/: tls baz (200; 12.13237ms)
+Jul  2 13:51:36.869: INFO: (12) /api/v1/namespaces/e2e-tests-proxy-zfjzs/pods/http:proxy-service-qsb8g-rr7rx:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-zfjzs/pods/http:proxy-service-qsb8g-rr7rx:1080/proxy/... (200; 14.161815ms)
+Jul  2 13:51:36.869: INFO: (12) /api/v1/namespaces/e2e-tests-proxy-zfjzs/services/https:proxy-service-qsb8g:tlsportname2/proxy/: tls qux (200; 14.877329ms)
+Jul  2 13:51:36.869: INFO: (12) /api/v1/namespaces/e2e-tests-proxy-zfjzs/services/http:proxy-service-qsb8g:portname1/proxy/: foo (200; 14.737104ms)
+Jul  2 13:51:36.869: INFO: (12) /api/v1/namespaces/e2e-tests-proxy-zfjzs/pods/http:proxy-service-qsb8g-rr7rx:160/proxy/: foo (200; 14.866877ms)
+Jul  2 13:51:36.869: INFO: (12) /api/v1/namespaces/e2e-tests-proxy-zfjzs/pods/proxy-service-qsb8g-rr7rx/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-zfjzs/pods/proxy-service-qsb8g-rr7rx/proxy/rewriteme"... (200; 14.632585ms)
+Jul  2 13:51:36.871: INFO: (12) /api/v1/namespaces/e2e-tests-proxy-zfjzs/services/proxy-service-qsb8g:portname2/proxy/: bar (200; 17.549093ms)
+Jul  2 13:51:36.871: INFO: (12) /api/v1/namespaces/e2e-tests-proxy-zfjzs/services/http:proxy-service-qsb8g:portname2/proxy/: bar (200; 16.947509ms)
+Jul  2 13:51:36.949: INFO: (12) /api/v1/namespaces/e2e-tests-proxy-zfjzs/services/proxy-service-qsb8g:portname1/proxy/: foo (200; 94.735659ms)
+Jul  2 13:51:36.949: INFO: (12) /api/v1/namespaces/e2e-tests-proxy-zfjzs/pods/proxy-service-qsb8g-rr7rx:160/proxy/: foo (200; 94.933668ms)
+Jul  2 13:51:36.960: INFO: (13) /api/v1/namespaces/e2e-tests-proxy-zfjzs/services/https:proxy-service-qsb8g:tlsportname1/proxy/: tls baz (200; 9.895808ms)
+Jul  2 13:51:36.961: INFO: (13) /api/v1/namespaces/e2e-tests-proxy-zfjzs/services/https:proxy-service-qsb8g:tlsportname2/proxy/: tls qux (200; 9.195358ms)
+Jul  2 13:51:36.961: INFO: (13) /api/v1/namespaces/e2e-tests-proxy-zfjzs/services/proxy-service-qsb8g:portname1/proxy/: foo (200; 11.250824ms)
+Jul  2 13:51:36.961: INFO: (13) /api/v1/namespaces/e2e-tests-proxy-zfjzs/pods/https:proxy-service-qsb8g-rr7rx:462/proxy/: tls qux (200; 11.6064ms)
+Jul  2 13:51:36.961: INFO: (13) /api/v1/namespaces/e2e-tests-proxy-zfjzs/services/http:proxy-service-qsb8g:portname2/proxy/: bar (200; 11.388769ms)
+Jul  2 13:51:36.962: INFO: (13) /api/v1/namespaces/e2e-tests-proxy-zfjzs/services/proxy-service-qsb8g:portname2/proxy/: bar (200; 11.854146ms)
+Jul  2 13:51:36.962: INFO: (13) /api/v1/namespaces/e2e-tests-proxy-zfjzs/pods/http:proxy-service-qsb8g-rr7rx:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-zfjzs/pods/http:proxy-service-qsb8g-rr7rx:1080/proxy/... (200; 11.674447ms)
+Jul  2 13:51:36.962: INFO: (13) /api/v1/namespaces/e2e-tests-proxy-zfjzs/pods/proxy-service-qsb8g-rr7rx:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-zfjzs/pods/proxy-service-qsb8g-rr7rx:1080/proxy/rewri... (200; 11.370079ms)
+Jul  2 13:51:36.962: INFO: (13) /api/v1/namespaces/e2e-tests-proxy-zfjzs/services/http:proxy-service-qsb8g:portname1/proxy/: foo (200; 12.559263ms)
+Jul  2 13:51:36.962: INFO: (13) /api/v1/namespaces/e2e-tests-proxy-zfjzs/pods/https:proxy-service-qsb8g-rr7rx:443/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-zfjzs/pods/https:proxy-service-qsb8g-rr7rx:443/proxy/... (200; 12.304555ms)
+Jul  2 13:51:36.963: INFO: (13) /api/v1/namespaces/e2e-tests-proxy-zfjzs/pods/proxy-service-qsb8g-rr7rx/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-zfjzs/pods/proxy-service-qsb8g-rr7rx/proxy/rewriteme"... (200; 12.513959ms)
+Jul  2 13:51:36.963: INFO: (13) /api/v1/namespaces/e2e-tests-proxy-zfjzs/pods/https:proxy-service-qsb8g-rr7rx:460/proxy/: tls baz (200; 10.875332ms)
+Jul  2 13:51:37.001: INFO: (13) /api/v1/namespaces/e2e-tests-proxy-zfjzs/pods/proxy-service-qsb8g-rr7rx:162/proxy/: bar (200; 51.065562ms)
+Jul  2 13:51:37.001: INFO: (13) /api/v1/namespaces/e2e-tests-proxy-zfjzs/pods/http:proxy-service-qsb8g-rr7rx:162/proxy/: bar (200; 50.363858ms)
+Jul  2 13:51:37.001: INFO: (13) /api/v1/namespaces/e2e-tests-proxy-zfjzs/pods/http:proxy-service-qsb8g-rr7rx:160/proxy/: foo (200; 49.645432ms)
+Jul  2 13:51:37.001: INFO: (13) /api/v1/namespaces/e2e-tests-proxy-zfjzs/pods/proxy-service-qsb8g-rr7rx:160/proxy/: foo (200; 51.194938ms)
+Jul  2 13:51:37.010: INFO: (14) /api/v1/namespaces/e2e-tests-proxy-zfjzs/pods/proxy-service-qsb8g-rr7rx:160/proxy/: foo (200; 8.064709ms)
+Jul  2 13:51:37.010: INFO: (14) /api/v1/namespaces/e2e-tests-proxy-zfjzs/pods/proxy-service-qsb8g-rr7rx/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-zfjzs/pods/proxy-service-qsb8g-rr7rx/proxy/rewriteme"... (200; 7.739278ms)
+Jul  2 13:51:37.010: INFO: (14) /api/v1/namespaces/e2e-tests-proxy-zfjzs/pods/http:proxy-service-qsb8g-rr7rx:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-zfjzs/pods/http:proxy-service-qsb8g-rr7rx:1080/proxy/... (200; 8.560822ms)
+Jul  2 13:51:37.010: INFO: (14) /api/v1/namespaces/e2e-tests-proxy-zfjzs/pods/https:proxy-service-qsb8g-rr7rx:462/proxy/: tls qux (200; 8.596579ms)
+Jul  2 13:51:37.011: INFO: (14) /api/v1/namespaces/e2e-tests-proxy-zfjzs/services/proxy-service-qsb8g:portname1/proxy/: foo (200; 9.780946ms)
+Jul  2 13:51:37.011: INFO: (14) /api/v1/namespaces/e2e-tests-proxy-zfjzs/pods/https:proxy-service-qsb8g-rr7rx:443/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-zfjzs/pods/https:proxy-service-qsb8g-rr7rx:443/proxy/... (200; 9.362403ms)
+Jul  2 13:51:37.011: INFO: (14) /api/v1/namespaces/e2e-tests-proxy-zfjzs/services/proxy-service-qsb8g:portname2/proxy/: bar (200; 9.681127ms)
+Jul  2 13:51:37.012: INFO: (14) /api/v1/namespaces/e2e-tests-proxy-zfjzs/pods/https:proxy-service-qsb8g-rr7rx:460/proxy/: tls baz (200; 10.185718ms)
+Jul  2 13:51:37.012: INFO: (14) /api/v1/namespaces/e2e-tests-proxy-zfjzs/pods/http:proxy-service-qsb8g-rr7rx:162/proxy/: bar (200; 9.663037ms)
+Jul  2 13:51:37.012: INFO: (14) /api/v1/namespaces/e2e-tests-proxy-zfjzs/pods/proxy-service-qsb8g-rr7rx:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-zfjzs/pods/proxy-service-qsb8g-rr7rx:1080/proxy/rewri... (200; 9.803566ms)
+Jul  2 13:51:37.012: INFO: (14) /api/v1/namespaces/e2e-tests-proxy-zfjzs/pods/proxy-service-qsb8g-rr7rx:162/proxy/: bar (200; 10.381937ms)
+Jul  2 13:51:37.012: INFO: (14) /api/v1/namespaces/e2e-tests-proxy-zfjzs/pods/http:proxy-service-qsb8g-rr7rx:160/proxy/: foo (200; 10.308975ms)
+Jul  2 13:51:37.013: INFO: (14) /api/v1/namespaces/e2e-tests-proxy-zfjzs/services/https:proxy-service-qsb8g:tlsportname1/proxy/: tls baz (200; 11.481992ms)
+Jul  2 13:51:37.013: INFO: (14) /api/v1/namespaces/e2e-tests-proxy-zfjzs/services/https:proxy-service-qsb8g:tlsportname2/proxy/: tls qux (200; 11.269408ms)
+Jul  2 13:51:37.014: INFO: (14) /api/v1/namespaces/e2e-tests-proxy-zfjzs/services/http:proxy-service-qsb8g:portname1/proxy/: foo (200; 11.884285ms)
+Jul  2 13:51:37.014: INFO: (14) /api/v1/namespaces/e2e-tests-proxy-zfjzs/services/http:proxy-service-qsb8g:portname2/proxy/: bar (200; 11.461824ms)
+Jul  2 13:51:37.021: INFO: (15) /api/v1/namespaces/e2e-tests-proxy-zfjzs/pods/https:proxy-service-qsb8g-rr7rx:462/proxy/: tls qux (200; 7.430976ms)
+Jul  2 13:51:37.021: INFO: (15) /api/v1/namespaces/e2e-tests-proxy-zfjzs/pods/proxy-service-qsb8g-rr7rx:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-zfjzs/pods/proxy-service-qsb8g-rr7rx:1080/proxy/rewri... (200; 7.110476ms)
+Jul  2 13:51:37.021: INFO: (15) /api/v1/namespaces/e2e-tests-proxy-zfjzs/services/proxy-service-qsb8g:portname1/proxy/: foo (200; 7.489123ms)
+Jul  2 13:51:37.021: INFO: (15) /api/v1/namespaces/e2e-tests-proxy-zfjzs/pods/https:proxy-service-qsb8g-rr7rx:460/proxy/: tls baz (200; 7.114411ms)
+Jul  2 13:51:37.021: INFO: (15) /api/v1/namespaces/e2e-tests-proxy-zfjzs/pods/https:proxy-service-qsb8g-rr7rx:443/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-zfjzs/pods/https:proxy-service-qsb8g-rr7rx:443/proxy/... (200; 7.274736ms)
+Jul  2 13:51:37.021: INFO: (15) /api/v1/namespaces/e2e-tests-proxy-zfjzs/pods/http:proxy-service-qsb8g-rr7rx:162/proxy/: bar (200; 7.342801ms)
+Jul  2 13:51:37.021: INFO: (15) /api/v1/namespaces/e2e-tests-proxy-zfjzs/services/https:proxy-service-qsb8g:tlsportname1/proxy/: tls baz (200; 7.487369ms)
+Jul  2 13:51:37.022: INFO: (15) /api/v1/namespaces/e2e-tests-proxy-zfjzs/services/proxy-service-qsb8g:portname2/proxy/: bar (200; 7.589782ms)
+Jul  2 13:51:37.022: INFO: (15) /api/v1/namespaces/e2e-tests-proxy-zfjzs/pods/proxy-service-qsb8g-rr7rx/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-zfjzs/pods/proxy-service-qsb8g-rr7rx/proxy/rewriteme"... (200; 7.698012ms)
+Jul  2 13:51:37.022: INFO: (15) /api/v1/namespaces/e2e-tests-proxy-zfjzs/pods/http:proxy-service-qsb8g-rr7rx:160/proxy/: foo (200; 8.014685ms)
+Jul  2 13:51:37.022: INFO: (15) /api/v1/namespaces/e2e-tests-proxy-zfjzs/services/https:proxy-service-qsb8g:tlsportname2/proxy/: tls qux (200; 8.174079ms)
+Jul  2 13:51:37.022: INFO: (15) /api/v1/namespaces/e2e-tests-proxy-zfjzs/pods/http:proxy-service-qsb8g-rr7rx:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-zfjzs/pods/http:proxy-service-qsb8g-rr7rx:1080/proxy/... (200; 7.875808ms)
+Jul  2 13:51:37.024: INFO: (15) /api/v1/namespaces/e2e-tests-proxy-zfjzs/pods/proxy-service-qsb8g-rr7rx:160/proxy/: foo (200; 9.653029ms)
+Jul  2 13:51:37.024: INFO: (15) /api/v1/namespaces/e2e-tests-proxy-zfjzs/services/http:proxy-service-qsb8g:portname2/proxy/: bar (200; 9.793639ms)
+Jul  2 13:51:37.024: INFO: (15) /api/v1/namespaces/e2e-tests-proxy-zfjzs/services/http:proxy-service-qsb8g:portname1/proxy/: foo (200; 9.702908ms)
+Jul  2 13:51:37.024: INFO: (15) /api/v1/namespaces/e2e-tests-proxy-zfjzs/pods/proxy-service-qsb8g-rr7rx:162/proxy/: bar (200; 10.130294ms)
+Jul  2 13:51:37.032: INFO: (16) /api/v1/namespaces/e2e-tests-proxy-zfjzs/pods/http:proxy-service-qsb8g-rr7rx:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-zfjzs/pods/http:proxy-service-qsb8g-rr7rx:1080/proxy/... (200; 7.735204ms)
+Jul  2 13:51:37.032: INFO: (16) /api/v1/namespaces/e2e-tests-proxy-zfjzs/pods/https:proxy-service-qsb8g-rr7rx:443/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-zfjzs/pods/https:proxy-service-qsb8g-rr7rx:443/proxy/... (200; 7.90977ms)
+Jul  2 13:51:37.033: INFO: (16) /api/v1/namespaces/e2e-tests-proxy-zfjzs/pods/proxy-service-qsb8g-rr7rx:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-zfjzs/pods/proxy-service-qsb8g-rr7rx:1080/proxy/rewri... (200; 7.712983ms)
+Jul  2 13:51:37.033: INFO: (16) /api/v1/namespaces/e2e-tests-proxy-zfjzs/pods/proxy-service-qsb8g-rr7rx/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-zfjzs/pods/proxy-service-qsb8g-rr7rx/proxy/rewriteme"... (200; 7.924931ms)
+Jul  2 13:51:37.033: INFO: (16) /api/v1/namespaces/e2e-tests-proxy-zfjzs/pods/proxy-service-qsb8g-rr7rx:162/proxy/: bar (200; 8.048464ms)
+Jul  2 13:51:37.033: INFO: (16) /api/v1/namespaces/e2e-tests-proxy-zfjzs/pods/proxy-service-qsb8g-rr7rx:160/proxy/: foo (200; 7.645336ms)
+Jul  2 13:51:37.034: INFO: (16) /api/v1/namespaces/e2e-tests-proxy-zfjzs/services/https:proxy-service-qsb8g:tlsportname1/proxy/: tls baz (200; 9.292441ms)
+Jul  2 13:51:37.034: INFO: (16) /api/v1/namespaces/e2e-tests-proxy-zfjzs/services/https:proxy-service-qsb8g:tlsportname2/proxy/: tls qux (200; 9.25548ms)
+Jul  2 13:51:37.034: INFO: (16) /api/v1/namespaces/e2e-tests-proxy-zfjzs/pods/http:proxy-service-qsb8g-rr7rx:160/proxy/: foo (200; 9.266606ms)
+Jul  2 13:51:37.034: INFO: (16) /api/v1/namespaces/e2e-tests-proxy-zfjzs/pods/https:proxy-service-qsb8g-rr7rx:462/proxy/: tls qux (200; 9.279687ms)
+Jul  2 13:51:37.035: INFO: (16) /api/v1/namespaces/e2e-tests-proxy-zfjzs/pods/https:proxy-service-qsb8g-rr7rx:460/proxy/: tls baz (200; 9.484988ms)
+Jul  2 13:51:37.035: INFO: (16) /api/v1/namespaces/e2e-tests-proxy-zfjzs/pods/http:proxy-service-qsb8g-rr7rx:162/proxy/: bar (200; 9.709176ms)
+Jul  2 13:51:37.035: INFO: (16) /api/v1/namespaces/e2e-tests-proxy-zfjzs/services/proxy-service-qsb8g:portname2/proxy/: bar (200; 10.305489ms)
+Jul  2 13:51:37.035: INFO: (16) /api/v1/namespaces/e2e-tests-proxy-zfjzs/services/http:proxy-service-qsb8g:portname2/proxy/: bar (200; 10.496493ms)
+Jul  2 13:51:37.035: INFO: (16) /api/v1/namespaces/e2e-tests-proxy-zfjzs/services/http:proxy-service-qsb8g:portname1/proxy/: foo (200; 10.046988ms)
+Jul  2 13:51:37.036: INFO: (16) /api/v1/namespaces/e2e-tests-proxy-zfjzs/services/proxy-service-qsb8g:portname1/proxy/: foo (200; 11.013381ms)
+Jul  2 13:51:37.042: INFO: (17) /api/v1/namespaces/e2e-tests-proxy-zfjzs/pods/http:proxy-service-qsb8g-rr7rx:160/proxy/: foo (200; 6.008158ms)
+Jul  2 13:51:37.043: INFO: (17) /api/v1/namespaces/e2e-tests-proxy-zfjzs/pods/http:proxy-service-qsb8g-rr7rx:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-zfjzs/pods/http:proxy-service-qsb8g-rr7rx:1080/proxy/... (200; 6.120299ms)
+Jul  2 13:51:37.043: INFO: (17) /api/v1/namespaces/e2e-tests-proxy-zfjzs/pods/https:proxy-service-qsb8g-rr7rx:443/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-zfjzs/pods/https:proxy-service-qsb8g-rr7rx:443/proxy/... (200; 6.692045ms)
+Jul  2 13:51:37.043: INFO: (17) /api/v1/namespaces/e2e-tests-proxy-zfjzs/pods/proxy-service-qsb8g-rr7rx:162/proxy/: bar (200; 6.651244ms)
+Jul  2 13:51:37.043: INFO: (17) /api/v1/namespaces/e2e-tests-proxy-zfjzs/pods/https:proxy-service-qsb8g-rr7rx:462/proxy/: tls qux (200; 6.700907ms)
+Jul  2 13:51:37.043: INFO: (17) /api/v1/namespaces/e2e-tests-proxy-zfjzs/pods/https:proxy-service-qsb8g-rr7rx:460/proxy/: tls baz (200; 6.794173ms)
+Jul  2 13:51:37.044: INFO: (17) /api/v1/namespaces/e2e-tests-proxy-zfjzs/pods/http:proxy-service-qsb8g-rr7rx:162/proxy/: bar (200; 7.365568ms)
+Jul  2 13:51:37.044: INFO: (17) /api/v1/namespaces/e2e-tests-proxy-zfjzs/services/https:proxy-service-qsb8g:tlsportname2/proxy/: tls qux (200; 8.131962ms)
+Jul  2 13:51:37.045: INFO: (17) /api/v1/namespaces/e2e-tests-proxy-zfjzs/pods/proxy-service-qsb8g-rr7rx/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-zfjzs/pods/proxy-service-qsb8g-rr7rx/proxy/rewriteme"... (200; 8.625119ms)
+Jul  2 13:51:37.045: INFO: (17) /api/v1/namespaces/e2e-tests-proxy-zfjzs/pods/proxy-service-qsb8g-rr7rx:160/proxy/: foo (200; 8.259617ms)
+Jul  2 13:51:37.045: INFO: (17) /api/v1/namespaces/e2e-tests-proxy-zfjzs/pods/proxy-service-qsb8g-rr7rx:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-zfjzs/pods/proxy-service-qsb8g-rr7rx:1080/proxy/rewri... (200; 8.500882ms)
+Jul  2 13:51:37.046: INFO: (17) /api/v1/namespaces/e2e-tests-proxy-zfjzs/services/http:proxy-service-qsb8g:portname2/proxy/: bar (200; 9.636096ms)
+Jul  2 13:51:37.046: INFO: (17) /api/v1/namespaces/e2e-tests-proxy-zfjzs/services/http:proxy-service-qsb8g:portname1/proxy/: foo (200; 9.488442ms)
+Jul  2 13:51:37.046: INFO: (17) /api/v1/namespaces/e2e-tests-proxy-zfjzs/services/https:proxy-service-qsb8g:tlsportname1/proxy/: tls baz (200; 9.802853ms)
+Jul  2 13:51:37.047: INFO: (17) /api/v1/namespaces/e2e-tests-proxy-zfjzs/services/proxy-service-qsb8g:portname2/proxy/: bar (200; 10.56434ms)
+Jul  2 13:51:37.048: INFO: (17) /api/v1/namespaces/e2e-tests-proxy-zfjzs/services/proxy-service-qsb8g:portname1/proxy/: foo (200; 11.179264ms)
+Jul  2 13:51:37.053: INFO: (18) /api/v1/namespaces/e2e-tests-proxy-zfjzs/pods/https:proxy-service-qsb8g-rr7rx:460/proxy/: tls baz (200; 5.439156ms)
+Jul  2 13:51:37.055: INFO: (18) /api/v1/namespaces/e2e-tests-proxy-zfjzs/pods/proxy-service-qsb8g-rr7rx:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-zfjzs/pods/proxy-service-qsb8g-rr7rx:1080/proxy/rewri... (200; 6.313054ms)
+Jul  2 13:51:37.055: INFO: (18) /api/v1/namespaces/e2e-tests-proxy-zfjzs/pods/http:proxy-service-qsb8g-rr7rx:162/proxy/: bar (200; 6.602899ms)
+Jul  2 13:51:37.056: INFO: (18) /api/v1/namespaces/e2e-tests-proxy-zfjzs/services/proxy-service-qsb8g:portname2/proxy/: bar (200; 8.222502ms)
+Jul  2 13:51:37.056: INFO: (18) /api/v1/namespaces/e2e-tests-proxy-zfjzs/pods/https:proxy-service-qsb8g-rr7rx:462/proxy/: tls qux (200; 7.786121ms)
+Jul  2 13:51:37.057: INFO: (18) /api/v1/namespaces/e2e-tests-proxy-zfjzs/pods/http:proxy-service-qsb8g-rr7rx:160/proxy/: foo (200; 7.982901ms)
+Jul  2 13:51:37.057: INFO: (18) /api/v1/namespaces/e2e-tests-proxy-zfjzs/pods/https:proxy-service-qsb8g-rr7rx:443/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-zfjzs/pods/https:proxy-service-qsb8g-rr7rx:443/proxy/... (200; 8.226894ms)
+Jul  2 13:51:37.057: INFO: (18) /api/v1/namespaces/e2e-tests-proxy-zfjzs/pods/http:proxy-service-qsb8g-rr7rx:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-zfjzs/pods/http:proxy-service-qsb8g-rr7rx:1080/proxy/... (200; 9.019334ms)
+Jul  2 13:51:37.057: INFO: (18) /api/v1/namespaces/e2e-tests-proxy-zfjzs/pods/proxy-service-qsb8g-rr7rx/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-zfjzs/pods/proxy-service-qsb8g-rr7rx/proxy/rewriteme"... (200; 8.314631ms)
+Jul  2 13:51:37.057: INFO: (18) /api/v1/namespaces/e2e-tests-proxy-zfjzs/pods/proxy-service-qsb8g-rr7rx:160/proxy/: foo (200; 8.649146ms)
+Jul  2 13:51:37.058: INFO: (18) /api/v1/namespaces/e2e-tests-proxy-zfjzs/services/https:proxy-service-qsb8g:tlsportname2/proxy/: tls qux (200; 9.859389ms)
+Jul  2 13:51:37.058: INFO: (18) /api/v1/namespaces/e2e-tests-proxy-zfjzs/services/https:proxy-service-qsb8g:tlsportname1/proxy/: tls baz (200; 10.031994ms)
+Jul  2 13:51:37.058: INFO: (18) /api/v1/namespaces/e2e-tests-proxy-zfjzs/pods/proxy-service-qsb8g-rr7rx:162/proxy/: bar (200; 9.61184ms)
+Jul  2 13:51:37.059: INFO: (18) /api/v1/namespaces/e2e-tests-proxy-zfjzs/services/http:proxy-service-qsb8g:portname1/proxy/: foo (200; 10.550775ms)
+Jul  2 13:51:37.059: INFO: (18) /api/v1/namespaces/e2e-tests-proxy-zfjzs/services/http:proxy-service-qsb8g:portname2/proxy/: bar (200; 10.525273ms)
+Jul  2 13:51:37.060: INFO: (18) /api/v1/namespaces/e2e-tests-proxy-zfjzs/services/proxy-service-qsb8g:portname1/proxy/: foo (200; 11.588403ms)
+Jul  2 13:51:37.066: INFO: (19) /api/v1/namespaces/e2e-tests-proxy-zfjzs/pods/https:proxy-service-qsb8g-rr7rx:443/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-zfjzs/pods/https:proxy-service-qsb8g-rr7rx:443/proxy/... (200; 5.675499ms)
+Jul  2 13:51:37.069: INFO: (19) /api/v1/namespaces/e2e-tests-proxy-zfjzs/pods/https:proxy-service-qsb8g-rr7rx:462/proxy/: tls qux (200; 8.293566ms)
+Jul  2 13:51:37.069: INFO: (19) /api/v1/namespaces/e2e-tests-proxy-zfjzs/pods/http:proxy-service-qsb8g-rr7rx:160/proxy/: foo (200; 7.933575ms)
+Jul  2 13:51:37.069: INFO: (19) /api/v1/namespaces/e2e-tests-proxy-zfjzs/pods/http:proxy-service-qsb8g-rr7rx:162/proxy/: bar (200; 8.366721ms)
+Jul  2 13:51:37.070: INFO: (19) /api/v1/namespaces/e2e-tests-proxy-zfjzs/pods/https:proxy-service-qsb8g-rr7rx:460/proxy/: tls baz (200; 8.583509ms)
+Jul  2 13:51:37.070: INFO: (19) /api/v1/namespaces/e2e-tests-proxy-zfjzs/services/https:proxy-service-qsb8g:tlsportname2/proxy/: tls qux (200; 9.044547ms)
+Jul  2 13:51:37.070: INFO: (19) /api/v1/namespaces/e2e-tests-proxy-zfjzs/services/https:proxy-service-qsb8g:tlsportname1/proxy/: tls baz (200; 9.225564ms)
+Jul  2 13:51:37.070: INFO: (19) /api/v1/namespaces/e2e-tests-proxy-zfjzs/pods/proxy-service-qsb8g-rr7rx/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-zfjzs/pods/proxy-service-qsb8g-rr7rx/proxy/rewriteme"... (200; 8.787373ms)
+Jul  2 13:51:37.070: INFO: (19) /api/v1/namespaces/e2e-tests-proxy-zfjzs/pods/http:proxy-service-qsb8g-rr7rx:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-zfjzs/pods/http:proxy-service-qsb8g-rr7rx:1080/proxy/... (200; 8.933846ms)
+Jul  2 13:51:37.070: INFO: (19) /api/v1/namespaces/e2e-tests-proxy-zfjzs/pods/proxy-service-qsb8g-rr7rx:160/proxy/: foo (200; 9.380544ms)
+Jul  2 13:51:37.070: INFO: (19) /api/v1/namespaces/e2e-tests-proxy-zfjzs/pods/proxy-service-qsb8g-rr7rx:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-zfjzs/pods/proxy-service-qsb8g-rr7rx:1080/proxy/rewri... (200; 9.750286ms)
+Jul  2 13:51:37.070: INFO: (19) /api/v1/namespaces/e2e-tests-proxy-zfjzs/services/http:proxy-service-qsb8g:portname2/proxy/: bar (200; 9.29999ms)
+Jul  2 13:51:37.071: INFO: (19) /api/v1/namespaces/e2e-tests-proxy-zfjzs/services/proxy-service-qsb8g:portname2/proxy/: bar (200; 10.33673ms)
+Jul  2 13:51:37.072: INFO: (19) /api/v1/namespaces/e2e-tests-proxy-zfjzs/services/http:proxy-service-qsb8g:portname1/proxy/: foo (200; 10.926488ms)
+Jul  2 13:51:37.073: INFO: (19) /api/v1/namespaces/e2e-tests-proxy-zfjzs/pods/proxy-service-qsb8g-rr7rx:162/proxy/: bar (200; 11.826097ms)
+Jul  2 13:51:37.073: INFO: (19) /api/v1/namespaces/e2e-tests-proxy-zfjzs/services/proxy-service-qsb8g:portname1/proxy/: foo (200; 12.082852ms)
+STEP: deleting { ReplicationController} proxy-service-qsb8g in namespace e2e-tests-proxy-zfjzs, will wait for the garbage collector to delete the pods
+Jul  2 13:51:37.131: INFO: Deleting { ReplicationController} proxy-service-qsb8g took: 5.108493ms
+Jul  2 13:51:37.232: INFO: Terminating { ReplicationController} proxy-service-qsb8g pods took: 100.357369ms
+[AfterEach] version v1
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:51:39.832: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-proxy-zfjzs" for this suite.
+Jul  2 13:51:45.847: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:51:45.976: INFO: namespace: e2e-tests-proxy-zfjzs, resource: bindings, ignored listing per whitelist
+Jul  2 13:51:46.045: INFO: namespace e2e-tests-proxy-zfjzs deletion completed in 6.209055626s
+
+• [SLOW TEST:12.615 seconds]
+[sig-network] Proxy
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/network/framework.go:22
+  version v1
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/network/proxy.go:56
+    should proxy through a service and a pod  [Conformance]
+    /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSSSSSS
+------------------------------
+[sig-storage] EmptyDir volumes 
+  volume on tmpfs should have the correct mode [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-storage] EmptyDir volumes
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:51:46.045: INFO: >>> kubeConfig: /tmp/kubeconfig-411378559
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] volume on tmpfs should have the correct mode [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating a pod to test emptydir volume type on tmpfs
+Jul  2 13:51:46.154: INFO: Waiting up to 5m0s for pod "pod-0f4aa702-7dff-11e8-bae1-da96248f62d7" in namespace "e2e-tests-emptydir-9pg6b" to be "success or failure"
+Jul  2 13:51:46.158: INFO: Pod "pod-0f4aa702-7dff-11e8-bae1-da96248f62d7": Phase="Pending", Reason="", readiness=false. Elapsed: 4.375083ms
+Jul  2 13:51:48.162: INFO: Pod "pod-0f4aa702-7dff-11e8-bae1-da96248f62d7": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.008529146s
+STEP: Saw pod success
+Jul  2 13:51:48.162: INFO: Pod "pod-0f4aa702-7dff-11e8-bae1-da96248f62d7" satisfied condition "success or failure"
+Jul  2 13:51:48.165: INFO: Trying to get logs from node ip-10-250-24-1.ec2.internal pod pod-0f4aa702-7dff-11e8-bae1-da96248f62d7 container test-container: <nil>
+STEP: delete the pod
+Jul  2 13:51:48.252: INFO: Waiting for pod pod-0f4aa702-7dff-11e8-bae1-da96248f62d7 to disappear
+Jul  2 13:51:48.256: INFO: Pod pod-0f4aa702-7dff-11e8-bae1-da96248f62d7 no longer exists
+[AfterEach] [sig-storage] EmptyDir volumes
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:51:48.256: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-emptydir-9pg6b" for this suite.
+Jul  2 13:51:54.274: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:51:54.458: INFO: namespace: e2e-tests-emptydir-9pg6b, resource: bindings, ignored listing per whitelist
+Jul  2 13:51:54.533: INFO: namespace e2e-tests-emptydir-9pg6b deletion completed in 6.271253392s
+
+• [SLOW TEST:8.488 seconds]
+[sig-storage] EmptyDir volumes
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/empty_dir.go:40
+  volume on tmpfs should have the correct mode [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSS
+------------------------------
+[k8s.io] Pods 
+  should contain environment variables for services [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [k8s.io] Pods
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:51:54.534: INFO: >>> kubeConfig: /tmp/kubeconfig-411378559
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [k8s.io] Pods
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/pods.go:127
+[It] should contain environment variables for services [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+Jul  2 13:51:56.656: INFO: Waiting up to 5m0s for pod "client-envvars-158d6e45-7dff-11e8-bae1-da96248f62d7" in namespace "e2e-tests-pods-zbbsf" to be "success or failure"
+Jul  2 13:51:56.660: INFO: Pod "client-envvars-158d6e45-7dff-11e8-bae1-da96248f62d7": Phase="Pending", Reason="", readiness=false. Elapsed: 3.396402ms
+Jul  2 13:51:58.663: INFO: Pod "client-envvars-158d6e45-7dff-11e8-bae1-da96248f62d7": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.006695778s
+STEP: Saw pod success
+Jul  2 13:51:58.663: INFO: Pod "client-envvars-158d6e45-7dff-11e8-bae1-da96248f62d7" satisfied condition "success or failure"
+Jul  2 13:51:58.666: INFO: Trying to get logs from node ip-10-250-24-1.ec2.internal pod client-envvars-158d6e45-7dff-11e8-bae1-da96248f62d7 container env3cont: <nil>
+STEP: delete the pod
+Jul  2 13:51:58.681: INFO: Waiting for pod client-envvars-158d6e45-7dff-11e8-bae1-da96248f62d7 to disappear
+Jul  2 13:51:58.685: INFO: Pod client-envvars-158d6e45-7dff-11e8-bae1-da96248f62d7 no longer exists
+[AfterEach] [k8s.io] Pods
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:51:58.685: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-pods-zbbsf" for this suite.
+Jul  2 13:52:20.698: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:52:20.752: INFO: namespace: e2e-tests-pods-zbbsf, resource: bindings, ignored listing per whitelist
+Jul  2 13:52:20.801: INFO: namespace e2e-tests-pods-zbbsf deletion completed in 22.113445017s
+
+• [SLOW TEST:26.268 seconds]
+[k8s.io] Pods
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:679
+  should contain environment variables for services [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+S
+------------------------------
+[k8s.io] Probing container 
+  should be restarted with a /healthz http liveness probe [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [k8s.io] Probing container
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:52:20.801: INFO: >>> kubeConfig: /tmp/kubeconfig-411378559
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [k8s.io] Probing container
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/container_probe.go:48
+[It] should be restarted with a /healthz http liveness probe [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating pod liveness-http in namespace e2e-tests-container-probe-ql7fr
+Jul  2 13:52:22.908: INFO: Started pod liveness-http in namespace e2e-tests-container-probe-ql7fr
+STEP: checking the pod's current state and verifying that restartCount is present
+Jul  2 13:52:22.911: INFO: Initial restart count of pod liveness-http is 0
+Jul  2 13:52:41.053: INFO: Restart count of pod e2e-tests-container-probe-ql7fr/liveness-http is now 1 (18.142303681s elapsed)
+STEP: deleting the pod
+[AfterEach] [k8s.io] Probing container
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:52:41.064: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-container-probe-ql7fr" for this suite.
+Jul  2 13:52:47.088: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:52:47.198: INFO: namespace: e2e-tests-container-probe-ql7fr, resource: bindings, ignored listing per whitelist
+Jul  2 13:52:47.217: INFO: namespace e2e-tests-container-probe-ql7fr deletion completed in 6.14960897s
+
+• [SLOW TEST:26.415 seconds]
+[k8s.io] Probing container
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:679
+  should be restarted with a /healthz http liveness probe [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSS
+------------------------------
+[sig-storage] Secrets 
+  optional updates should be reflected in volume [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-storage] Secrets
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:52:47.217: INFO: >>> kubeConfig: /tmp/kubeconfig-411378559
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] optional updates should be reflected in volume [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating secret with name s-test-opt-del-33c45e37-7dff-11e8-bae1-da96248f62d7
+STEP: Creating secret with name s-test-opt-upd-33c45e9d-7dff-11e8-bae1-da96248f62d7
+STEP: Creating the pod
+STEP: Deleting secret s-test-opt-del-33c45e37-7dff-11e8-bae1-da96248f62d7
+STEP: Updating secret s-test-opt-upd-33c45e9d-7dff-11e8-bae1-da96248f62d7
+STEP: Creating secret with name s-test-opt-create-33c45ec9-7dff-11e8-bae1-da96248f62d7
+STEP: waiting to observe update in volume
+[AfterEach] [sig-storage] Secrets
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:54:02.776: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-secrets-cgm7j" for this suite.
+Jul  2 13:54:24.847: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:54:24.883: INFO: namespace: e2e-tests-secrets-cgm7j, resource: bindings, ignored listing per whitelist
+Jul  2 13:54:24.949: INFO: namespace e2e-tests-secrets-cgm7j deletion completed in 22.168779757s
+
+• [SLOW TEST:97.732 seconds]
+[sig-storage] Secrets
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/secrets_volume.go:33
+  optional updates should be reflected in volume [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSSSSSSSSSSSSSSSSS
+------------------------------
+[sig-scheduling] SchedulerPredicates [Serial] 
+  validates that NodeSelector is respected if not matching  [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-scheduling] SchedulerPredicates [Serial]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:54:24.951: INFO: >>> kubeConfig: /tmp/kubeconfig-411378559
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-scheduling] SchedulerPredicates [Serial]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/scheduling/predicates.go:79
+Jul  2 13:54:25.045: INFO: Waiting up to 1m0s for all nodes to be ready
+Jul  2 13:55:25.069: INFO: Waiting for terminating namespaces to be deleted...
+Jul  2 13:55:25.075: INFO: Waiting up to 5m0s for all pods (need at least 0) in namespace 'kube-system' to be running and ready
+Jul  2 13:55:25.154: INFO: 14 / 14 pods in namespace 'kube-system' are running and ready (0 seconds elapsed)
+Jul  2 13:55:25.154: INFO: expected 8 pod replicas in namespace 'kube-system', 8 are Running and Ready.
+Jul  2 13:55:25.158: INFO: Waiting for pods to enter Success, but no pods in "kube-system" match label map[name:e2e-image-puller]
+Jul  2 13:55:25.158: INFO: 
+Logging pods the kubelet thinks is on node ip-10-250-20-212.ec2.internal before test
+Jul  2 13:55:25.246: INFO: kube-proxy-r9nzr from kube-system started at 2018-07-02 12:47:40 +0000 UTC (1 container statuses recorded)
+Jul  2 13:55:25.246: INFO: 	Container kube-proxy ready: true, restart count 0
+Jul  2 13:55:25.246: INFO: addons-nginx-ingress-controller-77fffb78c6-rvwcv from kube-system started at 2018-07-02 12:48:00 +0000 UTC (1 container statuses recorded)
+Jul  2 13:55:25.246: INFO: 	Container nginx-ingress-controller ready: true, restart count 0
+Jul  2 13:55:25.246: INFO: kube-dns-9c4dfc4fb-8q2xj from kube-system started at 2018-07-02 12:49:17 +0000 UTC (3 container statuses recorded)
+Jul  2 13:55:25.246: INFO: 	Container dnsmasq ready: true, restart count 0
+Jul  2 13:55:25.246: INFO: 	Container kubedns ready: true, restart count 0
+Jul  2 13:55:25.246: INFO: 	Container sidecar ready: true, restart count 0
+Jul  2 13:55:25.246: INFO: addons-nginx-ingress-nginx-ingress-k8s-backend-7b5569797f-64wcj from kube-system started at 2018-07-02 12:48:00 +0000 UTC (1 container statuses recorded)
+Jul  2 13:55:25.246: INFO: 	Container nginx-ingress-nginx-ingress-k8s-backend ready: true, restart count 0
+Jul  2 13:55:25.246: INFO: node-exporter-zm2rg from kube-system started at 2018-07-02 12:47:40 +0000 UTC (1 container statuses recorded)
+Jul  2 13:55:25.246: INFO: 	Container node-exporter ready: true, restart count 0
+Jul  2 13:55:25.246: INFO: kube-dns-autoscaler-6dd4765967-gqbtv from kube-system started at 2018-07-02 12:48:00 +0000 UTC (1 container statuses recorded)
+Jul  2 13:55:25.246: INFO: 	Container autoscaler ready: true, restart count 0
+Jul  2 13:55:25.246: INFO: addons-heapster-e3b0c-64455ddddb-m2pxn from kube-system started at 2018-07-02 12:48:00 +0000 UTC (2 container statuses recorded)
+Jul  2 13:55:25.246: INFO: 	Container heapster ready: true, restart count 0
+Jul  2 13:55:25.246: INFO: 	Container heapster-nanny ready: true, restart count 0
+Jul  2 13:55:25.246: INFO: kube-dns-9c4dfc4fb-hk72g from kube-system started at 2018-07-02 12:48:00 +0000 UTC (3 container statuses recorded)
+Jul  2 13:55:25.246: INFO: 	Container dnsmasq ready: true, restart count 0
+Jul  2 13:55:25.246: INFO: 	Container kubedns ready: true, restart count 0
+Jul  2 13:55:25.246: INFO: 	Container sidecar ready: true, restart count 0
+Jul  2 13:55:25.246: INFO: calico-node-4lmw2 from kube-system started at 2018-07-02 12:47:40 +0000 UTC (2 container statuses recorded)
+Jul  2 13:55:25.246: INFO: 	Container calico-node ready: true, restart count 0
+Jul  2 13:55:25.246: INFO: 	Container install-cni ready: true, restart count 0
+Jul  2 13:55:25.246: INFO: addons-kubernetes-dashboard-5486b968b7-kgkrm from kube-system started at 2018-07-02 12:48:00 +0000 UTC (1 container statuses recorded)
+Jul  2 13:55:25.246: INFO: 	Container main ready: true, restart count 0
+Jul  2 13:55:25.246: INFO: vpn-shoot-77bdbf95b-zdv7s from kube-system started at 2018-07-02 12:48:00 +0000 UTC (1 container statuses recorded)
+Jul  2 13:55:25.246: INFO: 	Container vpn-shoot ready: true, restart count 0
+Jul  2 13:55:25.246: INFO: 
+Logging pods the kubelet thinks is on node ip-10-250-24-1.ec2.internal before test
+Jul  2 13:55:25.255: INFO: kube-proxy-zj5gp from kube-system started at 2018-07-02 12:49:09 +0000 UTC (1 container statuses recorded)
+Jul  2 13:55:25.255: INFO: 	Container kube-proxy ready: true, restart count 0
+Jul  2 13:55:25.255: INFO: sonobuoy-e2e-job-28cb3bdc6acd48a9 from sonobuoy started at 2018-07-02 12:53:32 +0000 UTC (2 container statuses recorded)
+Jul  2 13:55:25.255: INFO: 	Container e2e ready: true, restart count 0
+Jul  2 13:55:25.255: INFO: 	Container sonobuoy-worker ready: true, restart count 0
+Jul  2 13:55:25.255: INFO: calico-node-sd5dt from kube-system started at 2018-07-02 12:49:09 +0000 UTC (2 container statuses recorded)
+Jul  2 13:55:25.255: INFO: 	Container calico-node ready: true, restart count 0
+Jul  2 13:55:25.255: INFO: 	Container install-cni ready: true, restart count 0
+Jul  2 13:55:25.255: INFO: node-exporter-mkl4n from kube-system started at 2018-07-02 12:49:09 +0000 UTC (1 container statuses recorded)
+Jul  2 13:55:25.255: INFO: 	Container node-exporter ready: true, restart count 0
+Jul  2 13:55:25.255: INFO: sonobuoy from sonobuoy started at 2018-07-02 12:53:17 +0000 UTC (1 container statuses recorded)
+Jul  2 13:55:25.255: INFO: 	Container kube-sonobuoy ready: true, restart count 0
+[It] validates that NodeSelector is respected if not matching  [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Trying to schedule Pod with nonempty NodeSelector.
+STEP: Considering event: 
+Type = [Warning], Name = [restricted-pod.153d91c55f7e4b39], Reason = [FailedScheduling], Message = [0/2 nodes are available: 2 node(s) didn't match node selector.]
+[AfterEach] [sig-scheduling] SchedulerPredicates [Serial]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:55:26.281: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-sched-pred-hjzjp" for this suite.
+Jul  2 13:55:48.349: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:55:48.383: INFO: namespace: e2e-tests-sched-pred-hjzjp, resource: bindings, ignored listing per whitelist
+Jul  2 13:55:48.448: INFO: namespace e2e-tests-sched-pred-hjzjp deletion completed in 22.163520486s
+[AfterEach] [sig-scheduling] SchedulerPredicates [Serial]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/scheduling/predicates.go:70
+
+• [SLOW TEST:83.498 seconds]
+[sig-scheduling] SchedulerPredicates [Serial]
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/scheduling/framework.go:22
+  validates that NodeSelector is respected if not matching  [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+[sig-api-machinery] Watchers 
+  should observe an object deletion if it stops meeting the requirements of the selector [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-api-machinery] Watchers
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:55:48.449: INFO: >>> kubeConfig: /tmp/kubeconfig-411378559
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should observe an object deletion if it stops meeting the requirements of the selector [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: creating a watch on configmaps with a certain label
+STEP: creating a new configmap
+STEP: modifying the configmap once
+STEP: changing the label value of the configmap
+STEP: Expecting to observe a delete notification for the watched object
+Jul  2 13:55:48.557: INFO: Got : ADDED &ConfigMap{ObjectMeta:k8s_io_apimachinery_pkg_apis_meta_v1.ObjectMeta{Name:e2e-watch-test-label-changed,GenerateName:,Namespace:e2e-tests-watch-gn4jn,SelfLink:/api/v1/namespaces/e2e-tests-watch-gn4jn/configmaps/e2e-watch-test-label-changed,UID:9fc4b800-7dff-11e8-9deb-8e4c5ec544fb,ResourceVersion:13618,Generation:0,CreationTimestamp:2018-07-02 13:55:48 +0000 UTC,DeletionTimestamp:<nil>,DeletionGracePeriodSeconds:nil,Labels:map[string]string{watch-this-configmap: label-changed-and-restored,},Annotations:map[string]string{},OwnerReferences:[],Finalizers:[],ClusterName:,Initializers:nil,},Data:map[string]string{},BinaryData:map[string][]byte{},}
+Jul  2 13:55:48.557: INFO: Got : MODIFIED &ConfigMap{ObjectMeta:k8s_io_apimachinery_pkg_apis_meta_v1.ObjectMeta{Name:e2e-watch-test-label-changed,GenerateName:,Namespace:e2e-tests-watch-gn4jn,SelfLink:/api/v1/namespaces/e2e-tests-watch-gn4jn/configmaps/e2e-watch-test-label-changed,UID:9fc4b800-7dff-11e8-9deb-8e4c5ec544fb,ResourceVersion:13619,Generation:0,CreationTimestamp:2018-07-02 13:55:48 +0000 UTC,DeletionTimestamp:<nil>,DeletionGracePeriodSeconds:nil,Labels:map[string]string{watch-this-configmap: label-changed-and-restored,},Annotations:map[string]string{},OwnerReferences:[],Finalizers:[],ClusterName:,Initializers:nil,},Data:map[string]string{mutation: 1,},BinaryData:map[string][]byte{},}
+Jul  2 13:55:48.557: INFO: Got : DELETED &ConfigMap{ObjectMeta:k8s_io_apimachinery_pkg_apis_meta_v1.ObjectMeta{Name:e2e-watch-test-label-changed,GenerateName:,Namespace:e2e-tests-watch-gn4jn,SelfLink:/api/v1/namespaces/e2e-tests-watch-gn4jn/configmaps/e2e-watch-test-label-changed,UID:9fc4b800-7dff-11e8-9deb-8e4c5ec544fb,ResourceVersion:13620,Generation:0,CreationTimestamp:2018-07-02 13:55:48 +0000 UTC,DeletionTimestamp:<nil>,DeletionGracePeriodSeconds:nil,Labels:map[string]string{watch-this-configmap: label-changed-and-restored,},Annotations:map[string]string{},OwnerReferences:[],Finalizers:[],ClusterName:,Initializers:nil,},Data:map[string]string{mutation: 1,},BinaryData:map[string][]byte{},}
+STEP: modifying the configmap a second time
+STEP: Expecting not to observe a notification because the object no longer meets the selector's requirements
+STEP: changing the label value of the configmap back
+STEP: modifying the configmap a third time
+STEP: deleting the configmap
+STEP: Expecting to observe an add notification for the watched object when the label value was restored
+Jul  2 13:55:58.581: INFO: Got : ADDED &ConfigMap{ObjectMeta:k8s_io_apimachinery_pkg_apis_meta_v1.ObjectMeta{Name:e2e-watch-test-label-changed,GenerateName:,Namespace:e2e-tests-watch-gn4jn,SelfLink:/api/v1/namespaces/e2e-tests-watch-gn4jn/configmaps/e2e-watch-test-label-changed,UID:9fc4b800-7dff-11e8-9deb-8e4c5ec544fb,ResourceVersion:13641,Generation:0,CreationTimestamp:2018-07-02 13:55:48 +0000 UTC,DeletionTimestamp:<nil>,DeletionGracePeriodSeconds:nil,Labels:map[string]string{watch-this-configmap: label-changed-and-restored,},Annotations:map[string]string{},OwnerReferences:[],Finalizers:[],ClusterName:,Initializers:nil,},Data:map[string]string{mutation: 2,},BinaryData:map[string][]byte{},}
+Jul  2 13:55:58.581: INFO: Got : MODIFIED &ConfigMap{ObjectMeta:k8s_io_apimachinery_pkg_apis_meta_v1.ObjectMeta{Name:e2e-watch-test-label-changed,GenerateName:,Namespace:e2e-tests-watch-gn4jn,SelfLink:/api/v1/namespaces/e2e-tests-watch-gn4jn/configmaps/e2e-watch-test-label-changed,UID:9fc4b800-7dff-11e8-9deb-8e4c5ec544fb,ResourceVersion:13642,Generation:0,CreationTimestamp:2018-07-02 13:55:48 +0000 UTC,DeletionTimestamp:<nil>,DeletionGracePeriodSeconds:nil,Labels:map[string]string{watch-this-configmap: label-changed-and-restored,},Annotations:map[string]string{},OwnerReferences:[],Finalizers:[],ClusterName:,Initializers:nil,},Data:map[string]string{mutation: 3,},BinaryData:map[string][]byte{},}
+Jul  2 13:55:58.581: INFO: Got : DELETED &ConfigMap{ObjectMeta:k8s_io_apimachinery_pkg_apis_meta_v1.ObjectMeta{Name:e2e-watch-test-label-changed,GenerateName:,Namespace:e2e-tests-watch-gn4jn,SelfLink:/api/v1/namespaces/e2e-tests-watch-gn4jn/configmaps/e2e-watch-test-label-changed,UID:9fc4b800-7dff-11e8-9deb-8e4c5ec544fb,ResourceVersion:13643,Generation:0,CreationTimestamp:2018-07-02 13:55:48 +0000 UTC,DeletionTimestamp:<nil>,DeletionGracePeriodSeconds:nil,Labels:map[string]string{watch-this-configmap: label-changed-and-restored,},Annotations:map[string]string{},OwnerReferences:[],Finalizers:[],ClusterName:,Initializers:nil,},Data:map[string]string{mutation: 3,},BinaryData:map[string][]byte{},}
+[AfterEach] [sig-api-machinery] Watchers
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:55:58.581: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-watch-gn4jn" for this suite.
+Jul  2 13:56:04.594: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:56:04.608: INFO: namespace: e2e-tests-watch-gn4jn, resource: bindings, ignored listing per whitelist
+Jul  2 13:56:04.697: INFO: namespace e2e-tests-watch-gn4jn deletion completed in 6.113016777s
+
+• [SLOW TEST:16.249 seconds]
+[sig-api-machinery] Watchers
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apimachinery/framework.go:22
+  should observe an object deletion if it stops meeting the requirements of the selector [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSSSSSSSSSSSSS
+------------------------------
+[sig-storage] Projected 
+  updates should be reflected in volume [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:56:04.698: INFO: >>> kubeConfig: /tmp/kubeconfig-411378559
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:858
+[It] updates should be reflected in volume [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating projection with configMap that has name projected-configmap-test-upd-a9752d71-7dff-11e8-bae1-da96248f62d7
+STEP: Creating the pod
+STEP: Updating configmap projected-configmap-test-upd-a9752d71-7dff-11e8-bae1-da96248f62d7
+STEP: waiting to observe update in volume
+[AfterEach] [sig-storage] Projected
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:56:08.918: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-48f6t" for this suite.
+Jul  2 13:56:30.932: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:56:31.020: INFO: namespace: e2e-tests-projected-48f6t, resource: bindings, ignored listing per whitelist
+Jul  2 13:56:31.054: INFO: namespace e2e-tests-projected-48f6t deletion completed in 22.132252307s
+
+• [SLOW TEST:26.356 seconds]
+[sig-storage] Projected
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:34
+  updates should be reflected in volume [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSSSS
+------------------------------
+[sig-storage] Secrets 
+  should be consumable in multiple volumes in a pod [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-storage] Secrets
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:56:31.054: INFO: >>> kubeConfig: /tmp/kubeconfig-411378559
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should be consumable in multiple volumes in a pod [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating secret with name secret-test-b929a7c3-7dff-11e8-bae1-da96248f62d7
+STEP: Creating a pod to test consume secrets
+Jul  2 13:56:31.153: INFO: Waiting up to 5m0s for pod "pod-secrets-b92a3124-7dff-11e8-bae1-da96248f62d7" in namespace "e2e-tests-secrets-ldmhg" to be "success or failure"
+Jul  2 13:56:31.157: INFO: Pod "pod-secrets-b92a3124-7dff-11e8-bae1-da96248f62d7": Phase="Pending", Reason="", readiness=false. Elapsed: 3.584284ms
+Jul  2 13:56:33.161: INFO: Pod "pod-secrets-b92a3124-7dff-11e8-bae1-da96248f62d7": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.007606667s
+STEP: Saw pod success
+Jul  2 13:56:33.161: INFO: Pod "pod-secrets-b92a3124-7dff-11e8-bae1-da96248f62d7" satisfied condition "success or failure"
+Jul  2 13:56:33.164: INFO: Trying to get logs from node ip-10-250-24-1.ec2.internal pod pod-secrets-b92a3124-7dff-11e8-bae1-da96248f62d7 container secret-volume-test: <nil>
+STEP: delete the pod
+Jul  2 13:56:33.183: INFO: Waiting for pod pod-secrets-b92a3124-7dff-11e8-bae1-da96248f62d7 to disappear
+Jul  2 13:56:33.209: INFO: Pod pod-secrets-b92a3124-7dff-11e8-bae1-da96248f62d7 no longer exists
+[AfterEach] [sig-storage] Secrets
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:56:33.209: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-secrets-ldmhg" for this suite.
+Jul  2 13:56:39.249: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:56:39.348: INFO: namespace: e2e-tests-secrets-ldmhg, resource: bindings, ignored listing per whitelist
+Jul  2 13:56:39.358: INFO: namespace e2e-tests-secrets-ldmhg deletion completed in 6.146482604s
+
+• [SLOW TEST:8.304 seconds]
+[sig-storage] Secrets
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/secrets_volume.go:33
+  should be consumable in multiple volumes in a pod [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS
+------------------------------
+[sig-apps] Daemon set [Serial] 
+  should run and stop complex daemon [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-apps] Daemon set [Serial]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:56:39.359: INFO: >>> kubeConfig: /tmp/kubeconfig-411378559
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-apps] Daemon set [Serial]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/daemon_set.go:99
+[It] should run and stop complex daemon [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+Jul  2 13:56:39.456: INFO: Creating daemon "daemon-set" with a node selector
+STEP: Initially, daemon pods should not be running on any nodes.
+Jul  2 13:56:39.463: INFO: Number of nodes with available pods: 0
+Jul  2 13:56:39.463: INFO: Number of running nodes: 0, number of available pods: 0
+STEP: Change node label to blue, check that daemon pod is launched.
+Jul  2 13:56:39.482: INFO: Number of nodes with available pods: 0
+Jul  2 13:56:39.482: INFO: Node ip-10-250-20-212.ec2.internal is running more than one daemon pod
+Jul  2 13:56:40.486: INFO: Number of nodes with available pods: 0
+Jul  2 13:56:40.486: INFO: Node ip-10-250-20-212.ec2.internal is running more than one daemon pod
+Jul  2 13:56:41.486: INFO: Number of nodes with available pods: 1
+Jul  2 13:56:41.486: INFO: Number of running nodes: 1, number of available pods: 1
+STEP: Update the node label to green, and wait for daemons to be unscheduled
+Jul  2 13:56:41.503: INFO: Number of nodes with available pods: 1
+Jul  2 13:56:41.503: INFO: Number of running nodes: 0, number of available pods: 1
+Jul  2 13:56:42.507: INFO: Number of nodes with available pods: 0
+Jul  2 13:56:42.507: INFO: Number of running nodes: 0, number of available pods: 0
+STEP: Update DaemonSet node selector to green, and change its update strategy to RollingUpdate
+Jul  2 13:56:42.515: INFO: Number of nodes with available pods: 0
+Jul  2 13:56:42.515: INFO: Node ip-10-250-20-212.ec2.internal is running more than one daemon pod
+Jul  2 13:56:43.519: INFO: Number of nodes with available pods: 0
+Jul  2 13:56:43.519: INFO: Node ip-10-250-20-212.ec2.internal is running more than one daemon pod
+Jul  2 13:56:44.545: INFO: Number of nodes with available pods: 0
+Jul  2 13:56:44.545: INFO: Node ip-10-250-20-212.ec2.internal is running more than one daemon pod
+Jul  2 13:56:45.518: INFO: Number of nodes with available pods: 0
+Jul  2 13:56:45.518: INFO: Node ip-10-250-20-212.ec2.internal is running more than one daemon pod
+Jul  2 13:56:46.519: INFO: Number of nodes with available pods: 1
+Jul  2 13:56:46.519: INFO: Number of running nodes: 1, number of available pods: 1
+[AfterEach] [sig-apps] Daemon set [Serial]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/daemon_set.go:65
+STEP: Deleting DaemonSet "daemon-set"
+STEP: deleting {extensions DaemonSet} daemon-set in namespace e2e-tests-daemonsets-shv5l, will wait for the garbage collector to delete the pods
+Jul  2 13:56:46.585: INFO: Deleting {extensions DaemonSet} daemon-set took: 6.939131ms
+Jul  2 13:56:46.685: INFO: Terminating {extensions DaemonSet} daemon-set pods took: 100.234385ms
+Jul  2 13:57:00.289: INFO: Number of nodes with available pods: 0
+Jul  2 13:57:00.289: INFO: Number of running nodes: 0, number of available pods: 0
+Jul  2 13:57:00.292: INFO: daemonset: {"kind":"DaemonSetList","apiVersion":"apps/v1","metadata":{"selfLink":"/apis/apps/v1/namespaces/e2e-tests-daemonsets-shv5l/daemonsets","resourceVersion":"13851"},"items":null}
+
+Jul  2 13:57:00.295: INFO: pods: {"kind":"PodList","apiVersion":"v1","metadata":{"selfLink":"/api/v1/namespaces/e2e-tests-daemonsets-shv5l/pods","resourceVersion":"13851"},"items":null}
+
+[AfterEach] [sig-apps] Daemon set [Serial]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:57:00.311: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-daemonsets-shv5l" for this suite.
+Jul  2 13:57:06.326: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:57:06.345: INFO: namespace: e2e-tests-daemonsets-shv5l, resource: bindings, ignored listing per whitelist
+Jul  2 13:57:06.438: INFO: namespace e2e-tests-daemonsets-shv5l deletion completed in 6.123010391s
+
+• [SLOW TEST:27.079 seconds]
+[sig-apps] Daemon set [Serial]
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/framework.go:22
+  should run and stop complex daemon [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+S
+------------------------------
+[sig-apps] Daemon set [Serial] 
+  should retry creating failed daemon pods [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-apps] Daemon set [Serial]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:57:06.439: INFO: >>> kubeConfig: /tmp/kubeconfig-411378559
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-apps] Daemon set [Serial]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/daemon_set.go:99
+[It] should retry creating failed daemon pods [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating a simple DaemonSet "daemon-set"
+STEP: Check that daemon pods launch on every node of the cluster.
+Jul  2 13:57:06.556: INFO: Number of nodes with available pods: 0
+Jul  2 13:57:06.556: INFO: Node ip-10-250-20-212.ec2.internal is running more than one daemon pod
+Jul  2 13:57:07.564: INFO: Number of nodes with available pods: 0
+Jul  2 13:57:07.564: INFO: Node ip-10-250-20-212.ec2.internal is running more than one daemon pod
+Jul  2 13:57:08.564: INFO: Number of nodes with available pods: 2
+Jul  2 13:57:08.564: INFO: Number of running nodes: 2, number of available pods: 2
+STEP: Set a daemon pod's phase to 'Failed', check that the daemon pod is revived.
+Jul  2 13:57:08.583: INFO: Number of nodes with available pods: 1
+Jul  2 13:57:08.583: INFO: Node ip-10-250-20-212.ec2.internal is running more than one daemon pod
+Jul  2 13:57:09.591: INFO: Number of nodes with available pods: 1
+Jul  2 13:57:09.591: INFO: Node ip-10-250-20-212.ec2.internal is running more than one daemon pod
+Jul  2 13:57:10.591: INFO: Number of nodes with available pods: 2
+Jul  2 13:57:10.591: INFO: Number of running nodes: 2, number of available pods: 2
+STEP: Wait for the failed daemon pod to be completely deleted.
+[AfterEach] [sig-apps] Daemon set [Serial]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/daemon_set.go:65
+STEP: Deleting DaemonSet "daemon-set"
+STEP: deleting {extensions DaemonSet} daemon-set in namespace e2e-tests-daemonsets-dsw7s, will wait for the garbage collector to delete the pods
+Jul  2 13:57:10.655: INFO: Deleting {extensions DaemonSet} daemon-set took: 5.428821ms
+Jul  2 13:57:10.755: INFO: Terminating {extensions DaemonSet} daemon-set pods took: 100.166685ms
+Jul  2 13:57:20.259: INFO: Number of nodes with available pods: 0
+Jul  2 13:57:20.259: INFO: Number of running nodes: 0, number of available pods: 0
+Jul  2 13:57:20.261: INFO: daemonset: {"kind":"DaemonSetList","apiVersion":"apps/v1","metadata":{"selfLink":"/apis/apps/v1/namespaces/e2e-tests-daemonsets-dsw7s/daemonsets","resourceVersion":"13934"},"items":null}
+
+Jul  2 13:57:20.264: INFO: pods: {"kind":"PodList","apiVersion":"v1","metadata":{"selfLink":"/api/v1/namespaces/e2e-tests-daemonsets-dsw7s/pods","resourceVersion":"13934"},"items":null}
+
+[AfterEach] [sig-apps] Daemon set [Serial]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:57:20.274: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-daemonsets-dsw7s" for this suite.
+Jul  2 13:57:26.288: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:57:26.296: INFO: namespace: e2e-tests-daemonsets-dsw7s, resource: bindings, ignored listing per whitelist
+Jul  2 13:57:26.462: INFO: namespace e2e-tests-daemonsets-dsw7s deletion completed in 6.184208272s
+
+• [SLOW TEST:20.023 seconds]
+[sig-apps] Daemon set [Serial]
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/framework.go:22
+  should retry creating failed daemon pods [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSSS
+------------------------------
+[sig-storage] Projected 
+  should provide container's memory limit [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:57:26.462: INFO: >>> kubeConfig: /tmp/kubeconfig-411378559
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:858
+[It] should provide container's memory limit [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating a pod to test downward API volume plugin
+Jul  2 13:57:26.564: INFO: Waiting up to 5m0s for pod "downwardapi-volume-da3145aa-7dff-11e8-bae1-da96248f62d7" in namespace "e2e-tests-projected-qkzpr" to be "success or failure"
+Jul  2 13:57:26.568: INFO: Pod "downwardapi-volume-da3145aa-7dff-11e8-bae1-da96248f62d7": Phase="Pending", Reason="", readiness=false. Elapsed: 3.714732ms
+Jul  2 13:57:28.572: INFO: Pod "downwardapi-volume-da3145aa-7dff-11e8-bae1-da96248f62d7": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.007402424s
+STEP: Saw pod success
+Jul  2 13:57:28.572: INFO: Pod "downwardapi-volume-da3145aa-7dff-11e8-bae1-da96248f62d7" satisfied condition "success or failure"
+Jul  2 13:57:28.575: INFO: Trying to get logs from node ip-10-250-24-1.ec2.internal pod downwardapi-volume-da3145aa-7dff-11e8-bae1-da96248f62d7 container client-container: <nil>
+STEP: delete the pod
+Jul  2 13:57:28.594: INFO: Waiting for pod downwardapi-volume-da3145aa-7dff-11e8-bae1-da96248f62d7 to disappear
+Jul  2 13:57:28.598: INFO: Pod downwardapi-volume-da3145aa-7dff-11e8-bae1-da96248f62d7 no longer exists
+[AfterEach] [sig-storage] Projected
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:57:28.606: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-qkzpr" for this suite.
+Jul  2 13:57:34.620: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:57:34.681: INFO: namespace: e2e-tests-projected-qkzpr, resource: bindings, ignored listing per whitelist
+Jul  2 13:57:34.722: INFO: namespace e2e-tests-projected-qkzpr deletion completed in 6.111845767s
+
+• [SLOW TEST:8.260 seconds]
+[sig-storage] Projected
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:34
+  should provide container's memory limit [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSS
+------------------------------
+[sig-storage] Downward API volume 
+  should set DefaultMode on files [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:57:34.722: INFO: >>> kubeConfig: /tmp/kubeconfig-411378559
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downwardapi_volume.go:38
+[It] should set DefaultMode on files [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating a pod to test downward API volume plugin
+Jul  2 13:57:34.815: INFO: Waiting up to 5m0s for pod "downwardapi-volume-df1c207c-7dff-11e8-bae1-da96248f62d7" in namespace "e2e-tests-downward-api-znktq" to be "success or failure"
+Jul  2 13:57:34.818: INFO: Pod "downwardapi-volume-df1c207c-7dff-11e8-bae1-da96248f62d7": Phase="Pending", Reason="", readiness=false. Elapsed: 3.29611ms
+Jul  2 13:57:36.822: INFO: Pod "downwardapi-volume-df1c207c-7dff-11e8-bae1-da96248f62d7": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.007241805s
+STEP: Saw pod success
+Jul  2 13:57:36.822: INFO: Pod "downwardapi-volume-df1c207c-7dff-11e8-bae1-da96248f62d7" satisfied condition "success or failure"
+Jul  2 13:57:36.825: INFO: Trying to get logs from node ip-10-250-24-1.ec2.internal pod downwardapi-volume-df1c207c-7dff-11e8-bae1-da96248f62d7 container client-container: <nil>
+STEP: delete the pod
+Jul  2 13:57:36.845: INFO: Waiting for pod downwardapi-volume-df1c207c-7dff-11e8-bae1-da96248f62d7 to disappear
+Jul  2 13:57:36.849: INFO: Pod downwardapi-volume-df1c207c-7dff-11e8-bae1-da96248f62d7 no longer exists
+[AfterEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:57:36.849: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-downward-api-znktq" for this suite.
+Jul  2 13:57:42.871: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:57:42.949: INFO: namespace: e2e-tests-downward-api-znktq, resource: bindings, ignored listing per whitelist
+Jul  2 13:57:42.986: INFO: namespace e2e-tests-downward-api-znktq deletion completed in 6.126871987s
+
+• [SLOW TEST:8.264 seconds]
+[sig-storage] Downward API volume
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downwardapi_volume.go:33
+  should set DefaultMode on files [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+[sig-scheduling] SchedulerPredicates [Serial] 
+  validates that NodeSelector is respected if matching  [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-scheduling] SchedulerPredicates [Serial]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:57:42.987: INFO: >>> kubeConfig: /tmp/kubeconfig-411378559
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-scheduling] SchedulerPredicates [Serial]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/scheduling/predicates.go:79
+Jul  2 13:57:43.079: INFO: Waiting up to 1m0s for all nodes to be ready
+Jul  2 13:58:43.107: INFO: Waiting for terminating namespaces to be deleted...
+Jul  2 13:58:43.113: INFO: Waiting up to 5m0s for all pods (need at least 0) in namespace 'kube-system' to be running and ready
+Jul  2 13:58:43.124: INFO: 14 / 14 pods in namespace 'kube-system' are running and ready (0 seconds elapsed)
+Jul  2 13:58:43.124: INFO: expected 8 pod replicas in namespace 'kube-system', 8 are Running and Ready.
+Jul  2 13:58:43.128: INFO: Waiting for pods to enter Success, but no pods in "kube-system" match label map[name:e2e-image-puller]
+Jul  2 13:58:43.128: INFO: 
+Logging pods the kubelet thinks is on node ip-10-250-20-212.ec2.internal before test
+Jul  2 13:58:43.220: INFO: addons-nginx-ingress-nginx-ingress-k8s-backend-7b5569797f-64wcj from kube-system started at 2018-07-02 12:48:00 +0000 UTC (1 container statuses recorded)
+Jul  2 13:58:43.220: INFO: 	Container nginx-ingress-nginx-ingress-k8s-backend ready: true, restart count 0
+Jul  2 13:58:43.220: INFO: addons-heapster-e3b0c-64455ddddb-m2pxn from kube-system started at 2018-07-02 12:48:00 +0000 UTC (2 container statuses recorded)
+Jul  2 13:58:43.220: INFO: 	Container heapster ready: true, restart count 0
+Jul  2 13:58:43.220: INFO: 	Container heapster-nanny ready: true, restart count 0
+Jul  2 13:58:43.220: INFO: kube-dns-9c4dfc4fb-hk72g from kube-system started at 2018-07-02 12:48:00 +0000 UTC (3 container statuses recorded)
+Jul  2 13:58:43.220: INFO: 	Container dnsmasq ready: true, restart count 0
+Jul  2 13:58:43.220: INFO: 	Container kubedns ready: true, restart count 0
+Jul  2 13:58:43.220: INFO: 	Container sidecar ready: true, restart count 0
+Jul  2 13:58:43.220: INFO: node-exporter-zm2rg from kube-system started at 2018-07-02 12:47:40 +0000 UTC (1 container statuses recorded)
+Jul  2 13:58:43.220: INFO: 	Container node-exporter ready: true, restart count 0
+Jul  2 13:58:43.220: INFO: kube-dns-autoscaler-6dd4765967-gqbtv from kube-system started at 2018-07-02 12:48:00 +0000 UTC (1 container statuses recorded)
+Jul  2 13:58:43.220: INFO: 	Container autoscaler ready: true, restart count 0
+Jul  2 13:58:43.220: INFO: vpn-shoot-77bdbf95b-zdv7s from kube-system started at 2018-07-02 12:48:00 +0000 UTC (1 container statuses recorded)
+Jul  2 13:58:43.220: INFO: 	Container vpn-shoot ready: true, restart count 0
+Jul  2 13:58:43.220: INFO: calico-node-4lmw2 from kube-system started at 2018-07-02 12:47:40 +0000 UTC (2 container statuses recorded)
+Jul  2 13:58:43.220: INFO: 	Container calico-node ready: true, restart count 0
+Jul  2 13:58:43.220: INFO: 	Container install-cni ready: true, restart count 0
+Jul  2 13:58:43.220: INFO: addons-kubernetes-dashboard-5486b968b7-kgkrm from kube-system started at 2018-07-02 12:48:00 +0000 UTC (1 container statuses recorded)
+Jul  2 13:58:43.220: INFO: 	Container main ready: true, restart count 0
+Jul  2 13:58:43.220: INFO: kube-dns-9c4dfc4fb-8q2xj from kube-system started at 2018-07-02 12:49:17 +0000 UTC (3 container statuses recorded)
+Jul  2 13:58:43.220: INFO: 	Container dnsmasq ready: true, restart count 0
+Jul  2 13:58:43.220: INFO: 	Container kubedns ready: true, restart count 0
+Jul  2 13:58:43.220: INFO: 	Container sidecar ready: true, restart count 0
+Jul  2 13:58:43.220: INFO: kube-proxy-r9nzr from kube-system started at 2018-07-02 12:47:40 +0000 UTC (1 container statuses recorded)
+Jul  2 13:58:43.220: INFO: 	Container kube-proxy ready: true, restart count 0
+Jul  2 13:58:43.220: INFO: addons-nginx-ingress-controller-77fffb78c6-rvwcv from kube-system started at 2018-07-02 12:48:00 +0000 UTC (1 container statuses recorded)
+Jul  2 13:58:43.220: INFO: 	Container nginx-ingress-controller ready: true, restart count 0
+Jul  2 13:58:43.220: INFO: 
+Logging pods the kubelet thinks is on node ip-10-250-24-1.ec2.internal before test
+Jul  2 13:58:43.261: INFO: kube-proxy-zj5gp from kube-system started at 2018-07-02 12:49:09 +0000 UTC (1 container statuses recorded)
+Jul  2 13:58:43.261: INFO: 	Container kube-proxy ready: true, restart count 0
+Jul  2 13:58:43.261: INFO: sonobuoy-e2e-job-28cb3bdc6acd48a9 from sonobuoy started at 2018-07-02 12:53:32 +0000 UTC (2 container statuses recorded)
+Jul  2 13:58:43.261: INFO: 	Container e2e ready: true, restart count 0
+Jul  2 13:58:43.261: INFO: 	Container sonobuoy-worker ready: true, restart count 0
+Jul  2 13:58:43.261: INFO: calico-node-sd5dt from kube-system started at 2018-07-02 12:49:09 +0000 UTC (2 container statuses recorded)
+Jul  2 13:58:43.261: INFO: 	Container calico-node ready: true, restart count 0
+Jul  2 13:58:43.261: INFO: 	Container install-cni ready: true, restart count 0
+Jul  2 13:58:43.261: INFO: node-exporter-mkl4n from kube-system started at 2018-07-02 12:49:09 +0000 UTC (1 container statuses recorded)
+Jul  2 13:58:43.261: INFO: 	Container node-exporter ready: true, restart count 0
+Jul  2 13:58:43.261: INFO: sonobuoy from sonobuoy started at 2018-07-02 12:53:17 +0000 UTC (1 container statuses recorded)
+Jul  2 13:58:43.261: INFO: 	Container kube-sonobuoy ready: true, restart count 0
+[It] validates that NodeSelector is respected if matching  [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Trying to launch a pod without a label to get a node which can launch it.
+STEP: Explicitly delete pod here to free the resource it takes.
+STEP: Trying to apply a random label on the found node.
+STEP: verifying the node has the label kubernetes.io/e2e-091f60d7-7e00-11e8-bae1-da96248f62d7 42
+STEP: Trying to relaunch the pod, now with labels.
+STEP: removing the label kubernetes.io/e2e-091f60d7-7e00-11e8-bae1-da96248f62d7 off the node ip-10-250-24-1.ec2.internal
+STEP: verifying the node doesn't have the label kubernetes.io/e2e-091f60d7-7e00-11e8-bae1-da96248f62d7
+[AfterEach] [sig-scheduling] SchedulerPredicates [Serial]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:58:49.358: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-sched-pred-gkhjw" for this suite.
+Jul  2 13:59:11.373: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:59:11.502: INFO: namespace: e2e-tests-sched-pred-gkhjw, resource: bindings, ignored listing per whitelist
+Jul  2 13:59:11.541: INFO: namespace e2e-tests-sched-pred-gkhjw deletion completed in 22.178415434s
+[AfterEach] [sig-scheduling] SchedulerPredicates [Serial]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/scheduling/predicates.go:70
+
+• [SLOW TEST:88.554 seconds]
+[sig-scheduling] SchedulerPredicates [Serial]
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/scheduling/framework.go:22
+  validates that NodeSelector is respected if matching  [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSSS
+------------------------------
+[sig-api-machinery] Downward API 
+  should provide container's limits.cpu/memory and requests.cpu/memory as env vars [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-api-machinery] Downward API
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:59:11.541: INFO: >>> kubeConfig: /tmp/kubeconfig-411378559
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should provide container's limits.cpu/memory and requests.cpu/memory as env vars [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating a pod to test downward api env vars
+Jul  2 13:59:11.636: INFO: Waiting up to 5m0s for pod "downward-api-18d1e4ca-7e00-11e8-bae1-da96248f62d7" in namespace "e2e-tests-downward-api-q5x7d" to be "success or failure"
+Jul  2 13:59:11.641: INFO: Pod "downward-api-18d1e4ca-7e00-11e8-bae1-da96248f62d7": Phase="Pending", Reason="", readiness=false. Elapsed: 4.882147ms
+Jul  2 13:59:13.645: INFO: Pod "downward-api-18d1e4ca-7e00-11e8-bae1-da96248f62d7": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.00864459s
+STEP: Saw pod success
+Jul  2 13:59:13.645: INFO: Pod "downward-api-18d1e4ca-7e00-11e8-bae1-da96248f62d7" satisfied condition "success or failure"
+Jul  2 13:59:13.648: INFO: Trying to get logs from node ip-10-250-24-1.ec2.internal pod downward-api-18d1e4ca-7e00-11e8-bae1-da96248f62d7 container dapi-container: <nil>
+STEP: delete the pod
+Jul  2 13:59:13.666: INFO: Waiting for pod downward-api-18d1e4ca-7e00-11e8-bae1-da96248f62d7 to disappear
+Jul  2 13:59:13.700: INFO: Pod downward-api-18d1e4ca-7e00-11e8-bae1-da96248f62d7 no longer exists
+[AfterEach] [sig-api-machinery] Downward API
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:59:13.700: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-downward-api-q5x7d" for this suite.
+Jul  2 13:59:19.726: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:59:19.829: INFO: namespace: e2e-tests-downward-api-q5x7d, resource: bindings, ignored listing per whitelist
+Jul  2 13:59:19.830: INFO: namespace e2e-tests-downward-api-q5x7d deletion completed in 6.119520177s
+
+• [SLOW TEST:8.288 seconds]
+[sig-api-machinery] Downward API
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downward_api.go:37
+  should provide container's limits.cpu/memory and requests.cpu/memory as env vars [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+[k8s.io] Probing container 
+  with readiness probe should not be ready before initial delay and never restart [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [k8s.io] Probing container
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:59:19.830: INFO: >>> kubeConfig: /tmp/kubeconfig-411378559
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [k8s.io] Probing container
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/container_probe.go:48
+[It] with readiness probe should not be ready before initial delay and never restart [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+Jul  2 13:59:43.929: INFO: Container started at 2018-07-02 13:59:21 +0000 UTC, pod became ready at 2018-07-02 13:59:42 +0000 UTC
+[AfterEach] [k8s.io] Probing container
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:59:43.929: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-container-probe-jgmxl" for this suite.
+Jul  2 14:00:05.954: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 14:00:06.223: INFO: namespace: e2e-tests-container-probe-jgmxl, resource: bindings, ignored listing per whitelist
+Jul  2 14:00:06.236: INFO: namespace e2e-tests-container-probe-jgmxl deletion completed in 22.303030851s
+
+• [SLOW TEST:46.406 seconds]
+[k8s.io] Probing container
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:679
+  with readiness probe should not be ready before initial delay and never restart [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSS
+------------------------------
+[sig-storage] ConfigMap 
+  should be consumable from pods in volume as non-root [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-storage] ConfigMap
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 14:00:06.236: INFO: >>> kubeConfig: /tmp/kubeconfig-411378559
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should be consumable from pods in volume as non-root [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating configMap with name configmap-test-volume-396c9560-7e00-11e8-bae1-da96248f62d7
+STEP: Creating a pod to test consume configMaps
+Jul  2 14:00:06.340: INFO: Waiting up to 5m0s for pod "pod-configmaps-396d2110-7e00-11e8-bae1-da96248f62d7" in namespace "e2e-tests-configmap-28t48" to be "success or failure"
+Jul  2 14:00:06.343: INFO: Pod "pod-configmaps-396d2110-7e00-11e8-bae1-da96248f62d7": Phase="Pending", Reason="", readiness=false. Elapsed: 3.0616ms
+Jul  2 14:00:08.347: INFO: Pod "pod-configmaps-396d2110-7e00-11e8-bae1-da96248f62d7": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.006976567s
+STEP: Saw pod success
+Jul  2 14:00:08.347: INFO: Pod "pod-configmaps-396d2110-7e00-11e8-bae1-da96248f62d7" satisfied condition "success or failure"
+Jul  2 14:00:08.350: INFO: Trying to get logs from node ip-10-250-24-1.ec2.internal pod pod-configmaps-396d2110-7e00-11e8-bae1-da96248f62d7 container configmap-volume-test: <nil>
+STEP: delete the pod
+Jul  2 14:00:08.465: INFO: Waiting for pod pod-configmaps-396d2110-7e00-11e8-bae1-da96248f62d7 to disappear
+Jul  2 14:00:08.468: INFO: Pod pod-configmaps-396d2110-7e00-11e8-bae1-da96248f62d7 no longer exists
+[AfterEach] [sig-storage] ConfigMap
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 14:00:08.468: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-configmap-28t48" for this suite.
+Jul  2 14:00:14.494: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 14:00:14.512: INFO: namespace: e2e-tests-configmap-28t48, resource: bindings, ignored listing per whitelist
+Jul  2 14:00:14.595: INFO: namespace e2e-tests-configmap-28t48 deletion completed in 6.113549664s
+
+• [SLOW TEST:8.359 seconds]
+[sig-storage] ConfigMap
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/configmap_volume.go:32
+  should be consumable from pods in volume as non-root [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSSSSSSSSSSSSSSSS
+------------------------------
+[sig-storage] Downward API volume 
+  should provide container's cpu request [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 14:00:14.595: INFO: >>> kubeConfig: /tmp/kubeconfig-411378559
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downwardapi_volume.go:38
+[It] should provide container's cpu request [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating a pod to test downward API volume plugin
+Jul  2 14:00:14.689: INFO: Waiting up to 5m0s for pod "downwardapi-volume-3e66d3c2-7e00-11e8-bae1-da96248f62d7" in namespace "e2e-tests-downward-api-xfrxq" to be "success or failure"
+Jul  2 14:00:14.694: INFO: Pod "downwardapi-volume-3e66d3c2-7e00-11e8-bae1-da96248f62d7": Phase="Pending", Reason="", readiness=false. Elapsed: 5.256388ms
+Jul  2 14:00:16.744: INFO: Pod "downwardapi-volume-3e66d3c2-7e00-11e8-bae1-da96248f62d7": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.055501016s
+STEP: Saw pod success
+Jul  2 14:00:16.744: INFO: Pod "downwardapi-volume-3e66d3c2-7e00-11e8-bae1-da96248f62d7" satisfied condition "success or failure"
+Jul  2 14:00:16.747: INFO: Trying to get logs from node ip-10-250-24-1.ec2.internal pod downwardapi-volume-3e66d3c2-7e00-11e8-bae1-da96248f62d7 container client-container: <nil>
+STEP: delete the pod
+Jul  2 14:00:16.767: INFO: Waiting for pod downwardapi-volume-3e66d3c2-7e00-11e8-bae1-da96248f62d7 to disappear
+Jul  2 14:00:16.786: INFO: Pod downwardapi-volume-3e66d3c2-7e00-11e8-bae1-da96248f62d7 no longer exists
+[AfterEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 14:00:16.787: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-downward-api-xfrxq" for this suite.
+Jul  2 14:00:22.801: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 14:00:22.827: INFO: namespace: e2e-tests-downward-api-xfrxq, resource: bindings, ignored listing per whitelist
+Jul  2 14:00:22.904: INFO: namespace e2e-tests-downward-api-xfrxq deletion completed in 6.113978027s
+
+• [SLOW TEST:8.309 seconds]
+[sig-storage] Downward API volume
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downwardapi_volume.go:33
+  should provide container's cpu request [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSSSSSSSSSSSSSJul  2 14:00:22.905: INFO: Running AfterSuite actions on all node
+Jul  2 14:00:22.905: INFO: Running AfterSuite actions on node 1
+Jul  2 14:00:22.905: INFO: Skipping dumping logs from cluster
+
+Ran 143 of 998 Specs in 3989.894 seconds
+SUCCESS! -- 143 Passed | 0 Failed | 0 Pending | 855 Skipped PASS
+
+Ginkgo ran 1 suite in 1h6m30.691831932s
+Test Suite Passed

--- a/v1.11/gardener-aws/junit_01.xml
+++ b/v1.11/gardener-aws/junit_01.xml
@@ -1,0 +1,2711 @@
+<?xml version="1.0" encoding="UTF-8"?>
+  <testsuite tests="143" failures="0" time="3989.893812108">
+      <testcase name="[k8s.io] [Feature:Example] [k8s.io] Storm should create and stop Zookeeper, Nimbus and Storm worker servers" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-auth] Metadata Concealment should run a check-metadata-concealment job to completion" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl Port forwarding [k8s.io] With a server listening on localhost [k8s.io] that expects a client request should support a client that connects, sends DATA, and disconnects" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: dir-bindmounted] Set fsGroup for local volume should set same fsGroup for two pods simultaneously" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] shouldn&#39;t scale up when expendable pod is preempted [Feature:ClusterSizeAutoscalingScaleUp]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gcePDPVC] should support readOnly file specified in the volumeMount" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] ReplicaSet should surface a failure condition on a common issue like exceeded quota" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: emptyDir] should fail if subpath with backstepping is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cluster-lifecycle] Upgrade [Feature:Upgrade] master upgrade should maintain a functioning cluster [Feature:MasterUpgrade]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: hostPathSymlink] should support file as subpath" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: tmpfs] Set fsGroup for local volume should set fsGroup for one pod" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Services should work after restarting kube-proxy [Disruptive]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PV Protection Verify &#34;immediate&#34; deletion of a PV that is not bound to a PVC" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] PrivilegedPod [NodeConformance] should enable privileged commands" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: blockfs] One pod requesting one prebound PVC should be able to mount volume and read from pod1" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes:vsphere should test that a vspehre volume mounted to a pod that is deleted while the kubelet is down unmounts when the kubelet returns [Disruptive]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scalability] Load capacity [Feature:ManualPerformance] should be able to handle 3 pods per node { ReplicationController} with 0 secrets, 0 configmaps and 0 daemons" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Etcd failure [Disruptive] should recover from SIGKILL" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scalability] Load capacity [Feature:ManualPerformance] should be able to handle 30 pods per node {batch Job} with 0 secrets, 0 configmaps and 0 daemons" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Storage Policy Based Volume Provisioning [Feature:vsphere] verify VSAN storage capability with valid diskStripes and objectSpaceReservation values is honored for dynamically provisioned pvc using storageclass" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Pod Disks should be able to delete a non-existent PD without error" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  Local volume provisioner [Serial] should create and recreate local persistent volume" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl Port forwarding [k8s.io] With a server listening on 0.0.0.0 [k8s.io] that expects NO client request should support a client that connects, sends DATA, and disconnects" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Loadbalancing: L7 GCE [Slow] [Feature:NEG] should be able to switch between IG and NEG modes" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gluster] should support restarting containers using file as subpath [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Secrets should be consumable from pods in volume [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="10.562773145"></testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gcePDPartitioned] should support existing directories when readOnly specified in the volumeSource" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Cluster size autoscaler scalability [Slow] should scale down underutilized nodes [Feature:ClusterAutoscalerScalability4]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cluster-lifecycle] [Feature:BootstrapTokens] should not delete the token secret when the secret is not expired" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: nfsPVC] should fail if subpath directory is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: hostPath] should support restarting containers using file as subpath [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] DNS horizontal autoscaling [DisabledForLargeClusters] kube-dns-autoscaler should scale kube-dns pods in both nonfaulty and faulty scenarios" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Loadbalancing: L7 GCE [Slow] [Feature:Ingress] should create ingress with given static-ip" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gcePDPartitioned] should support readOnly file specified in the volumeMount" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] DisruptionController evictions: too few pods, replicaSet, percentage =&gt; should not allow an eviction" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] [HPA] Horizontal pod autoscaling (scale resource: Custom Metrics from Stackdriver) should scale up with two metrics of type Pod from Stackdriver [Feature:CustomMetricsAutoscaling]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gcePDPVC] should support existing single file" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Kubectl describe should check if kubectl describe prints relevant information for rc and pods  [Conformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Projected should provide podname as non-root with fsgroup [NodeFeature:FSGroup]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] Multi-AZ Clusters should spread the pods of a service across zones" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] ReplicationController should surface a failure condition on a common issue like exceeded quota" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Namespaces [Serial] should delete fast enough (90 percent of 100 namespaces in 150 seconds)" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: dir] Two pods mounting a local volume at the same time should be able to write from pod1 and read from pod2" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Downward API [Serial] [Disruptive] [NodeFeature:EphemeralStorage] Downward API tests for local ephemeral storage should provide default limits.ephemeral-storage from node allocatable" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: dir] One pod requesting one prebound PVC should be able to mount volume and read from pod1" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] should scale down when expendable pod is running [Feature:ClusterSizeAutoscalingScaleDown]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] CSI Volumes CSI plugin test using CSI driver: hostPath should provision storage" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Dynamic Provisioning DynamicProvisioner Default should create and delete default persistent volumes [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cluster-lifecycle] Upgrade [Feature:Upgrade] cluster upgrade should maintain a functioning cluster [Feature:ClusterUpgrade]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: blockfs] Set fsGroup for local volume should set different fsGroup for second pod if first pod is deleted" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-instrumentation] [Feature:PrometheusMonitoring] Prometheus should contain correct container CPU metric." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Kubectl run rc should create an rc from an image  [Conformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: emptyDir] should support existing directories when readOnly specified in the volumeSource" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: dir-link] Set fsGroup for local volume should not set different fsGroups for two pods simultaneously" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] [Serial] Volume metrics PVController should create unbound pv count metrics for pvc controller after creating pv only" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Services should release NodePorts on delete" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gcePDPartitioned] should unmount if pod is force deleted while kubelet is down [Disruptive][Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Job should adopt matching orphans and release non-matching pods" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] EmptyDir volumes should support (non-root,0644,default) [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="8.370862148"></testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: emptyDir] should support file as subpath" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scalability] Density [Feature:ManualPerformance] should allow starting 30 pods per node using {extensions Deployment} with 0 secrets, 0 configmaps and 0 daemons" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volume Disk Format [Feature:vsphere] verify disk format type - eagerzeroedthick is honored for dynamically provisioned pv using storageclass" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-instrumentation] [Feature:PrometheusMonitoring] Prometheus should scrape metrics from annotated pods." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Services should provide secure master service  [Conformance]" classname="Kubernetes e2e suite" time="6.239642041"></testcase>
+      <testcase name="[sig-apps] ReplicaSet should serve a basic image on each replica with a public image  [Conformance]" classname="Kubernetes e2e suite" time="16.431384777"></testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: nfs] should support existing directories when readOnly specified in the volumeSource" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] ResourceQuota should create a ResourceQuota and capture the life of a configMap." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] NetworkPolicy NetworkPolicy between server and client should support allow-all policy [Feature:NetworkPolicy]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gcePDPartitioned] should fail if subpath directory is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cluster-lifecycle] Reboot [Disruptive] [Feature:Reboot] each node by switching off the network interface and ensure they function upon switch on" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes [Feature:ReclaimPolicy] [sig-storage] persistentvolumereclaim:vsphere should retain persistent volume when reclaimPolicy set to retain when associated claim is deleted" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] SchedulerPreemption [Serial] [Feature:PodPreemption] validates pod anti-affinity works in preemption" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Pods should have their auto-restart back-off timer reset on image update [Slow][NodeConformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Projected should be consumable from pods in volume as non-root with defaultMode and fsGroup set [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="8.369834687"></testcase>
+      <testcase name="[sig-scheduling] [Feature:GPUDevicePlugin] run Nvidia GPU Device Plugin tests on Container Optimized OS only" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] AdmissionWebhook Should mutate custom resource" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] AdmissionWebhook Should be able to deny pod and configmap creation" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Downward API volume should set mode on item file [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="8.234510336"></testcase>
+      <testcase name="[sig-scalability] Density [Feature:ManualPerformance] should allow starting 30 pods per node using { ReplicationController} with 0 secrets, 0 configmaps and 2 daemons" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gcePDPartitioned] should support readOnly directory specified in the volumeMount" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] EmptyDir volumes should support (non-root,0644,tmpfs) [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="10.356700589"></testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gcePDPVC] should unmount if pod is force deleted while kubelet is down [Disruptive][Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-service-catalog] [Feature:PodPreset] PodPreset should create a pod preset" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] EmptyDir wrapper volumes should not cause race condition when used for configmaps [Serial] [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: dir-link-bindmounted] Set fsGroup for local volume should not set different fsGroups for two pods simultaneously" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-auth] Advanced Audit should audit API calls [DisabledForLargeClusters]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] should create new node if there is no node for node selector [Feature:ClusterSizeAutoscalingScaleWithNAP]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gluster] should unmount if pod is gracefully deleted while kubelet is down [Disruptive][Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] [HPA] Horizontal pod autoscaling (scale resource: CPU) [sig-autoscaling] ReplicationController light Should scale from 1 pod to 2 pods" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gcePDPVC] should support creating multiple subpath from same volumes [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: nfsPVC] should unmount if pod is force deleted while kubelet is down [Disruptive][Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Etcd failure [Disruptive] should recover from network partition with master" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Sysctls [NodeFeature:Sysctls] should support sysctls" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] should increase cluster size if pending pods are small and one node is broken [Feature:ClusterSizeAutoscalingScaleUp]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gcePDPVC] should support existing directories when readOnly specified in the volumeSource" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: blockfs] Set fsGroup for local volume should set fsGroup for one pod" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: emptyDir] should fail if subpath directory is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Firewall rule [Slow] [Serial] should create valid firewall rules for LoadBalancer type service" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [sig-node] Security Context [Feature:SecurityContext] should support seccomp alpha unconfined annotation on the container [Feature:Seccomp]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: gce-localssd-scsi-fs] [Serial] Two pods mounting a local volume one after the other should be able to write from pod1 and read from pod2" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] ResourceQuota should create a ResourceQuota and capture the life of a replica set." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scalability] Load capacity [Feature:ManualPerformance] should be able to handle 30 pods per node { ReplicationController} with 0 secrets, 0 configmaps and 2 daemons" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Networking Granular Checks: Pods should function for node-pod communication: udp [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="43.294552605"></testcase>
+      <testcase name="[sig-storage] PersistentVolumes GCEPD should test that deleting a PVC before the pod does not cause pod deletion to fail on PD detach" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: nfsPVC] should support readOnly file specified in the volumeMount" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Kubectl run default should create an rc or deployment from an image  [Conformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] NetworkPolicy NetworkPolicy between server and client should enforce multiple, stacked policies with overlapping podSelectors [Feature:NetworkPolicy]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] ResourceQuota should create a ResourceQuota and capture the life of a service." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Services should have session affinity work for LoadBalancer service with ESIPP on [Slow] [DisabledForLargeClusters]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Networking should check kube-proxy urls" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] shouldn&#39;t scale up when expendable pod is created [Feature:ClusterSizeAutoscalingScaleUp]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] DNS should provide DNS for services  [Conformance]" classname="Kubernetes e2e suite" time="28.606946541"></testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gluster] should support readOnly file specified in the volumeMount" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: tmpfs] Two pods mounting a local volume one after the other should be able to write from pod1 and read from pod2" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: hostPath] should support restarting containers using directory as subpath [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Services should be able to create a functioning NodePort service" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] StatefulSet [k8s.io] Deploy clustered applications [Feature:StatefulSet] [Slow] should creating a working CockroachDB cluster" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Docker Containers should be able to override the image&#39;s default command (docker entrypoint) [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="10.388045637"></testcase>
+      <testcase name="[sig-api-machinery] CustomResourceDefinition resources Simple CustomResourceDefinition creating/deleting custom resource definition objects works  [Conformance]" classname="Kubernetes e2e suite" time="7.403055878"></testcase>
+      <testcase name="[k8s.io] Probing container should *not* be restarted with a /healthz http liveness probe [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="253.874004886"></testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: hostPath] should support existing directory" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Cluster size autoscaler scalability [Slow] should scale up at all [Feature:ClusterAutoscalerScalability1]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Projected should provide podname as non-root with fsgroup and defaultMode [NodeFeature:FSGroup]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-auth] PodSecurityPolicy should allow pods under the privileged extensions.PodSecurityPolicy" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: dir] One pod requesting one prebound PVC should be able to mount volume and write from pod1" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Secrets should be consumable from pods in env vars [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="8.358320607"></testcase>
+      <testcase name="[sig-storage] ConfigMap should be consumable from pods in volume [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="8.388777257"></testcase>
+      <testcase name="[sig-api-machinery] AdmissionWebhook Should mutate configmap" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Services should be able to change the type from ExternalName to ClusterIP" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: emptyDir] should fail if subpath file is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  Stress with local volume provisioner [Serial] should use be able to process many pods and reuse local volumes" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Projected should provide container&#39;s cpu limit [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="8.26898009"></testcase>
+      <testcase name="[sig-apps] DisruptionController evictions: enough pods, absolute =&gt; should allow an eviction" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] StatefulSet [k8s.io] Deploy clustered applications [Feature:StatefulSet] [Slow] should creating a working redis cluster" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: dir-bindmounted] Set fsGroup for local volume should set different fsGroup for second pod if first pod is deleted" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Downward API volume should provide container&#39;s cpu limit [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="8.328796537"></testcase>
+      <testcase name="[sig-network] Loadbalancing: L7 GCE [Slow] [Feature:Ingress] should not reconcile manually modified health check for ingress" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Servers with support for Table transformation should return pod details" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath Atomic writer volumes should support subpaths with configmap pod with mountPath of existing file" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes:vsphere should test that deleting the PV before the pod does not cause pod deletion to fail on vspehre volume detach" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl Port forwarding [k8s.io] With a server listening on localhost [k8s.io] that expects NO client request should support a client that connects, sends DATA, and disconnects" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volumes vsphere [Feature:Volumes] should be mountable" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] DNS configMap nameserver Forward PTR lookup should forward PTR records lookup to upstream nameserver [Slow][Serial]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes:vsphere should test that deleting the Namespace of a PVC and Pod causes the successful detach of vsphere volume" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Kubectl api-versions should check if v1 is in available api versions  [Conformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: hostPath] should fail if subpath with backstepping is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: hostPath] should support file as subpath" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cluster-lifecycle] [Feature:BootstrapTokens] should delete the token secret when the secret expired" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Loadbalancing: L7 Scalability GCE [Slow] [Serial] [Feature:IngressScale] Creating and updating ingresses should happen promptly with small/medium/large amount of ingresses" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-auth] [Feature:NodeAuthorizer] Getting a non-existent configmap should exit with the Forbidden error, not a NotFound error" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-auth] [Feature:NodeAuthorizer] A node shouldn&#39;t be able to create another node" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cluster-lifecycle] Downgrade [Feature:Downgrade] cluster downgrade should maintain a functioning cluster [Feature:ClusterDowngrade]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Daemon set [Serial] should run and stop simple daemon [Conformance]" classname="Kubernetes e2e suite" time="27.887161816"></testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: nfs] should support non-existent path" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Kubectl run --rm job should create a job from an image, then delete the job  [Conformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Variable Expansion should fail substituting values in a volume subpath with absolute path [Feature:VolumeSubpathEnvExpansion][NodeAlphaFeature:VolumeSubpathEnvExpansion][Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: nfs] should support readOnly file specified in the volumeMount" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] [Serial] Volume metrics PVController should create none metrics for pvc controller before creating any PV or PVC" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Networking Granular Checks: Services [Slow] should update endpoints: http" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: nfsPVC] should fail if subpath with backstepping is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-instrumentation] Cluster level logging implemented by Stackdriver [Feature:StackdriverLogging] [Soak] should ingest logs from applications running for a prolonged amount of time" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] DisruptionController should update PodDisruptionBudget status" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] GCP Volumes GlusterFS should be mountable" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Variable Expansion should allow substituting values in a container&#39;s args [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="10.472200981"></testcase>
+      <testcase name="[sig-apps] StatefulSet [k8s.io] Basic StatefulSet functionality [StatefulSetBasic] should adopt matching orphans and release non-matching pods" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] SchedulerPriorities [Serial] Pod should avoid to schedule to node that have avoidPod annotation" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] EmptyDir volumes when FSGroup is specified [NodeFeature:FSGroup] files with FSGroup ownership should support (root,0644,tmpfs)" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cluster-lifecycle] kube-proxy migration [Feature:KubeProxyDaemonSetMigration] Downgrade kube-proxy from a DaemonSet to static pods should maintain a functioning cluster [Feature:KubeProxyDaemonSetDowngrade]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-auth] [Feature:NodeAuthorizer] Getting a non-existent secret should exit with the Forbidden error, not a NotFound error" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] ESIPP [Slow] [DisabledForLargeClusters] should work from pods" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: hostPathSymlink] should support readOnly directory specified in the volumeMount" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] EquivalenceCache [Serial] validates pod anti-affinity works properly when new replica pod is scheduled" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Projected should provide node allocatable (memory) as default memory limit if the limit is not set [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="8.279327069"></testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Kubectl taint [Serial] should update the taint on a node" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cluster-lifecycle] Addon update should propagate add-on file changes [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: dir-bindmounted] Two pods mounting a local volume at the same time should be able to write from pod1 and read from pod2" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-instrumentation] MetricsGrabber should grab all metrics from a Kubelet." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] ServiceLoadBalancer [Feature:ServiceLoadBalancer] should support simple GET on Ingress ips" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-auth] PodSecurityPolicy should enforce the restricted extensions.PodSecurityPolicy" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Services should be able to up and down services" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] CronJob should not schedule jobs when suspended [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Probing container should *not* be restarted with a exec &#34;cat /tmp/health&#34; liveness probe [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="250.122629563"></testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: hostPath] should support existing single file" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] ESIPP [Slow] [DisabledForLargeClusters] should work for type=NodePort" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Networking Granular Checks: Services [Slow] should function for node-Service: http" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: tmpfs] Set fsGroup for local volume should set different fsGroup for second pod if first pod is deleted" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] StatefulSet [k8s.io] Deploy clustered applications [Feature:StatefulSet] [Slow] should creating a working zookeeper cluster" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: dir-link] Set fsGroup for local volume should set different fsGroup for second pod if first pod is deleted" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Pods should be updated [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="24.757791401"></testcase>
+      <testcase name="[sig-network] DNS should provide DNS for pods for Hostname and Subdomain" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Network Partition [Disruptive] [Slow] [k8s.io] Pods should be evicted from unready Node [Feature:TaintEviction] All pods on the unreachable node should be marked as NotReady upon the node turn NotReady AND all pods should be evicted after eviction timeout passes" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Initializers [Feature:Initializers] should dynamically register and apply initializers to pods [Serial]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] should add node to the particular mig [Feature:ClusterSizeAutoscalingScaleUp]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Daemon set [Serial] should run and stop complex daemon with node affinity" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-auth] ServiceAccounts should mount an API token into pods  [Conformance]" classname="Kubernetes e2e suite" time="13.049901275"></testcase>
+      <testcase name="[sig-network] Services should have session affinity work for service with type clusterIP" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [sig-node] Pods Extended [k8s.io] Pods Set QOS Class should be submitted and removed  [Conformance]" classname="Kubernetes e2e suite" time="22.223814601"></testcase>
+      <testcase name="[sig-cluster-lifecycle] Reboot [Disruptive] [Feature:Reboot] each node by ordering clean reboot and ensure they function upon restart" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volume Placement should create and delete pod with the same volume source on the same worker node" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: tmpfs] One pod requesting one prebound PVC should be able to mount volume and write from pod1" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] [HPA] Horizontal pod autoscaling (scale resource: CPU) [sig-autoscaling] [Serial] [Slow] ReplicationController Should scale from 1 pod to 3 pods and from 3 to 5 and verify decision stability" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: dir-bindmounted] Set fsGroup for local volume should not set different fsGroups for two pods simultaneously" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Proxy server should support proxy with --port 0  [Conformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Network should set TCP CLOSE_WAIT timeout" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl alpha client [k8s.io] Kubectl run CronJob should create a CronJob" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: hostPathSymlink] should fail if subpath file is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Services should be able to change the type from NodePort to ExternalName" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gluster] should support readOnly directory specified in the volumeMount" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gcePDPartitioned] should support restarting containers using directory as subpath [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volume FStype [Feature:vsphere] verify fstype - default value should be ext4" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [sig-node] Pod garbage collector [Feature:PodGarbageCollector] [Slow] should handle the creation of 1000 pods" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gluster] should unmount if pod is force deleted while kubelet is down [Disruptive][Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Job should exceed backoffLimit" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Projected should project all components that make up the projection API [Projection][NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="8.248352277"></testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gcePDPVC] should fail if subpath file is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] NoSNAT [Feature:NoSNAT] [Slow] Should be able to send traffic between Pods without SNAT" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: hostPath] should support existing directories when readOnly specified in the volumeSource" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volume Disk Format [Feature:vsphere] verify disk format type - zeroedthick is honored for dynamically provisioned pv using storageclass" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cluster-lifecycle] ingress Downgrade [Feature:IngressDowngrade] ingress downgrade should maintain a functioning ingress" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: hostPathSymlink] should support restarting containers using file as subpath [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Ephemeralstorage When pod refers to non-existent ephemeral storage should allow deletion of pod with invalid volume : secret" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Projected should be able to mount in a volume regardless of a different secret existing with same name in different namespace [NodeConformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Deployment deployment should delete old replica sets" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] HostPath should support existing single file subPath" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Projected should be consumable from pods in volume with mappings [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="8.342372882"></testcase>
+      <testcase name="[sig-network] Services should be able to switch session affinity for NodePort service" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] StatefulSet [k8s.io] Basic StatefulSet functionality [StatefulSetBasic] should perform canary updates and phased rolling updates of template modifications [Conformance]" classname="Kubernetes e2e suite" time="96.717902286"></testcase>
+      <testcase name="[sig-network] Networking IPerf IPv4 [Experimental] [Feature:Networking-IPv4] [Slow] [Feature:Networking-Performance] should transfer ~ 1GB onto the service endpoint 1 servers (maximum of 1 clients)" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cluster-lifecycle] ingress Upgrade [Feature:IngressUpgrade] ingress upgrade should maintain a functioning ingress" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Projected should provide node allocatable (cpu) as default cpu limit if the limit is not set [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="8.264339174"></testcase>
+      <testcase name="[sig-storage] Pod Disks schedule pods each with a PD, delete pod and verify detach [Slow] for read-only PD with pod delete grace period of &#34;default (30s)&#34;" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Network Partition [Disruptive] [Slow] [k8s.io] [ReplicationController] should recreate pods scheduled on the unreachable node AND allow scheduling of pods on a node after it rejoins the cluster" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] [HPA] Horizontal pod autoscaling (scale resource: CPU) [sig-autoscaling] ReplicationController light Should scale from 2 pods to 1 pod" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] Should scale up GPU pool from 0 [GpuType:nvidia-tesla-k80] [Feature:ClusterSizeAutoscalingGpu]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] EmptyDir volumes should support (non-root,0666,default) [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="8.261998465"></testcase>
+      <testcase name="[sig-storage] ConfigMap should be consumable from pods in volume with mappings [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="8.25385899"></testcase>
+      <testcase name="[k8s.io] [Feature:Example] [k8s.io] CassandraStatefulSet should create statefulset" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cluster-lifecycle] [Feature:BootstrapTokens] should delete the signed bootstrap tokens from clusterInfo ConfigMap when bootstrap token is deleted" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] shouldn&#39;t add new node group if not needed [Feature:ClusterSizeAutoscalingScaleWithNAP]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Storage Policy Based Volume Provisioning [Feature:vsphere] verify an if a SPBM policy and VSAN capabilities cannot be honored for dynamically provisioned pvc using storageclass" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Pod Disks detach in a disrupted environment [Slow] [Disruptive] when pod is evicted" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cluster-lifecycle] Reboot [Disruptive] [Feature:Reboot] each node by dropping all inbound packets for a while and ensure they function afterwards" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [sig-node] Kubelet [Serial] [Slow] [k8s.io] [sig-node] regular resource usage tracking resource tracking for 0 pods per node" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Storage Policy Based Volume Provisioning [Feature:vsphere] verify VSAN storage capability with valid objectSpaceReservation and iopsLimit values is honored for dynamically provisioned pvc using storageclass" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] [HPA] Horizontal pod autoscaling (scale resource: CPU) [sig-autoscaling] [Serial] [Slow] ReplicaSet Should scale from 1 pod to 3 pods and from 3 to 5" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: emptyDir] should support non-existent path" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gluster] should support restarting containers using directory as subpath [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Projected should be consumable from pods in volume with defaultMode set [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="8.30164214"></testcase>
+      <testcase name="[sig-api-machinery] Downward API should provide host IP as an env var [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="8.502240061"></testcase>
+      <testcase name="[sig-api-machinery] Generated clientset should create pods, set the deletionTimestamp and deletionGracePeriodSeconds of the pod" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Garbage collector should delete RS created by deployment when not orphaning [Conformance]" classname="Kubernetes e2e suite" time="7.290051584"></testcase>
+      <testcase name="[k8s.io] Probing container with readiness probe that fails should never be ready and never restart [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="82.309101334"></testcase>
+      <testcase name="[sig-storage] Volume FStype [Feature:vsphere] verify fstype - ext3 formatted volume" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: hostPathSymlink] should fail if subpath with backstepping is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Services should be able to switch session affinity for LoadBalancer service with ESIPP on [Slow] [DisabledForLargeClusters]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Garbage collector should orphan pods created by rc if deleteOptions.OrphanDependents is nil" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Kubectl apply should apply a new configuration to an existing RC" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: emptyDir] should support restarting containers using file as subpath [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] Should scale down GPU pool from 1 [GpuType:nvidia-tesla-v100] [Feature:ClusterSizeAutoscalingGpu]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Networking Granular Checks: Services [Slow] should function for endpoint-Service: http" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cluster-lifecycle] Reboot [Disruptive] [Feature:Reboot] each node by ordering unclean reboot and ensure they function upon restart" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] SchedulerPredicates [Serial] validates that there is no conflict between pods with same hostPort but different hostIP and protocol" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Loadbalancing: L7 GCE [Slow] [Feature:Ingress] should conform to Ingress spec" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Deployment deployment should support proportional scaling" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] AdmissionWebhook Should not be able to prevent deleting validating-webhook-configurations or mutating-webhook-configurations" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Daemon set [Serial] should rollback without unnecessary restarts [Conformance]" classname="Kubernetes e2e suite" time="6.238627006">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [Feature:Example] [k8s.io] Downward API should create a pod that prints his name and namespace" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-auth] [Feature:NodeAuthorizer] Getting an existing configmap should exit with the Forbidden error" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] ResourceQuota should verify ResourceQuota with terminating scopes." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] DNS should provide DNS for the cluster  [Conformance]" classname="Kubernetes e2e suite" time="21.954662844"></testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: hostPathSymlink] should support existing directory" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: hostPath] should unmount if pod is force deleted while kubelet is down [Disruptive][Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: nfs] should support restarting containers using directory as subpath [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: hostPath] should fail if subpath file is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [sig-node] Kubelet [Serial] [Slow] [k8s.io] [sig-node] regular resource usage tracking resource tracking for 100 pods per node" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Job should run a job to completion when tasks succeed" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Services should be able to create an internal type load balancer [Slow] [DisabledForLargeClusters]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Watchers should be able to restart watching from the last resource version observed by the previous watch [Conformance]" classname="Kubernetes e2e suite" time="6.283636164"></testcase>
+      <testcase name="[sig-network] Loadbalancing: L7 GCE [Slow] [Feature:Ingress] should create ingress with backend HTTPS" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [Feature:Example] [k8s.io] Secret should create a pod that reads a secret" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] StatefulSet [k8s.io] Basic StatefulSet functionality [StatefulSetBasic] should provide basic identity" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volume Placement should create and delete pod with multiple volumes from different datastore" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Deployment deployment reaping should cascade to its replica sets and pods" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Projected should provide container&#39;s memory request [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="8.417841355"></testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: hostPathSymlink] should fail for new directories when readOnly specified in the volumeSource" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Pods should get a host IP [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="24.304376329"></testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: nfsPVC] should support file as subpath" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-instrumentation] Logging soak [Performance] [Slow] [Disruptive] should survive logging 1KB every 1s seconds, for a duration of 2m0s, scaling up to 1 pods per node" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Cluster size autoscaler scalability [Slow] should scale up twice [Feature:ClusterAutoscalerScalability2]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-instrumentation] [Feature:PrometheusMonitoring] Prometheus should scrape container metrics from all nodes." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Node Poweroff [Feature:vsphere] [Slow] [Disruptive] verify volume status after node power off" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Downward API volume should update labels on modification [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="28.783684061"></testcase>
+      <testcase name="[sig-network] NetworkPolicy NetworkPolicy between server and client should allow ingress access on one named port [Feature:NetworkPolicy]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Deployment deployment should support rollover" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-instrumentation] Stackdriver Monitoring should run Stackdriver Metadata Agent [Feature:StackdriverMetadataAgent]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: dir-link-bindmounted] Two pods mounting a local volume at the same time should be able to write from pod1 and read from pod2" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] StatefulSet [k8s.io] Basic StatefulSet functionality [StatefulSetBasic] should perform rolling updates and roll backs of template modifications [Conformance]" classname="Kubernetes e2e suite" time="168.813020784"></testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: nfsPVC] should support restarting containers using file as subpath [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: dir-link-bindmounted] Set fsGroup for local volume should set different fsGroup for second pod if first pod is deleted" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volume Disk Format [Feature:vsphere] verify disk format type - thin is honored for dynamically provisioned pv using storageclass" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] EmptyDir volumes should support (non-root,0777,tmpfs) [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="8.299663874"></testcase>
+      <testcase name="[sig-storage] ConfigMap optional updates should be reflected in volume [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="115.250007544"></testcase>
+      <testcase name="[sig-api-machinery] Namespaces [Serial] should always delete fast (ALL of 100 namespaces in 150 seconds) [Feature:ComprehensiveNamespaceDraining]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] DisruptionController evictions: enough pods, replicaSet, percentage =&gt; should allow an eviction" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scalability] Density [Feature:HighDensityPerformance] should allow starting 95 pods per node using { ReplicationController} with 0 secrets, 0 configmaps and 0 daemons" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Loadbalancing: L7 GCE [Slow] [Feature:NEG] rolling update backend pods should not cause service disruption" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Services should check NodePort out-of-range" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl Port forwarding [k8s.io] With a server listening on 0.0.0.0 [k8s.io] that expects a client request should support a client that connects, sends NO DATA, and disconnects" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Downward API should provide default limits.cpu/memory from node allocatable [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="8.353688845"></testcase>
+      <testcase name="[sig-api-machinery] Secrets should be consumable via the environment [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="10.320737412"></testcase>
+      <testcase name="[sig-api-machinery] Garbage collector should delete pods created by rc when not orphaning [Conformance]" classname="Kubernetes e2e suite" time="16.310427297"></testcase>
+      <testcase name="[sig-scheduling] SchedulerPreemption [Serial] [Feature:PodPreemption] validates basic preemption works" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Projected should be consumable in multiple volumes in the same pod [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="8.372720789"></testcase>
+      <testcase name="[sig-apps] DisruptionController evictions: too few pods, absolute =&gt; should not allow an eviction" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] EmptyDir wrapper volumes should not cause race condition when used for git_repo [Serial] [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes:vsphere should test that a file written to the vspehre volume mount before kubelet restart can be read after restart [Disruptive]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Initializers [Feature:Initializers] don&#39;t cause replicaset controller creating extra pods if the initializer is not handled [Serial]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] ConfigMap should be consumable from pods in volume as non-root with FSGroup [NodeFeature:FSGroup]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] SchedulerPredicates [Serial] validates that taints-tolerations is respected if matching" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Namespaces [Serial] should ensure that all pods are removed when a namespace is deleted." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Verify Volume Attach Through vpxd Restart [Feature:vsphere][Serial][Disruptive] verify volume remains attached through vpxd restart" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] NFSPersistentVolumes[Disruptive][Flaky] when kubelet restarts Should test that a volume mounted to a pod that is force deleted while the kubelet is down unmounts when the kubelet returns." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Loadbalancing: L7 GCE [Slow] [Feature:Ingress] should support multiple TLS certs" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] GenericPersistentVolume[Disruptive] When kubelet restarts Should test that a file written to the mount before kubelet restart is readable after restart." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Downward API volume should update annotations on modification [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="29.105536863"></testcase>
+      <testcase name="[sig-storage] ConfigMap binary data should be reflected in volume [NodeConformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes [Feature:LabelSelector] [sig-storage] Selector-Label Volume Binding:vsphere should bind volume with claim for given label" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Flexvolumes [Disruptive] should be mountable when non-attachable" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: dir-link-bindmounted] Two pods mounting a local volume one after the other should be able to write from pod1 and read from pod2" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: hostPath] should fail for new directories when readOnly specified in the volumeSource" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Initializers [Feature:Initializers] should be invisible to controllers by default" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] should disable node pool autoscaling [Feature:ClusterSizeAutoscalingScaleUp]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [sig-node] Security Context [Feature:SecurityContext] should support volume SELinux relabeling" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] StatefulSet [k8s.io] Basic StatefulSet functionality [StatefulSetBasic] Should recreate evicted statefulset [Conformance]" classname="Kubernetes e2e suite" time="28.981103406"></testcase>
+      <testcase name="[sig-api-machinery] ConfigMap should be consumable via the environment [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="8.28542858"></testcase>
+      <testcase name="[sig-network] Loadbalancing: L7 GCE [Slow] [Feature:kubemci] should remove clusters as expected" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] should be able to scale down by draining multiple pods one by one as dictated by pdb[Feature:ClusterSizeAutoscalingScaleDown]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gluster] should support existing directories when readOnly specified in the volumeSource" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Kubectl run CronJob should create a CronJob" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] ConfigMap should be consumable from pods in volume with defaultMode set [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="8.31486656"></testcase>
+      <testcase name="[sig-api-machinery] AdmissionWebhook Should unconditionally reject operations on fail closed webhook" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] InitContainer [NodeConformance] should not start app containers if init containers fail on a RestartAlways pod" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gluster] should support existing single file" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-instrumentation] Stackdriver Monitoring should have accelerator metrics [Feature:StackdriverAcceleratorMonitoring]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] Rescheduler [Serial] should ensure that critical pod is scheduled in case there is no resources available" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes:vsphere should test that deleting a PVC before the pod does not cause pod deletion to fail on vsphere volume detach" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl Port forwarding [k8s.io] With a server listening on localhost should support forwarding over websockets" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Kubectl run deployment should create a deployment from an image  [Conformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: dir] Two pods mounting a local volume one after the other should be able to write from pod1 and read from pod2" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volume Placement should create and delete pod with the same volume source attach/detach to different worker nodes" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gcePDPartitioned] should support existing single file" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Kubectl version should check is all data is printed  [Conformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] NetworkPolicy NetworkPolicy between server and client should enforce policy based on PodSelector [Feature:NetworkPolicy]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Networking Granular Checks: Pods should function for intra-pod communication: http [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="45.31820213"></testcase>
+      <testcase name="[sig-storage] EmptyDir volumes should support (root,0777,default) [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="8.328446574"></testcase>
+      <testcase name="[sig-network] Proxy version v1 should proxy logs on node with explicit kubelet port using proxy subresource  [Conformance]" classname="Kubernetes e2e suite" time="6.42746154"></testcase>
+      <testcase name="[sig-storage] Downward API volume should provide node allocatable (memory) as default memory limit if the limit is not set [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="10.345401723"></testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: nfs] should fail if subpath with backstepping is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Downward API [Serial] [Disruptive] [NodeFeature:EphemeralStorage] Downward API tests for local ephemeral storage should provide container&#39;s limits.ephemeral-storage and requests.ephemeral-storage as env vars" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] Multi-AZ Clusters should spread the pods of a replication controller across zones" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Loadbalancing: L7 GCE [Slow] [Feature:Ingress] should update ingress while sync failures occur on other ingresses" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Networking IPerf IPv6 [Experimental] [Feature:Networking-IPv6] [Slow] [Feature:Networking-Performance] should transfer ~ 1GB onto the service endpoint 1 servers (maximum of 1 clients)" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] NetworkPolicy NetworkPolicy between server and client should enforce policy based on NamespaceSelector [Feature:NetworkPolicy]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes NFS with multiple PVs and PVCs all in same ns should create 3 PVs and 3 PVCs: test write access" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] ESIPP [Slow] [DisabledForLargeClusters] should only target nodes with endpoints" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] DisruptionController evictions: no PDB =&gt; should allow an eviction" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volumes ConfigMap should be mountable" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Kubectl rolling-update should support rolling-update to same image  [Conformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Pod Disks schedule a pod w/ RW PD(s) mounted to 1 or more containers, write to PD, verify content, delete pod, and repeat in rapid succession [Slow] using 1 containers and 2 PDs" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Network Partition [Disruptive] [Slow] [k8s.io] [StatefulSet] should not reschedule stateful pods if there is a network partition [Slow] [Disruptive]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [sig-node] Events should be sent by kubelets and the scheduler about pods scheduling and running  [Conformance]" classname="Kubernetes e2e suite" time="28.259313755"></testcase>
+      <testcase name="[k8s.io] [sig-node] Security Context [Feature:SecurityContext] should support seccomp alpha runtime/default annotation [Feature:Seccomp]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] should scale up correct target pool [Feature:ClusterSizeAutoscalingScaleUp]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: gce-localssd-scsi-fs] [Serial] Set fsGroup for local volume should set fsGroup for one pod" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Variable Expansion should allow substituting values in a volume subpath [Feature:VolumeSubpathEnvExpansion][NodeAlphaFeature:VolumeSubpathEnvExpansion]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] NetworkPolicy NetworkPolicy between server and client should allow egress access on one named port [Feature:NetworkPolicy]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Garbage collector should orphan pods created by rc if delete options say so [Conformance]" classname="Kubernetes e2e suite" time="46.28491817"></testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: dir-link] Two pods mounting a local volume at the same time should be able to write from pod1 and read from pod2" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] stateful Upgrade [Feature:StatefulUpgrade] [k8s.io] stateful upgrade should maintain a functioning cluster" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] should correctly scale down after a node is not needed [Feature:ClusterSizeAutoscalingScaleDown]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gluster] should support creating multiple subpath from same volumes [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Networking Granular Checks: Pods should function for intra-pod communication: udp [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="43.312598058"></testcase>
+      <testcase name="[k8s.io] [Feature:Example] [k8s.io] Hazelcast should create and scale hazelcast" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath Atomic writer volumes should support subpaths with downward pod" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] EmptyDir wrapper volumes should not conflict" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Mounted volume expand[Slow] Should verify mounted devices can be resized" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: hostPath] should support creating multiple subpath from same volumes [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Projected should be consumable from pods in volume with mappings and Item mode set [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="8.322695885"></testcase>
+      <testcase name="[sig-network] Service endpoints latency should not be very high  [Conformance]" classname="Kubernetes e2e suite" time="33.024969476"></testcase>
+      <testcase name="[sig-network] Proxy version v1 should proxy logs on node using proxy subresource  [Conformance]" classname="Kubernetes e2e suite" time="6.421838666"></testcase>
+      <testcase name="[sig-network] Firewall rule should have correct firewall rules for e2e cluster" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] ResourceQuota should create a ResourceQuota and capture the life of a pod." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Daemon set [Serial] should not update pod when spec was updated and update strategy is OnDelete" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: block] [Feature:BlockVolume] Set fsGroup for local volume should set same fsGroup for two pods simultaneously" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cluster-lifecycle] Nodes [Disruptive] Resize [Slow] should be able to delete nodes" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: nfs] should fail if non-existent subpath is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: block] [Feature:BlockVolume] Set fsGroup for local volume should not set different fsGroups for two pods simultaneously" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Services should be able to change the type and ports of a service [Slow] [DisabledForLargeClusters]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Garbage collector should support cascading deletion of custom resources" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] EmptyDir volumes when FSGroup is specified [NodeFeature:FSGroup] volume on tmpfs should have the correct mode using FSGroup" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Servers with support for API chunking should return chunks of results for list calls" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: dir] Set fsGroup for local volume should not set different fsGroups for two pods simultaneously" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Kubectl replace should update a single-container pod&#39;s image  [Conformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: hostPathSymlink] should fail if subpath directory is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Namespaces [Serial] should ensure that all services are removed when a namespace is deleted." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] ConfigMap should be consumable from pods in volume with mappings and Item mode set [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="8.259556755"></testcase>
+      <testcase name="[sig-apps] ReplicaSet should adopt matching pods on creation and release no longer matching pods" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] EmptyDir volumes should support (root,0666,default) [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="8.306652895"></testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: dir-link] Two pods mounting a local volume one after the other should be able to write from pod1 and read from pod2" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Deployment iterative rollouts should eventually progress" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Networking should provide Internet connection for containers [Feature:Networking-IPv6][Experimental]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] SchedulerPriorities [Serial] Pod should be schedule to node that don&#39;t match the PodAntiAffinity terms" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gcePDPVC] should support restarting containers using file as subpath [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gcePDPVC] should support readOnly directory specified in the volumeMount" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] DNS configMap nameserver Forward external name lookup should forward externalname lookup to upstream nameserver [Slow][Serial]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] SchedulerPreemption [Serial] [Feature:PodPreemption] validates lower priority pod preemption by critical pod" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-auth] PodSecurityPolicy should allow pods under the privileged policy.PodSecurityPolicy" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Simple pod should support inline execution and attach" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] PodPriorityResolution [Serial] [Feature:PodPreemption] validates critical system priorities are created and resolved" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Pod Disks schedule pods each with a PD, delete pod and verify detach [Slow] for read-only PD with pod delete grace period of &#34;immediate (0s)&#34;" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Secrets should be consumable from pods in volume with mappings [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="8.390996821"></testcase>
+      <testcase name="[sig-apps] ReplicationController should adopt matching pods on creation" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: emptyDir] should support creating multiple subpath from same volumes [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gluster] should fail for new directories when readOnly specified in the volumeSource" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Services should serve a basic endpoint from pods  [Conformance]" classname="Kubernetes e2e suite" time="27.328844142"></testcase>
+      <testcase name="[sig-scalability] Load capacity [Feature:ManualPerformance] should be able to handle 30 pods per node {extensions Deployment} with 0 secrets, 0 configmaps and 0 daemons" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Garbage collector should not be blocked by dependency circle [Conformance]" classname="Kubernetes e2e suite" time="11.359758758"></testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: tmpfs] Two pods mounting a local volume at the same time should be able to write from pod1 and read from pod2" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] AdmissionWebhook Should mutate pod and apply defaults after mutation" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Downward API volume should provide podname as non-root with fsgroup [NodeFeature:FSGroup]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cluster-lifecycle] HA-master [Feature:HAMaster] survive addition/removal replicas multizone workers [Serial][Disruptive]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Projected should be consumable from pods in volume with defaultMode set [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="10.316296847"></testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: dir-link-bindmounted] Set fsGroup for local volume should set fsGroup for one pod" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] should scale up when non expendable pod is created [Feature:ClusterSizeAutoscalingScaleUp]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Services should be able to switch session affinity for service with type clusterIP" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Pods should be submitted and removed [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="13.48548838"></testcase>
+      <testcase name="[sig-network] NetworkPolicy NetworkPolicy between server and client should support a &#39;default-deny&#39; policy [Feature:NetworkPolicy]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] SchedulerPriorities [Serial] Pod should perfer to scheduled to nodes pod can tolerate" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [sig-node] kubelet [k8s.io] [sig-node] host cleanup with volume mounts [sig-storage][HostCleanup][Flaky] Host cleanup after disrupting NFS volume [NFS] after stopping the nfs-server and deleting the (sleeping) client pod, the NFS mount and the pod&#39;s UID directory should be removed." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath Atomic writer volumes should support subpaths with configmap pod" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes [Feature:ReclaimPolicy] [sig-storage] persistentvolumereclaim:vsphere should delete persistent volume when reclaimPolicy set to delete and associated claim is deleted" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Loadbalancing: L7 GCE [Slow] [Feature:NEG] should be able to create a ClusterIP service [Unreleased]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Update Demo should create and stop a replication controller  [Conformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Servers with support for Table transformation should return a 406 for a backend which does not implement metadata" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] DaemonRestart [Disruptive] Kubelet should not restart containers across restart" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Projected should be consumable from pods in volume with mappings and Item Mode set [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="8.276915822"></testcase>
+      <testcase name="[sig-scalability] Density [Feature:ManualPerformance] should allow starting 50 pods per node using { ReplicationController} with 0 secrets, 0 configmaps and 0 daemons" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PVC Protection Verify &#34;immediate&#34; deletion of a PVC that is not in active use by a pod" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Projected should provide container&#39;s cpu request [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="8.324436023"></testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Simple pod should support port-forward" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] CronJob should schedule multiple jobs concurrently" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Docker Containers should be able to override the image&#39;s default arguments (docker cmd) [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="8.298950129"></testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gcePDPartitioned] should support restarting containers using file as subpath [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Downward API volume should provide container&#39;s memory limit [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="8.260078146"></testcase>
+      <testcase name="[sig-network] Networking Granular Checks: Services [Slow] should function for pod-Service: udp" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: dir-bindmounted] Set fsGroup for local volume should set fsGroup for one pod" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gcePDPartitioned] should support non-existent path" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] ConfigMap should be consumable from pods in volume with mappings as non-root [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="8.344221169"></testcase>
+      <testcase name="[sig-network] Services should use same NodePort with same port but different protocols" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Networking Granular Checks: Services [Slow] should function for client IP based session affinity: http" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gcePDPartitioned] should fail if subpath file is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Downward API should provide pod UID as env vars [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="8.357275162"></testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gcePDPVC] should support non-existent path" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volumes Azure Disk [Feature:Volumes] should be mountable [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: gce-localssd-scsi-fs] [Serial] Set fsGroup for local volume should not set different fsGroups for two pods simultaneously" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] StatefulSet [k8s.io] Basic StatefulSet functionality [StatefulSetBasic] should implement legacy replacement when the update strategy is OnDelete" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Networking should provide Internet connection for containers [Feature:Networking-IPv4]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Projected should be consumable from pods in volume as non-root with FSGroup [NodeFeature:FSGroup]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] ConfigMap updates should be reflected in volume [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="26.364124584"></testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gcePDPVC] should support restarting containers using directory as subpath [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] GKE node pools [Feature:GKENodePool] should create a cluster with multiple node pools [Feature:GKENodePool]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Services should be able to update NodePorts with two same port numbers but different protocols" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-auth] PodSecurityPolicy should enforce the restricted policy.PodSecurityPolicy" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: emptyDir] should unmount if pod is gracefully deleted while kubelet is down [Disruptive][Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] should increase cluster size if pod requesting EmptyDir volume is pending [Feature:ClusterSizeAutoscalingScaleUp]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Dynamic Provisioning DynamicProvisioner should not provision a volume in an unmanaged GCE zone." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Garbage collector should keep the rc around until all its pods are deleted if the deleteOptions says so [Conformance]" classname="Kubernetes e2e suite" time="12.468049965"></testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: emptyDir] should fail if non-existent subpath is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Network Partition [Disruptive] [Slow] [k8s.io] [StatefulSet] should come back up if node goes down [Slow] [Disruptive]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-instrumentation] Stackdriver Monitoring should run Custom Metrics - Stackdriver Adapter for external metrics [Feature:StackdriverExternalMetrics]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] should increase cluster size if pod requesting volume is pending [Feature:ClusterSizeAutoscalingScaleUp]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Kubectl create quota should create a quota with scopes" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Storage Policy Based Volume Provisioning [Feature:vsphere] verify VSAN storage capability with non-vsan datastore is not honored for dynamically provisioned pvc using storageclass" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Kubectl run job should create a job from an image when restart is OnFailure  [Conformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: nfs] should support file as subpath" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath Atomic writer volumes should support subpaths with secret pod" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volume FStype [Feature:vsphere] verify invalid fstype" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] ClusterDns [Feature:Example] should create pod that uses dns" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] should correctly scale down after a node is not needed when there is non autoscaled pool[Feature:ClusterSizeAutoscalingScaleDown]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Watchers should be able to start watching from a specific resource version [Conformance]" classname="Kubernetes e2e suite" time="6.341509067"></testcase>
+      <testcase name="[sig-scalability] Load capacity [Feature:ManualPerformance] should be able to handle 30 pods per node { ReplicationController} with 0 secrets, 0 configmaps and 0 daemons with quotas" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: nfsPVC] should support readOnly directory specified in the volumeMount" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] CronJob should not emit unexpected warnings" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Update Demo should do a rolling update of a replication controller  [Conformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] should increase cluster size if pods are pending due to host port conflict [Feature:ClusterSizeAutoscalingScaleUp]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] should increase cluster size if pending pods are small and there is another node pool that is not autoscaled [Feature:ClusterSizeAutoscalingScaleUp]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [Feature:Example] [k8s.io] RethinkDB should create and stop rethinkdb servers" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] ConfigMap should be consumable in multiple volumes in the same pod [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="8.25125882"></testcase>
+      <testcase name="[sig-storage] PVC Protection Verify that PVC in active use by a pod is not removed immediately" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] GenericPersistentVolume[Disruptive] When kubelet restarts Should test that a volume mounted to a pod that is force deleted while the kubelet is down unmounts when the kubelet returns." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] HostPath should support subPath [NodeConformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Projected should be consumable from pods in volume with mappings [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="8.42367762"></testcase>
+      <testcase name="[sig-instrumentation] Stackdriver Monitoring should run Custom Metrics - Stackdriver Adapter for new resource model [Feature:StackdriverCustomMetrics]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] should add new node and new node pool on too big pod, scale down to 1 and scale down to 0 [Feature:ClusterSizeAutoscalingScaleWithNAP]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Projected should update labels on modification [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="26.985959696"></testcase>
+      <testcase name="[sig-instrumentation] Stackdriver Monitoring should have cluster metrics [Feature:StackdriverMonitoring]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cluster-lifecycle] gpu Upgrade [Feature:GPUUpgrade] master upgrade should NOT disrupt gpu pod [Feature:GPUMasterUpgrade]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-auth] ServiceAccounts should allow opting out of API token automount  [Conformance]" classname="Kubernetes e2e suite" time="22.796687295"></testcase>
+      <testcase name="[sig-apps] StatefulSet [k8s.io] Basic StatefulSet functionality [StatefulSetBasic] should not deadlock when a pod&#39;s predecessor fails" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] should be able to scale down by draining system pods with pdb[Feature:ClusterSizeAutoscalingScaleDown]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Garbage collector should not delete dependents that have both valid owner and owner that&#39;s waiting for dependents to be deleted [Conformance]" classname="Kubernetes e2e suite" time="16.302105761"></testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] Should be able to scale a node group down to 0[Feature:ClusterSizeAutoscalingScaleDown]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Downward API volume should provide node allocatable (cpu) as default cpu limit if the limit is not set [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="8.262873714"></testcase>
+      <testcase name="[sig-storage] [Serial] Volume metrics PVController should create unbound pvc count metrics for pvc controller after creating pvc only" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] NFSPersistentVolumes[Disruptive][Flaky] when kubelet restarts Should test that a file written to the mount before kubelet restart is readable after restart." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: nfsPVC] should fail if subpath file is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Kubectl apply apply set/view last-applied" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scalability] Density [Feature:ManualPerformance] should allow starting 100 pods per node using { ReplicationController} with 0 secrets, 0 configmaps and 0 daemons" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] [HPA] Horizontal pod autoscaling (scale resource: Custom Metrics from Stackdriver) should scale down with Custom Metric of type Object from Stackdriver [Feature:CustomMetricsAutoscaling]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Deployment RollingUpdateDeployment should delete old pods and create new ones" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Loadbalancing: L7 GCE [Slow] [Feature:kubemci] should create ingress with backend HTTPS" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scalability] Density [Feature:ManualPerformance] should allow starting 30 pods per node using {extensions Deployment} with 0 secrets, 2 configmaps and 0 daemons" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [sig-node] Security Context [Feature:SecurityContext] should support seccomp alpha unconfined annotation on the pod [Feature:Seccomp]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Services should be able to change the type from ClusterIP to ExternalName" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Node Unregister [Feature:vsphere] [Slow] [Disruptive] node unregister" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gluster] should fail if subpath with backstepping is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] CronJob should remove from active list jobs that have been deleted" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Projected should set mode on item file [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="8.344224786"></testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: blockfs] Two pods mounting a local volume one after the other should be able to write from pod1 and read from pod2" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  Pod with node different from PV&#39;s NodeAffinity should fail scheduling due to different NodeAffinity" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] Should not scale GPU pool up if pod does not require GPUs [GpuType:nvidia-tesla-p100] [Feature:ClusterSizeAutoscalingGpu]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Pod Disks detach in a disrupted environment [Slow] [Disruptive] when node is deleted" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] [HPA] Horizontal pod autoscaling (scale resource: Custom Metrics from Stackdriver) should scale down with Custom Metric of type Pod from Stackdriver with Prometheus [Feature:CustomMetricsAutoscaling]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] SchedulerPredicates [Serial] validates MaxPods limit number of pods that are allowed to run [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: nfs] should fail if subpath file is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: nfs] should support restarting containers using file as subpath [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Loadbalancing: L7 GCE [Slow] [Feature:Ingress] multicluster ingress should get instance group annotation" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Aggregator Should be able to support the 1.7 Sample API Server using the current Aggregator" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-instrumentation] Cluster level logging implemented by Stackdriver should ingest logs" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Pods should cap back-off at MaxContainerBackOff [Slow][NodeConformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Pod Disks schedule a pod w/ RW PD(s) mounted to 1 or more containers, write to PD, verify content, delete pod, and repeat in rapid succession [Slow] using 4 containers and 1 PDs" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Networking Granular Checks: Services [Slow] should function for pod-Service: http" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [sig-node] SSH should SSH to all nodes and run commands" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volumes PD should be mountable with ext3" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] Should scale up GPU pool from 1 [GpuType:nvidia-tesla-v100] [Feature:ClusterSizeAutoscalingGpu]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scalability] Density [Feature:ManualPerformance] should allow starting 30 pods per node using {extensions Deployment} with 2 secrets, 0 configmaps and 0 daemons" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Services should only allow access from service loadbalancer source ranges [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: hostPath] should fail if non-existent subpath is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Dynamic Provisioning Block volume provisioning [Feature:BlockVolume] should create and delete block persistent volumes" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Loadbalancing: L7 [Slow] Nginx should conform to Ingress spec" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] EmptyDir volumes should support (root,0777,tmpfs) [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="8.320953934"></testcase>
+      <testcase name="[sig-storage] Volumes PD should be mountable with ext4" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Storage Policy Based Volume Provisioning [Feature:vsphere] verify VSAN storage capability with invalid hostFailuresToTolerate value is not honored for dynamically provisioned pvc using storageclass" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: nfs] should unmount if pod is gracefully deleted while kubelet is down [Disruptive][Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-instrumentation] Cluster level logging implemented by Stackdriver should ingest system logs from all nodes [Feature:StackdriverLogging]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [sig-node] Security Context [Feature:SecurityContext] should support container.SecurityContext.RunAsUser" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] ConfigMap should be consumable from pods in volume as non-root with defaultMode and fsGroup set [NodeFeature:FSGroup]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-auth] [Feature:NodeAuthorizer] Getting a secret for a workload the node has access to should succeed" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volume plugin streaming [Slow] GlusterFS should write files of various sizes, verify size, validate content" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Pod Disks schedule pods each with a PD, delete pod and verify detach [Slow] for RW PD with pod delete grace period of &#34;default (30s)&#34;" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Storage Policy Based Volume Provisioning [Feature:vsphere] verify clean up of stale dummy VM for dynamically provisioned pvc using SPBM policy" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Sysctls [NodeFeature:Sysctls] should support unsafe sysctls which are actually whitelisted" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] AdmissionWebhook Should deny crd creation" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [Feature:Example] [k8s.io] Liveness liveness pods should be automatically restarted" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] vsphere cloud provider stress [Feature:vsphere] vsphere stress tests" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Docker Containers should use the image defaults if command and args are blank [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="8.368762038"></testcase>
+      <testcase name="[sig-apps] CronJob should delete successful finished jobs with limit of one successful job" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: gce-localssd-scsi-fs] [Serial] Two pods mounting a local volume at the same time should be able to write from pod1 and read from pod2" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] Shouldn&#39;t perform scale up operation and should list unhealthy status if most of the cluster is broken[Feature:ClusterSizeAutoscalingScaleUp]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes NFS when invoking the Recycle reclaim policy should test that a PV becomes Available and is clean after the PVC is deleted." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] EmptyDir volumes should support (non-root,0666,tmpfs) [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="8.51623032"></testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: block] [Feature:BlockVolume] Set fsGroup for local volume should set fsGroup for one pod" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] should increase cluster size if pods are pending due to pod anti-affinity [Feature:ClusterSizeAutoscalingScaleUp]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-instrumentation] [Feature:PrometheusMonitoring] Prometheus should scrape metrics from annotated services." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: nfs] should fail if subpath directory is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Garbage collector should orphan RS created by deployment when deleteOptions.PropagationPolicy is Orphan [Conformance]" classname="Kubernetes e2e suite" time="36.729329665"></testcase>
+      <testcase name="[k8s.io] Variable Expansion should allow substituting values in a container&#39;s command [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="8.27234755"></testcase>
+      <testcase name="[sig-storage] Volume plugin streaming [Slow] iSCSI [Feature:Volumes] should write files of various sizes, verify size, validate content" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: nfs] should support readOnly directory specified in the volumeMount" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] [Serial] Volume metrics PVController should create bound pv/pvc count metrics for pvc controller after creating both pv and pvc" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: dir-link-bindmounted] One pod requesting one prebound PVC should be able to mount volume and write from pod1" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: nfsPVC] should support restarting containers using directory as subpath [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] CronJob should replace jobs when ReplaceConcurrent" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volumes PD should be mountable with xfs" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Job should delete a job" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Kubectl patch should add annotations for pods in rc  [Conformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] Should scale down GPU pool from 1 [GpuType:nvidia-tesla-p100] [Feature:ClusterSizeAutoscalingGpu]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Networking should provide unchanging, static URL paths for kubernetes api services" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: blockfs] Two pods mounting a local volume at the same time should be able to write from pod1 and read from pod2" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] [HPA] Horizontal pod autoscaling (scale resource: Custom Metrics from Stackdriver) should scale down with External Metric with target value from Stackdriver [Feature:CustomMetricsAutoscaling]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [sig-node] AppArmor load AppArmor profiles can disable an AppArmor profile, using unconfined" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: blockfs] Set fsGroup for local volume should set same fsGroup for two pods simultaneously" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes [Feature:ReclaimPolicy] [sig-storage] persistentvolumereclaim:vsphere should not detach and unmount PV when associated pvc with delete as reclaimPolicy is deleted when it is in use by the pod" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Pods should allow activeDeadlineSeconds to be updated [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="12.985273709"></testcase>
+      <testcase name="[sig-network] Networking Granular Checks: Services [Slow] should update nodePort: udp [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volume Provisioning On Clustered Datastore [Feature:vsphere] verify dynamic provision with default parameter on clustered datastore" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scalability] Density [Feature:Performance] should allow starting 30 pods per node using { ReplicationController} with 0 secrets, 0 configmaps and 0 daemons" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] EmptyDir volumes should support (root,0666,tmpfs) [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="8.394793407"></testcase>
+      <testcase name="[sig-storage] Storage Policy Based Volume Provisioning [Feature:vsphere] verify if a non-existing SPBM policy is not honored for dynamically provisioned pvc using storageclass" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Dynamic Provisioning DynamicProvisioner Default should be disabled by removing the default annotation [Serial] [Disruptive]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Loadbalancing: L7 GCE [Slow] [Feature:kubemci] single and multi-cluster ingresses should be able to exist together" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cluster-lifecycle] HA-master [Feature:HAMaster] survive addition/removal replicas same zone [Serial][Disruptive]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] EmptyDir volumes volume on default medium should have the correct mode [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="8.454151491"></testcase>
+      <testcase name="[sig-scheduling] SchedulerPredicates [Serial] validates that NodeAffinity is respected if not matching" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Daemon set [Serial] should update pod when spec was updated and update strategy is RollingUpdate [Conformance]" classname="Kubernetes e2e suite" time="42.212596614"></testcase>
+      <testcase name="[sig-autoscaling] DNS horizontal autoscaling [Serial] [Slow] kube-dns-autoscaler should scale kube-dns pods when cluster size changed" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: dir-link-bindmounted] One pod requesting one prebound PVC should be able to mount volume and read from pod1" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volumes iSCSI [Feature:Volumes] should be mountable" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volume Provisioning On Clustered Datastore [Feature:vsphere] verify static provisioning on clustered datastore" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: emptyDir] should support existing single file" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [sig-node] Security Context [Feature:SecurityContext] should support pod.Spec.SecurityContext.SupplementalGroups" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [sig-node] kubelet [k8s.io] [sig-node] host cleanup with volume mounts [sig-storage][HostCleanup][Flaky] Host cleanup after disrupting NFS volume [NFS] after stopping the nfs-server and deleting the (active) client pod, the NFS mount and the pod&#39;s UID directory should be removed." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Simple pod should return command exit codes" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] ReplicationController should release no longer matching pods" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  Local volume provisioner [Serial] should discover dynamicly created local persistent volume mountpoint in discovery directory" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-instrumentation] Cluster level logging using Elasticsearch [Feature:Elasticsearch] should check that logs from containers are ingested into Elasticsearch" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: nfsPVC] should fail if non-existent subpath is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Loadbalancing: L7 GCE [Slow] [Feature:NEG] should sync endpoints to NEG" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Downward API volume should provide container&#39;s memory request [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="8.339972944"></testcase>
+      <testcase name="[sig-scalability] Density [Feature:ManualPerformance] should allow starting 3 pods per node using { ReplicationController} with 0 secrets, 0 configmaps and 0 daemons" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: nfsPVC] should support existing single file" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volume expand [Slow] Verify if editing PVC allows resize" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] EmptyDir volumes when FSGroup is specified [NodeFeature:FSGroup] volume on default medium should have the correct mode using FSGroup" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Services should have session affinity work for LoadBalancer service with ESIPP off [Slow] [DisabledForLargeClusters]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: nfs] should support creating multiple subpath from same volumes [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Kubectl logs should be able to retrieve and filter logs  [Conformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] HostPath should support r/w [NodeConformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] Should scale up GPU pool from 1 [GpuType:nvidia-tesla-p100] [Feature:ClusterSizeAutoscalingGpu]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] GKE local SSD [Feature:GKELocalSSD] should write and read from node local SSD [Feature:GKELocalSSD]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: dir-link] Set fsGroup for local volume should set same fsGroup for two pods simultaneously" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] NFSPersistentVolumes[Disruptive][Flaky] when kubelet restarts Should test that a volume mounted to a pod that is deleted while the kubelet is down unmounts when the kubelet returns." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Simple pod should support exec through kubectl proxy" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] EmptyDir volumes should support (root,0644,default) [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="8.26487227"></testcase>
+      <testcase name="[sig-storage] Volume Provisioning on Datastore [Feature:vsphere] verify dynamically provisioned pv using storageclass fails on an invalid datastore" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Network Partition [Disruptive] [Slow] [k8s.io] [ReplicationController] should eagerly create replacement pod during network partition when termination grace is non-zero" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gluster] should fail if subpath directory is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Downward API volume should provide podname only [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="8.338097143"></testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: tmpfs] One pod requesting one prebound PVC should be able to mount volume and read from pod1" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-auth] ServiceAccounts should ensure a single API token exists" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] Multi-AZ Cluster Volumes [sig-storage] should schedule pods in the same zones as statically provisioned PVs" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cluster-lifecycle] etcd Upgrade [Feature:EtcdUpgrade] etcd upgrade should maintain a functioning cluster" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Projected should set DefaultMode on files [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="8.304079781"></testcase>
+      <testcase name="[sig-storage] Volume plugin streaming [Slow] Ceph-RBD [Feature:Volumes] should write files of various sizes, verify size, validate content" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] EmptyDir volumes should support (non-root,0777,default) [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="8.407380344"></testcase>
+      <testcase name="[k8s.io] [sig-node] kubelet [k8s.io] [sig-node] Clean up pods on node kubelet should be able to delete 10 pods per node in 1m0s." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: dir-bindmounted] One pod requesting one prebound PVC should be able to mount volume and write from pod1" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: nfsPVC] should support existing directories when readOnly specified in the volumeSource" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Networking Granular Checks: Services [Slow] should function for node-Service: udp" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Simple pod should support exec through an HTTP proxy" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Storage Policy Based Volume Provisioning [Feature:vsphere] verify VSAN storage capability with invalid diskStripes value is not honored for dynamically provisioned pvc using storageclass" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Probing container should have monotonically increasing restart count [Slow][NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="157.301839735"></testcase>
+      <testcase name="[sig-network] Networking Granular Checks: Services [Slow] should function for client IP based session affinity: udp" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-instrumentation] MetricsGrabber should grab all metrics from a ControllerManager." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: dir] Set fsGroup for local volume should set same fsGroup for two pods simultaneously" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gcePDPartitioned] should unmount if pod is gracefully deleted while kubelet is down [Disruptive][Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Loadbalancing: L7 GCE [Slow] [Feature:Ingress] should create ingress with pre-shared certificate" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gcePDPartitioned] should fail if subpath with backstepping is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] DaemonRestart [Disruptive] Controller Manager should not create/delete replicas across restart" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Generated clientset should create v1beta1 cronJobs, delete cronJobs, watch cronJobs" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gcePDPVC] should unmount if pod is gracefully deleted while kubelet is down [Disruptive][Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-instrumentation] Cadvisor should be healthy on every node." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Regional PD RegionalPD should failover to a different zone when all nodes in one zone become unreachable [Slow] [Disruptive]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Secrets should be consumable from pods in volume with defaultMode set [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="8.391607178"></testcase>
+      <testcase name="[sig-scheduling] SchedulerPredicates [Serial] validates that there exists conflict between pods with same hostPort and protocol but one using 0.0.0.0 hostIP" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  Local volume provisioner [Serial] should not create local persistent volume for filesystem volume that was not bind mounted" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] vcp-performance [Feature:vsphere] vcp performance tests" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: blockfs] Set fsGroup for local volume should not set different fsGroups for two pods simultaneously" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-auth] PodSecurityPolicy should forbid pod creation when no PSP is available" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes NFS with Single PV - PVC pairs create a PV and a pre-bound PVC: test write access" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [Feature:Example] [k8s.io] Spark should start spark master, driver and workers" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes NFS with Single PV - PVC pairs create a PVC and a pre-bound PV: test write access" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] shouldn&#39;t scale up if cores limit too low, should scale up after limit is changed [Feature:ClusterSizeAutoscalingScaleWithNAP]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] SchedulerPredicates [Serial] validates that required NodeAffinity setting is respected if matching" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Pod Disks schedule pods each with a PD, delete pod and verify detach [Slow] for RW PD with pod delete grace period of &#34;immediate (0s)&#34;" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Storage Policy Based Volume Provisioning [Feature:vsphere] verify if a SPBM policy is not honored on a non-compatible datastore for dynamically provisioned pvc using storageclass" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Cluster size autoscaler scalability [Slow] shouldn&#39;t scale down with underutilized nodes due to host port conflicts [Feature:ClusterAutoscalerScalability5]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: dir-bindmounted] One pod requesting one prebound PVC should be able to mount volume and read from pod1" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: dir-link-bindmounted] Set fsGroup for local volume should set same fsGroup for two pods simultaneously" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] [HPA] Horizontal pod autoscaling (scale resource: Custom Metrics from Stackdriver) should scale down with Custom Metric of type Pod from Stackdriver [Feature:CustomMetricsAutoscaling]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Garbage collector should delete jobs and pods created by cronjob" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes GCEPD should test that deleting the PV before the pod does not cause pod deletion to fail on PD detach" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Projected optional updates should be reflected in volume [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="26.7952882"></testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gcePDPVC] should support existing directory" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: nfsPVC] should support creating multiple subpath from same volumes [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gluster] should support non-existent path" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Dynamic Provisioning DynamicProvisioner deletion should be idempotent" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: tmpfs] Set fsGroup for local volume should set same fsGroup for two pods simultaneously" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cluster-lifecycle] Reboot [Disruptive] [Feature:Reboot] each node by dropping all outbound packets for a while and ensure they function afterwards" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: nfsPVC] should support non-existent path" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: emptyDir] should support readOnly directory specified in the volumeMount" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Projected should be consumable from pods in volume as non-root [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="8.306235976"></testcase>
+      <testcase name="[sig-apps] ReplicationController should serve a basic image on each replica with a public image  [Conformance]" classname="Kubernetes e2e suite" time="16.504361504"></testcase>
+      <testcase name="[sig-storage] Ephemeralstorage When pod refers to non-existent ephemeral storage should allow deletion of pod with invalid volume : projected" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: hostPath] should support readOnly directory specified in the volumeMount" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] DNS configMap nameserver Change stubDomain should be able to change stubDomain configuration [Slow][Serial]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cluster-lifecycle] [Feature:BootstrapTokens] should sign the new added bootstrap tokens" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Downward API should provide pod name, namespace and IP address as env vars [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="8.25738345"></testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] shouldn&#39;t scale down when non expendable pod is running [Feature:ClusterSizeAutoscalingScaleDown]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Pod Disks detach in a disrupted environment [Slow] [Disruptive] when node&#39;s API object is deleted" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gcePDPVC] should fail if subpath with backstepping is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gcePDPartitioned] should fail if non-existent subpath is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] ResourceQuota should create a ResourceQuota and capture the life of a replication controller." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Job should run a job to completion when tasks sometimes fail and are locally restarted" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [sig-node] Security Context [Feature:SecurityContext] should support pod.Spec.SecurityContext.RunAsUser And pod.Spec.SecurityContext.RunAsGroup [Feature:RunAsGroup]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Networking Granular Checks: Services [Slow] should function for endpoint-Service: udp" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volume Operations Storm [Feature:vsphere] should create pod with many volumes and verify no attach call fails" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Deployment RecreateDeployment should delete old pods and create new ones" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: nfs] should support existing single file" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] Multi-AZ Cluster Volumes [sig-storage] should only be allowed to provision PDs in zones where nodes exist" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: tmpfs] Set fsGroup for local volume should not set different fsGroups for two pods simultaneously" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [sig-node] Security Context [Feature:SecurityContext] should support seccomp default which is unconfined [Feature:Seccomp]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] vcp at scale [Feature:vsphere]  vsphere scale tests" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl Port forwarding [k8s.io] With a server listening on localhost [k8s.io] that expects a client request should support a client that connects, sends NO DATA, and disconnects" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: dir] Set fsGroup for local volume should set different fsGroup for second pod if first pod is deleted" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Networking Granular Checks: Services [Slow] should update endpoints: udp" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volumes Ceph RBD [Feature:Volumes] should be mountable" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: blockfs] One pod requesting one prebound PVC should be able to mount volume and write from pod1" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Variable Expansion should fail substituting values in a volume subpath with backticks [Feature:VolumeSubpathEnvExpansion][NodeAlphaFeature:VolumeSubpathEnvExpansion][Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Networking Granular Checks: Pods should function for node-pod communication: http [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="41.122768133"></testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: nfs] should unmount if pod is force deleted while kubelet is down [Disruptive][Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Secrets should be consumable from pods in volume as non-root with defaultMode and fsGroup set [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="8.320783263"></testcase>
+      <testcase name="[sig-cluster-lifecycle] Nodes [Disruptive] Resize [Slow] should be able to add nodes" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Services [Feature:GCEAlphaFeature][Slow] should be able to create and tear down a standard-tier load balancer [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Services should preserve source pod IP for traffic thru service cluster IP" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes GCEPD should test that deleting the Namespace of a PVC and Pod causes the successful detach of Persistent Disk" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-ui] Kubernetes Dashboard should check that the kubernetes-dashboard instance is alive" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Kubectl cluster-info should check if Kubernetes master services is included in cluster-info  [Conformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Services should prevent NodePort collisions" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] DisruptionController should create a PodDisruptionBudget" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes NFS with Single PV - PVC pairs should create a non-pre-bound PV and PVC: test write access " classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Projected should be consumable from pods in volume [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="8.293224147"></testcase>
+      <testcase name="[k8s.io] Cluster size autoscaler scalability [Slow] CA ignores unschedulable pods while scheduling schedulable pods [Feature:ClusterAutoscalerScalability6]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] KubeletManagedEtcHosts should test kubelet managed /etc/hosts file [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="58.691645978"></testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: block] [Feature:BlockVolume] Set fsGroup for local volume should set different fsGroup for second pod if first pod is deleted" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Kubectl taint [Serial] should remove all the taints with the same key off a node" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Projected should update annotations on modification [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="28.916715035"></testcase>
+      <testcase name="[sig-storage] Projected should be consumable in multiple volumes in a pod [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="8.278001996"></testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gluster] should support existing directory" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] [HPA] Horizontal pod autoscaling (scale resource: Custom Metrics from Stackdriver) should scale up with two External metrics from Stackdriver [Feature:CustomMetricsAutoscaling]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] DNS configMap federations should be able to change federation configuration [Slow][Serial]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Garbage collector should support orphan deletion of custom resources" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Flexvolumes [Disruptive] should install plugin without kubelet restart" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] [HPA] Horizontal pod autoscaling (scale resource: CPU) [sig-autoscaling] [Serial] [Slow] ReplicationController Should scale from 5 pods to 3 pods and from 3 to 1 and verify decision stability" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: hostPath] should unmount if pod is gracefully deleted while kubelet is down [Disruptive][Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: dir-bindmounted] Two pods mounting a local volume one after the other should be able to write from pod1 and read from pod2" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: nfsPVC] should support existing directory" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Variable Expansion should allow composing env vars into new env vars [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="8.311846018"></testcase>
+      <testcase name="[sig-apps] Deployment test Deployment ReplicaSet orphaning and adoption regarding controllerRef" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [sig-node] Security Context [Feature:SecurityContext] should support volume SELinux relabeling when using hostPID" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Secrets should be able to mount in a volume regardless of a different secret existing with same name in different namespace [NodeConformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Services should serve multiport endpoints from pods  [Conformance]" classname="Kubernetes e2e suite" time="27.450047939"></testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: gce-localssd-scsi-fs] [Serial] Set fsGroup for local volume should set same fsGroup for two pods simultaneously" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Dynamic Provisioning DynamicProvisioner should provision storage with different parameters [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: hostPathSymlink] should fail if non-existent subpath is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] ConfigMap should be consumable via environment variable [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="8.343835712"></testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: hostPathSymlink] should support creating multiple subpath from same volumes [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] Should scale up GPU pool from 1 [GpuType:nvidia-tesla-k80] [Feature:ClusterSizeAutoscalingGpu]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Services should be able to change the type from ExternalName to NodePort" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Storage Policy Based Volume Provisioning [Feature:vsphere] verify VSAN storage capability with invalid capability name objectSpaceReserve is not honored for dynamically provisioned pvc using storageclass" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] InitContainer [NodeConformance] should not start app containers and fail the pod if init containers fail on a RestartNever pod" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Simple pod should support exec" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] ResourceQuota should create a ResourceQuota and ensure its status is promptly calculated." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] ConfigMap should be consumable from pods in volume with mappings as non-root with FSGroup [NodeFeature:FSGroup]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Probing container should be restarted with a exec &#34;cat /tmp/health&#34; liveness probe [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="60.489238425"></testcase>
+      <testcase name="[sig-storage] [Serial] Volume metrics should create prometheus metrics for volume provisioning and attach/detach" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-auth] Certificates API should support building a client with a CSR" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] GCP Volumes NFSv4 should be mountable for NFSv4" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] EmptyDir volumes when FSGroup is specified [NodeFeature:FSGroup] new files should be created with FSGroup ownership when container is non-root" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: hostPath] should fail if subpath directory is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Kubectl label should update the label on a resource  [Conformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Projected should be consumable from pods in volume [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="8.263638138"></testcase>
+      <testcase name="[sig-storage] [Serial] Volume metrics should create volume metrics with the correct PVC ref" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Services should have session affinity work for NodePort service" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: hostPathSymlink] should unmount if pod is gracefully deleted while kubelet is down [Disruptive][Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] should be able to scale down when rescheduling a pod is required and pdb allows for it[Feature:ClusterSizeAutoscalingScaleDown]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-auth] [Feature:NodeAuthorizer] A node shouldn&#39;t be able to delete another node" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Kubectl apply should reuse port when apply to an existing SVC" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [sig-node] Security Context [Feature:SecurityContext] should support container.SecurityContext.RunAsUser And container.SecurityContext.RunAsGroup [Feature:RunAsGroup]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Dynamic Provisioning [k8s.io] GlusterDynamicProvisioner should create and delete persistent volumes [fast]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] StatefulSet [k8s.io] Basic StatefulSet functionality [StatefulSetBasic] Scaling should happen in predictable order and halt if any stateful pod is unhealthy [Conformance]" classname="Kubernetes e2e suite" time="372.969462759"></testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gcePDPVC] should fail if subpath directory is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  StatefulSet with pod anti-affinity should use volumes spread across nodes" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Simple pod should handle in-cluster config" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Projected should be consumable from pods in volume as non-root with defaultMode and fsGroup set [NodeFeature:FSGroup]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl Port forwarding [k8s.io] With a server listening on 0.0.0.0 [k8s.io] that expects a client request should support a client that connects, sends DATA, and disconnects" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] ReplicaSet should serve a basic image on each replica with a private image" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Sysctls [NodeFeature:Sysctls] should reject invalid sysctls" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volume Attach Verify [Feature:vsphere][Serial][Disruptive] verify volume remains attached after master kubelet restart" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gluster] should fail if subpath file is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] HostPath should give a volume the correct mode [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="8.281110482"></testcase>
+      <testcase name="[k8s.io] [sig-node] Pods Extended [k8s.io] Delete Grace Period should be submitted and removed  [Flaky] [Conformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cluster-lifecycle] kube-proxy migration [Feature:KubeProxyDaemonSetMigration] Upgrade kube-proxy from static pods to a DaemonSet should maintain a functioning cluster [Feature:KubeProxyDaemonSetUpgrade]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  Local volume that cannot be mounted [Slow] should fail due to non-existent path" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volumes Cinder [Feature:Volumes] should be mountable" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gluster] should fail if non-existent subpath is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volume Placement test back to back pod creation and deletion with different volume sources on the same worker node" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] Should scale up GPU pool from 0 [GpuType:nvidia-tesla-p100] [Feature:ClusterSizeAutoscalingGpu]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [sig-node] PreStop should call prestop when killing a pod  [Conformance]" classname="Kubernetes e2e suite" time="51.41866757"></testcase>
+      <testcase name="[sig-instrumentation] MetricsGrabber should grab all metrics from API server." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: gce-localssd-scsi-fs] [Serial] One pod requesting one prebound PVC should be able to mount volume and write from pod1" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Docker Containers should be able to override the image&#39;s default command and arguments [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="8.33434461"></testcase>
+      <testcase name="[sig-storage] Volume Placement should create and delete pod with multiple volumes from same datastore" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: block] [Feature:BlockVolume] One pod requesting one prebound PVC should be able to mount volume and write from pod1" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: dir-link] One pod requesting one prebound PVC should be able to mount volume and read from pod1" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] LimitRange should create a LimitRange with defaults and ensure pod has those defaults applied." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Watchers should observe add, update, and delete watch notifications on configmaps [Conformance]" classname="Kubernetes e2e suite" time="66.417154266"></testcase>
+      <testcase name="[k8s.io] [Feature:Example] [k8s.io] Redis should create and stop redis servers" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] Should not scale GPU pool up if pod does not require GPUs [GpuType:nvidia-tesla-v100] [Feature:ClusterSizeAutoscalingGpu]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] [Feature:ClusterSizeAutoscalingScaleUp] [Slow] Autoscaling [sig-autoscaling] Autoscaling a service from 1 pod and 3 nodes to 8 pods and &gt;=4 nodes takes less than 15 minutes" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Storage Policy Based Volume Provisioning [Feature:vsphere] verify an existing and compatible SPBM policy is honored for dynamically provisioned pvc using storageclass" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Projected should be consumable from pods in volume with mappings as non-root [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="8.307814949"></testcase>
+      <testcase name="[sig-autoscaling] [HPA] Horizontal pod autoscaling (scale resource: Custom Metrics from Stackdriver) should scale down with External Metric with target average value from Stackdriver [Feature:CustomMetricsAutoscaling]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] StatefulSet [k8s.io] Basic StatefulSet functionality [StatefulSetBasic] Burst scaling should run to completion even with unhealthy pods [Conformance]" classname="Kubernetes e2e suite" time="60.207326887"></testcase>
+      <testcase name="[sig-cluster-lifecycle] HA-master [Feature:HAMaster] survive addition/removal replicas different zones [Serial][Disruptive]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Job should exceed active deadline" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] AdmissionWebhook Should be able to deny custom resource creation" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes NFS with Single PV - PVC pairs create a PVC and non-pre-bound PV: test write access" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-instrumentation] Kibana Logging Instances Is Alive [Feature:Elasticsearch] should check that the Kibana logging instance is alive" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volume plugin streaming [Slow] NFS should write files of various sizes, verify size, validate content" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] GenericPersistentVolume[Disruptive] When kubelet restarts Should test that a volume mounted to a pod that is deleted while the kubelet is down unmounts when the kubelet returns." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] ESIPP [Slow] [DisabledForLargeClusters] should handle updates to ExternalTrafficPolicy field" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: emptyDir] should unmount if pod is force deleted while kubelet is down [Disruptive][Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: nfsPVC] should unmount if pod is gracefully deleted while kubelet is down [Disruptive][Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: hostPath] should support readOnly file specified in the volumeMount" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] ResourceQuota should create a ResourceQuota and capture the life of a secret." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Projected should provide podname only [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="8.312412236"></testcase>
+      <testcase name="[sig-scheduling] SchedulerPredicates [Serial] validates local ephemeral storage resource limits of pods that are allowed to run [Feature:LocalStorageCapacityIsolation]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Loadbalancing: L7 GCE [Slow] [Feature:Ingress] should be able to switch between HTTPS and HTTP2 modes" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Secrets should be consumable from pods in volume with mappings and Item Mode set [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="8.310692151"></testcase>
+      <testcase name="[k8s.io] [Feature:Example] [k8s.io] Cassandra should create and scale cassandra" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scalability] Load capacity [Feature:ManualPerformance] should be able to handle 30 pods per node { Random} with 0 secrets, 0 configmaps and 0 daemons" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] EmptyDir volumes should support (root,0644,tmpfs) [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="8.369400044"></testcase>
+      <testcase name="[sig-cli] Kubectl Port forwarding [k8s.io] With a server listening on 0.0.0.0 should support forwarding over websockets" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Loadbalancing: L7 GCE [Slow] [Feature:kubemci] should conform to Ingress spec" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Kubectl expose should create services for rc  [Conformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] SchedulerPredicates [Serial] validates resource limits of pods that are allowed to run  [Conformance]" classname="Kubernetes e2e suite" time="85.677705053"></testcase>
+      <testcase name="[sig-scalability] Density [Feature:ManualPerformance] should allow starting 30 pods per node using {batch Job} with 0 secrets, 0 configmaps and 0 daemons" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] DisruptionController evictions: maxUnavailable allow single eviction, percentage =&gt; should allow an eviction" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Projected optional updates should be reflected in volume [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="26.725020575"></testcase>
+      <testcase name="[sig-auth] [Feature:NodeAuthorizer] Getting an existing secret should exit with the Forbidden error" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Proxy version v1 should proxy through a service and a pod  [Conformance]" classname="Kubernetes e2e suite" time="12.615144036"></testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: block] [Feature:BlockVolume] One pod requesting one prebound PVC should be able to mount volume and read from pod1" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [sig-node] Security Context [Feature:SecurityContext] should support pod.Spec.SecurityContext.RunAsUser" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: nfsPVC] should fail for new directories when readOnly specified in the volumeSource" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] DNS should provide DNS for ExternalName services" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] EquivalenceCache [Serial] validates pod affinity works properly when new replica pod is scheduled" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] ESIPP [Slow] [DisabledForLargeClusters] should work for type=LoadBalancer" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gcePDPartitioned] should support file as subpath" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] HostPath should support existing directory subPath" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] EmptyDir volumes volume on tmpfs should have the correct mode [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="8.487794647"></testcase>
+      <testcase name="[sig-instrumentation] Stackdriver Monitoring should run Custom Metrics - Stackdriver Adapter for old resource model [Feature:StackdriverCustomMetrics]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Flexvolumes [Disruptive] should be mountable when attachable" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] shouldn&#39;t be able to scale down when rescheduling a pod is required, but pdb doesn&#39;t allow drain[Feature:ClusterSizeAutoscalingScaleDown]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Pods should contain environment variables for services [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="26.26762374"></testcase>
+      <testcase name="[sig-network] Services should be able to switch session affinity for LoadBalancer service with ESIPP off [Slow] [DisabledForLargeClusters]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Probing container should be restarted with a /healthz http liveness probe [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="26.415458429"></testcase>
+      <testcase name="[sig-api-machinery] Servers with support for Table transformation should return generic metadata details across all namespaces for nodes" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scalability] Load capacity [Feature:ManualPerformance] should be able to handle 30 pods per node {extensions Deployment} with 0 secrets, 2 configmaps and 0 daemons" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: nfs] should fail for new directories when readOnly specified in the volumeSource" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: hostPathSymlink] should support restarting containers using directory as subpath [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Secrets optional updates should be reflected in volume [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="97.732288338"></testcase>
+      <testcase name="[sig-storage] EmptyDir volumes when FSGroup is specified [NodeFeature:FSGroup] new files should be created with FSGroup ownership when container is root" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] StatefulSet [k8s.io] Deploy clustered applications [Feature:StatefulSet] [Slow] should creating a working mysql cluster" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes NFS with multiple PVs and PVCs all in same ns should create 2 PVs and 4 PVCs: test write access" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gcePDPartitioned] should support creating multiple subpath from same volumes [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] vsphere statefulset vsphere statefulset testing" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] DaemonRestart [Disruptive] Scheduler should continue assigning pods to nodes across restart" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Services should work after restarting apiserver [Disruptive]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: block] [Feature:BlockVolume] Two pods mounting a local volume one after the other should be able to write from pod1 and read from pod2" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] ResourceQuota should create a ResourceQuota and capture the life of a persistent volume claim. [sig-storage]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] should increase cluster size if pending pods are small [Feature:ClusterSizeAutoscalingScaleUp]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] CSI Volumes CSI plugin test using CSI driver: [Feature: GCE PD CSI Plugin] gcePD should provision storage" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gcePDPVC] should fail if non-existent subpath is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Kubectl create quota should create a quota without scopes" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Dynamic Provisioning DynamicProvisioner should test that deleting a claim before the volume is provisioned deletes the volume." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] [HPA] Horizontal pod autoscaling (scale resource: CPU) [sig-autoscaling] [Serial] [Slow] Deployment Should scale from 5 pods to 3 pods and from 3 to 1" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scalability] Load capacity [Feature:Performance] should be able to handle 30 pods per node { ReplicationController} with 0 secrets, 0 configmaps and 0 daemons" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] GCP Volumes NFSv3 should be mountable for NFSv3" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] should correctly scale down after a node is not needed and one node is broken [Feature:ClusterSizeAutoscalingScaleDown]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-service-catalog] [Feature:PodPreset] PodPreset should not modify the pod on conflict" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] SchedulerPredicates [Serial] validates that NodeSelector is respected if not matching  [Conformance]" classname="Kubernetes e2e suite" time="83.49776909"></testcase>
+      <testcase name="[sig-api-machinery] Watchers should observe an object deletion if it stops meeting the requirements of the selector [Conformance]" classname="Kubernetes e2e suite" time="16.248881858"></testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: block] [Feature:BlockVolume] Two pods mounting a local volume at the same time should be able to write from pod1 and read from pod2" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cluster-lifecycle] Reboot [Disruptive] [Feature:Reboot] each node by triggering kernel panic and ensure they function upon restart" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] Should be able to scale a node group up from 0[Feature:ClusterSizeAutoscalingScaleUp]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [sig-node] Mount propagation should propagate mounts to the host" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] ResourceQuota should verify ResourceQuota with best effort scope." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] SchedulerPredicates [Serial] validates that taints-tolerations is respected if not matching" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Services should create endpoints for unready pods" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Storage Policy Based Volume Provisioning [Feature:vsphere] verify VSAN storage capability with valid diskStripes and objectSpaceReservation values and a VSAN datastore is honored for dynamically provisioned pvc using storageclass" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scalability] Density [Feature:ManualPerformance] should allow starting 30 pods per node using { ReplicationController} with 0 secrets, 0 configmaps and 0 daemons with quotas" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Dynamic Provisioning DynamicProvisioner External should let an external dynamic provisioner create and delete persistent volumes [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: hostPathSymlink] should support non-existent path" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: emptyDir] should support restarting containers using directory as subpath [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes NFS with multiple PVs and PVCs all in same ns should create 4 PVs and 2 PVCs: test write access [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Cluster size autoscaler scalability [Slow] should scale down empty nodes [Feature:ClusterAutoscalerScalability3]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: hostPathSymlink] should support readOnly file specified in the volumeMount" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Projected updates should be reflected in volume [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="26.355625435"></testcase>
+      <testcase name="[sig-cluster-lifecycle] [Feature:BootstrapTokens] should resign the bootstrap tokens when the clusterInfo ConfigMap updated [Serial][Disruptive]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Ephemeralstorage When pod refers to non-existent ephemeral storage should allow deletion of pod with invalid volume : configmap" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cluster-lifecycle] Upgrade [Feature:Upgrade] node upgrade should maintain a functioning cluster [Feature:NodeUpgrade]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] ResourceQuota should create a ResourceQuota and capture the life of a persistent volume claim with a storage class. [sig-storage]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scalability] Load capacity [Feature:ManualPerformance] should be able to handle 30 pods per node {extensions Deployment} with 2 secrets, 0 configmaps and 0 daemons" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Kubectl create quota should reject quota with invalid scopes" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Secrets should be consumable in multiple volumes in a pod [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="8.304213913"></testcase>
+      <testcase name="[sig-network] Loadbalancing: L7 GCE [Slow] [Feature:kubemci] should create ingress with pre-shared certificate" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Dynamic Provisioning DynamicProvisioner should provision storage with non-default reclaim policy Retain" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  Pod with node different from PV&#39;s NodeAffinity should fail scheduling due to different NodeSelector" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: emptyDir] should support existing directory" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volume Disk Size [Feature:vsphere] verify dynamically provisioned pv using storageclass with an invalid disk size fails" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Sysctls [NodeFeature:Sysctls] should not launch unsafe, but not explicitly enabled sysctls on the node" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cluster-lifecycle] Restart [Disruptive] should restart all nodes and ensure all nodes and pods recover" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scalability] Empty [Feature:Empty] starts a pod" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Projected should be consumable from pods in volume with mappings as non-root with FSGroup [NodeFeature:FSGroup]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Job should run a job to completion when tasks sometimes fail and are not locally restarted" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gcePDPartitioned] should fail for new directories when readOnly specified in the volumeSource" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] NetworkPolicy NetworkPolicy between server and client should enforce policy based on Ports [Feature:NetworkPolicy]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  Local volume that cannot be mounted [Slow] should fail due to wrong node" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cluster-lifecycle] gpu Upgrade [Feature:GPUUpgrade] cluster upgrade should be able to run gpu pod after upgrade [Feature:GPUClusterUpgrade]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] [HPA] Horizontal pod autoscaling (scale resource: CPU) [sig-autoscaling] [Serial] [Slow] Deployment Should scale from 1 pod to 3 pods and from 3 to 5" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: hostPath] should support non-existent path" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-instrumentation] [Feature:PrometheusMonitoring] Prometheus should successfully scrape all targets" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Update Demo should scale a replication controller  [Conformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: hostPathSymlink] should unmount if pod is force deleted while kubelet is down [Disruptive][Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Downward API volume should provide podname as non-root with fsgroup and defaultMode [NodeFeature:FSGroup]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volumes CephFS [Feature:Volumes] should be mountable" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] DNS should support configurable pod resolv.conf" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PVC Protection Verify that scheduling of a pod that uses PVC that is being deleted fails and the pod becomes Unschedulable" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-instrumentation] Monitoring should verify monitoring pods and all cluster nodes are available on influxdb using heapster [Feature:InfluxdbMonitoring]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Storage Policy Based Volume Provisioning [Feature:vsphere] verify VSAN storage capability with valid hostFailuresToTolerate and cacheReservation values is honored for dynamically provisioned pvc using storageclass" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath Atomic writer volumes should support subpaths with projected pod" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] ReplicationController should serve a basic image on each replica with a private image" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Regional PD RegionalPD should provision storage [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Network Partition [Disruptive] [Slow] [k8s.io] [Job] should create new pods when node is partitioned" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PV Protection Verify that PV bound to a PVC is not removed immediately" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Network Partition [Disruptive] [Slow] [k8s.io] Pods should return to running and ready state after network partition is healed All pods on the unreachable node should be marked as NotReady upon the node turn NotReady AND all pods should be mark back to Ready when the node get back to Ready before pod eviction timeout" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: hostPathSymlink] should support existing directories when readOnly specified in the volumeSource" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gcePDPVC] should fail for new directories when readOnly specified in the volumeSource" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: dir-link] One pod requesting one prebound PVC should be able to mount volume and write from pod1" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Daemon set [Serial] should run and stop complex daemon [Conformance]" classname="Kubernetes e2e suite" time="27.078813444"></testcase>
+      <testcase name="[sig-apps] Deployment deployment should support rollback" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Daemon set [Serial] should retry creating failed daemon pods [Conformance]" classname="Kubernetes e2e suite" time="20.023150229"></testcase>
+      <testcase name="[k8s.io] InitContainer [NodeConformance] should invoke init containers on a RestartAlways pod" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [sig-node] AppArmor load AppArmor profiles should enforce an AppArmor profile" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] Should scale down GPU pool from 1 [GpuType:nvidia-tesla-k80] [Feature:ClusterSizeAutoscalingGpu]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Loadbalancing: L7 GCE [Slow] [Feature:NEG] should conform to Ingress spec" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] InitContainer [NodeConformance] should invoke init containers on a RestartNever pod" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Projected should provide container&#39;s memory limit [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="8.259893823"></testcase>
+      <testcase name="[sig-apps] CronJob should not schedule new jobs when ForbidConcurrent [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Probing container should be restarted with a docker exec liveness probe with timeout " classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volumes GlusterFS should be mountable" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Downward API volume should set DefaultMode on files [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="8.2640945"></testcase>
+      <testcase name="[sig-scheduling] SchedulerPredicates [Serial] validates that NodeSelector is respected if matching  [Conformance]" classname="Kubernetes e2e suite" time="88.554076241"></testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gcePDPVC] should support file as subpath" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Initializers [Feature:Initializers] will be set to nil if a patch removes the last pending initializer" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gluster] should support file as subpath" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Guestbook application should create and stop a working application  [Conformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] [Feature:PerformanceDNS] Should answer DNS query for maximum number of services per cluster" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Downward API should provide container&#39;s limits.cpu/memory and requests.cpu/memory as env vars [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="8.288220849"></testcase>
+      <testcase name="[k8s.io] Probing container with readiness probe should not be ready before initial delay and never restart [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="46.406087555"></testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: dir-link] Set fsGroup for local volume should set fsGroup for one pod" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [sig-node] Security Context [Feature:SecurityContext] should support volume SELinux relabeling when using hostIPC" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-instrumentation] Cluster level logging implemented by Stackdriver should ingest events" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] ConfigMap should be consumable from pods in volume as non-root [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="8.359013607"></testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: nfs] should support existing directory" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] ResourceQuota [Feature:Initializers] should create a ResourceQuota and capture the life of an uninitialized pod." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Servers with support for Table transformation should return chunks of table results for list calls" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] DisruptionController evictions: maxUnavailable deny evictions, integer =&gt; should not allow an eviction" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: gce-localssd-scsi-fs] [Serial] One pod requesting one prebound PVC should be able to mount volume and read from pod1" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volume Provisioning On Clustered Datastore [Feature:vsphere] verify dynamic provision with spbm policy on clustered datastore" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Pods should support retrieving logs from the container over websockets [NodeConformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Pods should support remote command execution over websockets [NodeConformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-instrumentation] MetricsGrabber should grab all metrics from a Scheduler." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Proxy server should support --unix-socket=/path  [Conformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Networking Granular Checks: Services [Slow] should update nodePort: http [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: emptyDir] should support readOnly file specified in the volumeMount" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] CustomResourceDefinition Watch CustomResourceDefinition Watch watch on custom resource definition objects" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Dynamic Provisioning DynamicProvisioner should provision storage with mount options" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] Should not scale GPU pool up if pod does not require GPUs [GpuType:nvidia-tesla-k80] [Feature:ClusterSizeAutoscalingGpu]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Kubectl run pod should create a pod from an image when restart is Never  [Conformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] shouldn&#39;t trigger additional scale-ups during processing scale-up [Feature:ClusterSizeAutoscalingScaleUp]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] EmptyDir volumes when FSGroup is specified [NodeFeature:FSGroup] nonexistent volume subPath should have the correct mode and owner using FSGroup" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Downward API volume should provide container&#39;s cpu request [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="8.309261838"></testcase>
+      <testcase name="[sig-storage] Volumes NFS should be mountable" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Loadbalancing: L7 GCE [Slow] [Feature:kubemci] should support https-only annotation" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] Should scale up GPU pool from 0 [GpuType:nvidia-tesla-v100] [Feature:ClusterSizeAutoscalingGpu]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [sig-node] Kubelet [Serial] [Slow] [k8s.io] [sig-node] experimental resource usage tracking [Feature:ExperimentalResourceUsageTracking] resource tracking for 100 pods per node" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: gce-localssd-scsi-fs] [Serial] Set fsGroup for local volume should set different fsGroup for second pod if first pod is deleted" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Dynamic Provisioning DynamicProvisioner Default should be disabled by changing the default annotation [Serial] [Disruptive]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] NFSPersistentVolumes[Disruptive][Flaky] when kube-controller-manager restarts should delete a bound PVC from a clientPod, restart the kube-control-manager, and ensure the kube-controller-manager does not crash" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] [HPA] Horizontal pod autoscaling (scale resource: CPU) [sig-autoscaling] [Serial] [Slow] ReplicaSet Should scale from 5 pods to 3 pods and from 3 to 1" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scalability] Load capacity [Feature:ManualPerformance] should be able to handle 30 pods per node { Random} with 0 secrets, 0 configmaps and 0 daemons with quotas" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: dir] Set fsGroup for local volume should set fsGroup for one pod" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: emptyDir] should fail for new directories when readOnly specified in the volumeSource" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] EquivalenceCache [Serial] validates GeneralPredicates is properly invalidated when a pod is scheduled [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] shouldn&#39;t increase cluster size if pending pod is too large [Feature:ClusterSizeAutoscalingScaleUp]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gcePDPartitioned] should support existing directory" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: hostPathSymlink] should support existing single file" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+  </testsuite>

--- a/v1.11/gardener-aws/version.txt
+++ b/v1.11/gardener-aws/version.txt
@@ -1,0 +1,2 @@
+Client Version: version.Info{Major:"1", Minor:"11", GitVersion:"v1.11.0", GitCommit:"91e7b4fd31fcd3d5f436da26c980becec37ceefe", GitTreeState:"clean", BuildDate:"2018-06-27T20:17:28Z", GoVersion:"go1.10.2", Compiler:"gc", Platform:"linux/amd64"}
+Server Version: version.Info{Major:"1", Minor:"11", GitVersion:"v1.11.0", GitCommit:"91e7b4fd31fcd3d5f436da26c980becec37ceefe", GitTreeState:"clean", BuildDate:"2018-06-27T20:08:34Z", GoVersion:"go1.10.2", Compiler:"gc", Platform:"linux/amd64"}

--- a/v1.11/gardener-azure/PRODUCT.yaml
+++ b/v1.11/gardener-azure/PRODUCT.yaml
@@ -1,0 +1,8 @@
+vendor: SAP
+name: Gardener (https://github.com/gardener/gardener) shoot cluster deployed on Microsoft Azure
+version: 0.8.0
+website_url: https://gardener.cloud
+documentation_url: https://github.com/gardener/documentation/wiki
+product_logo_url: https://raw.githubusercontent.com/gardener/documentation/master/images/logo_w_saplogo.svg
+type: installer
+description: The Gardener implements automated management and operation of Kubernetes clusters as a service and aims to support that service on multiple Cloud providers.

--- a/v1.11/gardener-azure/README.md
+++ b/v1.11/gardener-azure/README.md
@@ -1,0 +1,43 @@
+# To reproduce:
+
+## Create Kubernetes Cluster
+
+Login to SAP Gardener Dashboard to create a Kubernetes Clusters on Amazon Web Services, Microsoft Azure, Google Cloud Platform, or OpenStack cloud provider.
+
+After the creation completed, copy the cluster's kubeconfig, which is provided by the Gardener Dashboard in the cluster's detail view, to ~/.kube/config and launch the Kubernetes E2E conformance tests.
+
+## Launch E2E Conformance Tests
+1. Launch e2e pod and sonobuoy master under namespace `sonobuoy`   
+    ```shell
+    curl -L https://raw.githubusercontent.com/cncf/k8s-conformance/master/sonobuoy-conformance.yaml | kubectl apply -f -
+    ```
+
+2. Check logs of `sonobuoy` pod to see when test can be finished   
+Run
+
+    ```shell
+    kubectl logs -f -n sonobuoy sonobuoy
+    ```
+    and wait for line `no-exit was specified, sonobuoy is now blocking`.
+
+3. Use `kubectl cp` to copy the results to the client   
+Get the name of the <result archive> from the log output in step 2.
+
+    ```shell
+    kubectl cp sonobuoy/sonobuoy:/tmp/sonobuoy/<result archive> /home/result
+    ```
+
+4. Delete the conformance test resources
+
+    ```shell
+    curl -L https://raw.githubusercontent.com/cncf/k8s-conformance/master/sonobuoy-conformance.yaml | kubectl delete -f -
+    ```
+
+5. Untar the tarball
+
+    ```shell
+    cd /home/result
+    tar -xzf *_sonobuoy_*.tar.gz
+    ```
+
+    The result files `e2e.log` and `junit_01.xml` are located in the in the directory `plugins/e2e/results/`.

--- a/v1.11/gardener-azure/e2e.log
+++ b/v1.11/gardener-azure/e2e.log
@@ -1,0 +1,7541 @@
+Jul  2 12:54:51.361: INFO: Overriding default scale value of zero to 1
+Jul  2 12:54:51.361: INFO: Overriding default milliseconds value of zero to 5000
+I0702 12:54:51.485344      15 test_context.go:382] Using a temporary kubeconfig file from in-cluster config : /tmp/kubeconfig-324782104
+I0702 12:54:51.485494      15 e2e.go:333] Starting e2e run "1be2c1b4-7df7-11e8-8e15-aefe7bc77cc2" on Ginkgo node 1
+Running Suite: Kubernetes e2e suite
+===================================
+Random Seed: 1530536091 - Will randomize all specs
+Will run 144 of 998 specs
+
+Jul  2 12:54:51.547: INFO: >>> kubeConfig: /tmp/kubeconfig-324782104
+Jul  2 12:54:51.549: INFO: Waiting up to 30m0s for all (but 0) nodes to be schedulable
+Jul  2 12:54:51.566: INFO: Waiting up to 10m0s for all pods (need at least 0) in namespace 'kube-system' to be running and ready
+Jul  2 12:54:51.597: INFO: 14 / 14 pods in namespace 'kube-system' are running and ready (0 seconds elapsed)
+Jul  2 12:54:51.598: INFO: expected 8 pod replicas in namespace 'kube-system', 8 are Running and Ready.
+Jul  2 12:54:51.632: INFO: Waiting for pods to enter Success, but no pods in "kube-system" match label map[name:e2e-image-puller]
+Jul  2 12:54:51.632: INFO: Dumping network health container logs from all nodes to file /tmp/results/nethealth.txt
+Jul  2 12:54:51.636: INFO: e2e test version: v1.11.0
+Jul  2 12:54:51.637: INFO: kube-apiserver version: v1.11.0
+[sig-storage] EmptyDir volumes 
+  should support (non-root,0666,tmpfs) [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-storage] EmptyDir volumes
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 12:54:51.637: INFO: >>> kubeConfig: /tmp/kubeconfig-324782104
+STEP: Building a namespace api object
+Jul  2 12:54:51.771: INFO: No PodSecurityPolicies found; assuming PodSecurityPolicy is disabled.
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should support (non-root,0666,tmpfs) [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating a pod to test emptydir 0666 on tmpfs
+Jul  2 12:54:51.786: INFO: Waiting up to 5m0s for pod "pod-1c2a727e-7df7-11e8-8e15-aefe7bc77cc2" in namespace "e2e-tests-emptydir-kzns6" to be "success or failure"
+Jul  2 12:54:51.789: INFO: Pod "pod-1c2a727e-7df7-11e8-8e15-aefe7bc77cc2": Phase="Pending", Reason="", readiness=false. Elapsed: 2.699503ms
+Jul  2 12:54:53.832: INFO: Pod "pod-1c2a727e-7df7-11e8-8e15-aefe7bc77cc2": Phase="Pending", Reason="", readiness=false. Elapsed: 2.045463222s
+Jul  2 12:54:55.835: INFO: Pod "pod-1c2a727e-7df7-11e8-8e15-aefe7bc77cc2": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.048923219s
+STEP: Saw pod success
+Jul  2 12:54:55.835: INFO: Pod "pod-1c2a727e-7df7-11e8-8e15-aefe7bc77cc2" satisfied condition "success or failure"
+Jul  2 12:54:55.931: INFO: Trying to get logs from node shoot--core--confaz-worker-qfmi9-79968b77d9-kcr6j pod pod-1c2a727e-7df7-11e8-8e15-aefe7bc77cc2 container test-container: <nil>
+STEP: delete the pod
+Jul  2 12:54:56.121: INFO: Waiting for pod pod-1c2a727e-7df7-11e8-8e15-aefe7bc77cc2 to disappear
+Jul  2 12:54:56.132: INFO: Pod pod-1c2a727e-7df7-11e8-8e15-aefe7bc77cc2 no longer exists
+[AfterEach] [sig-storage] EmptyDir volumes
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 12:54:56.132: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-emptydir-kzns6" for this suite.
+Jul  2 12:55:02.150: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 12:55:02.176: INFO: namespace: e2e-tests-emptydir-kzns6, resource: bindings, ignored listing per whitelist
+Jul  2 12:55:02.293: INFO: namespace e2e-tests-emptydir-kzns6 deletion completed in 6.157649183s
+
+• [SLOW TEST:10.656 seconds]
+[sig-storage] EmptyDir volumes
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/empty_dir.go:40
+  should support (non-root,0666,tmpfs) [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+S
+------------------------------
+[k8s.io] Probing container 
+  should *not* be restarted with a exec "cat /tmp/health" liveness probe [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [k8s.io] Probing container
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 12:55:02.293: INFO: >>> kubeConfig: /tmp/kubeconfig-324782104
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [k8s.io] Probing container
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/container_probe.go:48
+[It] should *not* be restarted with a exec "cat /tmp/health" liveness probe [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating pod liveness-exec in namespace e2e-tests-container-probe-fpj7z
+Jul  2 12:55:14.431: INFO: Started pod liveness-exec in namespace e2e-tests-container-probe-fpj7z
+STEP: checking the pod's current state and verifying that restartCount is present
+Jul  2 12:55:14.434: INFO: Initial restart count of pod liveness-exec is 0
+STEP: deleting the pod
+[AfterEach] [k8s.io] Probing container
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 12:59:15.989: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-container-probe-fpj7z" for this suite.
+Jul  2 12:59:22.009: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 12:59:22.102: INFO: namespace: e2e-tests-container-probe-fpj7z, resource: bindings, ignored listing per whitelist
+Jul  2 12:59:22.186: INFO: namespace e2e-tests-container-probe-fpj7z deletion completed in 6.187311279s
+
+• [SLOW TEST:259.893 seconds]
+[k8s.io] Probing container
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:679
+  should *not* be restarted with a exec "cat /tmp/health" liveness probe [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSS
+------------------------------
+[sig-storage] ConfigMap 
+  should be consumable from pods in volume with mappings as non-root [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-storage] ConfigMap
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 12:59:22.186: INFO: >>> kubeConfig: /tmp/kubeconfig-324782104
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should be consumable from pods in volume with mappings as non-root [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating configMap with name configmap-test-volume-map-bd6906d7-7df7-11e8-8e15-aefe7bc77cc2
+STEP: Creating a pod to test consume configMaps
+Jul  2 12:59:22.318: INFO: Waiting up to 5m0s for pod "pod-configmaps-bd697b8d-7df7-11e8-8e15-aefe7bc77cc2" in namespace "e2e-tests-configmap-n6g8q" to be "success or failure"
+Jul  2 12:59:22.328: INFO: Pod "pod-configmaps-bd697b8d-7df7-11e8-8e15-aefe7bc77cc2": Phase="Pending", Reason="", readiness=false. Elapsed: 10.341804ms
+Jul  2 12:59:24.332: INFO: Pod "pod-configmaps-bd697b8d-7df7-11e8-8e15-aefe7bc77cc2": Phase="Pending", Reason="", readiness=false. Elapsed: 2.013744726s
+Jul  2 12:59:26.335: INFO: Pod "pod-configmaps-bd697b8d-7df7-11e8-8e15-aefe7bc77cc2": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.017281413s
+STEP: Saw pod success
+Jul  2 12:59:26.335: INFO: Pod "pod-configmaps-bd697b8d-7df7-11e8-8e15-aefe7bc77cc2" satisfied condition "success or failure"
+Jul  2 12:59:26.338: INFO: Trying to get logs from node shoot--core--confaz-worker-qfmi9-79968b77d9-kcr6j pod pod-configmaps-bd697b8d-7df7-11e8-8e15-aefe7bc77cc2 container configmap-volume-test: <nil>
+STEP: delete the pod
+Jul  2 12:59:26.392: INFO: Waiting for pod pod-configmaps-bd697b8d-7df7-11e8-8e15-aefe7bc77cc2 to disappear
+Jul  2 12:59:26.395: INFO: Pod pod-configmaps-bd697b8d-7df7-11e8-8e15-aefe7bc77cc2 no longer exists
+[AfterEach] [sig-storage] ConfigMap
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 12:59:26.395: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-configmap-n6g8q" for this suite.
+Jul  2 12:59:32.411: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 12:59:32.418: INFO: namespace: e2e-tests-configmap-n6g8q, resource: bindings, ignored listing per whitelist
+Jul  2 12:59:32.545: INFO: namespace e2e-tests-configmap-n6g8q deletion completed in 6.14605742s
+
+• [SLOW TEST:10.359 seconds]
+[sig-storage] ConfigMap
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/configmap_volume.go:32
+  should be consumable from pods in volume with mappings as non-root [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SS
+------------------------------
+[k8s.io] KubeletManagedEtcHosts 
+  should test kubelet managed /etc/hosts file [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [k8s.io] KubeletManagedEtcHosts
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 12:59:32.545: INFO: >>> kubeConfig: /tmp/kubeconfig-324782104
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should test kubelet managed /etc/hosts file [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Setting up the test
+STEP: Creating hostNetwork=false pod
+STEP: Creating hostNetwork=true pod
+STEP: Running the test
+STEP: Verifying /etc/hosts of container is kubelet-managed for pod with hostNetwork=false
+Jul  2 12:59:38.838: INFO: ExecWithOptions {Command:[cat /etc/hosts] Namespace:e2e-tests-e2e-kubelet-etc-hosts-8g7c8 PodName:test-pod ContainerName:busybox-1 Stdin:<nil> CaptureStdout:true CaptureStderr:true PreserveWhitespace:false}
+Jul  2 12:59:38.839: INFO: >>> kubeConfig: /tmp/kubeconfig-324782104
+Jul  2 12:59:39.180: INFO: Exec stderr: ""
+Jul  2 12:59:39.180: INFO: ExecWithOptions {Command:[cat /etc/hosts-original] Namespace:e2e-tests-e2e-kubelet-etc-hosts-8g7c8 PodName:test-pod ContainerName:busybox-1 Stdin:<nil> CaptureStdout:true CaptureStderr:true PreserveWhitespace:false}
+Jul  2 12:59:39.180: INFO: >>> kubeConfig: /tmp/kubeconfig-324782104
+Jul  2 12:59:39.600: INFO: Exec stderr: ""
+Jul  2 12:59:39.600: INFO: ExecWithOptions {Command:[cat /etc/hosts] Namespace:e2e-tests-e2e-kubelet-etc-hosts-8g7c8 PodName:test-pod ContainerName:busybox-2 Stdin:<nil> CaptureStdout:true CaptureStderr:true PreserveWhitespace:false}
+Jul  2 12:59:39.600: INFO: >>> kubeConfig: /tmp/kubeconfig-324782104
+Jul  2 12:59:39.976: INFO: Exec stderr: ""
+Jul  2 12:59:39.976: INFO: ExecWithOptions {Command:[cat /etc/hosts-original] Namespace:e2e-tests-e2e-kubelet-etc-hosts-8g7c8 PodName:test-pod ContainerName:busybox-2 Stdin:<nil> CaptureStdout:true CaptureStderr:true PreserveWhitespace:false}
+Jul  2 12:59:39.976: INFO: >>> kubeConfig: /tmp/kubeconfig-324782104
+Jul  2 12:59:40.365: INFO: Exec stderr: ""
+STEP: Verifying /etc/hosts of container is not kubelet-managed since container specifies /etc/hosts mount
+Jul  2 12:59:40.365: INFO: ExecWithOptions {Command:[cat /etc/hosts] Namespace:e2e-tests-e2e-kubelet-etc-hosts-8g7c8 PodName:test-pod ContainerName:busybox-3 Stdin:<nil> CaptureStdout:true CaptureStderr:true PreserveWhitespace:false}
+Jul  2 12:59:40.365: INFO: >>> kubeConfig: /tmp/kubeconfig-324782104
+Jul  2 12:59:40.748: INFO: Exec stderr: ""
+Jul  2 12:59:40.748: INFO: ExecWithOptions {Command:[cat /etc/hosts-original] Namespace:e2e-tests-e2e-kubelet-etc-hosts-8g7c8 PodName:test-pod ContainerName:busybox-3 Stdin:<nil> CaptureStdout:true CaptureStderr:true PreserveWhitespace:false}
+Jul  2 12:59:40.748: INFO: >>> kubeConfig: /tmp/kubeconfig-324782104
+Jul  2 12:59:41.210: INFO: Exec stderr: ""
+STEP: Verifying /etc/hosts content of container is not kubelet-managed for pod with hostNetwork=true
+Jul  2 12:59:41.210: INFO: ExecWithOptions {Command:[cat /etc/hosts] Namespace:e2e-tests-e2e-kubelet-etc-hosts-8g7c8 PodName:test-host-network-pod ContainerName:busybox-1 Stdin:<nil> CaptureStdout:true CaptureStderr:true PreserveWhitespace:false}
+Jul  2 12:59:41.210: INFO: >>> kubeConfig: /tmp/kubeconfig-324782104
+Jul  2 12:59:41.675: INFO: Exec stderr: ""
+Jul  2 12:59:41.675: INFO: ExecWithOptions {Command:[cat /etc/hosts-original] Namespace:e2e-tests-e2e-kubelet-etc-hosts-8g7c8 PodName:test-host-network-pod ContainerName:busybox-1 Stdin:<nil> CaptureStdout:true CaptureStderr:true PreserveWhitespace:false}
+Jul  2 12:59:41.675: INFO: >>> kubeConfig: /tmp/kubeconfig-324782104
+Jul  2 12:59:42.066: INFO: Exec stderr: ""
+Jul  2 12:59:42.066: INFO: ExecWithOptions {Command:[cat /etc/hosts] Namespace:e2e-tests-e2e-kubelet-etc-hosts-8g7c8 PodName:test-host-network-pod ContainerName:busybox-2 Stdin:<nil> CaptureStdout:true CaptureStderr:true PreserveWhitespace:false}
+Jul  2 12:59:42.066: INFO: >>> kubeConfig: /tmp/kubeconfig-324782104
+Jul  2 12:59:42.462: INFO: Exec stderr: ""
+Jul  2 12:59:42.462: INFO: ExecWithOptions {Command:[cat /etc/hosts-original] Namespace:e2e-tests-e2e-kubelet-etc-hosts-8g7c8 PodName:test-host-network-pod ContainerName:busybox-2 Stdin:<nil> CaptureStdout:true CaptureStderr:true PreserveWhitespace:false}
+Jul  2 12:59:42.462: INFO: >>> kubeConfig: /tmp/kubeconfig-324782104
+Jul  2 12:59:42.892: INFO: Exec stderr: ""
+[AfterEach] [k8s.io] KubeletManagedEtcHosts
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 12:59:42.892: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-e2e-kubelet-etc-hosts-8g7c8" for this suite.
+Jul  2 13:00:20.913: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:00:21.000: INFO: namespace: e2e-tests-e2e-kubelet-etc-hosts-8g7c8, resource: bindings, ignored listing per whitelist
+Jul  2 13:00:21.017: INFO: namespace e2e-tests-e2e-kubelet-etc-hosts-8g7c8 deletion completed in 38.121877475s
+
+• [SLOW TEST:48.473 seconds]
+[k8s.io] KubeletManagedEtcHosts
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:679
+  should test kubelet managed /etc/hosts file [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSSSS
+------------------------------
+[sig-storage] Projected 
+  should provide node allocatable (memory) as default memory limit if the limit is not set [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:00:21.019: INFO: >>> kubeConfig: /tmp/kubeconfig-324782104
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:858
+[It] should provide node allocatable (memory) as default memory limit if the limit is not set [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating a pod to test downward API volume plugin
+Jul  2 13:00:21.158: INFO: Waiting up to 5m0s for pod "downwardapi-volume-e07cb1ed-7df7-11e8-8e15-aefe7bc77cc2" in namespace "e2e-tests-projected-7vt5n" to be "success or failure"
+Jul  2 13:00:21.186: INFO: Pod "downwardapi-volume-e07cb1ed-7df7-11e8-8e15-aefe7bc77cc2": Phase="Pending", Reason="", readiness=false. Elapsed: 28.824645ms
+Jul  2 13:00:23.190: INFO: Pod "downwardapi-volume-e07cb1ed-7df7-11e8-8e15-aefe7bc77cc2": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.032238028s
+STEP: Saw pod success
+Jul  2 13:00:23.190: INFO: Pod "downwardapi-volume-e07cb1ed-7df7-11e8-8e15-aefe7bc77cc2" satisfied condition "success or failure"
+Jul  2 13:00:23.193: INFO: Trying to get logs from node shoot--core--confaz-worker-qfmi9-79968b77d9-kcr6j pod downwardapi-volume-e07cb1ed-7df7-11e8-8e15-aefe7bc77cc2 container client-container: <nil>
+STEP: delete the pod
+Jul  2 13:00:23.271: INFO: Waiting for pod downwardapi-volume-e07cb1ed-7df7-11e8-8e15-aefe7bc77cc2 to disappear
+Jul  2 13:00:23.282: INFO: Pod downwardapi-volume-e07cb1ed-7df7-11e8-8e15-aefe7bc77cc2 no longer exists
+[AfterEach] [sig-storage] Projected
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:00:23.282: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-7vt5n" for this suite.
+Jul  2 13:00:29.330: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:00:29.348: INFO: namespace: e2e-tests-projected-7vt5n, resource: bindings, ignored listing per whitelist
+Jul  2 13:00:29.479: INFO: namespace e2e-tests-projected-7vt5n deletion completed in 6.192637372s
+
+• [SLOW TEST:8.460 seconds]
+[sig-storage] Projected
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:34
+  should provide node allocatable (memory) as default memory limit if the limit is not set [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SS
+------------------------------
+[sig-api-machinery] ConfigMap 
+  should be consumable via environment variable [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-api-machinery] ConfigMap
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:00:29.480: INFO: >>> kubeConfig: /tmp/kubeconfig-324782104
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should be consumable via environment variable [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating configMap e2e-tests-configmap-l8w7s/configmap-test-e583d39d-7df7-11e8-8e15-aefe7bc77cc2
+STEP: Creating a pod to test consume configMaps
+Jul  2 13:00:29.631: INFO: Waiting up to 5m0s for pod "pod-configmaps-e58946bd-7df7-11e8-8e15-aefe7bc77cc2" in namespace "e2e-tests-configmap-l8w7s" to be "success or failure"
+Jul  2 13:00:29.636: INFO: Pod "pod-configmaps-e58946bd-7df7-11e8-8e15-aefe7bc77cc2": Phase="Pending", Reason="", readiness=false. Elapsed: 5.14661ms
+Jul  2 13:00:31.643: INFO: Pod "pod-configmaps-e58946bd-7df7-11e8-8e15-aefe7bc77cc2": Phase="Pending", Reason="", readiness=false. Elapsed: 2.012129025s
+Jul  2 13:00:33.647: INFO: Pod "pod-configmaps-e58946bd-7df7-11e8-8e15-aefe7bc77cc2": Phase="Pending", Reason="", readiness=false. Elapsed: 4.015431618s
+Jul  2 13:00:35.668: INFO: Pod "pod-configmaps-e58946bd-7df7-11e8-8e15-aefe7bc77cc2": Phase="Succeeded", Reason="", readiness=false. Elapsed: 6.036256014s
+STEP: Saw pod success
+Jul  2 13:00:35.668: INFO: Pod "pod-configmaps-e58946bd-7df7-11e8-8e15-aefe7bc77cc2" satisfied condition "success or failure"
+Jul  2 13:00:35.670: INFO: Trying to get logs from node shoot--core--confaz-worker-qfmi9-79968b77d9-kcr6j pod pod-configmaps-e58946bd-7df7-11e8-8e15-aefe7bc77cc2 container env-test: <nil>
+STEP: delete the pod
+Jul  2 13:00:35.690: INFO: Waiting for pod pod-configmaps-e58946bd-7df7-11e8-8e15-aefe7bc77cc2 to disappear
+Jul  2 13:00:35.693: INFO: Pod pod-configmaps-e58946bd-7df7-11e8-8e15-aefe7bc77cc2 no longer exists
+[AfterEach] [sig-api-machinery] ConfigMap
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:00:35.693: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-configmap-l8w7s" for this suite.
+Jul  2 13:00:41.746: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:00:41.773: INFO: namespace: e2e-tests-configmap-l8w7s, resource: bindings, ignored listing per whitelist
+Jul  2 13:00:41.843: INFO: namespace e2e-tests-configmap-l8w7s deletion completed in 6.147483713s
+
+• [SLOW TEST:12.364 seconds]
+[sig-api-machinery] ConfigMap
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/configmap.go:29
+  should be consumable via environment variable [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSS
+------------------------------
+[sig-network] Networking Granular Checks: Pods 
+  should function for node-pod communication: udp [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-network] Networking
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:00:41.843: INFO: >>> kubeConfig: /tmp/kubeconfig-324782104
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should function for node-pod communication: udp [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Performing setup for networking test in namespace e2e-tests-pod-network-test-pkznc
+STEP: creating a selector
+STEP: Creating the service pods in kubernetes
+Jul  2 13:00:41.967: INFO: Waiting up to 10m0s for all (but 0) nodes to be schedulable
+STEP: Creating test pods
+Jul  2 13:01:04.347: INFO: ExecWithOptions {Command:[/bin/sh -c echo 'hostName' | timeout -t 2 nc -w 1 -u 100.96.1.10 8081 | grep -v '^\s*$'] Namespace:e2e-tests-pod-network-test-pkznc PodName:host-test-container-pod ContainerName:hostexec Stdin:<nil> CaptureStdout:true CaptureStderr:true PreserveWhitespace:false}
+Jul  2 13:01:04.347: INFO: >>> kubeConfig: /tmp/kubeconfig-324782104
+Jul  2 13:01:05.688: INFO: Found all expected endpoints: [netserver-0]
+Jul  2 13:01:05.691: INFO: ExecWithOptions {Command:[/bin/sh -c echo 'hostName' | timeout -t 2 nc -w 1 -u 100.96.0.10 8081 | grep -v '^\s*$'] Namespace:e2e-tests-pod-network-test-pkznc PodName:host-test-container-pod ContainerName:hostexec Stdin:<nil> CaptureStdout:true CaptureStderr:true PreserveWhitespace:false}
+Jul  2 13:01:05.691: INFO: >>> kubeConfig: /tmp/kubeconfig-324782104
+Jul  2 13:01:07.195: INFO: Found all expected endpoints: [netserver-1]
+[AfterEach] [sig-network] Networking
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:01:07.195: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-pod-network-test-pkznc" for this suite.
+Jul  2 13:01:29.209: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:01:29.372: INFO: namespace: e2e-tests-pod-network-test-pkznc, resource: bindings, ignored listing per whitelist
+Jul  2 13:01:29.372: INFO: namespace e2e-tests-pod-network-test-pkznc deletion completed in 22.173665276s
+
+• [SLOW TEST:47.529 seconds]
+[sig-network] Networking
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/networking.go:25
+  Granular Checks: Pods
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/networking.go:28
+    should function for node-pod communication: udp [NodeConformance] [Conformance]
+    /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+[sig-api-machinery] Garbage collector 
+  should not delete dependents that have both valid owner and owner that's waiting for dependents to be deleted [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-api-machinery] Garbage collector
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:01:29.373: INFO: >>> kubeConfig: /tmp/kubeconfig-324782104
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should not delete dependents that have both valid owner and owner that's waiting for dependents to be deleted [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: create the rc1
+STEP: create the rc2
+STEP: set half of pods created by rc simpletest-rc-to-be-deleted to have rc simpletest-rc-to-stay as owner as well
+STEP: delete the rc simpletest-rc-to-be-deleted
+STEP: wait for the rc to be deleted
+STEP: Gathering metrics
+W0702 13:01:39.707444      15 metrics_grabber.go:81] Master node is not registered. Grabbing metrics from Scheduler, ControllerManager and ClusterAutoscaler is disabled.
+Jul  2 13:01:39.707: INFO: For apiserver_request_count:
+For apiserver_request_latencies_summary:
+For etcd_helper_cache_entry_count:
+For etcd_helper_cache_hit_count:
+For etcd_helper_cache_miss_count:
+For etcd_request_cache_add_latencies_summary:
+For etcd_request_cache_get_latencies_summary:
+For etcd_request_latencies_summary:
+For garbage_collector_attempt_to_delete_queue_latency:
+For garbage_collector_attempt_to_delete_work_duration:
+For garbage_collector_attempt_to_orphan_queue_latency:
+For garbage_collector_attempt_to_orphan_work_duration:
+For garbage_collector_dirty_processing_latency_microseconds:
+For garbage_collector_event_processing_latency_microseconds:
+For garbage_collector_graph_changes_queue_latency:
+For garbage_collector_graph_changes_work_duration:
+For garbage_collector_orphan_processing_latency_microseconds:
+For namespace_queue_latency:
+For namespace_queue_latency_sum:
+For namespace_queue_latency_count:
+For namespace_retries:
+For namespace_work_duration:
+For namespace_work_duration_sum:
+For namespace_work_duration_count:
+For function_duration_seconds:
+For errors_total:
+For evicted_pods_total:
+
+[AfterEach] [sig-api-machinery] Garbage collector
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:01:39.707: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-gc-f9gtb" for this suite.
+Jul  2 13:01:45.728: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:01:45.806: INFO: namespace: e2e-tests-gc-f9gtb, resource: bindings, ignored listing per whitelist
+Jul  2 13:01:45.847: INFO: namespace e2e-tests-gc-f9gtb deletion completed in 6.133665423s
+
+• [SLOW TEST:16.475 seconds]
+[sig-api-machinery] Garbage collector
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apimachinery/framework.go:22
+  should not delete dependents that have both valid owner and owner that's waiting for dependents to be deleted [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSSSSSSS
+------------------------------
+[k8s.io] Pods 
+  should be updated [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [k8s.io] Pods
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:01:45.848: INFO: >>> kubeConfig: /tmp/kubeconfig-324782104
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [k8s.io] Pods
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/pods.go:127
+[It] should be updated [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: creating the pod
+STEP: submitting the pod to kubernetes
+STEP: verifying the pod is in kubernetes
+STEP: updating the pod
+Jul  2 13:01:48.732: INFO: Successfully updated pod "pod-update-13138a3e-7df8-11e8-8e15-aefe7bc77cc2"
+STEP: verifying the updated pod is in kubernetes
+Jul  2 13:01:48.737: INFO: Pod update OK
+[AfterEach] [k8s.io] Pods
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:01:48.737: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-pods-gdbh9" for this suite.
+Jul  2 13:02:10.751: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:02:10.891: INFO: namespace: e2e-tests-pods-gdbh9, resource: bindings, ignored listing per whitelist
+Jul  2 13:02:10.911: INFO: namespace e2e-tests-pods-gdbh9 deletion completed in 22.169701027s
+
+• [SLOW TEST:25.063 seconds]
+[k8s.io] Pods
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:679
+  should be updated [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSSSS
+------------------------------
+[sig-apps] Daemon set [Serial] 
+  should retry creating failed daemon pods [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-apps] Daemon set [Serial]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:02:10.911: INFO: >>> kubeConfig: /tmp/kubeconfig-324782104
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-apps] Daemon set [Serial]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/daemon_set.go:99
+[It] should retry creating failed daemon pods [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating a simple DaemonSet "daemon-set"
+STEP: Check that daemon pods launch on every node of the cluster.
+Jul  2 13:02:11.029: INFO: Number of nodes with available pods: 0
+Jul  2 13:02:11.029: INFO: Node shoot--core--confaz-worker-qfmi9-79968b77d9-24hm4 is running more than one daemon pod
+Jul  2 13:02:12.067: INFO: Number of nodes with available pods: 0
+Jul  2 13:02:12.067: INFO: Node shoot--core--confaz-worker-qfmi9-79968b77d9-24hm4 is running more than one daemon pod
+Jul  2 13:02:13.041: INFO: Number of nodes with available pods: 0
+Jul  2 13:02:13.041: INFO: Node shoot--core--confaz-worker-qfmi9-79968b77d9-24hm4 is running more than one daemon pod
+Jul  2 13:02:14.041: INFO: Number of nodes with available pods: 1
+Jul  2 13:02:14.041: INFO: Node shoot--core--confaz-worker-qfmi9-79968b77d9-kcr6j is running more than one daemon pod
+Jul  2 13:02:15.131: INFO: Number of nodes with available pods: 2
+Jul  2 13:02:15.131: INFO: Number of running nodes: 2, number of available pods: 2
+STEP: Set a daemon pod's phase to 'Failed', check that the daemon pod is revived.
+Jul  2 13:02:15.163: INFO: Number of nodes with available pods: 1
+Jul  2 13:02:15.163: INFO: Node shoot--core--confaz-worker-qfmi9-79968b77d9-kcr6j is running more than one daemon pod
+Jul  2 13:02:16.171: INFO: Number of nodes with available pods: 1
+Jul  2 13:02:16.171: INFO: Node shoot--core--confaz-worker-qfmi9-79968b77d9-kcr6j is running more than one daemon pod
+Jul  2 13:02:17.189: INFO: Number of nodes with available pods: 2
+Jul  2 13:02:17.189: INFO: Number of running nodes: 2, number of available pods: 2
+STEP: Wait for the failed daemon pod to be completely deleted.
+[AfterEach] [sig-apps] Daemon set [Serial]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/daemon_set.go:65
+STEP: Deleting DaemonSet "daemon-set"
+STEP: deleting {extensions DaemonSet} daemon-set in namespace e2e-tests-daemonsets-xpsjm, will wait for the garbage collector to delete the pods
+Jul  2 13:02:17.255: INFO: Deleting {extensions DaemonSet} daemon-set took: 6.127108ms
+Jul  2 13:02:17.355: INFO: Terminating {extensions DaemonSet} daemon-set pods took: 100.181739ms
+Jul  2 13:02:29.258: INFO: Number of nodes with available pods: 0
+Jul  2 13:02:29.258: INFO: Number of running nodes: 0, number of available pods: 0
+Jul  2 13:02:29.262: INFO: daemonset: {"kind":"DaemonSetList","apiVersion":"apps/v1","metadata":{"selfLink":"/apis/apps/v1/namespaces/e2e-tests-daemonsets-xpsjm/daemonsets","resourceVersion":"2383"},"items":null}
+
+Jul  2 13:02:29.265: INFO: pods: {"kind":"PodList","apiVersion":"v1","metadata":{"selfLink":"/api/v1/namespaces/e2e-tests-daemonsets-xpsjm/pods","resourceVersion":"2383"},"items":null}
+
+[AfterEach] [sig-apps] Daemon set [Serial]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:02:29.280: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-daemonsets-xpsjm" for this suite.
+Jul  2 13:02:35.318: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:02:35.377: INFO: namespace: e2e-tests-daemonsets-xpsjm, resource: bindings, ignored listing per whitelist
+Jul  2 13:02:35.413: INFO: namespace e2e-tests-daemonsets-xpsjm deletion completed in 6.129567732s
+
+• [SLOW TEST:24.503 seconds]
+[sig-apps] Daemon set [Serial]
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/framework.go:22
+  should retry creating failed daemon pods [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+[sig-apps] Daemon set [Serial] 
+  should run and stop complex daemon [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-apps] Daemon set [Serial]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:02:35.414: INFO: >>> kubeConfig: /tmp/kubeconfig-324782104
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-apps] Daemon set [Serial]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/daemon_set.go:99
+[It] should run and stop complex daemon [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+Jul  2 13:02:35.556: INFO: Creating daemon "daemon-set" with a node selector
+STEP: Initially, daemon pods should not be running on any nodes.
+Jul  2 13:02:35.598: INFO: Number of nodes with available pods: 0
+Jul  2 13:02:35.598: INFO: Number of running nodes: 0, number of available pods: 0
+STEP: Change node label to blue, check that daemon pod is launched.
+Jul  2 13:02:35.685: INFO: Number of nodes with available pods: 0
+Jul  2 13:02:35.685: INFO: Node shoot--core--confaz-worker-qfmi9-79968b77d9-24hm4 is running more than one daemon pod
+Jul  2 13:02:36.689: INFO: Number of nodes with available pods: 0
+Jul  2 13:02:36.689: INFO: Node shoot--core--confaz-worker-qfmi9-79968b77d9-24hm4 is running more than one daemon pod
+Jul  2 13:02:37.689: INFO: Number of nodes with available pods: 0
+Jul  2 13:02:37.689: INFO: Node shoot--core--confaz-worker-qfmi9-79968b77d9-24hm4 is running more than one daemon pod
+Jul  2 13:02:38.689: INFO: Number of nodes with available pods: 1
+Jul  2 13:02:38.689: INFO: Number of running nodes: 1, number of available pods: 1
+STEP: Update the node label to green, and wait for daemons to be unscheduled
+Jul  2 13:02:38.710: INFO: Number of nodes with available pods: 1
+Jul  2 13:02:38.710: INFO: Number of running nodes: 0, number of available pods: 1
+Jul  2 13:02:39.714: INFO: Number of nodes with available pods: 0
+Jul  2 13:02:39.714: INFO: Number of running nodes: 0, number of available pods: 0
+STEP: Update DaemonSet node selector to green, and change its update strategy to RollingUpdate
+Jul  2 13:02:39.747: INFO: Number of nodes with available pods: 0
+Jul  2 13:02:39.747: INFO: Node shoot--core--confaz-worker-qfmi9-79968b77d9-24hm4 is running more than one daemon pod
+Jul  2 13:02:40.753: INFO: Number of nodes with available pods: 0
+Jul  2 13:02:40.753: INFO: Node shoot--core--confaz-worker-qfmi9-79968b77d9-24hm4 is running more than one daemon pod
+Jul  2 13:02:41.755: INFO: Number of nodes with available pods: 0
+Jul  2 13:02:41.755: INFO: Node shoot--core--confaz-worker-qfmi9-79968b77d9-24hm4 is running more than one daemon pod
+Jul  2 13:02:42.751: INFO: Number of nodes with available pods: 0
+Jul  2 13:02:42.751: INFO: Node shoot--core--confaz-worker-qfmi9-79968b77d9-24hm4 is running more than one daemon pod
+Jul  2 13:02:43.751: INFO: Number of nodes with available pods: 0
+Jul  2 13:02:43.751: INFO: Node shoot--core--confaz-worker-qfmi9-79968b77d9-24hm4 is running more than one daemon pod
+Jul  2 13:02:44.751: INFO: Number of nodes with available pods: 0
+Jul  2 13:02:44.751: INFO: Node shoot--core--confaz-worker-qfmi9-79968b77d9-24hm4 is running more than one daemon pod
+Jul  2 13:02:45.751: INFO: Number of nodes with available pods: 0
+Jul  2 13:02:45.751: INFO: Node shoot--core--confaz-worker-qfmi9-79968b77d9-24hm4 is running more than one daemon pod
+Jul  2 13:02:46.752: INFO: Number of nodes with available pods: 0
+Jul  2 13:02:46.752: INFO: Node shoot--core--confaz-worker-qfmi9-79968b77d9-24hm4 is running more than one daemon pod
+Jul  2 13:02:47.831: INFO: Number of nodes with available pods: 0
+Jul  2 13:02:47.831: INFO: Node shoot--core--confaz-worker-qfmi9-79968b77d9-24hm4 is running more than one daemon pod
+Jul  2 13:02:48.780: INFO: Number of nodes with available pods: 0
+Jul  2 13:02:48.780: INFO: Node shoot--core--confaz-worker-qfmi9-79968b77d9-24hm4 is running more than one daemon pod
+Jul  2 13:02:49.751: INFO: Number of nodes with available pods: 0
+Jul  2 13:02:49.751: INFO: Node shoot--core--confaz-worker-qfmi9-79968b77d9-24hm4 is running more than one daemon pod
+Jul  2 13:02:50.751: INFO: Number of nodes with available pods: 1
+Jul  2 13:02:50.751: INFO: Number of running nodes: 1, number of available pods: 1
+[AfterEach] [sig-apps] Daemon set [Serial]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/daemon_set.go:65
+STEP: Deleting DaemonSet "daemon-set"
+STEP: deleting {extensions DaemonSet} daemon-set in namespace e2e-tests-daemonsets-h2jzx, will wait for the garbage collector to delete the pods
+Jul  2 13:02:50.816: INFO: Deleting {extensions DaemonSet} daemon-set took: 6.479014ms
+Jul  2 13:02:50.916: INFO: Terminating {extensions DaemonSet} daemon-set pods took: 100.181706ms
+Jul  2 13:02:53.819: INFO: Number of nodes with available pods: 0
+Jul  2 13:02:53.820: INFO: Number of running nodes: 0, number of available pods: 0
+Jul  2 13:02:53.822: INFO: daemonset: {"kind":"DaemonSetList","apiVersion":"apps/v1","metadata":{"selfLink":"/apis/apps/v1/namespaces/e2e-tests-daemonsets-h2jzx/daemonsets","resourceVersion":"2474"},"items":null}
+
+Jul  2 13:02:53.826: INFO: pods: {"kind":"PodList","apiVersion":"v1","metadata":{"selfLink":"/api/v1/namespaces/e2e-tests-daemonsets-h2jzx/pods","resourceVersion":"2474"},"items":null}
+
+[AfterEach] [sig-apps] Daemon set [Serial]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:02:53.869: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-daemonsets-h2jzx" for this suite.
+Jul  2 13:02:59.912: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:02:59.969: INFO: namespace: e2e-tests-daemonsets-h2jzx, resource: bindings, ignored listing per whitelist
+Jul  2 13:03:00.004: INFO: namespace e2e-tests-daemonsets-h2jzx deletion completed in 6.103989154s
+
+• [SLOW TEST:24.590 seconds]
+[sig-apps] Daemon set [Serial]
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/framework.go:22
+  should run and stop complex daemon [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSS
+------------------------------
+[sig-auth] ServiceAccounts 
+  should allow opting out of API token automount  [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-auth] ServiceAccounts
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:03:00.004: INFO: >>> kubeConfig: /tmp/kubeconfig-324782104
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should allow opting out of API token automount  [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: getting the auto-created API token
+Jul  2 13:03:00.636: INFO: created pod pod-service-account-defaultsa
+Jul  2 13:03:00.636: INFO: pod pod-service-account-defaultsa service account token volume mount: true
+Jul  2 13:03:00.640: INFO: created pod pod-service-account-mountsa
+Jul  2 13:03:00.640: INFO: pod pod-service-account-mountsa service account token volume mount: true
+Jul  2 13:03:00.659: INFO: created pod pod-service-account-nomountsa
+Jul  2 13:03:00.659: INFO: pod pod-service-account-nomountsa service account token volume mount: false
+Jul  2 13:03:00.673: INFO: created pod pod-service-account-defaultsa-mountspec
+Jul  2 13:03:00.673: INFO: pod pod-service-account-defaultsa-mountspec service account token volume mount: true
+Jul  2 13:03:00.686: INFO: created pod pod-service-account-mountsa-mountspec
+Jul  2 13:03:00.686: INFO: pod pod-service-account-mountsa-mountspec service account token volume mount: true
+Jul  2 13:03:00.733: INFO: created pod pod-service-account-nomountsa-mountspec
+Jul  2 13:03:00.733: INFO: pod pod-service-account-nomountsa-mountspec service account token volume mount: true
+Jul  2 13:03:00.750: INFO: created pod pod-service-account-defaultsa-nomountspec
+Jul  2 13:03:00.750: INFO: pod pod-service-account-defaultsa-nomountspec service account token volume mount: false
+Jul  2 13:03:00.760: INFO: created pod pod-service-account-mountsa-nomountspec
+Jul  2 13:03:00.760: INFO: pod pod-service-account-mountsa-nomountspec service account token volume mount: false
+Jul  2 13:03:00.773: INFO: created pod pod-service-account-nomountsa-nomountspec
+Jul  2 13:03:00.773: INFO: pod pod-service-account-nomountsa-nomountspec service account token volume mount: false
+[AfterEach] [sig-auth] ServiceAccounts
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:03:00.773: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-svcaccounts-p6mh7" for this suite.
+Jul  2 13:03:24.884: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:03:24.965: INFO: namespace: e2e-tests-svcaccounts-p6mh7, resource: bindings, ignored listing per whitelist
+Jul  2 13:03:24.994: INFO: namespace e2e-tests-svcaccounts-p6mh7 deletion completed in 24.202661246s
+
+• [SLOW TEST:24.990 seconds]
+[sig-auth] ServiceAccounts
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/auth/framework.go:22
+  should allow opting out of API token automount  [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSSSSSSSSSS
+------------------------------
+[sig-storage] EmptyDir volumes 
+  should support (non-root,0777,default) [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-storage] EmptyDir volumes
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:03:24.994: INFO: >>> kubeConfig: /tmp/kubeconfig-324782104
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should support (non-root,0777,default) [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating a pod to test emptydir 0777 on node default medium
+Jul  2 13:03:25.127: INFO: Waiting up to 5m0s for pod "pod-4e250ed8-7df8-11e8-8e15-aefe7bc77cc2" in namespace "e2e-tests-emptydir-k8jn5" to be "success or failure"
+Jul  2 13:03:25.129: INFO: Pod "pod-4e250ed8-7df8-11e8-8e15-aefe7bc77cc2": Phase="Pending", Reason="", readiness=false. Elapsed: 2.642408ms
+Jul  2 13:03:27.133: INFO: Pod "pod-4e250ed8-7df8-11e8-8e15-aefe7bc77cc2": Phase="Pending", Reason="", readiness=false. Elapsed: 2.006221047s
+Jul  2 13:03:29.138: INFO: Pod "pod-4e250ed8-7df8-11e8-8e15-aefe7bc77cc2": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.011723796s
+STEP: Saw pod success
+Jul  2 13:03:29.141: INFO: Pod "pod-4e250ed8-7df8-11e8-8e15-aefe7bc77cc2" satisfied condition "success or failure"
+Jul  2 13:03:29.143: INFO: Trying to get logs from node shoot--core--confaz-worker-qfmi9-79968b77d9-kcr6j pod pod-4e250ed8-7df8-11e8-8e15-aefe7bc77cc2 container test-container: <nil>
+STEP: delete the pod
+Jul  2 13:03:29.182: INFO: Waiting for pod pod-4e250ed8-7df8-11e8-8e15-aefe7bc77cc2 to disappear
+Jul  2 13:03:29.192: INFO: Pod pod-4e250ed8-7df8-11e8-8e15-aefe7bc77cc2 no longer exists
+[AfterEach] [sig-storage] EmptyDir volumes
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:03:29.199: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-emptydir-k8jn5" for this suite.
+Jul  2 13:03:35.230: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:03:35.322: INFO: namespace: e2e-tests-emptydir-k8jn5, resource: bindings, ignored listing per whitelist
+Jul  2 13:03:35.395: INFO: namespace e2e-tests-emptydir-k8jn5 deletion completed in 6.191680378s
+
+• [SLOW TEST:10.401 seconds]
+[sig-storage] EmptyDir volumes
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/empty_dir.go:40
+  should support (non-root,0777,default) [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSS
+------------------------------
+[sig-storage] Projected 
+  should be consumable from pods in volume [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:03:35.395: INFO: >>> kubeConfig: /tmp/kubeconfig-324782104
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:858
+[It] should be consumable from pods in volume [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating configMap with name projected-configmap-test-volume-545337f6-7df8-11e8-8e15-aefe7bc77cc2
+STEP: Creating a pod to test consume configMaps
+Jul  2 13:03:35.527: INFO: Waiting up to 5m0s for pod "pod-projected-configmaps-5456ce15-7df8-11e8-8e15-aefe7bc77cc2" in namespace "e2e-tests-projected-hx4mg" to be "success or failure"
+Jul  2 13:03:35.541: INFO: Pod "pod-projected-configmaps-5456ce15-7df8-11e8-8e15-aefe7bc77cc2": Phase="Pending", Reason="", readiness=false. Elapsed: 14.245838ms
+Jul  2 13:03:37.544: INFO: Pod "pod-projected-configmaps-5456ce15-7df8-11e8-8e15-aefe7bc77cc2": Phase="Pending", Reason="", readiness=false. Elapsed: 2.017691317s
+Jul  2 13:03:39.548: INFO: Pod "pod-projected-configmaps-5456ce15-7df8-11e8-8e15-aefe7bc77cc2": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.021252965s
+STEP: Saw pod success
+Jul  2 13:03:39.548: INFO: Pod "pod-projected-configmaps-5456ce15-7df8-11e8-8e15-aefe7bc77cc2" satisfied condition "success or failure"
+Jul  2 13:03:39.630: INFO: Trying to get logs from node shoot--core--confaz-worker-qfmi9-79968b77d9-kcr6j pod pod-projected-configmaps-5456ce15-7df8-11e8-8e15-aefe7bc77cc2 container projected-configmap-volume-test: <nil>
+STEP: delete the pod
+Jul  2 13:03:39.753: INFO: Waiting for pod pod-projected-configmaps-5456ce15-7df8-11e8-8e15-aefe7bc77cc2 to disappear
+Jul  2 13:03:39.756: INFO: Pod pod-projected-configmaps-5456ce15-7df8-11e8-8e15-aefe7bc77cc2 no longer exists
+[AfterEach] [sig-storage] Projected
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:03:39.756: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-hx4mg" for this suite.
+Jul  2 13:03:45.774: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:03:45.845: INFO: namespace: e2e-tests-projected-hx4mg, resource: bindings, ignored listing per whitelist
+Jul  2 13:03:45.880: INFO: namespace e2e-tests-projected-hx4mg deletion completed in 6.120538061s
+
+• [SLOW TEST:10.485 seconds]
+[sig-storage] Projected
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:34
+  should be consumable from pods in volume [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+S
+------------------------------
+[k8s.io] Pods 
+  should be submitted and removed [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [k8s.io] Pods
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:03:45.880: INFO: >>> kubeConfig: /tmp/kubeconfig-324782104
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [k8s.io] Pods
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/pods.go:127
+[It] should be submitted and removed [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: creating the pod
+STEP: setting up watch
+STEP: submitting the pod to kubernetes
+STEP: verifying the pod is in kubernetes
+STEP: verifying pod creation was observed
+Jul  2 13:03:50.175: INFO: running pod: &v1.Pod{TypeMeta:v1.TypeMeta{Kind:"", APIVersion:""}, ObjectMeta:v1.ObjectMeta{Name:"pod-submit-remove-5a92fcc2-7df8-11e8-8e15-aefe7bc77cc2", GenerateName:"", Namespace:"e2e-tests-pods-8vjw4", SelfLink:"/api/v1/namespaces/e2e-tests-pods-8vjw4/pods/pod-submit-remove-5a92fcc2-7df8-11e8-8e15-aefe7bc77cc2", UID:"5a95ff79-7df8-11e8-bc8c-d657551927e5", ResourceVersion:"2725", Generation:0, CreationTimestamp:v1.Time{Time:time.Time{wall:0x0, ext:63666133425, loc:(*time.Location)(0x642c9a0)}}, DeletionTimestamp:(*v1.Time)(nil), DeletionGracePeriodSeconds:(*int64)(nil), Labels:map[string]string{"name":"foo", "time":"974397484"}, Annotations:map[string]string{"cni.projectcalico.org/podIP":"100.96.1.33/32"}, OwnerReferences:[]v1.OwnerReference(nil), Initializers:(*v1.Initializers)(nil), Finalizers:[]string(nil), ClusterName:""}, Spec:v1.PodSpec{Volumes:[]v1.Volume{v1.Volume{Name:"default-token-57vwz", VolumeSource:v1.VolumeSource{HostPath:(*v1.HostPathVolumeSource)(nil), EmptyDir:(*v1.EmptyDirVolumeSource)(nil), GCEPersistentDisk:(*v1.GCEPersistentDiskVolumeSource)(nil), AWSElasticBlockStore:(*v1.AWSElasticBlockStoreVolumeSource)(nil), GitRepo:(*v1.GitRepoVolumeSource)(nil), Secret:(*v1.SecretVolumeSource)(0xc4217cf040), NFS:(*v1.NFSVolumeSource)(nil), ISCSI:(*v1.ISCSIVolumeSource)(nil), Glusterfs:(*v1.GlusterfsVolumeSource)(nil), PersistentVolumeClaim:(*v1.PersistentVolumeClaimVolumeSource)(nil), RBD:(*v1.RBDVolumeSource)(nil), FlexVolume:(*v1.FlexVolumeSource)(nil), Cinder:(*v1.CinderVolumeSource)(nil), CephFS:(*v1.CephFSVolumeSource)(nil), Flocker:(*v1.FlockerVolumeSource)(nil), DownwardAPI:(*v1.DownwardAPIVolumeSource)(nil), FC:(*v1.FCVolumeSource)(nil), AzureFile:(*v1.AzureFileVolumeSource)(nil), ConfigMap:(*v1.ConfigMapVolumeSource)(nil), VsphereVolume:(*v1.VsphereVirtualDiskVolumeSource)(nil), Quobyte:(*v1.QuobyteVolumeSource)(nil), AzureDisk:(*v1.AzureDiskVolumeSource)(nil), PhotonPersistentDisk:(*v1.PhotonPersistentDiskVolumeSource)(nil), Projected:(*v1.ProjectedVolumeSource)(nil), PortworxVolume:(*v1.PortworxVolumeSource)(nil), ScaleIO:(*v1.ScaleIOVolumeSource)(nil), StorageOS:(*v1.StorageOSVolumeSource)(nil)}}}, InitContainers:[]v1.Container(nil), Containers:[]v1.Container{v1.Container{Name:"nginx", Image:"k8s.gcr.io/nginx-slim-amd64:0.20", Command:[]string(nil), Args:[]string(nil), WorkingDir:"", Ports:[]v1.ContainerPort(nil), EnvFrom:[]v1.EnvFromSource(nil), Env:[]v1.EnvVar(nil), Resources:v1.ResourceRequirements{Limits:v1.ResourceList(nil), Requests:v1.ResourceList(nil)}, VolumeMounts:[]v1.VolumeMount{v1.VolumeMount{Name:"default-token-57vwz", ReadOnly:true, MountPath:"/var/run/secrets/kubernetes.io/serviceaccount", SubPath:"", MountPropagation:(*v1.MountPropagationMode)(nil)}}, VolumeDevices:[]v1.VolumeDevice(nil), LivenessProbe:(*v1.Probe)(nil), ReadinessProbe:(*v1.Probe)(nil), Lifecycle:(*v1.Lifecycle)(nil), TerminationMessagePath:"/dev/termination-log", TerminationMessagePolicy:"File", ImagePullPolicy:"IfNotPresent", SecurityContext:(*v1.SecurityContext)(nil), Stdin:false, StdinOnce:false, TTY:false}}, RestartPolicy:"Always", TerminationGracePeriodSeconds:(*int64)(0xc421c7c578), ActiveDeadlineSeconds:(*int64)(nil), DNSPolicy:"ClusterFirst", NodeSelector:map[string]string(nil), ServiceAccountName:"default", DeprecatedServiceAccount:"default", AutomountServiceAccountToken:(*bool)(nil), NodeName:"shoot--core--confaz-worker-qfmi9-79968b77d9-kcr6j", HostNetwork:false, HostPID:false, HostIPC:false, ShareProcessNamespace:(*bool)(nil), SecurityContext:(*v1.PodSecurityContext)(0xc4212290e0), ImagePullSecrets:[]v1.LocalObjectReference(nil), Hostname:"", Subdomain:"", Affinity:(*v1.Affinity)(nil), SchedulerName:"default-scheduler", Tolerations:[]v1.Toleration{v1.Toleration{Key:"node.kubernetes.io/not-ready", Operator:"Exists", Value:"", Effect:"NoExecute", TolerationSeconds:(*int64)(0xc421c7c5b0)}, v1.Toleration{Key:"node.kubernetes.io/unreachable", Operator:"Exists", Value:"", Effect:"NoExecute", TolerationSeconds:(*int64)(0xc421c7c5d0)}}, HostAliases:[]v1.HostAlias(nil), PriorityClassName:"", Priority:(*int32)(nil), DNSConfig:(*v1.PodDNSConfig)(nil), ReadinessGates:[]v1.PodReadinessGate(nil)}, Status:v1.PodStatus{Phase:"Running", Conditions:[]v1.PodCondition{v1.PodCondition{Type:"Initialized", Status:"True", LastProbeTime:v1.Time{Time:time.Time{wall:0x0, ext:0, loc:(*time.Location)(nil)}}, LastTransitionTime:v1.Time{Time:time.Time{wall:0x0, ext:63666133426, loc:(*time.Location)(0x642c9a0)}}, Reason:"", Message:""}, v1.PodCondition{Type:"Ready", Status:"True", LastProbeTime:v1.Time{Time:time.Time{wall:0x0, ext:0, loc:(*time.Location)(nil)}}, LastTransitionTime:v1.Time{Time:time.Time{wall:0x0, ext:63666133428, loc:(*time.Location)(0x642c9a0)}}, Reason:"", Message:""}, v1.PodCondition{Type:"ContainersReady", Status:"True", LastProbeTime:v1.Time{Time:time.Time{wall:0x0, ext:0, loc:(*time.Location)(nil)}}, LastTransitionTime:v1.Time{Time:time.Time{wall:0x0, ext:0, loc:(*time.Location)(nil)}}, Reason:"", Message:""}, v1.PodCondition{Type:"PodScheduled", Status:"True", LastProbeTime:v1.Time{Time:time.Time{wall:0x0, ext:0, loc:(*time.Location)(nil)}}, LastTransitionTime:v1.Time{Time:time.Time{wall:0x0, ext:63666133425, loc:(*time.Location)(0x642c9a0)}}, Reason:"", Message:""}}, Message:"", Reason:"", NominatedNodeName:"", HostIP:"10.250.0.5", PodIP:"100.96.1.33", StartTime:(*v1.Time)(0xc4212742a0), InitContainerStatuses:[]v1.ContainerStatus(nil), ContainerStatuses:[]v1.ContainerStatus{v1.ContainerStatus{Name:"nginx", State:v1.ContainerState{Waiting:(*v1.ContainerStateWaiting)(nil), Running:(*v1.ContainerStateRunning)(0xc4212742c0), Terminated:(*v1.ContainerStateTerminated)(nil)}, LastTerminationState:v1.ContainerState{Waiting:(*v1.ContainerStateWaiting)(nil), Running:(*v1.ContainerStateRunning)(nil), Terminated:(*v1.ContainerStateTerminated)(nil)}, Ready:true, RestartCount:0, Image:"k8s.gcr.io/nginx-slim-amd64:0.20", ImageID:"docker-pullable://k8s.gcr.io/nginx-slim-amd64@sha256:6654db6d4028756062edac466454ee5c9cf9b20ef79e35a81e3c840031eb1e2b", ContainerID:"docker://000224908bbd5651e2adbf88a2fbdca78b86415a3ae5af803a41e63297efbc19"}}, QOSClass:"BestEffort"}}
+STEP: deleting the pod gracefully
+STEP: verifying the kubelet observed the termination notice
+STEP: verifying pod deletion was observed
+[AfterEach] [k8s.io] Pods
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:03:59.181: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-pods-8vjw4" for this suite.
+Jul  2 13:04:05.196: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:04:05.319: INFO: namespace: e2e-tests-pods-8vjw4, resource: bindings, ignored listing per whitelist
+Jul  2 13:04:05.327: INFO: namespace e2e-tests-pods-8vjw4 deletion completed in 6.142589886s
+
+• [SLOW TEST:19.447 seconds]
+[k8s.io] Pods
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:679
+  should be submitted and removed [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+S
+------------------------------
+[sig-api-machinery] Garbage collector 
+  should keep the rc around until all its pods are deleted if the deleteOptions says so [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-api-machinery] Garbage collector
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:04:05.327: INFO: >>> kubeConfig: /tmp/kubeconfig-324782104
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should keep the rc around until all its pods are deleted if the deleteOptions says so [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: create the rc
+STEP: delete the rc
+STEP: wait for the rc to be deleted
+STEP: Gathering metrics
+W0702 13:04:11.546774      15 metrics_grabber.go:81] Master node is not registered. Grabbing metrics from Scheduler, ControllerManager and ClusterAutoscaler is disabled.
+Jul  2 13:04:11.546: INFO: For apiserver_request_count:
+For apiserver_request_latencies_summary:
+For etcd_helper_cache_entry_count:
+For etcd_helper_cache_hit_count:
+For etcd_helper_cache_miss_count:
+For etcd_request_cache_add_latencies_summary:
+For etcd_request_cache_get_latencies_summary:
+For etcd_request_latencies_summary:
+For garbage_collector_attempt_to_delete_queue_latency:
+For garbage_collector_attempt_to_delete_work_duration:
+For garbage_collector_attempt_to_orphan_queue_latency:
+For garbage_collector_attempt_to_orphan_work_duration:
+For garbage_collector_dirty_processing_latency_microseconds:
+For garbage_collector_event_processing_latency_microseconds:
+For garbage_collector_graph_changes_queue_latency:
+For garbage_collector_graph_changes_work_duration:
+For garbage_collector_orphan_processing_latency_microseconds:
+For namespace_queue_latency:
+For namespace_queue_latency_sum:
+For namespace_queue_latency_count:
+For namespace_retries:
+For namespace_work_duration:
+For namespace_work_duration_sum:
+For namespace_work_duration_count:
+For function_duration_seconds:
+For errors_total:
+For evicted_pods_total:
+
+[AfterEach] [sig-api-machinery] Garbage collector
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:04:11.546: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-gc-9jjzt" for this suite.
+Jul  2 13:04:17.562: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:04:17.636: INFO: namespace: e2e-tests-gc-9jjzt, resource: bindings, ignored listing per whitelist
+Jul  2 13:04:17.649: INFO: namespace e2e-tests-gc-9jjzt deletion completed in 6.099776464s
+
+• [SLOW TEST:12.322 seconds]
+[sig-api-machinery] Garbage collector
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apimachinery/framework.go:22
+  should keep the rc around until all its pods are deleted if the deleteOptions says so [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SS
+------------------------------
+[sig-storage] HostPath 
+  should give a volume the correct mode [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-storage] HostPath
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:04:17.649: INFO: >>> kubeConfig: /tmp/kubeconfig-324782104
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] HostPath
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/host_path.go:36
+[It] should give a volume the correct mode [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating a pod to test hostPath mode
+Jul  2 13:04:17.782: INFO: Waiting up to 5m0s for pod "pod-host-path-test" in namespace "e2e-tests-hostpath-gk8qc" to be "success or failure"
+Jul  2 13:04:17.785: INFO: Pod "pod-host-path-test": Phase="Pending", Reason="", readiness=false. Elapsed: 3.000209ms
+Jul  2 13:04:19.789: INFO: Pod "pod-host-path-test": Phase="Pending", Reason="", readiness=false. Elapsed: 2.007060526s
+Jul  2 13:04:21.791: INFO: Pod "pod-host-path-test": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.009678051s
+STEP: Saw pod success
+Jul  2 13:04:21.791: INFO: Pod "pod-host-path-test" satisfied condition "success or failure"
+Jul  2 13:04:21.794: INFO: Trying to get logs from node shoot--core--confaz-worker-qfmi9-79968b77d9-kcr6j pod pod-host-path-test container test-container-1: <nil>
+STEP: delete the pod
+Jul  2 13:04:21.813: INFO: Waiting for pod pod-host-path-test to disappear
+Jul  2 13:04:21.824: INFO: Pod pod-host-path-test no longer exists
+[AfterEach] [sig-storage] HostPath
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:04:21.824: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-hostpath-gk8qc" for this suite.
+Jul  2 13:04:27.846: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:04:27.938: INFO: namespace: e2e-tests-hostpath-gk8qc, resource: bindings, ignored listing per whitelist
+Jul  2 13:04:27.953: INFO: namespace e2e-tests-hostpath-gk8qc deletion completed in 6.125374073s
+
+• [SLOW TEST:10.304 seconds]
+[sig-storage] HostPath
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/host_path.go:33
+  should give a volume the correct mode [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SS
+------------------------------
+[sig-storage] Projected 
+  should provide container's memory request [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:04:27.953: INFO: >>> kubeConfig: /tmp/kubeconfig-324782104
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:858
+[It] should provide container's memory request [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating a pod to test downward API volume plugin
+Jul  2 13:04:28.095: INFO: Waiting up to 5m0s for pod "downwardapi-volume-73ab5ebe-7df8-11e8-8e15-aefe7bc77cc2" in namespace "e2e-tests-projected-jdgjd" to be "success or failure"
+Jul  2 13:04:28.099: INFO: Pod "downwardapi-volume-73ab5ebe-7df8-11e8-8e15-aefe7bc77cc2": Phase="Pending", Reason="", readiness=false. Elapsed: 3.888412ms
+Jul  2 13:04:30.113: INFO: Pod "downwardapi-volume-73ab5ebe-7df8-11e8-8e15-aefe7bc77cc2": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.017928463s
+STEP: Saw pod success
+Jul  2 13:04:30.113: INFO: Pod "downwardapi-volume-73ab5ebe-7df8-11e8-8e15-aefe7bc77cc2" satisfied condition "success or failure"
+Jul  2 13:04:30.117: INFO: Trying to get logs from node shoot--core--confaz-worker-qfmi9-79968b77d9-kcr6j pod downwardapi-volume-73ab5ebe-7df8-11e8-8e15-aefe7bc77cc2 container client-container: <nil>
+STEP: delete the pod
+Jul  2 13:04:30.151: INFO: Waiting for pod downwardapi-volume-73ab5ebe-7df8-11e8-8e15-aefe7bc77cc2 to disappear
+Jul  2 13:04:30.155: INFO: Pod downwardapi-volume-73ab5ebe-7df8-11e8-8e15-aefe7bc77cc2 no longer exists
+[AfterEach] [sig-storage] Projected
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:04:30.155: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-jdgjd" for this suite.
+Jul  2 13:04:36.234: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:04:36.284: INFO: namespace: e2e-tests-projected-jdgjd, resource: bindings, ignored listing per whitelist
+Jul  2 13:04:36.351: INFO: namespace e2e-tests-projected-jdgjd deletion completed in 6.192692646s
+
+• [SLOW TEST:8.399 seconds]
+[sig-storage] Projected
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:34
+  should provide container's memory request [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSSSSS
+------------------------------
+[sig-auth] ServiceAccounts 
+  should mount an API token into pods  [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-auth] ServiceAccounts
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:04:36.351: INFO: >>> kubeConfig: /tmp/kubeconfig-324782104
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should mount an API token into pods  [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: getting the auto-created API token
+STEP: Creating a pod to test consume service account token
+Jul  2 13:04:36.960: INFO: Waiting up to 5m0s for pod "pod-service-account-78f5d278-7df8-11e8-8e15-aefe7bc77cc2-9j62n" in namespace "e2e-tests-svcaccounts-ctjtd" to be "success or failure"
+Jul  2 13:04:36.963: INFO: Pod "pod-service-account-78f5d278-7df8-11e8-8e15-aefe7bc77cc2-9j62n": Phase="Pending", Reason="", readiness=false. Elapsed: 3.067308ms
+Jul  2 13:04:38.967: INFO: Pod "pod-service-account-78f5d278-7df8-11e8-8e15-aefe7bc77cc2-9j62n": Phase="Pending", Reason="", readiness=false. Elapsed: 2.006818393s
+Jul  2 13:04:41.054: INFO: Pod "pod-service-account-78f5d278-7df8-11e8-8e15-aefe7bc77cc2-9j62n": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.09445962s
+STEP: Saw pod success
+Jul  2 13:04:41.054: INFO: Pod "pod-service-account-78f5d278-7df8-11e8-8e15-aefe7bc77cc2-9j62n" satisfied condition "success or failure"
+Jul  2 13:04:41.130: INFO: Trying to get logs from node shoot--core--confaz-worker-qfmi9-79968b77d9-kcr6j pod pod-service-account-78f5d278-7df8-11e8-8e15-aefe7bc77cc2-9j62n container token-test: <nil>
+STEP: delete the pod
+Jul  2 13:04:41.158: INFO: Waiting for pod pod-service-account-78f5d278-7df8-11e8-8e15-aefe7bc77cc2-9j62n to disappear
+Jul  2 13:04:41.169: INFO: Pod pod-service-account-78f5d278-7df8-11e8-8e15-aefe7bc77cc2-9j62n no longer exists
+STEP: Creating a pod to test consume service account root CA
+Jul  2 13:04:41.173: INFO: Waiting up to 5m0s for pod "pod-service-account-78f5d278-7df8-11e8-8e15-aefe7bc77cc2-rfg74" in namespace "e2e-tests-svcaccounts-ctjtd" to be "success or failure"
+Jul  2 13:04:41.176: INFO: Pod "pod-service-account-78f5d278-7df8-11e8-8e15-aefe7bc77cc2-rfg74": Phase="Pending", Reason="", readiness=false. Elapsed: 3.65061ms
+Jul  2 13:04:43.180: INFO: Pod "pod-service-account-78f5d278-7df8-11e8-8e15-aefe7bc77cc2-rfg74": Phase="Pending", Reason="", readiness=false. Elapsed: 2.007036974s
+Jul  2 13:04:45.184: INFO: Pod "pod-service-account-78f5d278-7df8-11e8-8e15-aefe7bc77cc2-rfg74": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.011143139s
+STEP: Saw pod success
+Jul  2 13:04:45.184: INFO: Pod "pod-service-account-78f5d278-7df8-11e8-8e15-aefe7bc77cc2-rfg74" satisfied condition "success or failure"
+Jul  2 13:04:45.186: INFO: Trying to get logs from node shoot--core--confaz-worker-qfmi9-79968b77d9-kcr6j pod pod-service-account-78f5d278-7df8-11e8-8e15-aefe7bc77cc2-rfg74 container root-ca-test: <nil>
+STEP: delete the pod
+Jul  2 13:04:45.261: INFO: Waiting for pod pod-service-account-78f5d278-7df8-11e8-8e15-aefe7bc77cc2-rfg74 to disappear
+Jul  2 13:04:45.274: INFO: Pod pod-service-account-78f5d278-7df8-11e8-8e15-aefe7bc77cc2-rfg74 no longer exists
+STEP: Creating a pod to test consume service account namespace
+Jul  2 13:04:45.287: INFO: Waiting up to 5m0s for pod "pod-service-account-78f5d278-7df8-11e8-8e15-aefe7bc77cc2-vdwv4" in namespace "e2e-tests-svcaccounts-ctjtd" to be "success or failure"
+Jul  2 13:04:45.290: INFO: Pod "pod-service-account-78f5d278-7df8-11e8-8e15-aefe7bc77cc2-vdwv4": Phase="Pending", Reason="", readiness=false. Elapsed: 3.506709ms
+Jul  2 13:04:47.294: INFO: Pod "pod-service-account-78f5d278-7df8-11e8-8e15-aefe7bc77cc2-vdwv4": Phase="Pending", Reason="", readiness=false. Elapsed: 2.006960424s
+Jul  2 13:04:49.297: INFO: Pod "pod-service-account-78f5d278-7df8-11e8-8e15-aefe7bc77cc2-vdwv4": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.010450948s
+STEP: Saw pod success
+Jul  2 13:04:49.297: INFO: Pod "pod-service-account-78f5d278-7df8-11e8-8e15-aefe7bc77cc2-vdwv4" satisfied condition "success or failure"
+Jul  2 13:04:49.300: INFO: Trying to get logs from node shoot--core--confaz-worker-qfmi9-79968b77d9-kcr6j pod pod-service-account-78f5d278-7df8-11e8-8e15-aefe7bc77cc2-vdwv4 container namespace-test: <nil>
+STEP: delete the pod
+Jul  2 13:04:49.332: INFO: Waiting for pod pod-service-account-78f5d278-7df8-11e8-8e15-aefe7bc77cc2-vdwv4 to disappear
+Jul  2 13:04:49.352: INFO: Pod pod-service-account-78f5d278-7df8-11e8-8e15-aefe7bc77cc2-vdwv4 no longer exists
+[AfterEach] [sig-auth] ServiceAccounts
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:04:49.352: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-svcaccounts-ctjtd" for this suite.
+Jul  2 13:04:55.432: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:04:55.441: INFO: namespace: e2e-tests-svcaccounts-ctjtd, resource: bindings, ignored listing per whitelist
+Jul  2 13:04:55.615: INFO: namespace e2e-tests-svcaccounts-ctjtd deletion completed in 6.259783496s
+
+• [SLOW TEST:19.264 seconds]
+[sig-auth] ServiceAccounts
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/auth/framework.go:22
+  should mount an API token into pods  [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SS
+------------------------------
+[sig-apps] Daemon set [Serial] 
+  should rollback without unnecessary restarts [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-apps] Daemon set [Serial]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:04:55.616: INFO: >>> kubeConfig: /tmp/kubeconfig-324782104
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-apps] Daemon set [Serial]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/daemon_set.go:99
+[It] should rollback without unnecessary restarts [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+Jul  2 13:04:55.726: INFO: Requires at least 2 nodes (not -1)
+[AfterEach] [sig-apps] Daemon set [Serial]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/daemon_set.go:65
+Jul  2 13:04:55.732: INFO: daemonset: {"kind":"DaemonSetList","apiVersion":"apps/v1","metadata":{"selfLink":"/apis/apps/v1/namespaces/e2e-tests-daemonsets-bclkv/daemonsets","resourceVersion":"3033"},"items":null}
+
+Jul  2 13:04:55.734: INFO: pods: {"kind":"PodList","apiVersion":"v1","metadata":{"selfLink":"/api/v1/namespaces/e2e-tests-daemonsets-bclkv/pods","resourceVersion":"3033"},"items":null}
+
+[AfterEach] [sig-apps] Daemon set [Serial]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:04:55.751: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-daemonsets-bclkv" for this suite.
+Jul  2 13:05:01.766: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:05:01.974: INFO: namespace: e2e-tests-daemonsets-bclkv, resource: bindings, ignored listing per whitelist
+Jul  2 13:05:02.011: INFO: namespace e2e-tests-daemonsets-bclkv deletion completed in 6.256748338s
+
+S [SKIPPING] [6.395 seconds]
+[sig-apps] Daemon set [Serial]
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/framework.go:22
+  should rollback without unnecessary restarts [Conformance] [It]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+
+  Jul  2 13:04:55.726: Requires at least 2 nodes (not -1)
+
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/util.go:305
+------------------------------
+SSSSSSSSSSSS
+------------------------------
+[sig-storage] EmptyDir volumes 
+  volume on tmpfs should have the correct mode [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-storage] EmptyDir volumes
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:05:02.011: INFO: >>> kubeConfig: /tmp/kubeconfig-324782104
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] volume on tmpfs should have the correct mode [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating a pod to test emptydir volume type on tmpfs
+Jul  2 13:05:02.102: INFO: Waiting up to 5m0s for pod "pod-87f18bcf-7df8-11e8-8e15-aefe7bc77cc2" in namespace "e2e-tests-emptydir-8rg7t" to be "success or failure"
+Jul  2 13:05:02.106: INFO: Pod "pod-87f18bcf-7df8-11e8-8e15-aefe7bc77cc2": Phase="Pending", Reason="", readiness=false. Elapsed: 3.416009ms
+Jul  2 13:05:04.109: INFO: Pod "pod-87f18bcf-7df8-11e8-8e15-aefe7bc77cc2": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.00717527s
+STEP: Saw pod success
+Jul  2 13:05:04.109: INFO: Pod "pod-87f18bcf-7df8-11e8-8e15-aefe7bc77cc2" satisfied condition "success or failure"
+Jul  2 13:05:04.112: INFO: Trying to get logs from node shoot--core--confaz-worker-qfmi9-79968b77d9-kcr6j pod pod-87f18bcf-7df8-11e8-8e15-aefe7bc77cc2 container test-container: <nil>
+STEP: delete the pod
+Jul  2 13:05:04.140: INFO: Waiting for pod pod-87f18bcf-7df8-11e8-8e15-aefe7bc77cc2 to disappear
+Jul  2 13:05:04.152: INFO: Pod pod-87f18bcf-7df8-11e8-8e15-aefe7bc77cc2 no longer exists
+[AfterEach] [sig-storage] EmptyDir volumes
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:05:04.152: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-emptydir-8rg7t" for this suite.
+Jul  2 13:05:10.182: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:05:10.224: INFO: namespace: e2e-tests-emptydir-8rg7t, resource: bindings, ignored listing per whitelist
+Jul  2 13:05:10.283: INFO: namespace e2e-tests-emptydir-8rg7t deletion completed in 6.12810539s
+
+• [SLOW TEST:8.272 seconds]
+[sig-storage] EmptyDir volumes
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/empty_dir.go:40
+  volume on tmpfs should have the correct mode [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSSSS
+------------------------------
+[sig-storage] EmptyDir volumes 
+  should support (non-root,0644,tmpfs) [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-storage] EmptyDir volumes
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:05:10.284: INFO: >>> kubeConfig: /tmp/kubeconfig-324782104
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should support (non-root,0644,tmpfs) [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating a pod to test emptydir 0644 on tmpfs
+Jul  2 13:05:10.388: INFO: Waiting up to 5m0s for pod "pod-8ce142c3-7df8-11e8-8e15-aefe7bc77cc2" in namespace "e2e-tests-emptydir-f8jbn" to be "success or failure"
+Jul  2 13:05:10.392: INFO: Pod "pod-8ce142c3-7df8-11e8-8e15-aefe7bc77cc2": Phase="Pending", Reason="", readiness=false. Elapsed: 3.675309ms
+Jul  2 13:05:12.396: INFO: Pod "pod-8ce142c3-7df8-11e8-8e15-aefe7bc77cc2": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.007759272s
+STEP: Saw pod success
+Jul  2 13:05:12.396: INFO: Pod "pod-8ce142c3-7df8-11e8-8e15-aefe7bc77cc2" satisfied condition "success or failure"
+Jul  2 13:05:12.398: INFO: Trying to get logs from node shoot--core--confaz-worker-qfmi9-79968b77d9-kcr6j pod pod-8ce142c3-7df8-11e8-8e15-aefe7bc77cc2 container test-container: <nil>
+STEP: delete the pod
+Jul  2 13:05:12.423: INFO: Waiting for pod pod-8ce142c3-7df8-11e8-8e15-aefe7bc77cc2 to disappear
+Jul  2 13:05:12.426: INFO: Pod pod-8ce142c3-7df8-11e8-8e15-aefe7bc77cc2 no longer exists
+[AfterEach] [sig-storage] EmptyDir volumes
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:05:12.426: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-emptydir-f8jbn" for this suite.
+Jul  2 13:05:18.446: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:05:18.454: INFO: namespace: e2e-tests-emptydir-f8jbn, resource: bindings, ignored listing per whitelist
+Jul  2 13:05:18.609: INFO: namespace e2e-tests-emptydir-f8jbn deletion completed in 6.179948148s
+
+• [SLOW TEST:8.325 seconds]
+[sig-storage] EmptyDir volumes
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/empty_dir.go:40
+  should support (non-root,0644,tmpfs) [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSSSS
+------------------------------
+[k8s.io] Variable Expansion 
+  should allow substituting values in a container's args [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [k8s.io] Variable Expansion
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:05:18.609: INFO: >>> kubeConfig: /tmp/kubeconfig-324782104
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should allow substituting values in a container's args [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating a pod to test substitution in container's args
+Jul  2 13:05:18.708: INFO: Waiting up to 5m0s for pod "var-expansion-91d864f3-7df8-11e8-8e15-aefe7bc77cc2" in namespace "e2e-tests-var-expansion-kgkn7" to be "success or failure"
+Jul  2 13:05:18.722: INFO: Pod "var-expansion-91d864f3-7df8-11e8-8e15-aefe7bc77cc2": Phase="Pending", Reason="", readiness=false. Elapsed: 14.12904ms
+Jul  2 13:05:20.726: INFO: Pod "var-expansion-91d864f3-7df8-11e8-8e15-aefe7bc77cc2": Phase="Pending", Reason="", readiness=false. Elapsed: 2.017365933s
+Jul  2 13:05:22.730: INFO: Pod "var-expansion-91d864f3-7df8-11e8-8e15-aefe7bc77cc2": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.021722705s
+STEP: Saw pod success
+Jul  2 13:05:22.730: INFO: Pod "var-expansion-91d864f3-7df8-11e8-8e15-aefe7bc77cc2" satisfied condition "success or failure"
+Jul  2 13:05:22.733: INFO: Trying to get logs from node shoot--core--confaz-worker-qfmi9-79968b77d9-kcr6j pod var-expansion-91d864f3-7df8-11e8-8e15-aefe7bc77cc2 container dapi-container: <nil>
+STEP: delete the pod
+Jul  2 13:05:22.761: INFO: Waiting for pod var-expansion-91d864f3-7df8-11e8-8e15-aefe7bc77cc2 to disappear
+Jul  2 13:05:22.780: INFO: Pod var-expansion-91d864f3-7df8-11e8-8e15-aefe7bc77cc2 no longer exists
+[AfterEach] [k8s.io] Variable Expansion
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:05:22.782: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-var-expansion-kgkn7" for this suite.
+Jul  2 13:05:28.806: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:05:28.924: INFO: namespace: e2e-tests-var-expansion-kgkn7, resource: bindings, ignored listing per whitelist
+Jul  2 13:05:28.974: INFO: namespace e2e-tests-var-expansion-kgkn7 deletion completed in 6.187247797s
+
+• [SLOW TEST:10.365 seconds]
+[k8s.io] Variable Expansion
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:679
+  should allow substituting values in a container's args [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSS
+------------------------------
+[sig-storage] Downward API volume 
+  should provide podname only [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:05:28.976: INFO: >>> kubeConfig: /tmp/kubeconfig-324782104
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downwardapi_volume.go:38
+[It] should provide podname only [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating a pod to test downward API volume plugin
+Jul  2 13:05:29.130: INFO: Waiting up to 5m0s for pod "downwardapi-volume-980dc61f-7df8-11e8-8e15-aefe7bc77cc2" in namespace "e2e-tests-downward-api-fvffr" to be "success or failure"
+Jul  2 13:05:29.134: INFO: Pod "downwardapi-volume-980dc61f-7df8-11e8-8e15-aefe7bc77cc2": Phase="Pending", Reason="", readiness=false. Elapsed: 3.946811ms
+Jul  2 13:05:31.138: INFO: Pod "downwardapi-volume-980dc61f-7df8-11e8-8e15-aefe7bc77cc2": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.008166821s
+STEP: Saw pod success
+Jul  2 13:05:31.138: INFO: Pod "downwardapi-volume-980dc61f-7df8-11e8-8e15-aefe7bc77cc2" satisfied condition "success or failure"
+Jul  2 13:05:31.150: INFO: Trying to get logs from node shoot--core--confaz-worker-qfmi9-79968b77d9-kcr6j pod downwardapi-volume-980dc61f-7df8-11e8-8e15-aefe7bc77cc2 container client-container: <nil>
+STEP: delete the pod
+Jul  2 13:05:31.172: INFO: Waiting for pod downwardapi-volume-980dc61f-7df8-11e8-8e15-aefe7bc77cc2 to disappear
+Jul  2 13:05:31.184: INFO: Pod downwardapi-volume-980dc61f-7df8-11e8-8e15-aefe7bc77cc2 no longer exists
+[AfterEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:05:31.185: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-downward-api-fvffr" for this suite.
+Jul  2 13:05:37.995: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:05:38.327: INFO: namespace: e2e-tests-downward-api-fvffr, resource: bindings, ignored listing per whitelist
+Jul  2 13:05:38.410: INFO: namespace e2e-tests-downward-api-fvffr deletion completed in 7.221428501s
+
+• [SLOW TEST:9.434 seconds]
+[sig-storage] Downward API volume
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downwardapi_volume.go:33
+  should provide podname only [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSSSSSSSSSSSSSSSSSSSS
+------------------------------
+[sig-network] Networking Granular Checks: Pods 
+  should function for node-pod communication: http [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-network] Networking
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:05:38.410: INFO: >>> kubeConfig: /tmp/kubeconfig-324782104
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should function for node-pod communication: http [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Performing setup for networking test in namespace e2e-tests-pod-network-test-hvkpj
+STEP: creating a selector
+STEP: Creating the service pods in kubernetes
+Jul  2 13:05:38.503: INFO: Waiting up to 10m0s for all (but 0) nodes to be schedulable
+STEP: Creating test pods
+Jul  2 13:06:02.593: INFO: ExecWithOptions {Command:[/bin/sh -c timeout -t 15 curl -g -q -s --connect-timeout 1 http://100.96.1.49:8080/hostName | grep -v '^\s*$'] Namespace:e2e-tests-pod-network-test-hvkpj PodName:host-test-container-pod ContainerName:hostexec Stdin:<nil> CaptureStdout:true CaptureStderr:true PreserveWhitespace:false}
+Jul  2 13:06:02.593: INFO: >>> kubeConfig: /tmp/kubeconfig-324782104
+Jul  2 13:06:02.968: INFO: Found all expected endpoints: [netserver-0]
+Jul  2 13:06:02.971: INFO: ExecWithOptions {Command:[/bin/sh -c timeout -t 15 curl -g -q -s --connect-timeout 1 http://100.96.0.22:8080/hostName | grep -v '^\s*$'] Namespace:e2e-tests-pod-network-test-hvkpj PodName:host-test-container-pod ContainerName:hostexec Stdin:<nil> CaptureStdout:true CaptureStderr:true PreserveWhitespace:false}
+Jul  2 13:06:02.971: INFO: >>> kubeConfig: /tmp/kubeconfig-324782104
+Jul  2 13:06:03.362: INFO: Found all expected endpoints: [netserver-1]
+[AfterEach] [sig-network] Networking
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:06:03.362: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-pod-network-test-hvkpj" for this suite.
+Jul  2 13:06:25.379: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:06:25.386: INFO: namespace: e2e-tests-pod-network-test-hvkpj, resource: bindings, ignored listing per whitelist
+Jul  2 13:06:25.476: INFO: namespace e2e-tests-pod-network-test-hvkpj deletion completed in 22.109990253s
+
+• [SLOW TEST:47.066 seconds]
+[sig-network] Networking
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/networking.go:25
+  Granular Checks: Pods
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/networking.go:28
+    should function for node-pod communication: http [NodeConformance] [Conformance]
+    /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SS
+------------------------------
+[sig-storage] EmptyDir volumes 
+  volume on default medium should have the correct mode [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-storage] EmptyDir volumes
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:06:25.476: INFO: >>> kubeConfig: /tmp/kubeconfig-324782104
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] volume on default medium should have the correct mode [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating a pod to test emptydir volume type on node default medium
+Jul  2 13:06:25.583: INFO: Waiting up to 5m0s for pod "pod-b9b39a50-7df8-11e8-8e15-aefe7bc77cc2" in namespace "e2e-tests-emptydir-9xhqm" to be "success or failure"
+Jul  2 13:06:25.612: INFO: Pod "pod-b9b39a50-7df8-11e8-8e15-aefe7bc77cc2": Phase="Pending", Reason="", readiness=false. Elapsed: 28.683181ms
+Jul  2 13:06:27.615: INFO: Pod "pod-b9b39a50-7df8-11e8-8e15-aefe7bc77cc2": Phase="Pending", Reason="", readiness=false. Elapsed: 2.032126091s
+Jul  2 13:06:29.618: INFO: Pod "pod-b9b39a50-7df8-11e8-8e15-aefe7bc77cc2": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.035193035s
+STEP: Saw pod success
+Jul  2 13:06:29.618: INFO: Pod "pod-b9b39a50-7df8-11e8-8e15-aefe7bc77cc2" satisfied condition "success or failure"
+Jul  2 13:06:29.621: INFO: Trying to get logs from node shoot--core--confaz-worker-qfmi9-79968b77d9-kcr6j pod pod-b9b39a50-7df8-11e8-8e15-aefe7bc77cc2 container test-container: <nil>
+STEP: delete the pod
+Jul  2 13:06:29.684: INFO: Waiting for pod pod-b9b39a50-7df8-11e8-8e15-aefe7bc77cc2 to disappear
+Jul  2 13:06:29.687: INFO: Pod pod-b9b39a50-7df8-11e8-8e15-aefe7bc77cc2 no longer exists
+[AfterEach] [sig-storage] EmptyDir volumes
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:06:29.687: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-emptydir-9xhqm" for this suite.
+Jul  2 13:06:35.701: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:06:35.769: INFO: namespace: e2e-tests-emptydir-9xhqm, resource: bindings, ignored listing per whitelist
+Jul  2 13:06:35.805: INFO: namespace e2e-tests-emptydir-9xhqm deletion completed in 6.114511856s
+
+• [SLOW TEST:10.329 seconds]
+[sig-storage] EmptyDir volumes
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/empty_dir.go:40
+  volume on default medium should have the correct mode [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSSSSS
+------------------------------
+[sig-storage] Projected 
+  should set mode on item file [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:06:35.805: INFO: >>> kubeConfig: /tmp/kubeconfig-324782104
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:858
+[It] should set mode on item file [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating a pod to test downward API volume plugin
+Jul  2 13:06:35.908: INFO: Waiting up to 5m0s for pod "downwardapi-volume-bfdaf37c-7df8-11e8-8e15-aefe7bc77cc2" in namespace "e2e-tests-projected-6zhx2" to be "success or failure"
+Jul  2 13:06:35.911: INFO: Pod "downwardapi-volume-bfdaf37c-7df8-11e8-8e15-aefe7bc77cc2": Phase="Pending", Reason="", readiness=false. Elapsed: 3.49051ms
+Jul  2 13:06:37.930: INFO: Pod "downwardapi-volume-bfdaf37c-7df8-11e8-8e15-aefe7bc77cc2": Phase="Pending", Reason="", readiness=false. Elapsed: 2.022646739s
+Jul  2 13:06:39.934: INFO: Pod "downwardapi-volume-bfdaf37c-7df8-11e8-8e15-aefe7bc77cc2": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.026439458s
+STEP: Saw pod success
+Jul  2 13:06:39.934: INFO: Pod "downwardapi-volume-bfdaf37c-7df8-11e8-8e15-aefe7bc77cc2" satisfied condition "success or failure"
+Jul  2 13:06:39.938: INFO: Trying to get logs from node shoot--core--confaz-worker-qfmi9-79968b77d9-kcr6j pod downwardapi-volume-bfdaf37c-7df8-11e8-8e15-aefe7bc77cc2 container client-container: <nil>
+STEP: delete the pod
+Jul  2 13:06:39.956: INFO: Waiting for pod downwardapi-volume-bfdaf37c-7df8-11e8-8e15-aefe7bc77cc2 to disappear
+Jul  2 13:06:39.962: INFO: Pod downwardapi-volume-bfdaf37c-7df8-11e8-8e15-aefe7bc77cc2 no longer exists
+[AfterEach] [sig-storage] Projected
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:06:39.962: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-6zhx2" for this suite.
+Jul  2 13:06:46.004: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:06:46.102: INFO: namespace: e2e-tests-projected-6zhx2, resource: bindings, ignored listing per whitelist
+Jul  2 13:06:46.112: INFO: namespace e2e-tests-projected-6zhx2 deletion completed in 6.147490835s
+
+• [SLOW TEST:10.307 seconds]
+[sig-storage] Projected
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:34
+  should set mode on item file [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSSSSSSSSSSSSS
+------------------------------
+[k8s.io] Probing container 
+  with readiness probe should not be ready before initial delay and never restart [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [k8s.io] Probing container
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:06:46.112: INFO: >>> kubeConfig: /tmp/kubeconfig-324782104
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [k8s.io] Probing container
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/container_probe.go:48
+[It] with readiness probe should not be ready before initial delay and never restart [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+Jul  2 13:07:12.330: INFO: Container started at 2018-07-02 13:06:48 +0000 UTC, pod became ready at 2018-07-02 13:07:11 +0000 UTC
+[AfterEach] [k8s.io] Probing container
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:07:12.330: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-container-probe-l4m26" for this suite.
+Jul  2 13:07:34.349: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:07:34.422: INFO: namespace: e2e-tests-container-probe-l4m26, resource: bindings, ignored listing per whitelist
+Jul  2 13:07:34.504: INFO: namespace e2e-tests-container-probe-l4m26 deletion completed in 22.169936374s
+
+• [SLOW TEST:48.391 seconds]
+[k8s.io] Probing container
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:679
+  with readiness probe should not be ready before initial delay and never restart [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSSSS
+------------------------------
+[sig-api-machinery] Secrets 
+  should be consumable via the environment [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-api-machinery] Secrets
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:07:34.504: INFO: >>> kubeConfig: /tmp/kubeconfig-324782104
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should be consumable via the environment [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: creating secret e2e-tests-secrets-jhc2p/secret-test-e2d7b4fd-7df8-11e8-8e15-aefe7bc77cc2
+STEP: Creating a pod to test consume secrets
+Jul  2 13:07:34.613: INFO: Waiting up to 5m0s for pod "pod-configmaps-e2d8ad4e-7df8-11e8-8e15-aefe7bc77cc2" in namespace "e2e-tests-secrets-jhc2p" to be "success or failure"
+Jul  2 13:07:34.630: INFO: Pod "pod-configmaps-e2d8ad4e-7df8-11e8-8e15-aefe7bc77cc2": Phase="Pending", Reason="", readiness=false. Elapsed: 16.994744ms
+Jul  2 13:07:36.634: INFO: Pod "pod-configmaps-e2d8ad4e-7df8-11e8-8e15-aefe7bc77cc2": Phase="Pending", Reason="", readiness=false. Elapsed: 2.02041907s
+Jul  2 13:07:38.637: INFO: Pod "pod-configmaps-e2d8ad4e-7df8-11e8-8e15-aefe7bc77cc2": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.024214054s
+STEP: Saw pod success
+Jul  2 13:07:38.638: INFO: Pod "pod-configmaps-e2d8ad4e-7df8-11e8-8e15-aefe7bc77cc2" satisfied condition "success or failure"
+Jul  2 13:07:38.640: INFO: Trying to get logs from node shoot--core--confaz-worker-qfmi9-79968b77d9-kcr6j pod pod-configmaps-e2d8ad4e-7df8-11e8-8e15-aefe7bc77cc2 container env-test: <nil>
+STEP: delete the pod
+Jul  2 13:07:38.681: INFO: Waiting for pod pod-configmaps-e2d8ad4e-7df8-11e8-8e15-aefe7bc77cc2 to disappear
+Jul  2 13:07:38.684: INFO: Pod pod-configmaps-e2d8ad4e-7df8-11e8-8e15-aefe7bc77cc2 no longer exists
+[AfterEach] [sig-api-machinery] Secrets
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:07:38.684: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-secrets-jhc2p" for this suite.
+Jul  2 13:07:44.703: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:07:44.757: INFO: namespace: e2e-tests-secrets-jhc2p, resource: bindings, ignored listing per whitelist
+Jul  2 13:07:44.806: INFO: namespace e2e-tests-secrets-jhc2p deletion completed in 6.11942336s
+
+• [SLOW TEST:10.302 seconds]
+[sig-api-machinery] Secrets
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/secrets.go:30
+  should be consumable via the environment [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSSSSSSSSSSSSSSSSSSSSSS
+------------------------------
+[sig-storage] Projected 
+  optional updates should be reflected in volume [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:07:44.811: INFO: >>> kubeConfig: /tmp/kubeconfig-324782104
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:858
+[It] optional updates should be reflected in volume [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating configMap with name cm-test-opt-del-e8ff3533-7df8-11e8-8e15-aefe7bc77cc2
+STEP: Creating configMap with name cm-test-opt-upd-e8ff355f-7df8-11e8-8e15-aefe7bc77cc2
+STEP: Creating the pod
+STEP: Deleting configmap cm-test-opt-del-e8ff3533-7df8-11e8-8e15-aefe7bc77cc2
+STEP: Updating configmap cm-test-opt-upd-e8ff355f-7df8-11e8-8e15-aefe7bc77cc2
+STEP: Creating configMap with name cm-test-opt-create-e8ff356d-7df8-11e8-8e15-aefe7bc77cc2
+STEP: waiting to observe update in volume
+[AfterEach] [sig-storage] Projected
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:07:51.399: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-6ljqf" for this suite.
+Jul  2 13:08:13.414: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:08:13.500: INFO: namespace: e2e-tests-projected-6ljqf, resource: bindings, ignored listing per whitelist
+Jul  2 13:08:13.506: INFO: namespace e2e-tests-projected-6ljqf deletion completed in 22.103065023s
+
+• [SLOW TEST:28.695 seconds]
+[sig-storage] Projected
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:34
+  optional updates should be reflected in volume [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+[sig-storage] EmptyDir volumes 
+  should support (root,0777,tmpfs) [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-storage] EmptyDir volumes
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:08:13.506: INFO: >>> kubeConfig: /tmp/kubeconfig-324782104
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should support (root,0777,tmpfs) [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating a pod to test emptydir 0777 on tmpfs
+Jul  2 13:08:13.617: INFO: Waiting up to 5m0s for pod "pod-fa16b673-7df8-11e8-8e15-aefe7bc77cc2" in namespace "e2e-tests-emptydir-dqwvl" to be "success or failure"
+Jul  2 13:08:13.619: INFO: Pod "pod-fa16b673-7df8-11e8-8e15-aefe7bc77cc2": Phase="Pending", Reason="", readiness=false. Elapsed: 2.429906ms
+Jul  2 13:08:15.622: INFO: Pod "pod-fa16b673-7df8-11e8-8e15-aefe7bc77cc2": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.00548798s
+STEP: Saw pod success
+Jul  2 13:08:15.622: INFO: Pod "pod-fa16b673-7df8-11e8-8e15-aefe7bc77cc2" satisfied condition "success or failure"
+Jul  2 13:08:15.625: INFO: Trying to get logs from node shoot--core--confaz-worker-qfmi9-79968b77d9-kcr6j pod pod-fa16b673-7df8-11e8-8e15-aefe7bc77cc2 container test-container: <nil>
+STEP: delete the pod
+Jul  2 13:08:15.694: INFO: Waiting for pod pod-fa16b673-7df8-11e8-8e15-aefe7bc77cc2 to disappear
+Jul  2 13:08:15.704: INFO: Pod pod-fa16b673-7df8-11e8-8e15-aefe7bc77cc2 no longer exists
+[AfterEach] [sig-storage] EmptyDir volumes
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:08:15.704: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-emptydir-dqwvl" for this suite.
+Jul  2 13:08:21.724: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:08:21.807: INFO: namespace: e2e-tests-emptydir-dqwvl, resource: bindings, ignored listing per whitelist
+Jul  2 13:08:21.859: INFO: namespace e2e-tests-emptydir-dqwvl deletion completed in 6.145013056s
+
+• [SLOW TEST:8.353 seconds]
+[sig-storage] EmptyDir volumes
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/empty_dir.go:40
+  should support (root,0777,tmpfs) [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSSSSSSSSSSSSSSS
+------------------------------
+[sig-storage] Projected 
+  should provide container's memory limit [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:08:21.859: INFO: >>> kubeConfig: /tmp/kubeconfig-324782104
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:858
+[It] should provide container's memory limit [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating a pod to test downward API volume plugin
+Jul  2 13:08:21.960: INFO: Waiting up to 5m0s for pod "downwardapi-volume-ff117a81-7df8-11e8-8e15-aefe7bc77cc2" in namespace "e2e-tests-projected-wb58f" to be "success or failure"
+Jul  2 13:08:21.976: INFO: Pod "downwardapi-volume-ff117a81-7df8-11e8-8e15-aefe7bc77cc2": Phase="Pending", Reason="", readiness=false. Elapsed: 16.846754ms
+Jul  2 13:08:23.979: INFO: Pod "downwardapi-volume-ff117a81-7df8-11e8-8e15-aefe7bc77cc2": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.019506709s
+STEP: Saw pod success
+Jul  2 13:08:23.979: INFO: Pod "downwardapi-volume-ff117a81-7df8-11e8-8e15-aefe7bc77cc2" satisfied condition "success or failure"
+Jul  2 13:08:23.981: INFO: Trying to get logs from node shoot--core--confaz-worker-qfmi9-79968b77d9-kcr6j pod downwardapi-volume-ff117a81-7df8-11e8-8e15-aefe7bc77cc2 container client-container: <nil>
+STEP: delete the pod
+Jul  2 13:08:24.007: INFO: Waiting for pod downwardapi-volume-ff117a81-7df8-11e8-8e15-aefe7bc77cc2 to disappear
+Jul  2 13:08:24.019: INFO: Pod downwardapi-volume-ff117a81-7df8-11e8-8e15-aefe7bc77cc2 no longer exists
+[AfterEach] [sig-storage] Projected
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:08:24.019: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-wb58f" for this suite.
+Jul  2 13:08:30.041: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:08:30.055: INFO: namespace: e2e-tests-projected-wb58f, resource: bindings, ignored listing per whitelist
+Jul  2 13:08:30.155: INFO: namespace e2e-tests-projected-wb58f deletion completed in 6.133096369s
+
+• [SLOW TEST:8.297 seconds]
+[sig-storage] Projected
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:34
+  should provide container's memory limit [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+S
+------------------------------
+[k8s.io] Probing container 
+  should *not* be restarted with a /healthz http liveness probe [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [k8s.io] Probing container
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:08:30.156: INFO: >>> kubeConfig: /tmp/kubeconfig-324782104
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [k8s.io] Probing container
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/container_probe.go:48
+[It] should *not* be restarted with a /healthz http liveness probe [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating pod liveness-http in namespace e2e-tests-container-probe-fhnfv
+Jul  2 13:08:32.268: INFO: Started pod liveness-http in namespace e2e-tests-container-probe-fhnfv
+STEP: checking the pod's current state and verifying that restartCount is present
+Jul  2 13:08:32.270: INFO: Initial restart count of pod liveness-http is 0
+STEP: deleting the pod
+[AfterEach] [k8s.io] Probing container
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:12:33.675: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-container-probe-fhnfv" for this suite.
+Jul  2 13:12:39.699: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:12:39.749: INFO: namespace: e2e-tests-container-probe-fhnfv, resource: bindings, ignored listing per whitelist
+Jul  2 13:12:39.821: INFO: namespace e2e-tests-container-probe-fhnfv deletion completed in 6.140130615s
+
+• [SLOW TEST:249.665 seconds]
+[k8s.io] Probing container
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:679
+  should *not* be restarted with a /healthz http liveness probe [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSSSSS
+------------------------------
+[sig-storage] ConfigMap 
+  optional updates should be reflected in volume [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-storage] ConfigMap
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:12:39.821: INFO: >>> kubeConfig: /tmp/kubeconfig-324782104
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] optional updates should be reflected in volume [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating configMap with name cm-test-opt-del-98d7294b-7df9-11e8-8e15-aefe7bc77cc2
+STEP: Creating configMap with name cm-test-opt-upd-98d72974-7df9-11e8-8e15-aefe7bc77cc2
+STEP: Creating the pod
+STEP: Deleting configmap cm-test-opt-del-98d7294b-7df9-11e8-8e15-aefe7bc77cc2
+STEP: Updating configmap cm-test-opt-upd-98d72974-7df9-11e8-8e15-aefe7bc77cc2
+STEP: Creating configMap with name cm-test-opt-create-98d72983-7df9-11e8-8e15-aefe7bc77cc2
+STEP: waiting to observe update in volume
+[AfterEach] [sig-storage] ConfigMap
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:13:58.063: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-configmap-kqkj2" for this suite.
+Jul  2 13:14:22.076: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:14:22.117: INFO: namespace: e2e-tests-configmap-kqkj2, resource: bindings, ignored listing per whitelist
+Jul  2 13:14:22.178: INFO: namespace e2e-tests-configmap-kqkj2 deletion completed in 24.111920982s
+
+• [SLOW TEST:102.356 seconds]
+[sig-storage] ConfigMap
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/configmap_volume.go:32
+  optional updates should be reflected in volume [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSSSS
+------------------------------
+[sig-storage] Projected 
+  should set DefaultMode on files [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:14:22.178: INFO: >>> kubeConfig: /tmp/kubeconfig-324782104
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:858
+[It] should set DefaultMode on files [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating a pod to test downward API volume plugin
+Jul  2 13:14:22.282: INFO: Waiting up to 5m0s for pod "downwardapi-volume-d5d61c3b-7df9-11e8-8e15-aefe7bc77cc2" in namespace "e2e-tests-projected-7kgpx" to be "success or failure"
+Jul  2 13:14:22.286: INFO: Pod "downwardapi-volume-d5d61c3b-7df9-11e8-8e15-aefe7bc77cc2": Phase="Pending", Reason="", readiness=false. Elapsed: 3.629512ms
+Jul  2 13:14:24.290: INFO: Pod "downwardapi-volume-d5d61c3b-7df9-11e8-8e15-aefe7bc77cc2": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.007548241s
+STEP: Saw pod success
+Jul  2 13:14:24.290: INFO: Pod "downwardapi-volume-d5d61c3b-7df9-11e8-8e15-aefe7bc77cc2" satisfied condition "success or failure"
+Jul  2 13:14:24.292: INFO: Trying to get logs from node shoot--core--confaz-worker-qfmi9-79968b77d9-kcr6j pod downwardapi-volume-d5d61c3b-7df9-11e8-8e15-aefe7bc77cc2 container client-container: <nil>
+STEP: delete the pod
+Jul  2 13:14:24.312: INFO: Waiting for pod downwardapi-volume-d5d61c3b-7df9-11e8-8e15-aefe7bc77cc2 to disappear
+Jul  2 13:14:24.317: INFO: Pod downwardapi-volume-d5d61c3b-7df9-11e8-8e15-aefe7bc77cc2 no longer exists
+[AfterEach] [sig-storage] Projected
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:14:24.317: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-7kgpx" for this suite.
+Jul  2 13:14:30.356: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:14:30.486: INFO: namespace: e2e-tests-projected-7kgpx, resource: bindings, ignored listing per whitelist
+Jul  2 13:14:30.486: INFO: namespace e2e-tests-projected-7kgpx deletion completed in 6.151325154s
+
+• [SLOW TEST:8.308 seconds]
+[sig-storage] Projected
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:34
+  should set DefaultMode on files [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSSSSSSSSSS
+------------------------------
+[sig-storage] Projected 
+  should provide container's cpu limit [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:14:30.486: INFO: >>> kubeConfig: /tmp/kubeconfig-324782104
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:858
+[It] should provide container's cpu limit [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating a pod to test downward API volume plugin
+Jul  2 13:14:30.597: INFO: Waiting up to 5m0s for pod "downwardapi-volume-daca4c93-7df9-11e8-8e15-aefe7bc77cc2" in namespace "e2e-tests-projected-hj6r5" to be "success or failure"
+Jul  2 13:14:30.604: INFO: Pod "downwardapi-volume-daca4c93-7df9-11e8-8e15-aefe7bc77cc2": Phase="Pending", Reason="", readiness=false. Elapsed: 6.802822ms
+Jul  2 13:14:32.665: INFO: Pod "downwardapi-volume-daca4c93-7df9-11e8-8e15-aefe7bc77cc2": Phase="Pending", Reason="", readiness=false. Elapsed: 2.068388599s
+Jul  2 13:14:34.669: INFO: Pod "downwardapi-volume-daca4c93-7df9-11e8-8e15-aefe7bc77cc2": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.072230126s
+STEP: Saw pod success
+Jul  2 13:14:34.669: INFO: Pod "downwardapi-volume-daca4c93-7df9-11e8-8e15-aefe7bc77cc2" satisfied condition "success or failure"
+Jul  2 13:14:34.730: INFO: Trying to get logs from node shoot--core--confaz-worker-qfmi9-79968b77d9-kcr6j pod downwardapi-volume-daca4c93-7df9-11e8-8e15-aefe7bc77cc2 container client-container: <nil>
+STEP: delete the pod
+Jul  2 13:14:34.748: INFO: Waiting for pod downwardapi-volume-daca4c93-7df9-11e8-8e15-aefe7bc77cc2 to disappear
+Jul  2 13:14:34.755: INFO: Pod downwardapi-volume-daca4c93-7df9-11e8-8e15-aefe7bc77cc2 no longer exists
+[AfterEach] [sig-storage] Projected
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:14:34.758: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-hj6r5" for this suite.
+Jul  2 13:14:40.793: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:14:40.839: INFO: namespace: e2e-tests-projected-hj6r5, resource: bindings, ignored listing per whitelist
+Jul  2 13:14:40.977: INFO: namespace e2e-tests-projected-hj6r5 deletion completed in 6.211542537s
+
+• [SLOW TEST:10.492 seconds]
+[sig-storage] Projected
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:34
+  should provide container's cpu limit [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSSSSSSS
+------------------------------
+[k8s.io] Variable Expansion 
+  should allow substituting values in a container's command [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [k8s.io] Variable Expansion
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:14:40.978: INFO: >>> kubeConfig: /tmp/kubeconfig-324782104
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should allow substituting values in a container's command [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating a pod to test substitution in container's command
+Jul  2 13:14:41.138: INFO: Waiting up to 5m0s for pod "var-expansion-e11443bc-7df9-11e8-8e15-aefe7bc77cc2" in namespace "e2e-tests-var-expansion-ssfj4" to be "success or failure"
+Jul  2 13:14:41.152: INFO: Pod "var-expansion-e11443bc-7df9-11e8-8e15-aefe7bc77cc2": Phase="Pending", Reason="", readiness=false. Elapsed: 14.301549ms
+Jul  2 13:14:43.156: INFO: Pod "var-expansion-e11443bc-7df9-11e8-8e15-aefe7bc77cc2": Phase="Pending", Reason="", readiness=false. Elapsed: 2.017514136s
+Jul  2 13:14:45.165: INFO: Pod "var-expansion-e11443bc-7df9-11e8-8e15-aefe7bc77cc2": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.026892427s
+STEP: Saw pod success
+Jul  2 13:14:45.165: INFO: Pod "var-expansion-e11443bc-7df9-11e8-8e15-aefe7bc77cc2" satisfied condition "success or failure"
+Jul  2 13:14:45.168: INFO: Trying to get logs from node shoot--core--confaz-worker-qfmi9-79968b77d9-kcr6j pod var-expansion-e11443bc-7df9-11e8-8e15-aefe7bc77cc2 container dapi-container: <nil>
+STEP: delete the pod
+Jul  2 13:14:45.210: INFO: Waiting for pod var-expansion-e11443bc-7df9-11e8-8e15-aefe7bc77cc2 to disappear
+Jul  2 13:14:45.214: INFO: Pod var-expansion-e11443bc-7df9-11e8-8e15-aefe7bc77cc2 no longer exists
+[AfterEach] [k8s.io] Variable Expansion
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:14:45.217: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-var-expansion-ssfj4" for this suite.
+Jul  2 13:14:51.249: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:14:51.257: INFO: namespace: e2e-tests-var-expansion-ssfj4, resource: bindings, ignored listing per whitelist
+Jul  2 13:14:51.377: INFO: namespace e2e-tests-var-expansion-ssfj4 deletion completed in 6.153777678s
+
+• [SLOW TEST:10.399 seconds]
+[k8s.io] Variable Expansion
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:679
+  should allow substituting values in a container's command [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSS
+------------------------------
+[sig-storage] Projected 
+  should be consumable in multiple volumes in the same pod [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:14:51.377: INFO: >>> kubeConfig: /tmp/kubeconfig-324782104
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:858
+[It] should be consumable in multiple volumes in the same pod [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating configMap with name projected-configmap-test-volume-e74210fa-7df9-11e8-8e15-aefe7bc77cc2
+STEP: Creating a pod to test consume configMaps
+Jul  2 13:14:51.509: INFO: Waiting up to 5m0s for pod "pod-projected-configmaps-e7427eba-7df9-11e8-8e15-aefe7bc77cc2" in namespace "e2e-tests-projected-c4f85" to be "success or failure"
+Jul  2 13:14:51.524: INFO: Pod "pod-projected-configmaps-e7427eba-7df9-11e8-8e15-aefe7bc77cc2": Phase="Pending", Reason="", readiness=false. Elapsed: 14.683558ms
+Jul  2 13:14:53.527: INFO: Pod "pod-projected-configmaps-e7427eba-7df9-11e8-8e15-aefe7bc77cc2": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.017888922s
+STEP: Saw pod success
+Jul  2 13:14:53.527: INFO: Pod "pod-projected-configmaps-e7427eba-7df9-11e8-8e15-aefe7bc77cc2" satisfied condition "success or failure"
+Jul  2 13:14:53.529: INFO: Trying to get logs from node shoot--core--confaz-worker-qfmi9-79968b77d9-kcr6j pod pod-projected-configmaps-e7427eba-7df9-11e8-8e15-aefe7bc77cc2 container projected-configmap-volume-test: <nil>
+STEP: delete the pod
+Jul  2 13:14:53.559: INFO: Waiting for pod pod-projected-configmaps-e7427eba-7df9-11e8-8e15-aefe7bc77cc2 to disappear
+Jul  2 13:14:53.567: INFO: Pod pod-projected-configmaps-e7427eba-7df9-11e8-8e15-aefe7bc77cc2 no longer exists
+[AfterEach] [sig-storage] Projected
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:14:53.567: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-c4f85" for this suite.
+Jul  2 13:14:59.587: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:14:59.914: INFO: namespace: e2e-tests-projected-c4f85, resource: bindings, ignored listing per whitelist
+Jul  2 13:14:59.952: INFO: namespace e2e-tests-projected-c4f85 deletion completed in 6.377130165s
+
+• [SLOW TEST:8.575 seconds]
+[sig-storage] Projected
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:34
+  should be consumable in multiple volumes in the same pod [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+S
+------------------------------
+[sig-storage] Downward API volume 
+  should set DefaultMode on files [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:14:59.952: INFO: >>> kubeConfig: /tmp/kubeconfig-324782104
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downwardapi_volume.go:38
+[It] should set DefaultMode on files [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating a pod to test downward API volume plugin
+Jul  2 13:15:00.089: INFO: Waiting up to 5m0s for pod "downwardapi-volume-ec5d8455-7df9-11e8-8e15-aefe7bc77cc2" in namespace "e2e-tests-downward-api-xdllc" to be "success or failure"
+Jul  2 13:15:00.110: INFO: Pod "downwardapi-volume-ec5d8455-7df9-11e8-8e15-aefe7bc77cc2": Phase="Pending", Reason="", readiness=false. Elapsed: 20.883579ms
+Jul  2 13:15:02.118: INFO: Pod "downwardapi-volume-ec5d8455-7df9-11e8-8e15-aefe7bc77cc2": Phase="Pending", Reason="", readiness=false. Elapsed: 2.028463817s
+Jul  2 13:15:04.121: INFO: Pod "downwardapi-volume-ec5d8455-7df9-11e8-8e15-aefe7bc77cc2": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.031457352s
+STEP: Saw pod success
+Jul  2 13:15:04.121: INFO: Pod "downwardapi-volume-ec5d8455-7df9-11e8-8e15-aefe7bc77cc2" satisfied condition "success or failure"
+Jul  2 13:15:04.130: INFO: Trying to get logs from node shoot--core--confaz-worker-qfmi9-79968b77d9-kcr6j pod downwardapi-volume-ec5d8455-7df9-11e8-8e15-aefe7bc77cc2 container client-container: <nil>
+STEP: delete the pod
+Jul  2 13:15:04.153: INFO: Waiting for pod downwardapi-volume-ec5d8455-7df9-11e8-8e15-aefe7bc77cc2 to disappear
+Jul  2 13:15:04.167: INFO: Pod downwardapi-volume-ec5d8455-7df9-11e8-8e15-aefe7bc77cc2 no longer exists
+[AfterEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:15:04.167: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-downward-api-xdllc" for this suite.
+Jul  2 13:15:10.212: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:15:10.222: INFO: namespace: e2e-tests-downward-api-xdllc, resource: bindings, ignored listing per whitelist
+Jul  2 13:15:10.306: INFO: namespace e2e-tests-downward-api-xdllc deletion completed in 6.129651292s
+
+• [SLOW TEST:10.354 seconds]
+[sig-storage] Downward API volume
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downwardapi_volume.go:33
+  should set DefaultMode on files [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSSSSSS
+------------------------------
+[sig-network] Networking Granular Checks: Pods 
+  should function for intra-pod communication: http [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-network] Networking
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:15:10.306: INFO: >>> kubeConfig: /tmp/kubeconfig-324782104
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should function for intra-pod communication: http [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Performing setup for networking test in namespace e2e-tests-pod-network-test-2mkdr
+STEP: creating a selector
+STEP: Creating the service pods in kubernetes
+Jul  2 13:15:10.443: INFO: Waiting up to 10m0s for all (but 0) nodes to be schedulable
+STEP: Creating test pods
+Jul  2 13:15:30.632: INFO: ExecWithOptions {Command:[/bin/sh -c curl -g -q -s 'http://100.96.1.69:8080/dial?request=hostName&protocol=http&host=100.96.1.68&port=8080&tries=1'] Namespace:e2e-tests-pod-network-test-2mkdr PodName:host-test-container-pod ContainerName:hostexec Stdin:<nil> CaptureStdout:true CaptureStderr:true PreserveWhitespace:false}
+Jul  2 13:15:30.632: INFO: >>> kubeConfig: /tmp/kubeconfig-324782104
+Jul  2 13:15:31.102: INFO: Waiting for endpoints: map[]
+Jul  2 13:15:31.104: INFO: ExecWithOptions {Command:[/bin/sh -c curl -g -q -s 'http://100.96.1.69:8080/dial?request=hostName&protocol=http&host=100.96.0.23&port=8080&tries=1'] Namespace:e2e-tests-pod-network-test-2mkdr PodName:host-test-container-pod ContainerName:hostexec Stdin:<nil> CaptureStdout:true CaptureStderr:true PreserveWhitespace:false}
+Jul  2 13:15:31.105: INFO: >>> kubeConfig: /tmp/kubeconfig-324782104
+Jul  2 13:15:31.483: INFO: Waiting for endpoints: map[]
+[AfterEach] [sig-network] Networking
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:15:31.483: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-pod-network-test-2mkdr" for this suite.
+Jul  2 13:15:55.548: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:15:55.592: INFO: namespace: e2e-tests-pod-network-test-2mkdr, resource: bindings, ignored listing per whitelist
+Jul  2 13:15:55.711: INFO: namespace e2e-tests-pod-network-test-2mkdr deletion completed in 24.223810653s
+
+• [SLOW TEST:45.404 seconds]
+[sig-network] Networking
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/networking.go:25
+  Granular Checks: Pods
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/networking.go:28
+    should function for intra-pod communication: http [NodeConformance] [Conformance]
+    /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSSSSSSSS
+------------------------------
+[sig-storage] Projected 
+  should provide podname only [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:15:55.711: INFO: >>> kubeConfig: /tmp/kubeconfig-324782104
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:858
+[It] should provide podname only [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating a pod to test downward API volume plugin
+Jul  2 13:15:55.822: INFO: Waiting up to 5m0s for pod "downwardapi-volume-0d973acd-7dfa-11e8-8e15-aefe7bc77cc2" in namespace "e2e-tests-projected-wbnrf" to be "success or failure"
+Jul  2 13:15:55.826: INFO: Pod "downwardapi-volume-0d973acd-7dfa-11e8-8e15-aefe7bc77cc2": Phase="Pending", Reason="", readiness=false. Elapsed: 4.467615ms
+Jul  2 13:15:57.832: INFO: Pod "downwardapi-volume-0d973acd-7dfa-11e8-8e15-aefe7bc77cc2": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.009762949s
+STEP: Saw pod success
+Jul  2 13:15:57.832: INFO: Pod "downwardapi-volume-0d973acd-7dfa-11e8-8e15-aefe7bc77cc2" satisfied condition "success or failure"
+Jul  2 13:15:57.861: INFO: Trying to get logs from node shoot--core--confaz-worker-qfmi9-79968b77d9-kcr6j pod downwardapi-volume-0d973acd-7dfa-11e8-8e15-aefe7bc77cc2 container client-container: <nil>
+STEP: delete the pod
+Jul  2 13:15:57.883: INFO: Waiting for pod downwardapi-volume-0d973acd-7dfa-11e8-8e15-aefe7bc77cc2 to disappear
+Jul  2 13:15:57.893: INFO: Pod downwardapi-volume-0d973acd-7dfa-11e8-8e15-aefe7bc77cc2 no longer exists
+[AfterEach] [sig-storage] Projected
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:15:57.893: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-wbnrf" for this suite.
+Jul  2 13:16:03.914: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:16:04.015: INFO: namespace: e2e-tests-projected-wbnrf, resource: bindings, ignored listing per whitelist
+Jul  2 13:16:04.035: INFO: namespace e2e-tests-projected-wbnrf deletion completed in 6.131979717s
+
+• [SLOW TEST:8.323 seconds]
+[sig-storage] Projected
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:34
+  should provide podname only [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSSSSS
+------------------------------
+[sig-storage] Projected 
+  should be consumable from pods in volume [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:16:04.035: INFO: >>> kubeConfig: /tmp/kubeconfig-324782104
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:858
+[It] should be consumable from pods in volume [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating projection with secret that has name projected-secret-test-128ca940-7dfa-11e8-8e15-aefe7bc77cc2
+STEP: Creating a pod to test consume secrets
+Jul  2 13:16:04.147: INFO: Waiting up to 5m0s for pod "pod-projected-secrets-128e4475-7dfa-11e8-8e15-aefe7bc77cc2" in namespace "e2e-tests-projected-sg565" to be "success or failure"
+Jul  2 13:16:04.153: INFO: Pod "pod-projected-secrets-128e4475-7dfa-11e8-8e15-aefe7bc77cc2": Phase="Pending", Reason="", readiness=false. Elapsed: 6.349821ms
+Jul  2 13:16:06.157: INFO: Pod "pod-projected-secrets-128e4475-7dfa-11e8-8e15-aefe7bc77cc2": Phase="Pending", Reason="", readiness=false. Elapsed: 2.009977247s
+Jul  2 13:16:08.161: INFO: Pod "pod-projected-secrets-128e4475-7dfa-11e8-8e15-aefe7bc77cc2": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.013777644s
+STEP: Saw pod success
+Jul  2 13:16:08.161: INFO: Pod "pod-projected-secrets-128e4475-7dfa-11e8-8e15-aefe7bc77cc2" satisfied condition "success or failure"
+Jul  2 13:16:08.230: INFO: Trying to get logs from node shoot--core--confaz-worker-qfmi9-79968b77d9-kcr6j pod pod-projected-secrets-128e4475-7dfa-11e8-8e15-aefe7bc77cc2 container projected-secret-volume-test: <nil>
+STEP: delete the pod
+Jul  2 13:16:08.263: INFO: Waiting for pod pod-projected-secrets-128e4475-7dfa-11e8-8e15-aefe7bc77cc2 to disappear
+Jul  2 13:16:08.283: INFO: Pod pod-projected-secrets-128e4475-7dfa-11e8-8e15-aefe7bc77cc2 no longer exists
+[AfterEach] [sig-storage] Projected
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:16:08.283: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-sg565" for this suite.
+Jul  2 13:16:14.338: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:16:14.433: INFO: namespace: e2e-tests-projected-sg565, resource: bindings, ignored listing per whitelist
+Jul  2 13:16:14.474: INFO: namespace e2e-tests-projected-sg565 deletion completed in 6.170479916s
+
+• [SLOW TEST:10.439 seconds]
+[sig-storage] Projected
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:34
+  should be consumable from pods in volume [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSSS
+------------------------------
+[sig-api-machinery] Garbage collector 
+  should not be blocked by dependency circle [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-api-machinery] Garbage collector
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:16:14.474: INFO: >>> kubeConfig: /tmp/kubeconfig-324782104
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should not be blocked by dependency circle [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+Jul  2 13:16:14.641: INFO: pod1.ObjectMeta.OwnerReferences=[]v1.OwnerReference{v1.OwnerReference{APIVersion:"v1", Kind:"Pod", Name:"pod3", UID:"18cdd1c7-7dfa-11e8-bc8c-d657551927e5", Controller:(*bool)(0xc421485656), BlockOwnerDeletion:(*bool)(0xc421485657)}}
+Jul  2 13:16:14.655: INFO: pod2.ObjectMeta.OwnerReferences=[]v1.OwnerReference{v1.OwnerReference{APIVersion:"v1", Kind:"Pod", Name:"pod1", UID:"18cc48be-7dfa-11e8-bc8c-d657551927e5", Controller:(*bool)(0xc421d25846), BlockOwnerDeletion:(*bool)(0xc421d25847)}}
+Jul  2 13:16:14.676: INFO: pod3.ObjectMeta.OwnerReferences=[]v1.OwnerReference{v1.OwnerReference{APIVersion:"v1", Kind:"Pod", Name:"pod2", UID:"18cce143-7dfa-11e8-bc8c-d657551927e5", Controller:(*bool)(0xc42148593e), BlockOwnerDeletion:(*bool)(0xc42148593f)}}
+[AfterEach] [sig-api-machinery] Garbage collector
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:16:19.731: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-gc-psff8" for this suite.
+Jul  2 13:16:25.746: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:16:25.907: INFO: namespace: e2e-tests-gc-psff8, resource: bindings, ignored listing per whitelist
+Jul  2 13:16:25.945: INFO: namespace e2e-tests-gc-psff8 deletion completed in 6.210824652s
+
+• [SLOW TEST:11.471 seconds]
+[sig-api-machinery] Garbage collector
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apimachinery/framework.go:22
+  should not be blocked by dependency circle [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSSSSSSSS
+------------------------------
+[sig-storage] ConfigMap 
+  updates should be reflected in volume [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-storage] ConfigMap
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:16:25.946: INFO: >>> kubeConfig: /tmp/kubeconfig-324782104
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] updates should be reflected in volume [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating configMap with name configmap-test-upd-1fa2469f-7dfa-11e8-8e15-aefe7bc77cc2
+STEP: Creating the pod
+STEP: Updating configmap configmap-test-upd-1fa2469f-7dfa-11e8-8e15-aefe7bc77cc2
+STEP: waiting to observe update in volume
+[AfterEach] [sig-storage] ConfigMap
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:17:43.571: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-configmap-mzztt" for this suite.
+Jul  2 13:18:05.733: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:18:05.901: INFO: namespace: e2e-tests-configmap-mzztt, resource: bindings, ignored listing per whitelist
+Jul  2 13:18:05.944: INFO: namespace e2e-tests-configmap-mzztt deletion completed in 22.367742382s
+
+• [SLOW TEST:99.998 seconds]
+[sig-storage] ConfigMap
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/configmap_volume.go:32
+  updates should be reflected in volume [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+[sig-storage] Projected 
+  should be consumable from pods in volume with mappings [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:18:05.944: INFO: >>> kubeConfig: /tmp/kubeconfig-324782104
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:858
+[It] should be consumable from pods in volume with mappings [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating configMap with name projected-configmap-test-volume-map-5b356d6d-7dfa-11e8-8e15-aefe7bc77cc2
+STEP: Creating a pod to test consume configMaps
+Jul  2 13:18:06.049: INFO: Waiting up to 5m0s for pod "pod-projected-configmaps-5b371dae-7dfa-11e8-8e15-aefe7bc77cc2" in namespace "e2e-tests-projected-smrmz" to be "success or failure"
+Jul  2 13:18:06.052: INFO: Pod "pod-projected-configmaps-5b371dae-7dfa-11e8-8e15-aefe7bc77cc2": Phase="Pending", Reason="", readiness=false. Elapsed: 3.05751ms
+Jul  2 13:18:08.055: INFO: Pod "pod-projected-configmaps-5b371dae-7dfa-11e8-8e15-aefe7bc77cc2": Phase="Pending", Reason="", readiness=false. Elapsed: 2.006091989s
+Jul  2 13:18:10.058: INFO: Pod "pod-projected-configmaps-5b371dae-7dfa-11e8-8e15-aefe7bc77cc2": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.009386333s
+STEP: Saw pod success
+Jul  2 13:18:10.058: INFO: Pod "pod-projected-configmaps-5b371dae-7dfa-11e8-8e15-aefe7bc77cc2" satisfied condition "success or failure"
+Jul  2 13:18:10.061: INFO: Trying to get logs from node shoot--core--confaz-worker-qfmi9-79968b77d9-kcr6j pod pod-projected-configmaps-5b371dae-7dfa-11e8-8e15-aefe7bc77cc2 container projected-configmap-volume-test: <nil>
+STEP: delete the pod
+Jul  2 13:18:10.096: INFO: Waiting for pod pod-projected-configmaps-5b371dae-7dfa-11e8-8e15-aefe7bc77cc2 to disappear
+Jul  2 13:18:10.111: INFO: Pod pod-projected-configmaps-5b371dae-7dfa-11e8-8e15-aefe7bc77cc2 no longer exists
+[AfterEach] [sig-storage] Projected
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:18:10.111: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-smrmz" for this suite.
+Jul  2 13:18:16.125: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:18:16.152: INFO: namespace: e2e-tests-projected-smrmz, resource: bindings, ignored listing per whitelist
+Jul  2 13:18:16.235: INFO: namespace e2e-tests-projected-smrmz deletion completed in 6.121052229s
+
+• [SLOW TEST:10.291 seconds]
+[sig-storage] Projected
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:34
+  should be consumable from pods in volume with mappings [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+S
+------------------------------
+[sig-storage] Secrets 
+  should be consumable in multiple volumes in a pod [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-storage] Secrets
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:18:16.236: INFO: >>> kubeConfig: /tmp/kubeconfig-324782104
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should be consumable in multiple volumes in a pod [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating secret with name secret-test-615fa124-7dfa-11e8-8e15-aefe7bc77cc2
+STEP: Creating a pod to test consume secrets
+Jul  2 13:18:16.384: INFO: Waiting up to 5m0s for pod "pod-secrets-6160263c-7dfa-11e8-8e15-aefe7bc77cc2" in namespace "e2e-tests-secrets-xdnnr" to be "success or failure"
+Jul  2 13:18:16.398: INFO: Pod "pod-secrets-6160263c-7dfa-11e8-8e15-aefe7bc77cc2": Phase="Pending", Reason="", readiness=false. Elapsed: 13.557945ms
+Jul  2 13:18:18.529: INFO: Pod "pod-secrets-6160263c-7dfa-11e8-8e15-aefe7bc77cc2": Phase="Pending", Reason="", readiness=false. Elapsed: 2.145320022s
+Jul  2 13:18:20.533: INFO: Pod "pod-secrets-6160263c-7dfa-11e8-8e15-aefe7bc77cc2": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.149050173s
+STEP: Saw pod success
+Jul  2 13:18:20.533: INFO: Pod "pod-secrets-6160263c-7dfa-11e8-8e15-aefe7bc77cc2" satisfied condition "success or failure"
+Jul  2 13:18:20.536: INFO: Trying to get logs from node shoot--core--confaz-worker-qfmi9-79968b77d9-kcr6j pod pod-secrets-6160263c-7dfa-11e8-8e15-aefe7bc77cc2 container secret-volume-test: <nil>
+STEP: delete the pod
+Jul  2 13:18:20.654: INFO: Waiting for pod pod-secrets-6160263c-7dfa-11e8-8e15-aefe7bc77cc2 to disappear
+Jul  2 13:18:20.671: INFO: Pod pod-secrets-6160263c-7dfa-11e8-8e15-aefe7bc77cc2 no longer exists
+[AfterEach] [sig-storage] Secrets
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:18:20.671: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-secrets-xdnnr" for this suite.
+Jul  2 13:18:26.685: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:18:26.703: INFO: namespace: e2e-tests-secrets-xdnnr, resource: bindings, ignored listing per whitelist
+Jul  2 13:18:26.780: INFO: namespace e2e-tests-secrets-xdnnr deletion completed in 6.105596841s
+
+• [SLOW TEST:10.544 seconds]
+[sig-storage] Secrets
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/secrets_volume.go:33
+  should be consumable in multiple volumes in a pod [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSSS
+------------------------------
+[sig-storage] Projected 
+  should provide container's cpu request [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:18:26.780: INFO: >>> kubeConfig: /tmp/kubeconfig-324782104
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:858
+[It] should provide container's cpu request [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating a pod to test downward API volume plugin
+Jul  2 13:18:26.891: INFO: Waiting up to 5m0s for pod "downwardapi-volume-67a29382-7dfa-11e8-8e15-aefe7bc77cc2" in namespace "e2e-tests-projected-jppzx" to be "success or failure"
+Jul  2 13:18:26.894: INFO: Pod "downwardapi-volume-67a29382-7dfa-11e8-8e15-aefe7bc77cc2": Phase="Pending", Reason="", readiness=false. Elapsed: 3.055311ms
+Jul  2 13:18:28.906: INFO: Pod "downwardapi-volume-67a29382-7dfa-11e8-8e15-aefe7bc77cc2": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.015553754s
+STEP: Saw pod success
+Jul  2 13:18:28.906: INFO: Pod "downwardapi-volume-67a29382-7dfa-11e8-8e15-aefe7bc77cc2" satisfied condition "success or failure"
+Jul  2 13:18:28.909: INFO: Trying to get logs from node shoot--core--confaz-worker-qfmi9-79968b77d9-kcr6j pod downwardapi-volume-67a29382-7dfa-11e8-8e15-aefe7bc77cc2 container client-container: <nil>
+STEP: delete the pod
+Jul  2 13:18:28.938: INFO: Waiting for pod downwardapi-volume-67a29382-7dfa-11e8-8e15-aefe7bc77cc2 to disappear
+Jul  2 13:18:28.950: INFO: Pod downwardapi-volume-67a29382-7dfa-11e8-8e15-aefe7bc77cc2 no longer exists
+[AfterEach] [sig-storage] Projected
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:18:28.950: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-jppzx" for this suite.
+Jul  2 13:18:34.970: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:18:35.099: INFO: namespace: e2e-tests-projected-jppzx, resource: bindings, ignored listing per whitelist
+Jul  2 13:18:35.114: INFO: namespace e2e-tests-projected-jppzx deletion completed in 6.155537478s
+
+• [SLOW TEST:8.334 seconds]
+[sig-storage] Projected
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:34
+  should provide container's cpu request [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSSSS
+------------------------------
+[sig-storage] Downward API volume 
+  should provide container's memory request [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:18:35.114: INFO: >>> kubeConfig: /tmp/kubeconfig-324782104
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downwardapi_volume.go:38
+[It] should provide container's memory request [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating a pod to test downward API volume plugin
+Jul  2 13:18:35.244: INFO: Waiting up to 5m0s for pod "downwardapi-volume-6c99ab43-7dfa-11e8-8e15-aefe7bc77cc2" in namespace "e2e-tests-downward-api-fmxd7" to be "success or failure"
+Jul  2 13:18:35.259: INFO: Pod "downwardapi-volume-6c99ab43-7dfa-11e8-8e15-aefe7bc77cc2": Phase="Pending", Reason="", readiness=false. Elapsed: 14.938252ms
+Jul  2 13:18:37.264: INFO: Pod "downwardapi-volume-6c99ab43-7dfa-11e8-8e15-aefe7bc77cc2": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.019646358s
+STEP: Saw pod success
+Jul  2 13:18:37.264: INFO: Pod "downwardapi-volume-6c99ab43-7dfa-11e8-8e15-aefe7bc77cc2" satisfied condition "success or failure"
+Jul  2 13:18:37.268: INFO: Trying to get logs from node shoot--core--confaz-worker-qfmi9-79968b77d9-kcr6j pod downwardapi-volume-6c99ab43-7dfa-11e8-8e15-aefe7bc77cc2 container client-container: <nil>
+STEP: delete the pod
+Jul  2 13:18:37.302: INFO: Waiting for pod downwardapi-volume-6c99ab43-7dfa-11e8-8e15-aefe7bc77cc2 to disappear
+Jul  2 13:18:37.309: INFO: Pod downwardapi-volume-6c99ab43-7dfa-11e8-8e15-aefe7bc77cc2 no longer exists
+[AfterEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:18:37.309: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-downward-api-fmxd7" for this suite.
+Jul  2 13:18:43.325: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:18:43.356: INFO: namespace: e2e-tests-downward-api-fmxd7, resource: bindings, ignored listing per whitelist
+Jul  2 13:18:43.425: INFO: namespace e2e-tests-downward-api-fmxd7 deletion completed in 6.111177465s
+
+• [SLOW TEST:8.310 seconds]
+[sig-storage] Downward API volume
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downwardapi_volume.go:33
+  should provide container's memory request [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SS
+------------------------------
+[sig-apps] StatefulSet [k8s.io] Basic StatefulSet functionality [StatefulSetBasic] 
+  should perform rolling updates and roll backs of template modifications [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-apps] StatefulSet
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:18:43.425: INFO: >>> kubeConfig: /tmp/kubeconfig-324782104
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-apps] StatefulSet
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/statefulset.go:57
+[BeforeEach] [k8s.io] Basic StatefulSet functionality [StatefulSetBasic]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/statefulset.go:72
+STEP: Creating service test in namespace e2e-tests-statefulset-mr4c8
+[It] should perform rolling updates and roll backs of template modifications [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating a new StatefulSet
+Jul  2 13:18:43.534: INFO: Found 0 stateful pods, waiting for 3
+Jul  2 13:18:53.538: INFO: Waiting for pod ss2-0 to enter Running - Ready=true, currently Running - Ready=true
+Jul  2 13:18:53.538: INFO: Waiting for pod ss2-1 to enter Running - Ready=true, currently Running - Ready=true
+Jul  2 13:18:53.538: INFO: Waiting for pod ss2-2 to enter Running - Ready=true, currently Running - Ready=true
+Jul  2 13:18:53.634: INFO: Running '/usr/local/bin/kubectl --kubeconfig=/tmp/kubeconfig-324782104 exec --namespace=e2e-tests-statefulset-mr4c8 ss2-1 -- /bin/sh -c mv -v /usr/share/nginx/html/index.html /tmp/ || true'
+Jul  2 13:18:54.074: INFO: stderr: ""
+Jul  2 13:18:54.074: INFO: stdout: "'/usr/share/nginx/html/index.html' -> '/tmp/index.html'\n"
+Jul  2 13:18:54.074: INFO: stdout of mv -v /usr/share/nginx/html/index.html /tmp/ || true on ss2-1: '/usr/share/nginx/html/index.html' -> '/tmp/index.html'
+
+STEP: Updating StatefulSet template: update image from k8s.gcr.io/nginx-slim-amd64:0.20 to k8s.gcr.io/nginx-slim-amd64:0.21
+Jul  2 13:19:04.248: INFO: Updating stateful set ss2
+STEP: Creating a new revision
+STEP: Updating Pods in reverse ordinal order
+Jul  2 13:19:14.305: INFO: Running '/usr/local/bin/kubectl --kubeconfig=/tmp/kubeconfig-324782104 exec --namespace=e2e-tests-statefulset-mr4c8 ss2-1 -- /bin/sh -c mv -v /tmp/index.html /usr/share/nginx/html/ || true'
+Jul  2 13:19:14.736: INFO: stderr: ""
+Jul  2 13:19:14.736: INFO: stdout: "'/tmp/index.html' -> '/usr/share/nginx/html/index.html'\n"
+Jul  2 13:19:14.736: INFO: stdout of mv -v /tmp/index.html /usr/share/nginx/html/ || true on ss2-1: '/tmp/index.html' -> '/usr/share/nginx/html/index.html'
+
+Jul  2 13:19:14.965: INFO: Waiting for StatefulSet e2e-tests-statefulset-mr4c8/ss2 to complete update
+Jul  2 13:19:14.965: INFO: Waiting for Pod e2e-tests-statefulset-mr4c8/ss2-0 to have revision ss2-56dd5fb9c4 update revision ss2-76cb68b6ff
+Jul  2 13:19:14.965: INFO: Waiting for Pod e2e-tests-statefulset-mr4c8/ss2-1 to have revision ss2-56dd5fb9c4 update revision ss2-76cb68b6ff
+Jul  2 13:19:14.965: INFO: Waiting for Pod e2e-tests-statefulset-mr4c8/ss2-2 to have revision ss2-56dd5fb9c4 update revision ss2-76cb68b6ff
+Jul  2 13:19:25.034: INFO: Waiting for StatefulSet e2e-tests-statefulset-mr4c8/ss2 to complete update
+Jul  2 13:19:25.034: INFO: Waiting for Pod e2e-tests-statefulset-mr4c8/ss2-0 to have revision ss2-56dd5fb9c4 update revision ss2-76cb68b6ff
+Jul  2 13:19:25.034: INFO: Waiting for Pod e2e-tests-statefulset-mr4c8/ss2-1 to have revision ss2-56dd5fb9c4 update revision ss2-76cb68b6ff
+Jul  2 13:19:35.030: INFO: Waiting for StatefulSet e2e-tests-statefulset-mr4c8/ss2 to complete update
+Jul  2 13:19:35.030: INFO: Waiting for Pod e2e-tests-statefulset-mr4c8/ss2-0 to have revision ss2-56dd5fb9c4 update revision ss2-76cb68b6ff
+Jul  2 13:19:45.040: INFO: Waiting for StatefulSet e2e-tests-statefulset-mr4c8/ss2 to complete update
+Jul  2 13:19:45.040: INFO: Waiting for Pod e2e-tests-statefulset-mr4c8/ss2-0 to have revision ss2-56dd5fb9c4 update revision ss2-76cb68b6ff
+STEP: Rolling back to a previous revision
+Jul  2 13:19:55.064: INFO: Running '/usr/local/bin/kubectl --kubeconfig=/tmp/kubeconfig-324782104 exec --namespace=e2e-tests-statefulset-mr4c8 ss2-1 -- /bin/sh -c mv -v /usr/share/nginx/html/index.html /tmp/ || true'
+Jul  2 13:19:55.559: INFO: stderr: ""
+Jul  2 13:19:55.559: INFO: stdout: "'/usr/share/nginx/html/index.html' -> '/tmp/index.html'\n"
+Jul  2 13:19:55.559: INFO: stdout of mv -v /usr/share/nginx/html/index.html /tmp/ || true on ss2-1: '/usr/share/nginx/html/index.html' -> '/tmp/index.html'
+
+Jul  2 13:20:05.751: INFO: Updating stateful set ss2
+STEP: Rolling back update in reverse ordinal order
+Jul  2 13:20:15.776: INFO: Running '/usr/local/bin/kubectl --kubeconfig=/tmp/kubeconfig-324782104 exec --namespace=e2e-tests-statefulset-mr4c8 ss2-1 -- /bin/sh -c mv -v /tmp/index.html /usr/share/nginx/html/ || true'
+Jul  2 13:20:16.204: INFO: stderr: ""
+Jul  2 13:20:16.204: INFO: stdout: "'/tmp/index.html' -> '/usr/share/nginx/html/index.html'\n"
+Jul  2 13:20:16.204: INFO: stdout of mv -v /tmp/index.html /usr/share/nginx/html/ || true on ss2-1: '/tmp/index.html' -> '/usr/share/nginx/html/index.html'
+
+Jul  2 13:20:26.271: INFO: Waiting for StatefulSet e2e-tests-statefulset-mr4c8/ss2 to complete update
+Jul  2 13:20:26.271: INFO: Waiting for Pod e2e-tests-statefulset-mr4c8/ss2-0 to have revision ss2-76cb68b6ff update revision ss2-56dd5fb9c4
+Jul  2 13:20:26.271: INFO: Waiting for Pod e2e-tests-statefulset-mr4c8/ss2-1 to have revision ss2-76cb68b6ff update revision ss2-56dd5fb9c4
+Jul  2 13:20:26.271: INFO: Waiting for Pod e2e-tests-statefulset-mr4c8/ss2-2 to have revision ss2-76cb68b6ff update revision ss2-56dd5fb9c4
+Jul  2 13:20:36.279: INFO: Waiting for StatefulSet e2e-tests-statefulset-mr4c8/ss2 to complete update
+Jul  2 13:20:36.279: INFO: Waiting for Pod e2e-tests-statefulset-mr4c8/ss2-0 to have revision ss2-76cb68b6ff update revision ss2-56dd5fb9c4
+Jul  2 13:20:46.278: INFO: Waiting for StatefulSet e2e-tests-statefulset-mr4c8/ss2 to complete update
+Jul  2 13:20:46.278: INFO: Waiting for Pod e2e-tests-statefulset-mr4c8/ss2-0 to have revision ss2-76cb68b6ff update revision ss2-56dd5fb9c4
+[AfterEach] [k8s.io] Basic StatefulSet functionality [StatefulSetBasic]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/statefulset.go:83
+Jul  2 13:20:56.277: INFO: Deleting all statefulset in ns e2e-tests-statefulset-mr4c8
+Jul  2 13:20:56.280: INFO: Scaling statefulset ss2 to 0
+Jul  2 13:21:26.297: INFO: Waiting for statefulset status.replicas updated to 0
+Jul  2 13:21:26.330: INFO: Deleting statefulset ss2
+[AfterEach] [sig-apps] StatefulSet
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:21:26.382: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-statefulset-mr4c8" for this suite.
+Jul  2 13:21:32.400: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:21:32.498: INFO: namespace: e2e-tests-statefulset-mr4c8, resource: bindings, ignored listing per whitelist
+Jul  2 13:21:32.552: INFO: namespace e2e-tests-statefulset-mr4c8 deletion completed in 6.162957563s
+
+• [SLOW TEST:169.127 seconds]
+[sig-apps] StatefulSet
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/framework.go:22
+  [k8s.io] Basic StatefulSet functionality [StatefulSetBasic]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:679
+    should perform rolling updates and roll backs of template modifications [Conformance]
+    /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSSSSSSSSSSSS
+------------------------------
+[sig-api-machinery] Downward API 
+  should provide container's limits.cpu/memory and requests.cpu/memory as env vars [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-api-machinery] Downward API
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:21:32.553: INFO: >>> kubeConfig: /tmp/kubeconfig-324782104
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should provide container's limits.cpu/memory and requests.cpu/memory as env vars [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating a pod to test downward api env vars
+Jul  2 13:21:32.660: INFO: Waiting up to 5m0s for pod "downward-api-d65c7cf3-7dfa-11e8-8e15-aefe7bc77cc2" in namespace "e2e-tests-downward-api-5p68z" to be "success or failure"
+Jul  2 13:21:32.687: INFO: Pod "downward-api-d65c7cf3-7dfa-11e8-8e15-aefe7bc77cc2": Phase="Pending", Reason="", readiness=false. Elapsed: 26.217491ms
+Jul  2 13:21:34.740: INFO: Pod "downward-api-d65c7cf3-7dfa-11e8-8e15-aefe7bc77cc2": Phase="Pending", Reason="", readiness=false. Elapsed: 2.079440342s
+Jul  2 13:21:36.834: INFO: Pod "downward-api-d65c7cf3-7dfa-11e8-8e15-aefe7bc77cc2": Phase="Pending", Reason="", readiness=false. Elapsed: 4.173386431s
+Jul  2 13:21:38.865: INFO: Pod "downward-api-d65c7cf3-7dfa-11e8-8e15-aefe7bc77cc2": Phase="Succeeded", Reason="", readiness=false. Elapsed: 6.204992551s
+STEP: Saw pod success
+Jul  2 13:21:38.865: INFO: Pod "downward-api-d65c7cf3-7dfa-11e8-8e15-aefe7bc77cc2" satisfied condition "success or failure"
+Jul  2 13:21:38.868: INFO: Trying to get logs from node shoot--core--confaz-worker-qfmi9-79968b77d9-kcr6j pod downward-api-d65c7cf3-7dfa-11e8-8e15-aefe7bc77cc2 container dapi-container: <nil>
+STEP: delete the pod
+Jul  2 13:21:38.956: INFO: Waiting for pod downward-api-d65c7cf3-7dfa-11e8-8e15-aefe7bc77cc2 to disappear
+Jul  2 13:21:38.960: INFO: Pod downward-api-d65c7cf3-7dfa-11e8-8e15-aefe7bc77cc2 no longer exists
+[AfterEach] [sig-api-machinery] Downward API
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:21:38.960: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-downward-api-5p68z" for this suite.
+Jul  2 13:21:44.980: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:21:45.114: INFO: namespace: e2e-tests-downward-api-5p68z, resource: bindings, ignored listing per whitelist
+Jul  2 13:21:45.124: INFO: namespace e2e-tests-downward-api-5p68z deletion completed in 6.161041482s
+
+• [SLOW TEST:12.571 seconds]
+[sig-api-machinery] Downward API
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downward_api.go:37
+  should provide container's limits.cpu/memory and requests.cpu/memory as env vars [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSSS
+------------------------------
+[sig-apps] ReplicaSet 
+  should serve a basic image on each replica with a public image  [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-apps] ReplicaSet
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:21:45.130: INFO: >>> kubeConfig: /tmp/kubeconfig-324782104
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should serve a basic image on each replica with a public image  [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+Jul  2 13:21:45.225: INFO: Creating ReplicaSet my-hostname-basic-dddb9c76-7dfa-11e8-8e15-aefe7bc77cc2
+Jul  2 13:21:45.240: INFO: Pod name my-hostname-basic-dddb9c76-7dfa-11e8-8e15-aefe7bc77cc2: Found 0 pods out of 1
+Jul  2 13:21:50.244: INFO: Pod name my-hostname-basic-dddb9c76-7dfa-11e8-8e15-aefe7bc77cc2: Found 1 pods out of 1
+Jul  2 13:21:50.244: INFO: Ensuring a pod for ReplicaSet "my-hostname-basic-dddb9c76-7dfa-11e8-8e15-aefe7bc77cc2" is running
+Jul  2 13:21:50.246: INFO: Pod "my-hostname-basic-dddb9c76-7dfa-11e8-8e15-aefe7bc77cc2-gn75v" is running (conditions: [{Type:Initialized Status:True LastProbeTime:0001-01-01 00:00:00 +0000 UTC LastTransitionTime:2018-07-02 13:21:45 +0000 UTC Reason: Message:} {Type:Ready Status:True LastProbeTime:0001-01-01 00:00:00 +0000 UTC LastTransitionTime:2018-07-02 13:21:47 +0000 UTC Reason: Message:} {Type:ContainersReady Status:True LastProbeTime:0001-01-01 00:00:00 +0000 UTC LastTransitionTime:0001-01-01 00:00:00 +0000 UTC Reason: Message:} {Type:PodScheduled Status:True LastProbeTime:0001-01-01 00:00:00 +0000 UTC LastTransitionTime:2018-07-02 13:21:45 +0000 UTC Reason: Message:}])
+Jul  2 13:21:50.246: INFO: Trying to dial the pod
+Jul  2 13:21:55.341: INFO: Controller my-hostname-basic-dddb9c76-7dfa-11e8-8e15-aefe7bc77cc2: Got expected result from replica 1 [my-hostname-basic-dddb9c76-7dfa-11e8-8e15-aefe7bc77cc2-gn75v]: "my-hostname-basic-dddb9c76-7dfa-11e8-8e15-aefe7bc77cc2-gn75v", 1 of 1 required successes so far
+[AfterEach] [sig-apps] ReplicaSet
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:21:55.341: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-replicaset-8nz5k" for this suite.
+Jul  2 13:22:01.430: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:22:01.521: INFO: namespace: e2e-tests-replicaset-8nz5k, resource: bindings, ignored listing per whitelist
+Jul  2 13:22:01.583: INFO: namespace e2e-tests-replicaset-8nz5k deletion completed in 6.237913844s
+
+• [SLOW TEST:16.454 seconds]
+[sig-apps] ReplicaSet
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/framework.go:22
+  should serve a basic image on each replica with a public image  [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSSSS
+------------------------------
+[sig-apps] StatefulSet [k8s.io] Basic StatefulSet functionality [StatefulSetBasic] 
+  should perform canary updates and phased rolling updates of template modifications [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-apps] StatefulSet
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:22:01.583: INFO: >>> kubeConfig: /tmp/kubeconfig-324782104
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-apps] StatefulSet
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/statefulset.go:57
+[BeforeEach] [k8s.io] Basic StatefulSet functionality [StatefulSetBasic]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/statefulset.go:72
+STEP: Creating service test in namespace e2e-tests-statefulset-5gr6v
+[It] should perform canary updates and phased rolling updates of template modifications [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating a new StaefulSet
+Jul  2 13:22:01.701: INFO: Found 0 stateful pods, waiting for 3
+Jul  2 13:22:11.706: INFO: Waiting for pod ss2-0 to enter Running - Ready=true, currently Running - Ready=true
+Jul  2 13:22:11.706: INFO: Waiting for pod ss2-1 to enter Running - Ready=true, currently Running - Ready=true
+Jul  2 13:22:11.706: INFO: Waiting for pod ss2-2 to enter Running - Ready=true, currently Running - Ready=true
+STEP: Updating stateful set template: update image from k8s.gcr.io/nginx-slim-amd64:0.20 to k8s.gcr.io/nginx-slim-amd64:0.21
+Jul  2 13:22:11.755: INFO: Updating stateful set ss2
+STEP: Creating a new revision
+STEP: Not applying an update when the partition is greater than the number of replicas
+STEP: Performing a canary update
+Jul  2 13:22:21.833: INFO: Updating stateful set ss2
+Jul  2 13:22:21.848: INFO: Waiting for Pod e2e-tests-statefulset-5gr6v/ss2-2 to have revision ss2-56dd5fb9c4 update revision ss2-76cb68b6ff
+STEP: Restoring Pods to the correct revision when they are deleted
+Jul  2 13:22:32.051: INFO: Found 2 stateful pods, waiting for 3
+Jul  2 13:22:42.055: INFO: Waiting for pod ss2-0 to enter Running - Ready=true, currently Running - Ready=true
+Jul  2 13:22:42.055: INFO: Waiting for pod ss2-1 to enter Running - Ready=true, currently Running - Ready=true
+Jul  2 13:22:42.055: INFO: Waiting for pod ss2-2 to enter Running - Ready=true, currently Running - Ready=true
+STEP: Performing a phased rolling update
+Jul  2 13:22:42.078: INFO: Updating stateful set ss2
+Jul  2 13:22:42.089: INFO: Waiting for Pod e2e-tests-statefulset-5gr6v/ss2-1 to have revision ss2-56dd5fb9c4 update revision ss2-76cb68b6ff
+Jul  2 13:22:52.147: INFO: Updating stateful set ss2
+Jul  2 13:22:52.160: INFO: Waiting for StatefulSet e2e-tests-statefulset-5gr6v/ss2 to complete update
+Jul  2 13:22:52.160: INFO: Waiting for Pod e2e-tests-statefulset-5gr6v/ss2-0 to have revision ss2-56dd5fb9c4 update revision ss2-76cb68b6ff
+[AfterEach] [k8s.io] Basic StatefulSet functionality [StatefulSetBasic]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/statefulset.go:83
+Jul  2 13:23:02.167: INFO: Deleting all statefulset in ns e2e-tests-statefulset-5gr6v
+Jul  2 13:23:02.170: INFO: Scaling statefulset ss2 to 0
+Jul  2 13:23:22.193: INFO: Waiting for statefulset status.replicas updated to 0
+Jul  2 13:23:22.196: INFO: Deleting statefulset ss2
+[AfterEach] [sig-apps] StatefulSet
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:23:22.208: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-statefulset-5gr6v" for this suite.
+Jul  2 13:23:28.235: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:23:28.347: INFO: namespace: e2e-tests-statefulset-5gr6v, resource: bindings, ignored listing per whitelist
+Jul  2 13:23:28.363: INFO: namespace e2e-tests-statefulset-5gr6v deletion completed in 6.151637316s
+
+• [SLOW TEST:86.779 seconds]
+[sig-apps] StatefulSet
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/framework.go:22
+  [k8s.io] Basic StatefulSet functionality [StatefulSetBasic]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:679
+    should perform canary updates and phased rolling updates of template modifications [Conformance]
+    /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSSSS
+------------------------------
+[sig-apps] StatefulSet [k8s.io] Basic StatefulSet functionality [StatefulSetBasic] 
+  Scaling should happen in predictable order and halt if any stateful pod is unhealthy [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-apps] StatefulSet
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:23:28.364: INFO: >>> kubeConfig: /tmp/kubeconfig-324782104
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-apps] StatefulSet
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/statefulset.go:57
+[BeforeEach] [k8s.io] Basic StatefulSet functionality [StatefulSetBasic]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/statefulset.go:72
+STEP: Creating service test in namespace e2e-tests-statefulset-bqs5d
+[It] Scaling should happen in predictable order and halt if any stateful pod is unhealthy [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Initializing watcher for selector baz=blah,foo=bar
+STEP: Creating stateful set ss in namespace e2e-tests-statefulset-bqs5d
+STEP: Waiting until all stateful set ss replicas will be running in namespace e2e-tests-statefulset-bqs5d
+Jul  2 13:23:28.541: INFO: Found 0 stateful pods, waiting for 1
+Jul  2 13:23:38.545: INFO: Waiting for pod ss-0 to enter Running - Ready=true, currently Running - Ready=true
+STEP: Confirming that stateful set scale up will halt with unhealthy stateful pod
+Jul  2 13:23:38.548: INFO: Running '/usr/local/bin/kubectl --kubeconfig=/tmp/kubeconfig-324782104 exec --namespace=e2e-tests-statefulset-bqs5d ss-0 -- /bin/sh -c mv -v /usr/share/nginx/html/index.html /tmp/ || true'
+Jul  2 13:23:39.033: INFO: stderr: ""
+Jul  2 13:23:39.033: INFO: stdout: "'/usr/share/nginx/html/index.html' -> '/tmp/index.html'\n"
+Jul  2 13:23:39.033: INFO: stdout of mv -v /usr/share/nginx/html/index.html /tmp/ || true on ss-0: '/usr/share/nginx/html/index.html' -> '/tmp/index.html'
+
+Jul  2 13:23:39.037: INFO: Waiting for pod ss-0 to enter Running - Ready=false, currently Running - Ready=true
+Jul  2 13:23:49.041: INFO: Waiting for pod ss-0 to enter Running - Ready=false, currently Running - Ready=false
+Jul  2 13:23:49.041: INFO: Waiting for statefulset status.replicas updated to 0
+Jul  2 13:23:49.055: INFO: Verifying statefulset ss doesn't scale past 1 for another 9.9999998s
+Jul  2 13:23:50.060: INFO: Verifying statefulset ss doesn't scale past 1 for another 8.994393524s
+Jul  2 13:23:51.088: INFO: Verifying statefulset ss doesn't scale past 1 for another 7.989728858s
+Jul  2 13:23:52.092: INFO: Verifying statefulset ss doesn't scale past 1 for another 6.961640916s
+Jul  2 13:23:53.096: INFO: Verifying statefulset ss doesn't scale past 1 for another 5.957501265s
+Jul  2 13:23:54.131: INFO: Verifying statefulset ss doesn't scale past 1 for another 4.953529222s
+Jul  2 13:23:55.139: INFO: Verifying statefulset ss doesn't scale past 1 for another 3.91657287s
+Jul  2 13:23:56.147: INFO: Verifying statefulset ss doesn't scale past 1 for another 2.910608433s
+Jul  2 13:23:57.230: INFO: Verifying statefulset ss doesn't scale past 1 for another 1.902499396s
+Jul  2 13:23:58.234: INFO: Verifying statefulset ss doesn't scale past 1 for another 819.176502ms
+STEP: Scaling up stateful set ss to 3 replicas and waiting until all of them will be running in namespace e2e-tests-statefulset-bqs5d
+Jul  2 13:23:59.238: INFO: Running '/usr/local/bin/kubectl --kubeconfig=/tmp/kubeconfig-324782104 exec --namespace=e2e-tests-statefulset-bqs5d ss-0 -- /bin/sh -c mv -v /tmp/index.html /usr/share/nginx/html/ || true'
+Jul  2 13:23:59.765: INFO: stderr: ""
+Jul  2 13:23:59.766: INFO: stdout: "'/tmp/index.html' -> '/usr/share/nginx/html/index.html'\n"
+Jul  2 13:23:59.766: INFO: stdout of mv -v /tmp/index.html /usr/share/nginx/html/ || true on ss-0: '/tmp/index.html' -> '/usr/share/nginx/html/index.html'
+
+Jul  2 13:23:59.845: INFO: Found 1 stateful pods, waiting for 3
+Jul  2 13:24:09.849: INFO: Waiting for pod ss-0 to enter Running - Ready=true, currently Running - Ready=true
+Jul  2 13:24:09.849: INFO: Waiting for pod ss-1 to enter Running - Ready=true, currently Running - Ready=true
+Jul  2 13:24:09.849: INFO: Waiting for pod ss-2 to enter Running - Ready=true, currently Running - Ready=true
+STEP: Verifying that stateful set ss was scaled up in order
+STEP: Scale down will halt with unhealthy stateful pod
+Jul  2 13:24:09.930: INFO: Running '/usr/local/bin/kubectl --kubeconfig=/tmp/kubeconfig-324782104 exec --namespace=e2e-tests-statefulset-bqs5d ss-0 -- /bin/sh -c mv -v /usr/share/nginx/html/index.html /tmp/ || true'
+Jul  2 13:24:10.452: INFO: stderr: ""
+Jul  2 13:24:10.452: INFO: stdout: "'/usr/share/nginx/html/index.html' -> '/tmp/index.html'\n"
+Jul  2 13:24:10.452: INFO: stdout of mv -v /usr/share/nginx/html/index.html /tmp/ || true on ss-0: '/usr/share/nginx/html/index.html' -> '/tmp/index.html'
+
+Jul  2 13:24:10.452: INFO: Running '/usr/local/bin/kubectl --kubeconfig=/tmp/kubeconfig-324782104 exec --namespace=e2e-tests-statefulset-bqs5d ss-1 -- /bin/sh -c mv -v /usr/share/nginx/html/index.html /tmp/ || true'
+Jul  2 13:24:11.014: INFO: stderr: ""
+Jul  2 13:24:11.014: INFO: stdout: "'/usr/share/nginx/html/index.html' -> '/tmp/index.html'\n"
+Jul  2 13:24:11.014: INFO: stdout of mv -v /usr/share/nginx/html/index.html /tmp/ || true on ss-1: '/usr/share/nginx/html/index.html' -> '/tmp/index.html'
+
+Jul  2 13:24:11.014: INFO: Running '/usr/local/bin/kubectl --kubeconfig=/tmp/kubeconfig-324782104 exec --namespace=e2e-tests-statefulset-bqs5d ss-2 -- /bin/sh -c mv -v /usr/share/nginx/html/index.html /tmp/ || true'
+Jul  2 13:24:11.509: INFO: stderr: ""
+Jul  2 13:24:11.509: INFO: stdout: "'/usr/share/nginx/html/index.html' -> '/tmp/index.html'\n"
+Jul  2 13:24:11.509: INFO: stdout of mv -v /usr/share/nginx/html/index.html /tmp/ || true on ss-2: '/usr/share/nginx/html/index.html' -> '/tmp/index.html'
+
+Jul  2 13:24:11.509: INFO: Waiting for statefulset status.replicas updated to 0
+Jul  2 13:24:11.513: INFO: Waiting for stateful set status.readyReplicas to become 0, currently 2
+Jul  2 13:24:21.521: INFO: Waiting for pod ss-0 to enter Running - Ready=false, currently Running - Ready=false
+Jul  2 13:24:21.521: INFO: Waiting for pod ss-1 to enter Running - Ready=false, currently Running - Ready=false
+Jul  2 13:24:21.521: INFO: Waiting for pod ss-2 to enter Running - Ready=false, currently Running - Ready=false
+Jul  2 13:24:21.530: INFO: Verifying statefulset ss doesn't scale past 3 for another 9.9999998s
+Jul  2 13:24:22.535: INFO: Verifying statefulset ss doesn't scale past 3 for another 8.99653695s
+Jul  2 13:24:23.540: INFO: Verifying statefulset ss doesn't scale past 3 for another 7.991824402s
+Jul  2 13:24:24.544: INFO: Verifying statefulset ss doesn't scale past 3 for another 6.98726656s
+Jul  2 13:24:25.548: INFO: Verifying statefulset ss doesn't scale past 3 for another 5.982889725s
+Jul  2 13:24:26.555: INFO: Verifying statefulset ss doesn't scale past 3 for another 4.978271295s
+Jul  2 13:24:27.560: INFO: Verifying statefulset ss doesn't scale past 3 for another 3.972137166s
+Jul  2 13:24:28.567: INFO: Verifying statefulset ss doesn't scale past 3 for another 2.963607736s
+Jul  2 13:24:29.571: INFO: Verifying statefulset ss doesn't scale past 3 for another 1.959748926s
+Jul  2 13:24:30.575: INFO: Verifying statefulset ss doesn't scale past 3 for another 955.813621ms
+STEP: Scaling down stateful set ss to 0 replicas and waiting until none of pods will run in namespacee2e-tests-statefulset-bqs5d
+Jul  2 13:24:31.630: INFO: Running '/usr/local/bin/kubectl --kubeconfig=/tmp/kubeconfig-324782104 exec --namespace=e2e-tests-statefulset-bqs5d ss-0 -- /bin/sh -c mv -v /tmp/index.html /usr/share/nginx/html/ || true'
+Jul  2 13:24:32.117: INFO: stderr: ""
+Jul  2 13:24:32.117: INFO: stdout: "'/tmp/index.html' -> '/usr/share/nginx/html/index.html'\n"
+Jul  2 13:24:32.117: INFO: stdout of mv -v /tmp/index.html /usr/share/nginx/html/ || true on ss-0: '/tmp/index.html' -> '/usr/share/nginx/html/index.html'
+
+Jul  2 13:24:32.117: INFO: Running '/usr/local/bin/kubectl --kubeconfig=/tmp/kubeconfig-324782104 exec --namespace=e2e-tests-statefulset-bqs5d ss-1 -- /bin/sh -c mv -v /tmp/index.html /usr/share/nginx/html/ || true'
+Jul  2 13:24:32.596: INFO: stderr: ""
+Jul  2 13:24:32.596: INFO: stdout: "'/tmp/index.html' -> '/usr/share/nginx/html/index.html'\n"
+Jul  2 13:24:32.596: INFO: stdout of mv -v /tmp/index.html /usr/share/nginx/html/ || true on ss-1: '/tmp/index.html' -> '/usr/share/nginx/html/index.html'
+
+Jul  2 13:24:32.596: INFO: Running '/usr/local/bin/kubectl --kubeconfig=/tmp/kubeconfig-324782104 exec --namespace=e2e-tests-statefulset-bqs5d ss-2 -- /bin/sh -c mv -v /tmp/index.html /usr/share/nginx/html/ || true'
+Jul  2 13:24:33.082: INFO: rc: 1
+Jul  2 13:24:33.082: INFO: Waiting 10s to retry failed RunHostCmd: error running &{/usr/local/bin/kubectl [kubectl --kubeconfig=/tmp/kubeconfig-324782104 exec --namespace=e2e-tests-statefulset-bqs5d ss-2 -- /bin/sh -c mv -v /tmp/index.html /usr/share/nginx/html/ || true] []  <nil>  Error from server: 
+ [] <nil> 0xc421088960 exit status 1 <nil> <nil> true [0xc4206780f8 0xc420678190 0xc4206783b8] [0xc4206780f8 0xc420678190 0xc4206783b8] [0xc420678178 0xc4206783b0] [0x8f98d0 0x8f98d0] 0xc4215b8180 <nil>}:
+Command stdout:
+
+stderr:
+Error from server: 
+
+error:
+exit status 1
+
+Jul  2 13:24:43.086: INFO: Running '/usr/local/bin/kubectl --kubeconfig=/tmp/kubeconfig-324782104 exec --namespace=e2e-tests-statefulset-bqs5d ss-2 -- /bin/sh -c mv -v /tmp/index.html /usr/share/nginx/html/ || true'
+Jul  2 13:24:43.296: INFO: rc: 1
+Jul  2 13:24:43.296: INFO: Waiting 10s to retry failed RunHostCmd: error running &{/usr/local/bin/kubectl [kubectl --kubeconfig=/tmp/kubeconfig-324782104 exec --namespace=e2e-tests-statefulset-bqs5d ss-2 -- /bin/sh -c mv -v /tmp/index.html /usr/share/nginx/html/ || true] []  <nil>  Error from server (NotFound): pods "ss-2" not found
+ [] <nil> 0xc420f223c0 exit status 1 <nil> <nil> true [0xc4201e85a8 0xc4201e85d8 0xc4201e8630] [0xc4201e85a8 0xc4201e85d8 0xc4201e8630] [0xc4201e85c0 0xc4201e8618] [0x8f98d0 0x8f98d0] 0xc420fcc9c0 <nil>}:
+Command stdout:
+
+stderr:
+Error from server (NotFound): pods "ss-2" not found
+
+error:
+exit status 1
+
+Jul  2 13:24:53.296: INFO: Running '/usr/local/bin/kubectl --kubeconfig=/tmp/kubeconfig-324782104 exec --namespace=e2e-tests-statefulset-bqs5d ss-2 -- /bin/sh -c mv -v /tmp/index.html /usr/share/nginx/html/ || true'
+Jul  2 13:24:53.377: INFO: rc: 1
+Jul  2 13:24:53.377: INFO: Waiting 10s to retry failed RunHostCmd: error running &{/usr/local/bin/kubectl [kubectl --kubeconfig=/tmp/kubeconfig-324782104 exec --namespace=e2e-tests-statefulset-bqs5d ss-2 -- /bin/sh -c mv -v /tmp/index.html /usr/share/nginx/html/ || true] []  <nil>  Error from server (NotFound): pods "ss-2" not found
+ [] <nil> 0xc421088f00 exit status 1 <nil> <nil> true [0xc4206783d8 0xc420678438 0xc420678470] [0xc4206783d8 0xc420678438 0xc420678470] [0xc420678430 0xc420678448] [0x8f98d0 0x8f98d0] 0xc4215b82a0 <nil>}:
+Command stdout:
+
+stderr:
+Error from server (NotFound): pods "ss-2" not found
+
+error:
+exit status 1
+
+Jul  2 13:25:03.377: INFO: Running '/usr/local/bin/kubectl --kubeconfig=/tmp/kubeconfig-324782104 exec --namespace=e2e-tests-statefulset-bqs5d ss-2 -- /bin/sh -c mv -v /tmp/index.html /usr/share/nginx/html/ || true'
+Jul  2 13:25:03.458: INFO: rc: 1
+Jul  2 13:25:03.458: INFO: Waiting 10s to retry failed RunHostCmd: error running &{/usr/local/bin/kubectl [kubectl --kubeconfig=/tmp/kubeconfig-324782104 exec --namespace=e2e-tests-statefulset-bqs5d ss-2 -- /bin/sh -c mv -v /tmp/index.html /usr/share/nginx/html/ || true] []  <nil>  Error from server (NotFound): pods "ss-2" not found
+ [] <nil> 0xc420f22810 exit status 1 <nil> <nil> true [0xc4201e8648 0xc4201e8780 0xc4201e8b50] [0xc4201e8648 0xc4201e8780 0xc4201e8b50] [0xc4201e8688 0xc4201e8b10] [0x8f98d0 0x8f98d0] 0xc420fccb40 <nil>}:
+Command stdout:
+
+stderr:
+Error from server (NotFound): pods "ss-2" not found
+
+error:
+exit status 1
+
+Jul  2 13:25:13.459: INFO: Running '/usr/local/bin/kubectl --kubeconfig=/tmp/kubeconfig-324782104 exec --namespace=e2e-tests-statefulset-bqs5d ss-2 -- /bin/sh -c mv -v /tmp/index.html /usr/share/nginx/html/ || true'
+Jul  2 13:25:13.574: INFO: rc: 1
+Jul  2 13:25:13.574: INFO: Waiting 10s to retry failed RunHostCmd: error running &{/usr/local/bin/kubectl [kubectl --kubeconfig=/tmp/kubeconfig-324782104 exec --namespace=e2e-tests-statefulset-bqs5d ss-2 -- /bin/sh -c mv -v /tmp/index.html /usr/share/nginx/html/ || true] []  <nil>  Error from server (NotFound): pods "ss-2" not found
+ [] <nil> 0xc420f22c60 exit status 1 <nil> <nil> true [0xc4201e8b88 0xc4201e8bd0 0xc4201e8c00] [0xc4201e8b88 0xc4201e8bd0 0xc4201e8c00] [0xc4201e8bb8 0xc4201e8be8] [0x8f98d0 0x8f98d0] 0xc420fcccc0 <nil>}:
+Command stdout:
+
+stderr:
+Error from server (NotFound): pods "ss-2" not found
+
+error:
+exit status 1
+
+Jul  2 13:25:23.574: INFO: Running '/usr/local/bin/kubectl --kubeconfig=/tmp/kubeconfig-324782104 exec --namespace=e2e-tests-statefulset-bqs5d ss-2 -- /bin/sh -c mv -v /tmp/index.html /usr/share/nginx/html/ || true'
+Jul  2 13:25:23.662: INFO: rc: 1
+Jul  2 13:25:23.662: INFO: Waiting 10s to retry failed RunHostCmd: error running &{/usr/local/bin/kubectl [kubectl --kubeconfig=/tmp/kubeconfig-324782104 exec --namespace=e2e-tests-statefulset-bqs5d ss-2 -- /bin/sh -c mv -v /tmp/index.html /usr/share/nginx/html/ || true] []  <nil>  Error from server (NotFound): pods "ss-2" not found
+ [] <nil> 0xc420f230b0 exit status 1 <nil> <nil> true [0xc4201e8c08 0xc4201e8c28 0xc4201e8c58] [0xc4201e8c08 0xc4201e8c28 0xc4201e8c58] [0xc4201e8c20 0xc4201e8c48] [0x8f98d0 0x8f98d0] 0xc420fcce40 <nil>}:
+Command stdout:
+
+stderr:
+Error from server (NotFound): pods "ss-2" not found
+
+error:
+exit status 1
+
+Jul  2 13:25:33.662: INFO: Running '/usr/local/bin/kubectl --kubeconfig=/tmp/kubeconfig-324782104 exec --namespace=e2e-tests-statefulset-bqs5d ss-2 -- /bin/sh -c mv -v /tmp/index.html /usr/share/nginx/html/ || true'
+Jul  2 13:25:33.741: INFO: rc: 1
+Jul  2 13:25:33.741: INFO: Waiting 10s to retry failed RunHostCmd: error running &{/usr/local/bin/kubectl [kubectl --kubeconfig=/tmp/kubeconfig-324782104 exec --namespace=e2e-tests-statefulset-bqs5d ss-2 -- /bin/sh -c mv -v /tmp/index.html /usr/share/nginx/html/ || true] []  <nil>  Error from server (NotFound): pods "ss-2" not found
+ [] <nil> 0xc420f235f0 exit status 1 <nil> <nil> true [0xc4201e8c70 0xc4201e9a10 0xc4201e9a78] [0xc4201e8c70 0xc4201e9a10 0xc4201e9a78] [0xc4201e8c90 0xc4201e9a50] [0x8f98d0 0x8f98d0] 0xc420fccf60 <nil>}:
+Command stdout:
+
+stderr:
+Error from server (NotFound): pods "ss-2" not found
+
+error:
+exit status 1
+
+Jul  2 13:25:43.742: INFO: Running '/usr/local/bin/kubectl --kubeconfig=/tmp/kubeconfig-324782104 exec --namespace=e2e-tests-statefulset-bqs5d ss-2 -- /bin/sh -c mv -v /tmp/index.html /usr/share/nginx/html/ || true'
+Jul  2 13:25:43.822: INFO: rc: 1
+Jul  2 13:25:43.822: INFO: Waiting 10s to retry failed RunHostCmd: error running &{/usr/local/bin/kubectl [kubectl --kubeconfig=/tmp/kubeconfig-324782104 exec --namespace=e2e-tests-statefulset-bqs5d ss-2 -- /bin/sh -c mv -v /tmp/index.html /usr/share/nginx/html/ || true] []  <nil>  Error from server (NotFound): pods "ss-2" not found
+ [] <nil> 0xc420f23a40 exit status 1 <nil> <nil> true [0xc4201e9a80 0xc4201e9ad0 0xc4201e9b30] [0xc4201e9a80 0xc4201e9ad0 0xc4201e9b30] [0xc4201e9ab0 0xc4201e9af8] [0x8f98d0 0x8f98d0] 0xc420fcd080 <nil>}:
+Command stdout:
+
+stderr:
+Error from server (NotFound): pods "ss-2" not found
+
+error:
+exit status 1
+
+Jul  2 13:25:53.823: INFO: Running '/usr/local/bin/kubectl --kubeconfig=/tmp/kubeconfig-324782104 exec --namespace=e2e-tests-statefulset-bqs5d ss-2 -- /bin/sh -c mv -v /tmp/index.html /usr/share/nginx/html/ || true'
+Jul  2 13:25:53.901: INFO: rc: 1
+Jul  2 13:25:53.901: INFO: Waiting 10s to retry failed RunHostCmd: error running &{/usr/local/bin/kubectl [kubectl --kubeconfig=/tmp/kubeconfig-324782104 exec --namespace=e2e-tests-statefulset-bqs5d ss-2 -- /bin/sh -c mv -v /tmp/index.html /usr/share/nginx/html/ || true] []  <nil>  Error from server (NotFound): pods "ss-2" not found
+ [] <nil> 0xc421089470 exit status 1 <nil> <nil> true [0xc420678478 0xc4206784d0 0xc420678518] [0xc420678478 0xc4206784d0 0xc420678518] [0xc4206784b0 0xc420678510] [0x8f98d0 0x8f98d0] 0xc4215b83c0 <nil>}:
+Command stdout:
+
+stderr:
+Error from server (NotFound): pods "ss-2" not found
+
+error:
+exit status 1
+
+Jul  2 13:26:03.901: INFO: Running '/usr/local/bin/kubectl --kubeconfig=/tmp/kubeconfig-324782104 exec --namespace=e2e-tests-statefulset-bqs5d ss-2 -- /bin/sh -c mv -v /tmp/index.html /usr/share/nginx/html/ || true'
+Jul  2 13:26:04.001: INFO: rc: 1
+Jul  2 13:26:04.001: INFO: Waiting 10s to retry failed RunHostCmd: error running &{/usr/local/bin/kubectl [kubectl --kubeconfig=/tmp/kubeconfig-324782104 exec --namespace=e2e-tests-statefulset-bqs5d ss-2 -- /bin/sh -c mv -v /tmp/index.html /usr/share/nginx/html/ || true] []  <nil>  Error from server (NotFound): pods "ss-2" not found
+ [] <nil> 0xc4210898c0 exit status 1 <nil> <nil> true [0xc420678548 0xc4206785e0 0xc420678658] [0xc420678548 0xc4206785e0 0xc420678658] [0xc4206785c8 0xc420678638] [0x8f98d0 0x8f98d0] 0xc4215b84e0 <nil>}:
+Command stdout:
+
+stderr:
+Error from server (NotFound): pods "ss-2" not found
+
+error:
+exit status 1
+
+Jul  2 13:26:14.002: INFO: Running '/usr/local/bin/kubectl --kubeconfig=/tmp/kubeconfig-324782104 exec --namespace=e2e-tests-statefulset-bqs5d ss-2 -- /bin/sh -c mv -v /tmp/index.html /usr/share/nginx/html/ || true'
+Jul  2 13:26:14.127: INFO: rc: 1
+Jul  2 13:26:14.127: INFO: Waiting 10s to retry failed RunHostCmd: error running &{/usr/local/bin/kubectl [kubectl --kubeconfig=/tmp/kubeconfig-324782104 exec --namespace=e2e-tests-statefulset-bqs5d ss-2 -- /bin/sh -c mv -v /tmp/index.html /usr/share/nginx/html/ || true] []  <nil>  Error from server (NotFound): pods "ss-2" not found
+ [] <nil> 0xc420f23e30 exit status 1 <nil> <nil> true [0xc4201e9b58 0xc4201e9b88 0xc4201e9bb0] [0xc4201e9b58 0xc4201e9b88 0xc4201e9bb0] [0xc4201e9b70 0xc4201e9ba0] [0x8f98d0 0x8f98d0] 0xc420fcd200 <nil>}:
+Command stdout:
+
+stderr:
+Error from server (NotFound): pods "ss-2" not found
+
+error:
+exit status 1
+
+Jul  2 13:26:24.128: INFO: Running '/usr/local/bin/kubectl --kubeconfig=/tmp/kubeconfig-324782104 exec --namespace=e2e-tests-statefulset-bqs5d ss-2 -- /bin/sh -c mv -v /tmp/index.html /usr/share/nginx/html/ || true'
+Jul  2 13:26:24.206: INFO: rc: 1
+Jul  2 13:26:24.206: INFO: Waiting 10s to retry failed RunHostCmd: error running &{/usr/local/bin/kubectl [kubectl --kubeconfig=/tmp/kubeconfig-324782104 exec --namespace=e2e-tests-statefulset-bqs5d ss-2 -- /bin/sh -c mv -v /tmp/index.html /usr/share/nginx/html/ || true] []  <nil>  Error from server (NotFound): pods "ss-2" not found
+ [] <nil> 0xc4210b42d0 exit status 1 <nil> <nil> true [0xc420678668 0xc420678710 0xc420678740] [0xc420678668 0xc420678710 0xc420678740] [0xc4206786c8 0xc420678728] [0x8f98d0 0x8f98d0] 0xc4215b8600 <nil>}:
+Command stdout:
+
+stderr:
+Error from server (NotFound): pods "ss-2" not found
+
+error:
+exit status 1
+
+Jul  2 13:26:34.206: INFO: Running '/usr/local/bin/kubectl --kubeconfig=/tmp/kubeconfig-324782104 exec --namespace=e2e-tests-statefulset-bqs5d ss-2 -- /bin/sh -c mv -v /tmp/index.html /usr/share/nginx/html/ || true'
+Jul  2 13:26:34.285: INFO: rc: 1
+Jul  2 13:26:34.285: INFO: Waiting 10s to retry failed RunHostCmd: error running &{/usr/local/bin/kubectl [kubectl --kubeconfig=/tmp/kubeconfig-324782104 exec --namespace=e2e-tests-statefulset-bqs5d ss-2 -- /bin/sh -c mv -v /tmp/index.html /usr/share/nginx/html/ || true] []  <nil>  Error from server (NotFound): pods "ss-2" not found
+ [] <nil> 0xc421088420 exit status 1 <nil> <nil> true [0xc4201e8000 0xc4201e8138 0xc4201e81d0] [0xc4201e8000 0xc4201e8138 0xc4201e81d0] [0xc4201e80d0 0xc4201e81c8] [0x8f98d0 0x8f98d0] 0xc420fcc2a0 <nil>}:
+Command stdout:
+
+stderr:
+Error from server (NotFound): pods "ss-2" not found
+
+error:
+exit status 1
+
+Jul  2 13:26:44.285: INFO: Running '/usr/local/bin/kubectl --kubeconfig=/tmp/kubeconfig-324782104 exec --namespace=e2e-tests-statefulset-bqs5d ss-2 -- /bin/sh -c mv -v /tmp/index.html /usr/share/nginx/html/ || true'
+Jul  2 13:26:44.380: INFO: rc: 1
+Jul  2 13:26:44.380: INFO: Waiting 10s to retry failed RunHostCmd: error running &{/usr/local/bin/kubectl [kubectl --kubeconfig=/tmp/kubeconfig-324782104 exec --namespace=e2e-tests-statefulset-bqs5d ss-2 -- /bin/sh -c mv -v /tmp/index.html /usr/share/nginx/html/ || true] []  <nil>  Error from server (NotFound): pods "ss-2" not found
+ [] <nil> 0xc421088900 exit status 1 <nil> <nil> true [0xc4201e81d8 0xc4201e8268 0xc4201e82b8] [0xc4201e81d8 0xc4201e8268 0xc4201e82b8] [0xc4201e8210 0xc4201e82b0] [0x8f98d0 0x8f98d0] 0xc420fcc3c0 <nil>}:
+Command stdout:
+
+stderr:
+Error from server (NotFound): pods "ss-2" not found
+
+error:
+exit status 1
+
+Jul  2 13:26:54.380: INFO: Running '/usr/local/bin/kubectl --kubeconfig=/tmp/kubeconfig-324782104 exec --namespace=e2e-tests-statefulset-bqs5d ss-2 -- /bin/sh -c mv -v /tmp/index.html /usr/share/nginx/html/ || true'
+Jul  2 13:26:54.505: INFO: rc: 1
+Jul  2 13:26:54.505: INFO: Waiting 10s to retry failed RunHostCmd: error running &{/usr/local/bin/kubectl [kubectl --kubeconfig=/tmp/kubeconfig-324782104 exec --namespace=e2e-tests-statefulset-bqs5d ss-2 -- /bin/sh -c mv -v /tmp/index.html /usr/share/nginx/html/ || true] []  <nil>  Error from server (NotFound): pods "ss-2" not found
+ [] <nil> 0xc421088ea0 exit status 1 <nil> <nil> true [0xc4201e82c8 0xc4201e8320 0xc4201e83a0] [0xc4201e82c8 0xc4201e8320 0xc4201e83a0] [0xc4201e8310 0xc4201e8358] [0x8f98d0 0x8f98d0] 0xc420fcc4e0 <nil>}:
+Command stdout:
+
+stderr:
+Error from server (NotFound): pods "ss-2" not found
+
+error:
+exit status 1
+
+Jul  2 13:27:04.505: INFO: Running '/usr/local/bin/kubectl --kubeconfig=/tmp/kubeconfig-324782104 exec --namespace=e2e-tests-statefulset-bqs5d ss-2 -- /bin/sh -c mv -v /tmp/index.html /usr/share/nginx/html/ || true'
+Jul  2 13:27:04.578: INFO: rc: 1
+Jul  2 13:27:04.578: INFO: Waiting 10s to retry failed RunHostCmd: error running &{/usr/local/bin/kubectl [kubectl --kubeconfig=/tmp/kubeconfig-324782104 exec --namespace=e2e-tests-statefulset-bqs5d ss-2 -- /bin/sh -c mv -v /tmp/index.html /usr/share/nginx/html/ || true] []  <nil>  Error from server (NotFound): pods "ss-2" not found
+ [] <nil> 0xc421089350 exit status 1 <nil> <nil> true [0xc4201e83d0 0xc4201e8478 0xc4201e84c0] [0xc4201e83d0 0xc4201e8478 0xc4201e84c0] [0xc4201e8450 0xc4201e84b0] [0x8f98d0 0x8f98d0] 0xc420fcc720 <nil>}:
+Command stdout:
+
+stderr:
+Error from server (NotFound): pods "ss-2" not found
+
+error:
+exit status 1
+
+Jul  2 13:27:14.578: INFO: Running '/usr/local/bin/kubectl --kubeconfig=/tmp/kubeconfig-324782104 exec --namespace=e2e-tests-statefulset-bqs5d ss-2 -- /bin/sh -c mv -v /tmp/index.html /usr/share/nginx/html/ || true'
+Jul  2 13:27:14.654: INFO: rc: 1
+Jul  2 13:27:14.654: INFO: Waiting 10s to retry failed RunHostCmd: error running &{/usr/local/bin/kubectl [kubectl --kubeconfig=/tmp/kubeconfig-324782104 exec --namespace=e2e-tests-statefulset-bqs5d ss-2 -- /bin/sh -c mv -v /tmp/index.html /usr/share/nginx/html/ || true] []  <nil>  Error from server (NotFound): pods "ss-2" not found
+ [] <nil> 0xc421089860 exit status 1 <nil> <nil> true [0xc4201e84d8 0xc4201e8580 0xc4201e85b8] [0xc4201e84d8 0xc4201e8580 0xc4201e85b8] [0xc4201e8530 0xc4201e85a8] [0x8f98d0 0x8f98d0] 0xc420fcc840 <nil>}:
+Command stdout:
+
+stderr:
+Error from server (NotFound): pods "ss-2" not found
+
+error:
+exit status 1
+
+Jul  2 13:27:24.654: INFO: Running '/usr/local/bin/kubectl --kubeconfig=/tmp/kubeconfig-324782104 exec --namespace=e2e-tests-statefulset-bqs5d ss-2 -- /bin/sh -c mv -v /tmp/index.html /usr/share/nginx/html/ || true'
+Jul  2 13:27:24.739: INFO: rc: 1
+Jul  2 13:27:24.739: INFO: Waiting 10s to retry failed RunHostCmd: error running &{/usr/local/bin/kubectl [kubectl --kubeconfig=/tmp/kubeconfig-324782104 exec --namespace=e2e-tests-statefulset-bqs5d ss-2 -- /bin/sh -c mv -v /tmp/index.html /usr/share/nginx/html/ || true] []  <nil>  Error from server (NotFound): pods "ss-2" not found
+ [] <nil> 0xc4211787e0 exit status 1 <nil> <nil> true [0xc4206780f8 0xc420678190 0xc4206783b8] [0xc4206780f8 0xc420678190 0xc4206783b8] [0xc420678178 0xc4206783b0] [0x8f98d0 0x8f98d0] 0xc4215b8060 <nil>}:
+Command stdout:
+
+stderr:
+Error from server (NotFound): pods "ss-2" not found
+
+error:
+exit status 1
+
+Jul  2 13:27:34.739: INFO: Running '/usr/local/bin/kubectl --kubeconfig=/tmp/kubeconfig-324782104 exec --namespace=e2e-tests-statefulset-bqs5d ss-2 -- /bin/sh -c mv -v /tmp/index.html /usr/share/nginx/html/ || true'
+Jul  2 13:27:34.822: INFO: rc: 1
+Jul  2 13:27:34.822: INFO: Waiting 10s to retry failed RunHostCmd: error running &{/usr/local/bin/kubectl [kubectl --kubeconfig=/tmp/kubeconfig-324782104 exec --namespace=e2e-tests-statefulset-bqs5d ss-2 -- /bin/sh -c mv -v /tmp/index.html /usr/share/nginx/html/ || true] []  <nil>  Error from server (NotFound): pods "ss-2" not found
+ [] <nil> 0xc421089dd0 exit status 1 <nil> <nil> true [0xc4201e85c0 0xc4201e8618 0xc4201e8658] [0xc4201e85c0 0xc4201e8618 0xc4201e8658] [0xc4201e85e8 0xc4201e8648] [0x8f98d0 0x8f98d0] 0xc420fcc960 <nil>}:
+Command stdout:
+
+stderr:
+Error from server (NotFound): pods "ss-2" not found
+
+error:
+exit status 1
+
+Jul  2 13:27:44.822: INFO: Running '/usr/local/bin/kubectl --kubeconfig=/tmp/kubeconfig-324782104 exec --namespace=e2e-tests-statefulset-bqs5d ss-2 -- /bin/sh -c mv -v /tmp/index.html /usr/share/nginx/html/ || true'
+Jul  2 13:27:44.899: INFO: rc: 1
+Jul  2 13:27:44.899: INFO: Waiting 10s to retry failed RunHostCmd: error running &{/usr/local/bin/kubectl [kubectl --kubeconfig=/tmp/kubeconfig-324782104 exec --namespace=e2e-tests-statefulset-bqs5d ss-2 -- /bin/sh -c mv -v /tmp/index.html /usr/share/nginx/html/ || true] []  <nil>  Error from server (NotFound): pods "ss-2" not found
+ [] <nil> 0xc420f22240 exit status 1 <nil> <nil> true [0xc4201e8688 0xc4201e8b10 0xc4201e8bb0] [0xc4201e8688 0xc4201e8b10 0xc4201e8bb0] [0xc4201e87c0 0xc4201e8b88] [0x8f98d0 0x8f98d0] 0xc420fcca80 <nil>}:
+Command stdout:
+
+stderr:
+Error from server (NotFound): pods "ss-2" not found
+
+error:
+exit status 1
+
+Jul  2 13:27:54.899: INFO: Running '/usr/local/bin/kubectl --kubeconfig=/tmp/kubeconfig-324782104 exec --namespace=e2e-tests-statefulset-bqs5d ss-2 -- /bin/sh -c mv -v /tmp/index.html /usr/share/nginx/html/ || true'
+Jul  2 13:27:55.081: INFO: rc: 1
+Jul  2 13:27:55.081: INFO: Waiting 10s to retry failed RunHostCmd: error running &{/usr/local/bin/kubectl [kubectl --kubeconfig=/tmp/kubeconfig-324782104 exec --namespace=e2e-tests-statefulset-bqs5d ss-2 -- /bin/sh -c mv -v /tmp/index.html /usr/share/nginx/html/ || true] []  <nil>  Error from server (NotFound): pods "ss-2" not found
+ [] <nil> 0xc421178bd0 exit status 1 <nil> <nil> true [0xc4206783d8 0xc420678438 0xc420678470] [0xc4206783d8 0xc420678438 0xc420678470] [0xc420678430 0xc420678448] [0x8f98d0 0x8f98d0] 0xc4215b8180 <nil>}:
+Command stdout:
+
+stderr:
+Error from server (NotFound): pods "ss-2" not found
+
+error:
+exit status 1
+
+Jul  2 13:28:05.081: INFO: Running '/usr/local/bin/kubectl --kubeconfig=/tmp/kubeconfig-324782104 exec --namespace=e2e-tests-statefulset-bqs5d ss-2 -- /bin/sh -c mv -v /tmp/index.html /usr/share/nginx/html/ || true'
+Jul  2 13:28:05.169: INFO: rc: 1
+Jul  2 13:28:05.169: INFO: Waiting 10s to retry failed RunHostCmd: error running &{/usr/local/bin/kubectl [kubectl --kubeconfig=/tmp/kubeconfig-324782104 exec --namespace=e2e-tests-statefulset-bqs5d ss-2 -- /bin/sh -c mv -v /tmp/index.html /usr/share/nginx/html/ || true] []  <nil>  Error from server (NotFound): pods "ss-2" not found
+ [] <nil> 0xc421179080 exit status 1 <nil> <nil> true [0xc420678478 0xc4206784d0 0xc420678518] [0xc420678478 0xc4206784d0 0xc420678518] [0xc4206784b0 0xc420678510] [0x8f98d0 0x8f98d0] 0xc4215b82a0 <nil>}:
+Command stdout:
+
+stderr:
+Error from server (NotFound): pods "ss-2" not found
+
+error:
+exit status 1
+
+Jul  2 13:28:15.169: INFO: Running '/usr/local/bin/kubectl --kubeconfig=/tmp/kubeconfig-324782104 exec --namespace=e2e-tests-statefulset-bqs5d ss-2 -- /bin/sh -c mv -v /tmp/index.html /usr/share/nginx/html/ || true'
+Jul  2 13:28:15.254: INFO: rc: 1
+Jul  2 13:28:15.254: INFO: Waiting 10s to retry failed RunHostCmd: error running &{/usr/local/bin/kubectl [kubectl --kubeconfig=/tmp/kubeconfig-324782104 exec --namespace=e2e-tests-statefulset-bqs5d ss-2 -- /bin/sh -c mv -v /tmp/index.html /usr/share/nginx/html/ || true] []  <nil>  Error from server (NotFound): pods "ss-2" not found
+ [] <nil> 0xc420f22660 exit status 1 <nil> <nil> true [0xc4201e8bb8 0xc4201e8be8 0xc4201e8c10] [0xc4201e8bb8 0xc4201e8be8 0xc4201e8c10] [0xc4201e8bd8 0xc4201e8c08] [0x8f98d0 0x8f98d0] 0xc420fccc60 <nil>}:
+Command stdout:
+
+stderr:
+Error from server (NotFound): pods "ss-2" not found
+
+error:
+exit status 1
+
+Jul  2 13:28:25.254: INFO: Running '/usr/local/bin/kubectl --kubeconfig=/tmp/kubeconfig-324782104 exec --namespace=e2e-tests-statefulset-bqs5d ss-2 -- /bin/sh -c mv -v /tmp/index.html /usr/share/nginx/html/ || true'
+Jul  2 13:28:25.336: INFO: rc: 1
+Jul  2 13:28:25.336: INFO: Waiting 10s to retry failed RunHostCmd: error running &{/usr/local/bin/kubectl [kubectl --kubeconfig=/tmp/kubeconfig-324782104 exec --namespace=e2e-tests-statefulset-bqs5d ss-2 -- /bin/sh -c mv -v /tmp/index.html /usr/share/nginx/html/ || true] []  <nil>  Error from server (NotFound): pods "ss-2" not found
+ [] <nil> 0xc420f22ab0 exit status 1 <nil> <nil> true [0xc4201e8c20 0xc4201e8c48 0xc4201e8c80] [0xc4201e8c20 0xc4201e8c48 0xc4201e8c80] [0xc4201e8c40 0xc4201e8c70] [0x8f98d0 0x8f98d0] 0xc420fccd80 <nil>}:
+Command stdout:
+
+stderr:
+Error from server (NotFound): pods "ss-2" not found
+
+error:
+exit status 1
+
+Jul  2 13:28:35.336: INFO: Running '/usr/local/bin/kubectl --kubeconfig=/tmp/kubeconfig-324782104 exec --namespace=e2e-tests-statefulset-bqs5d ss-2 -- /bin/sh -c mv -v /tmp/index.html /usr/share/nginx/html/ || true'
+Jul  2 13:28:35.435: INFO: rc: 1
+Jul  2 13:28:35.435: INFO: Waiting 10s to retry failed RunHostCmd: error running &{/usr/local/bin/kubectl [kubectl --kubeconfig=/tmp/kubeconfig-324782104 exec --namespace=e2e-tests-statefulset-bqs5d ss-2 -- /bin/sh -c mv -v /tmp/index.html /usr/share/nginx/html/ || true] []  <nil>  Error from server (NotFound): pods "ss-2" not found
+ [] <nil> 0xc421179950 exit status 1 <nil> <nil> true [0xc4206785c0 0xc420678630 0xc420678668] [0xc4206785c0 0xc420678630 0xc420678668] [0xc4206785e0 0xc420678658] [0x8f98d0 0x8f98d0] 0xc4215b83c0 <nil>}:
+Command stdout:
+
+stderr:
+Error from server (NotFound): pods "ss-2" not found
+
+error:
+exit status 1
+
+Jul  2 13:28:45.435: INFO: Running '/usr/local/bin/kubectl --kubeconfig=/tmp/kubeconfig-324782104 exec --namespace=e2e-tests-statefulset-bqs5d ss-2 -- /bin/sh -c mv -v /tmp/index.html /usr/share/nginx/html/ || true'
+Jul  2 13:28:45.566: INFO: rc: 1
+Jul  2 13:28:45.566: INFO: Waiting 10s to retry failed RunHostCmd: error running &{/usr/local/bin/kubectl [kubectl --kubeconfig=/tmp/kubeconfig-324782104 exec --namespace=e2e-tests-statefulset-bqs5d ss-2 -- /bin/sh -c mv -v /tmp/index.html /usr/share/nginx/html/ || true] []  <nil>  Error from server (NotFound): pods "ss-2" not found
+ [] <nil> 0xc421088450 exit status 1 <nil> <nil> true [0xc42000ffe8 0xc4201e80d0 0xc4201e81c8] [0xc42000ffe8 0xc4201e80d0 0xc4201e81c8] [0xc4201e8030 0xc4201e8188] [0x8f98d0 0x8f98d0] 0xc420fcc2a0 <nil>}:
+Command stdout:
+
+stderr:
+Error from server (NotFound): pods "ss-2" not found
+
+error:
+exit status 1
+
+Jul  2 13:28:55.567: INFO: Running '/usr/local/bin/kubectl --kubeconfig=/tmp/kubeconfig-324782104 exec --namespace=e2e-tests-statefulset-bqs5d ss-2 -- /bin/sh -c mv -v /tmp/index.html /usr/share/nginx/html/ || true'
+Jul  2 13:28:55.674: INFO: rc: 1
+Jul  2 13:28:55.674: INFO: Waiting 10s to retry failed RunHostCmd: error running &{/usr/local/bin/kubectl [kubectl --kubeconfig=/tmp/kubeconfig-324782104 exec --namespace=e2e-tests-statefulset-bqs5d ss-2 -- /bin/sh -c mv -v /tmp/index.html /usr/share/nginx/html/ || true] []  <nil>  Error from server (NotFound): pods "ss-2" not found
+ [] <nil> 0xc421088960 exit status 1 <nil> <nil> true [0xc4201e81d0 0xc4201e8210 0xc4201e82b0] [0xc4201e81d0 0xc4201e8210 0xc4201e82b0] [0xc4201e81e8 0xc4201e8278] [0x8f98d0 0x8f98d0] 0xc420fcc3c0 <nil>}:
+Command stdout:
+
+stderr:
+Error from server (NotFound): pods "ss-2" not found
+
+error:
+exit status 1
+
+Jul  2 13:29:05.674: INFO: Running '/usr/local/bin/kubectl --kubeconfig=/tmp/kubeconfig-324782104 exec --namespace=e2e-tests-statefulset-bqs5d ss-2 -- /bin/sh -c mv -v /tmp/index.html /usr/share/nginx/html/ || true'
+Jul  2 13:29:05.755: INFO: rc: 1
+Jul  2 13:29:05.755: INFO: Waiting 10s to retry failed RunHostCmd: error running &{/usr/local/bin/kubectl [kubectl --kubeconfig=/tmp/kubeconfig-324782104 exec --namespace=e2e-tests-statefulset-bqs5d ss-2 -- /bin/sh -c mv -v /tmp/index.html /usr/share/nginx/html/ || true] []  <nil>  Error from server (NotFound): pods "ss-2" not found
+ [] <nil> 0xc420f22420 exit status 1 <nil> <nil> true [0xc4206780f8 0xc420678190 0xc4206783b8] [0xc4206780f8 0xc420678190 0xc4206783b8] [0xc420678178 0xc4206783b0] [0x8f98d0 0x8f98d0] 0xc4215b8060 <nil>}:
+Command stdout:
+
+stderr:
+Error from server (NotFound): pods "ss-2" not found
+
+error:
+exit status 1
+
+Jul  2 13:29:15.755: INFO: Running '/usr/local/bin/kubectl --kubeconfig=/tmp/kubeconfig-324782104 exec --namespace=e2e-tests-statefulset-bqs5d ss-2 -- /bin/sh -c mv -v /tmp/index.html /usr/share/nginx/html/ || true'
+Jul  2 13:29:15.848: INFO: rc: 1
+Jul  2 13:29:15.848: INFO: Waiting 10s to retry failed RunHostCmd: error running &{/usr/local/bin/kubectl [kubectl --kubeconfig=/tmp/kubeconfig-324782104 exec --namespace=e2e-tests-statefulset-bqs5d ss-2 -- /bin/sh -c mv -v /tmp/index.html /usr/share/nginx/html/ || true] []  <nil>  Error from server (NotFound): pods "ss-2" not found
+ [] <nil> 0xc420f22870 exit status 1 <nil> <nil> true [0xc4206783d8 0xc420678438 0xc420678470] [0xc4206783d8 0xc420678438 0xc420678470] [0xc420678430 0xc420678448] [0x8f98d0 0x8f98d0] 0xc4215b8180 <nil>}:
+Command stdout:
+
+stderr:
+Error from server (NotFound): pods "ss-2" not found
+
+error:
+exit status 1
+
+Jul  2 13:29:25.849: INFO: Running '/usr/local/bin/kubectl --kubeconfig=/tmp/kubeconfig-324782104 exec --namespace=e2e-tests-statefulset-bqs5d ss-2 -- /bin/sh -c mv -v /tmp/index.html /usr/share/nginx/html/ || true'
+Jul  2 13:29:25.925: INFO: rc: 1
+Jul  2 13:29:25.926: INFO: Waiting 10s to retry failed RunHostCmd: error running &{/usr/local/bin/kubectl [kubectl --kubeconfig=/tmp/kubeconfig-324782104 exec --namespace=e2e-tests-statefulset-bqs5d ss-2 -- /bin/sh -c mv -v /tmp/index.html /usr/share/nginx/html/ || true] []  <nil>  Error from server (NotFound): pods "ss-2" not found
+ [] <nil> 0xc421088f30 exit status 1 <nil> <nil> true [0xc4201e82b8 0xc4201e8310 0xc4201e8358] [0xc4201e82b8 0xc4201e8310 0xc4201e8358] [0xc4201e82f0 0xc4201e8350] [0x8f98d0 0x8f98d0] 0xc420fcc4e0 <nil>}:
+Command stdout:
+
+stderr:
+Error from server (NotFound): pods "ss-2" not found
+
+error:
+exit status 1
+
+Jul  2 13:29:35.926: INFO: Running '/usr/local/bin/kubectl --kubeconfig=/tmp/kubeconfig-324782104 exec --namespace=e2e-tests-statefulset-bqs5d ss-2 -- /bin/sh -c mv -v /tmp/index.html /usr/share/nginx/html/ || true'
+Jul  2 13:29:36.004: INFO: rc: 1
+Jul  2 13:29:36.004: INFO: stdout of mv -v /tmp/index.html /usr/share/nginx/html/ || true on ss-2: 
+Jul  2 13:29:36.004: INFO: Scaling statefulset ss to 0
+STEP: Verifying that stateful set ss was scaled down in reverse order
+[AfterEach] [k8s.io] Basic StatefulSet functionality [StatefulSetBasic]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/statefulset.go:83
+Jul  2 13:29:36.014: INFO: Deleting all statefulset in ns e2e-tests-statefulset-bqs5d
+Jul  2 13:29:36.016: INFO: Scaling statefulset ss to 0
+Jul  2 13:29:36.027: INFO: Waiting for statefulset status.replicas updated to 0
+Jul  2 13:29:36.030: INFO: Deleting statefulset ss
+[AfterEach] [sig-apps] StatefulSet
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:29:36.044: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-statefulset-bqs5d" for this suite.
+Jul  2 13:29:42.130: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:29:42.247: INFO: namespace: e2e-tests-statefulset-bqs5d, resource: bindings, ignored listing per whitelist
+Jul  2 13:29:42.256: INFO: namespace e2e-tests-statefulset-bqs5d deletion completed in 6.208950535s
+
+• [SLOW TEST:373.892 seconds]
+[sig-apps] StatefulSet
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/framework.go:22
+  [k8s.io] Basic StatefulSet functionality [StatefulSetBasic]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:679
+    Scaling should happen in predictable order and halt if any stateful pod is unhealthy [Conformance]
+    /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSSSS
+------------------------------
+[sig-scheduling] SchedulerPredicates [Serial] 
+  validates that NodeSelector is respected if not matching  [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-scheduling] SchedulerPredicates [Serial]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:29:42.256: INFO: >>> kubeConfig: /tmp/kubeconfig-324782104
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-scheduling] SchedulerPredicates [Serial]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/scheduling/predicates.go:79
+Jul  2 13:29:42.353: INFO: Waiting up to 1m0s for all nodes to be ready
+Jul  2 13:30:42.371: INFO: Waiting for terminating namespaces to be deleted...
+Jul  2 13:30:42.429: INFO: Waiting up to 5m0s for all pods (need at least 0) in namespace 'kube-system' to be running and ready
+Jul  2 13:30:42.441: INFO: 14 / 14 pods in namespace 'kube-system' are running and ready (0 seconds elapsed)
+Jul  2 13:30:42.441: INFO: expected 8 pod replicas in namespace 'kube-system', 8 are Running and Ready.
+Jul  2 13:30:42.445: INFO: Waiting for pods to enter Success, but no pods in "kube-system" match label map[name:e2e-image-puller]
+Jul  2 13:30:42.445: INFO: 
+Logging pods the kubelet thinks is on node shoot--core--confaz-worker-qfmi9-79968b77d9-24hm4 before test
+Jul  2 13:30:42.568: INFO: node-exporter-fzzjt from kube-system started at 2018-07-02 12:51:19 +0000 UTC (1 container statuses recorded)
+Jul  2 13:30:42.568: INFO: 	Container node-exporter ready: true, restart count 0
+Jul  2 13:30:42.568: INFO: kube-dns-autoscaler-6dd4765967-wxfns from kube-system started at 2018-07-02 12:51:50 +0000 UTC (1 container statuses recorded)
+Jul  2 13:30:42.568: INFO: 	Container autoscaler ready: true, restart count 0
+Jul  2 13:30:42.568: INFO: addons-nginx-ingress-controller-79bfb57974-gxmr9 from kube-system started at 2018-07-02 12:51:50 +0000 UTC (1 container statuses recorded)
+Jul  2 13:30:42.568: INFO: 	Container nginx-ingress-controller ready: true, restart count 0
+Jul  2 13:30:42.568: INFO: calico-node-vzzmk from kube-system started at 2018-07-02 12:51:19 +0000 UTC (2 container statuses recorded)
+Jul  2 13:30:42.568: INFO: 	Container calico-node ready: true, restart count 0
+Jul  2 13:30:42.568: INFO: 	Container install-cni ready: true, restart count 0
+Jul  2 13:30:42.568: INFO: kube-proxy-9j7qk from kube-system started at 2018-07-02 12:51:19 +0000 UTC (1 container statuses recorded)
+Jul  2 13:30:42.568: INFO: 	Container kube-proxy ready: true, restart count 0
+Jul  2 13:30:42.568: INFO: vpn-shoot-dd669f8bb-vs6qw from kube-system started at 2018-07-02 12:51:50 +0000 UTC (1 container statuses recorded)
+Jul  2 13:30:42.568: INFO: 	Container vpn-shoot ready: true, restart count 0
+Jul  2 13:30:42.568: INFO: kube-dns-9c4dfc4fb-68s88 from kube-system started at 2018-07-02 12:52:17 +0000 UTC (3 container statuses recorded)
+Jul  2 13:30:42.568: INFO: 	Container dnsmasq ready: true, restart count 0
+Jul  2 13:30:42.568: INFO: 	Container kubedns ready: true, restart count 0
+Jul  2 13:30:42.568: INFO: 	Container sidecar ready: true, restart count 0
+Jul  2 13:30:42.568: INFO: addons-heapster-e3b0c-64455ddddb-4nqxw from kube-system started at 2018-07-02 12:51:50 +0000 UTC (2 container statuses recorded)
+Jul  2 13:30:42.568: INFO: 	Container heapster ready: true, restart count 0
+Jul  2 13:30:42.568: INFO: 	Container heapster-nanny ready: true, restart count 0
+Jul  2 13:30:42.568: INFO: addons-nginx-ingress-nginx-ingress-k8s-backend-7b5569797f-vs48p from kube-system started at 2018-07-02 12:51:50 +0000 UTC (1 container statuses recorded)
+Jul  2 13:30:42.568: INFO: 	Container nginx-ingress-nginx-ingress-k8s-backend ready: true, restart count 0
+Jul  2 13:30:42.568: INFO: kube-dns-9c4dfc4fb-wvnfk from kube-system started at 2018-07-02 12:51:50 +0000 UTC (3 container statuses recorded)
+Jul  2 13:30:42.568: INFO: 	Container dnsmasq ready: true, restart count 0
+Jul  2 13:30:42.568: INFO: 	Container kubedns ready: true, restart count 0
+Jul  2 13:30:42.568: INFO: 	Container sidecar ready: true, restart count 0
+Jul  2 13:30:42.568: INFO: addons-kubernetes-dashboard-5486b968b7-9bgvq from kube-system started at 2018-07-02 12:51:50 +0000 UTC (1 container statuses recorded)
+Jul  2 13:30:42.568: INFO: 	Container main ready: true, restart count 0
+Jul  2 13:30:42.568: INFO: 
+Logging pods the kubelet thinks is on node shoot--core--confaz-worker-qfmi9-79968b77d9-kcr6j before test
+Jul  2 13:30:42.669: INFO: calico-node-77jff from kube-system started at 2018-07-02 12:51:49 +0000 UTC (2 container statuses recorded)
+Jul  2 13:30:42.669: INFO: 	Container calico-node ready: true, restart count 0
+Jul  2 13:30:42.669: INFO: 	Container install-cni ready: true, restart count 0
+Jul  2 13:30:42.669: INFO: sonobuoy from sonobuoy started at 2018-07-02 12:54:15 +0000 UTC (1 container statuses recorded)
+Jul  2 13:30:42.669: INFO: 	Container kube-sonobuoy ready: true, restart count 0
+Jul  2 13:30:42.669: INFO: kube-proxy-f5qqz from kube-system started at 2018-07-02 12:51:49 +0000 UTC (1 container statuses recorded)
+Jul  2 13:30:42.669: INFO: 	Container kube-proxy ready: true, restart count 0
+Jul  2 13:30:42.669: INFO: sonobuoy-e2e-job-23e7c281ee4e4e5d from sonobuoy started at 2018-07-02 12:54:29 +0000 UTC (2 container statuses recorded)
+Jul  2 13:30:42.669: INFO: 	Container e2e ready: true, restart count 0
+Jul  2 13:30:42.669: INFO: 	Container sonobuoy-worker ready: true, restart count 0
+Jul  2 13:30:42.669: INFO: node-exporter-wh8n7 from kube-system started at 2018-07-02 12:51:49 +0000 UTC (1 container statuses recorded)
+Jul  2 13:30:42.669: INFO: 	Container node-exporter ready: true, restart count 0
+[It] validates that NodeSelector is respected if not matching  [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Trying to schedule Pod with nonempty NodeSelector.
+STEP: Considering event: 
+Type = [Warning], Name = [restricted-pod.153d906c32bce970], Reason = [FailedScheduling], Message = [0/2 nodes are available: 2 node(s) didn't match node selector.]
+[AfterEach] [sig-scheduling] SchedulerPredicates [Serial]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:30:43.763: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-sched-pred-phjjl" for this suite.
+Jul  2 13:31:05.798: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:31:05.861: INFO: namespace: e2e-tests-sched-pred-phjjl, resource: bindings, ignored listing per whitelist
+Jul  2 13:31:05.939: INFO: namespace e2e-tests-sched-pred-phjjl deletion completed in 22.172556409s
+[AfterEach] [sig-scheduling] SchedulerPredicates [Serial]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/scheduling/predicates.go:70
+
+• [SLOW TEST:83.683 seconds]
+[sig-scheduling] SchedulerPredicates [Serial]
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/scheduling/framework.go:22
+  validates that NodeSelector is respected if not matching  [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSSS
+------------------------------
+[sig-api-machinery] Watchers 
+  should observe add, update, and delete watch notifications on configmaps [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-api-machinery] Watchers
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:31:05.939: INFO: >>> kubeConfig: /tmp/kubeconfig-324782104
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should observe add, update, and delete watch notifications on configmaps [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: creating a watch on configmaps with label A
+STEP: creating a watch on configmaps with label B
+STEP: creating a watch on configmaps with label A or B
+STEP: creating a configmap with label A and ensuring the correct watchers observe the notification
+Jul  2 13:31:06.086: INFO: Got : ADDED &ConfigMap{ObjectMeta:k8s_io_apimachinery_pkg_apis_meta_v1.ObjectMeta{Name:e2e-watch-test-configmap-a,GenerateName:,Namespace:e2e-tests-watch-26j2s,SelfLink:/api/v1/namespaces/e2e-tests-watch-26j2s/configmaps/e2e-watch-test-configmap-a,UID:2c27e14b-7dfc-11e8-bc8c-d657551927e5,ResourceVersion:7223,Generation:0,CreationTimestamp:2018-07-02 13:31:06 +0000 UTC,DeletionTimestamp:<nil>,DeletionGracePeriodSeconds:nil,Labels:map[string]string{watch-this-configmap: multiple-watchers-A,},Annotations:map[string]string{},OwnerReferences:[],Finalizers:[],ClusterName:,Initializers:nil,},Data:map[string]string{},BinaryData:map[string][]byte{},}
+Jul  2 13:31:06.087: INFO: Got : ADDED &ConfigMap{ObjectMeta:k8s_io_apimachinery_pkg_apis_meta_v1.ObjectMeta{Name:e2e-watch-test-configmap-a,GenerateName:,Namespace:e2e-tests-watch-26j2s,SelfLink:/api/v1/namespaces/e2e-tests-watch-26j2s/configmaps/e2e-watch-test-configmap-a,UID:2c27e14b-7dfc-11e8-bc8c-d657551927e5,ResourceVersion:7223,Generation:0,CreationTimestamp:2018-07-02 13:31:06 +0000 UTC,DeletionTimestamp:<nil>,DeletionGracePeriodSeconds:nil,Labels:map[string]string{watch-this-configmap: multiple-watchers-A,},Annotations:map[string]string{},OwnerReferences:[],Finalizers:[],ClusterName:,Initializers:nil,},Data:map[string]string{},BinaryData:map[string][]byte{},}
+STEP: modifying configmap A and ensuring the correct watchers observe the notification
+Jul  2 13:31:16.093: INFO: Got : MODIFIED &ConfigMap{ObjectMeta:k8s_io_apimachinery_pkg_apis_meta_v1.ObjectMeta{Name:e2e-watch-test-configmap-a,GenerateName:,Namespace:e2e-tests-watch-26j2s,SelfLink:/api/v1/namespaces/e2e-tests-watch-26j2s/configmaps/e2e-watch-test-configmap-a,UID:2c27e14b-7dfc-11e8-bc8c-d657551927e5,ResourceVersion:7244,Generation:0,CreationTimestamp:2018-07-02 13:31:06 +0000 UTC,DeletionTimestamp:<nil>,DeletionGracePeriodSeconds:nil,Labels:map[string]string{watch-this-configmap: multiple-watchers-A,},Annotations:map[string]string{},OwnerReferences:[],Finalizers:[],ClusterName:,Initializers:nil,},Data:map[string]string{mutation: 1,},BinaryData:map[string][]byte{},}
+Jul  2 13:31:16.093: INFO: Got : MODIFIED &ConfigMap{ObjectMeta:k8s_io_apimachinery_pkg_apis_meta_v1.ObjectMeta{Name:e2e-watch-test-configmap-a,GenerateName:,Namespace:e2e-tests-watch-26j2s,SelfLink:/api/v1/namespaces/e2e-tests-watch-26j2s/configmaps/e2e-watch-test-configmap-a,UID:2c27e14b-7dfc-11e8-bc8c-d657551927e5,ResourceVersion:7244,Generation:0,CreationTimestamp:2018-07-02 13:31:06 +0000 UTC,DeletionTimestamp:<nil>,DeletionGracePeriodSeconds:nil,Labels:map[string]string{watch-this-configmap: multiple-watchers-A,},Annotations:map[string]string{},OwnerReferences:[],Finalizers:[],ClusterName:,Initializers:nil,},Data:map[string]string{mutation: 1,},BinaryData:map[string][]byte{},}
+STEP: modifying configmap A again and ensuring the correct watchers observe the notification
+Jul  2 13:31:26.101: INFO: Got : MODIFIED &ConfigMap{ObjectMeta:k8s_io_apimachinery_pkg_apis_meta_v1.ObjectMeta{Name:e2e-watch-test-configmap-a,GenerateName:,Namespace:e2e-tests-watch-26j2s,SelfLink:/api/v1/namespaces/e2e-tests-watch-26j2s/configmaps/e2e-watch-test-configmap-a,UID:2c27e14b-7dfc-11e8-bc8c-d657551927e5,ResourceVersion:7264,Generation:0,CreationTimestamp:2018-07-02 13:31:06 +0000 UTC,DeletionTimestamp:<nil>,DeletionGracePeriodSeconds:nil,Labels:map[string]string{watch-this-configmap: multiple-watchers-A,},Annotations:map[string]string{},OwnerReferences:[],Finalizers:[],ClusterName:,Initializers:nil,},Data:map[string]string{mutation: 2,},BinaryData:map[string][]byte{},}
+Jul  2 13:31:26.101: INFO: Got : MODIFIED &ConfigMap{ObjectMeta:k8s_io_apimachinery_pkg_apis_meta_v1.ObjectMeta{Name:e2e-watch-test-configmap-a,GenerateName:,Namespace:e2e-tests-watch-26j2s,SelfLink:/api/v1/namespaces/e2e-tests-watch-26j2s/configmaps/e2e-watch-test-configmap-a,UID:2c27e14b-7dfc-11e8-bc8c-d657551927e5,ResourceVersion:7264,Generation:0,CreationTimestamp:2018-07-02 13:31:06 +0000 UTC,DeletionTimestamp:<nil>,DeletionGracePeriodSeconds:nil,Labels:map[string]string{watch-this-configmap: multiple-watchers-A,},Annotations:map[string]string{},OwnerReferences:[],Finalizers:[],ClusterName:,Initializers:nil,},Data:map[string]string{mutation: 2,},BinaryData:map[string][]byte{},}
+STEP: deleting configmap A and ensuring the correct watchers observe the notification
+Jul  2 13:31:36.108: INFO: Got : DELETED &ConfigMap{ObjectMeta:k8s_io_apimachinery_pkg_apis_meta_v1.ObjectMeta{Name:e2e-watch-test-configmap-a,GenerateName:,Namespace:e2e-tests-watch-26j2s,SelfLink:/api/v1/namespaces/e2e-tests-watch-26j2s/configmaps/e2e-watch-test-configmap-a,UID:2c27e14b-7dfc-11e8-bc8c-d657551927e5,ResourceVersion:7285,Generation:0,CreationTimestamp:2018-07-02 13:31:06 +0000 UTC,DeletionTimestamp:<nil>,DeletionGracePeriodSeconds:nil,Labels:map[string]string{watch-this-configmap: multiple-watchers-A,},Annotations:map[string]string{},OwnerReferences:[],Finalizers:[],ClusterName:,Initializers:nil,},Data:map[string]string{mutation: 2,},BinaryData:map[string][]byte{},}
+Jul  2 13:31:36.108: INFO: Got : DELETED &ConfigMap{ObjectMeta:k8s_io_apimachinery_pkg_apis_meta_v1.ObjectMeta{Name:e2e-watch-test-configmap-a,GenerateName:,Namespace:e2e-tests-watch-26j2s,SelfLink:/api/v1/namespaces/e2e-tests-watch-26j2s/configmaps/e2e-watch-test-configmap-a,UID:2c27e14b-7dfc-11e8-bc8c-d657551927e5,ResourceVersion:7285,Generation:0,CreationTimestamp:2018-07-02 13:31:06 +0000 UTC,DeletionTimestamp:<nil>,DeletionGracePeriodSeconds:nil,Labels:map[string]string{watch-this-configmap: multiple-watchers-A,},Annotations:map[string]string{},OwnerReferences:[],Finalizers:[],ClusterName:,Initializers:nil,},Data:map[string]string{mutation: 2,},BinaryData:map[string][]byte{},}
+STEP: creating a configmap with label B and ensuring the correct watchers observe the notification
+Jul  2 13:31:46.239: INFO: Got : ADDED &ConfigMap{ObjectMeta:k8s_io_apimachinery_pkg_apis_meta_v1.ObjectMeta{Name:e2e-watch-test-configmap-b,GenerateName:,Namespace:e2e-tests-watch-26j2s,SelfLink:/api/v1/namespaces/e2e-tests-watch-26j2s/configmaps/e2e-watch-test-configmap-b,UID:4403c24a-7dfc-11e8-bc8c-d657551927e5,ResourceVersion:7307,Generation:0,CreationTimestamp:2018-07-02 13:31:46 +0000 UTC,DeletionTimestamp:<nil>,DeletionGracePeriodSeconds:nil,Labels:map[string]string{watch-this-configmap: multiple-watchers-B,},Annotations:map[string]string{},OwnerReferences:[],Finalizers:[],ClusterName:,Initializers:nil,},Data:map[string]string{},BinaryData:map[string][]byte{},}
+Jul  2 13:31:46.239: INFO: Got : ADDED &ConfigMap{ObjectMeta:k8s_io_apimachinery_pkg_apis_meta_v1.ObjectMeta{Name:e2e-watch-test-configmap-b,GenerateName:,Namespace:e2e-tests-watch-26j2s,SelfLink:/api/v1/namespaces/e2e-tests-watch-26j2s/configmaps/e2e-watch-test-configmap-b,UID:4403c24a-7dfc-11e8-bc8c-d657551927e5,ResourceVersion:7307,Generation:0,CreationTimestamp:2018-07-02 13:31:46 +0000 UTC,DeletionTimestamp:<nil>,DeletionGracePeriodSeconds:nil,Labels:map[string]string{watch-this-configmap: multiple-watchers-B,},Annotations:map[string]string{},OwnerReferences:[],Finalizers:[],ClusterName:,Initializers:nil,},Data:map[string]string{},BinaryData:map[string][]byte{},}
+STEP: deleting configmap B and ensuring the correct watchers observe the notification
+Jul  2 13:31:56.332: INFO: Got : DELETED &ConfigMap{ObjectMeta:k8s_io_apimachinery_pkg_apis_meta_v1.ObjectMeta{Name:e2e-watch-test-configmap-b,GenerateName:,Namespace:e2e-tests-watch-26j2s,SelfLink:/api/v1/namespaces/e2e-tests-watch-26j2s/configmaps/e2e-watch-test-configmap-b,UID:4403c24a-7dfc-11e8-bc8c-d657551927e5,ResourceVersion:7327,Generation:0,CreationTimestamp:2018-07-02 13:31:46 +0000 UTC,DeletionTimestamp:<nil>,DeletionGracePeriodSeconds:nil,Labels:map[string]string{watch-this-configmap: multiple-watchers-B,},Annotations:map[string]string{},OwnerReferences:[],Finalizers:[],ClusterName:,Initializers:nil,},Data:map[string]string{},BinaryData:map[string][]byte{},}
+Jul  2 13:31:56.332: INFO: Got : DELETED &ConfigMap{ObjectMeta:k8s_io_apimachinery_pkg_apis_meta_v1.ObjectMeta{Name:e2e-watch-test-configmap-b,GenerateName:,Namespace:e2e-tests-watch-26j2s,SelfLink:/api/v1/namespaces/e2e-tests-watch-26j2s/configmaps/e2e-watch-test-configmap-b,UID:4403c24a-7dfc-11e8-bc8c-d657551927e5,ResourceVersion:7327,Generation:0,CreationTimestamp:2018-07-02 13:31:46 +0000 UTC,DeletionTimestamp:<nil>,DeletionGracePeriodSeconds:nil,Labels:map[string]string{watch-this-configmap: multiple-watchers-B,},Annotations:map[string]string{},OwnerReferences:[],Finalizers:[],ClusterName:,Initializers:nil,},Data:map[string]string{},BinaryData:map[string][]byte{},}
+[AfterEach] [sig-api-machinery] Watchers
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:32:06.332: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-watch-26j2s" for this suite.
+Jul  2 13:32:12.529: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:32:12.585: INFO: namespace: e2e-tests-watch-26j2s, resource: bindings, ignored listing per whitelist
+Jul  2 13:32:12.654: INFO: namespace e2e-tests-watch-26j2s deletion completed in 6.290285547s
+
+• [SLOW TEST:66.714 seconds]
+[sig-api-machinery] Watchers
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apimachinery/framework.go:22
+  should observe add, update, and delete watch notifications on configmaps [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SS
+------------------------------
+[sig-network] DNS 
+  should provide DNS for the cluster  [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-network] DNS
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:32:12.654: INFO: >>> kubeConfig: /tmp/kubeconfig-324782104
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should provide DNS for the cluster  [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Running these commands on wheezy: for i in `seq 1 600`; do test -n "$$(dig +notcp +noall +answer +search kubernetes.default A)" && echo OK > /results/wheezy_udp@kubernetes.default;test -n "$$(dig +tcp +noall +answer +search kubernetes.default A)" && echo OK > /results/wheezy_tcp@kubernetes.default;test -n "$$(dig +notcp +noall +answer +search kubernetes.default.svc A)" && echo OK > /results/wheezy_udp@kubernetes.default.svc;test -n "$$(dig +tcp +noall +answer +search kubernetes.default.svc A)" && echo OK > /results/wheezy_tcp@kubernetes.default.svc;test -n "$$(dig +notcp +noall +answer +search kubernetes.default.svc.cluster.local A)" && echo OK > /results/wheezy_udp@kubernetes.default.svc.cluster.local;test -n "$$(dig +tcp +noall +answer +search kubernetes.default.svc.cluster.local A)" && echo OK > /results/wheezy_tcp@kubernetes.default.svc.cluster.local;test -n "$$(getent hosts dns-querier-1.dns-test-service.e2e-tests-dns-2w5hl.svc.cluster.local)" && echo OK > /results/wheezy_hosts@dns-querier-1.dns-test-service.e2e-tests-dns-2w5hl.svc.cluster.local;test -n "$$(getent hosts dns-querier-1)" && echo OK > /results/wheezy_hosts@dns-querier-1;podARec=$$(hostname -i| awk -F. '{print $$1"-"$$2"-"$$3"-"$$4".e2e-tests-dns-2w5hl.pod.cluster.local"}');test -n "$$(dig +notcp +noall +answer +search $${podARec} A)" && echo OK > /results/wheezy_udp@PodARecord;test -n "$$(dig +tcp +noall +answer +search $${podARec} A)" && echo OK > /results/wheezy_tcp@PodARecord;sleep 1; done
+
+STEP: Running these commands on jessie: for i in `seq 1 600`; do test -n "$$(dig +notcp +noall +answer +search kubernetes.default A)" && echo OK > /results/jessie_udp@kubernetes.default;test -n "$$(dig +tcp +noall +answer +search kubernetes.default A)" && echo OK > /results/jessie_tcp@kubernetes.default;test -n "$$(dig +notcp +noall +answer +search kubernetes.default.svc A)" && echo OK > /results/jessie_udp@kubernetes.default.svc;test -n "$$(dig +tcp +noall +answer +search kubernetes.default.svc A)" && echo OK > /results/jessie_tcp@kubernetes.default.svc;test -n "$$(dig +notcp +noall +answer +search kubernetes.default.svc.cluster.local A)" && echo OK > /results/jessie_udp@kubernetes.default.svc.cluster.local;test -n "$$(dig +tcp +noall +answer +search kubernetes.default.svc.cluster.local A)" && echo OK > /results/jessie_tcp@kubernetes.default.svc.cluster.local;test -n "$$(getent hosts dns-querier-1.dns-test-service.e2e-tests-dns-2w5hl.svc.cluster.local)" && echo OK > /results/jessie_hosts@dns-querier-1.dns-test-service.e2e-tests-dns-2w5hl.svc.cluster.local;test -n "$$(getent hosts dns-querier-1)" && echo OK > /results/jessie_hosts@dns-querier-1;podARec=$$(hostname -i| awk -F. '{print $$1"-"$$2"-"$$3"-"$$4".e2e-tests-dns-2w5hl.pod.cluster.local"}');test -n "$$(dig +notcp +noall +answer +search $${podARec} A)" && echo OK > /results/jessie_udp@PodARecord;test -n "$$(dig +tcp +noall +answer +search $${podARec} A)" && echo OK > /results/jessie_tcp@PodARecord;sleep 1; done
+
+STEP: creating a pod to probe DNS
+STEP: submitting the pod to kubernetes
+STEP: retrieving the pod
+STEP: looking for the results for each expected name from probers
+Jul  2 13:32:36.276: INFO: DNS probes using dns-test-53e79c1f-7dfc-11e8-8e15-aefe7bc77cc2 succeeded
+
+STEP: deleting the pod
+[AfterEach] [sig-network] DNS
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:32:36.360: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-dns-2w5hl" for this suite.
+Jul  2 13:32:42.379: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:32:42.514: INFO: namespace: e2e-tests-dns-2w5hl, resource: bindings, ignored listing per whitelist
+Jul  2 13:32:42.583: INFO: namespace e2e-tests-dns-2w5hl deletion completed in 6.215142735s
+
+• [SLOW TEST:29.930 seconds]
+[sig-network] DNS
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/network/framework.go:22
+  should provide DNS for the cluster  [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSSSSSSSS
+------------------------------
+[sig-network] Proxy version v1 
+  should proxy logs on node using proxy subresource  [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] version v1
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:32:42.584: INFO: >>> kubeConfig: /tmp/kubeconfig-324782104
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should proxy logs on node using proxy subresource  [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+Jul  2 13:32:42.697: INFO: (0) /api/v1/nodes/shoot--core--confaz-worker-qfmi9-79968b77d9-24hm4/proxy/logs/: <pre>
+<a href="azure/">azure/</a>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<... (200; 6.893636ms)
+Jul  2 13:32:42.742: INFO: (1) /api/v1/nodes/shoot--core--confaz-worker-qfmi9-79968b77d9-24hm4/proxy/logs/: <pre>
+<a href="azure/">azure/</a>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<... (200; 44.868337ms)
+Jul  2 13:32:42.746: INFO: (2) /api/v1/nodes/shoot--core--confaz-worker-qfmi9-79968b77d9-24hm4/proxy/logs/: <pre>
+<a href="azure/">azure/</a>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<... (200; 4.285023ms)
+Jul  2 13:32:42.750: INFO: (3) /api/v1/nodes/shoot--core--confaz-worker-qfmi9-79968b77d9-24hm4/proxy/logs/: <pre>
+<a href="azure/">azure/</a>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<... (200; 4.217822ms)
+Jul  2 13:32:42.755: INFO: (4) /api/v1/nodes/shoot--core--confaz-worker-qfmi9-79968b77d9-24hm4/proxy/logs/: <pre>
+<a href="azure/">azure/</a>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<... (200; 4.947226ms)
+Jul  2 13:32:42.763: INFO: (5) /api/v1/nodes/shoot--core--confaz-worker-qfmi9-79968b77d9-24hm4/proxy/logs/: <pre>
+<a href="azure/">azure/</a>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<... (200; 7.996542ms)
+Jul  2 13:32:42.784: INFO: (6) /api/v1/nodes/shoot--core--confaz-worker-qfmi9-79968b77d9-24hm4/proxy/logs/: <pre>
+<a href="azure/">azure/</a>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<... (200; 21.245912ms)
+Jul  2 13:32:42.789: INFO: (7) /api/v1/nodes/shoot--core--confaz-worker-qfmi9-79968b77d9-24hm4/proxy/logs/: <pre>
+<a href="azure/">azure/</a>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<... (200; 4.184823ms)
+Jul  2 13:32:42.793: INFO: (8) /api/v1/nodes/shoot--core--confaz-worker-qfmi9-79968b77d9-24hm4/proxy/logs/: <pre>
+<a href="azure/">azure/</a>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<... (200; 4.091322ms)
+Jul  2 13:32:42.863: INFO: (9) /api/v1/nodes/shoot--core--confaz-worker-qfmi9-79968b77d9-24hm4/proxy/logs/: <pre>
+<a href="azure/">azure/</a>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<... (200; 69.96577ms)
+Jul  2 13:32:42.867: INFO: (10) /api/v1/nodes/shoot--core--confaz-worker-qfmi9-79968b77d9-24hm4/proxy/logs/: <pre>
+<a href="azure/">azure/</a>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<... (200; 4.217022ms)
+Jul  2 13:32:42.871: INFO: (11) /api/v1/nodes/shoot--core--confaz-worker-qfmi9-79968b77d9-24hm4/proxy/logs/: <pre>
+<a href="azure/">azure/</a>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<... (200; 3.516418ms)
+Jul  2 13:32:42.874: INFO: (12) /api/v1/nodes/shoot--core--confaz-worker-qfmi9-79968b77d9-24hm4/proxy/logs/: <pre>
+<a href="azure/">azure/</a>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<... (200; 3.562919ms)
+Jul  2 13:32:42.878: INFO: (13) /api/v1/nodes/shoot--core--confaz-worker-qfmi9-79968b77d9-24hm4/proxy/logs/: <pre>
+<a href="azure/">azure/</a>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<... (200; 3.460919ms)
+Jul  2 13:32:42.881: INFO: (14) /api/v1/nodes/shoot--core--confaz-worker-qfmi9-79968b77d9-24hm4/proxy/logs/: <pre>
+<a href="azure/">azure/</a>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<... (200; 3.320017ms)
+Jul  2 13:32:42.885: INFO: (15) /api/v1/nodes/shoot--core--confaz-worker-qfmi9-79968b77d9-24hm4/proxy/logs/: <pre>
+<a href="azure/">azure/</a>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<... (200; 3.67772ms)
+Jul  2 13:32:42.889: INFO: (16) /api/v1/nodes/shoot--core--confaz-worker-qfmi9-79968b77d9-24hm4/proxy/logs/: <pre>
+<a href="azure/">azure/</a>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<... (200; 3.79232ms)
+Jul  2 13:32:42.892: INFO: (17) /api/v1/nodes/shoot--core--confaz-worker-qfmi9-79968b77d9-24hm4/proxy/logs/: <pre>
+<a href="azure/">azure/</a>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<... (200; 3.553819ms)
+Jul  2 13:32:42.896: INFO: (18) /api/v1/nodes/shoot--core--confaz-worker-qfmi9-79968b77d9-24hm4/proxy/logs/: <pre>
+<a href="azure/">azure/</a>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<... (200; 3.413018ms)
+Jul  2 13:32:42.900: INFO: (19) /api/v1/nodes/shoot--core--confaz-worker-qfmi9-79968b77d9-24hm4/proxy/logs/: <pre>
+<a href="azure/">azure/</a>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<... (200; 4.651624ms)
+[AfterEach] version v1
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:32:42.900: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-proxy-fwnxz" for this suite.
+Jul  2 13:32:48.965: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:32:48.992: INFO: namespace: e2e-tests-proxy-fwnxz, resource: bindings, ignored listing per whitelist
+Jul  2 13:32:49.102: INFO: namespace e2e-tests-proxy-fwnxz deletion completed in 6.198174874s
+
+• [SLOW TEST:6.518 seconds]
+[sig-network] Proxy
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/network/framework.go:22
+  version v1
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/network/proxy.go:56
+    should proxy logs on node using proxy subresource  [Conformance]
+    /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSS
+------------------------------
+[k8s.io] Docker Containers 
+  should use the image defaults if command and args are blank [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [k8s.io] Docker Containers
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:32:49.102: INFO: >>> kubeConfig: /tmp/kubeconfig-324782104
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should use the image defaults if command and args are blank [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating a pod to test use defaults
+Jul  2 13:32:49.212: INFO: Waiting up to 5m0s for pod "client-containers-699e1e14-7dfc-11e8-8e15-aefe7bc77cc2" in namespace "e2e-tests-containers-c49fp" to be "success or failure"
+Jul  2 13:32:49.215: INFO: Pod "client-containers-699e1e14-7dfc-11e8-8e15-aefe7bc77cc2": Phase="Pending", Reason="", readiness=false. Elapsed: 3.774219ms
+Jul  2 13:32:51.219: INFO: Pod "client-containers-699e1e14-7dfc-11e8-8e15-aefe7bc77cc2": Phase="Pending", Reason="", readiness=false. Elapsed: 2.007014067s
+Jul  2 13:32:53.222: INFO: Pod "client-containers-699e1e14-7dfc-11e8-8e15-aefe7bc77cc2": Phase="Pending", Reason="", readiness=false. Elapsed: 4.010193476s
+Jul  2 13:32:55.225: INFO: Pod "client-containers-699e1e14-7dfc-11e8-8e15-aefe7bc77cc2": Phase="Pending", Reason="", readiness=false. Elapsed: 6.013821686s
+Jul  2 13:32:57.229: INFO: Pod "client-containers-699e1e14-7dfc-11e8-8e15-aefe7bc77cc2": Phase="Succeeded", Reason="", readiness=false. Elapsed: 8.017200856s
+STEP: Saw pod success
+Jul  2 13:32:57.229: INFO: Pod "client-containers-699e1e14-7dfc-11e8-8e15-aefe7bc77cc2" satisfied condition "success or failure"
+Jul  2 13:32:57.231: INFO: Trying to get logs from node shoot--core--confaz-worker-qfmi9-79968b77d9-kcr6j pod client-containers-699e1e14-7dfc-11e8-8e15-aefe7bc77cc2 container test-container: <nil>
+STEP: delete the pod
+Jul  2 13:32:57.258: INFO: Waiting for pod client-containers-699e1e14-7dfc-11e8-8e15-aefe7bc77cc2 to disappear
+Jul  2 13:32:57.261: INFO: Pod client-containers-699e1e14-7dfc-11e8-8e15-aefe7bc77cc2 no longer exists
+[AfterEach] [k8s.io] Docker Containers
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:32:57.261: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-containers-c49fp" for this suite.
+Jul  2 13:33:03.281: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:33:03.540: INFO: namespace: e2e-tests-containers-c49fp, resource: bindings, ignored listing per whitelist
+Jul  2 13:33:03.659: INFO: namespace e2e-tests-containers-c49fp deletion completed in 6.395215937s
+
+• [SLOW TEST:14.556 seconds]
+[k8s.io] Docker Containers
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:679
+  should use the image defaults if command and args are blank [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+[sig-network] Networking Granular Checks: Pods 
+  should function for intra-pod communication: udp [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-network] Networking
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:33:03.659: INFO: >>> kubeConfig: /tmp/kubeconfig-324782104
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should function for intra-pod communication: udp [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Performing setup for networking test in namespace e2e-tests-pod-network-test-9rgtn
+STEP: creating a selector
+STEP: Creating the service pods in kubernetes
+Jul  2 13:33:03.753: INFO: Waiting up to 10m0s for all (but 0) nodes to be schedulable
+STEP: Creating test pods
+Jul  2 13:33:23.970: INFO: ExecWithOptions {Command:[/bin/sh -c curl -g -q -s 'http://100.96.1.96:8080/dial?request=hostName&protocol=udp&host=100.96.0.30&port=8081&tries=1'] Namespace:e2e-tests-pod-network-test-9rgtn PodName:host-test-container-pod ContainerName:hostexec Stdin:<nil> CaptureStdout:true CaptureStderr:true PreserveWhitespace:false}
+Jul  2 13:33:23.970: INFO: >>> kubeConfig: /tmp/kubeconfig-324782104
+Jul  2 13:33:24.388: INFO: Waiting for endpoints: map[]
+Jul  2 13:33:24.391: INFO: ExecWithOptions {Command:[/bin/sh -c curl -g -q -s 'http://100.96.1.96:8080/dial?request=hostName&protocol=udp&host=100.96.1.95&port=8081&tries=1'] Namespace:e2e-tests-pod-network-test-9rgtn PodName:host-test-container-pod ContainerName:hostexec Stdin:<nil> CaptureStdout:true CaptureStderr:true PreserveWhitespace:false}
+Jul  2 13:33:24.391: INFO: >>> kubeConfig: /tmp/kubeconfig-324782104
+Jul  2 13:33:24.849: INFO: Waiting for endpoints: map[]
+[AfterEach] [sig-network] Networking
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:33:24.849: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-pod-network-test-9rgtn" for this suite.
+Jul  2 13:33:46.865: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:33:46.922: INFO: namespace: e2e-tests-pod-network-test-9rgtn, resource: bindings, ignored listing per whitelist
+Jul  2 13:33:46.969: INFO: namespace e2e-tests-pod-network-test-9rgtn deletion completed in 22.115712347s
+
+• [SLOW TEST:43.310 seconds]
+[sig-network] Networking
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/networking.go:25
+  Granular Checks: Pods
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/networking.go:28
+    should function for intra-pod communication: udp [NodeConformance] [Conformance]
+    /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSSSS
+------------------------------
+[sig-storage] Projected 
+  should update labels on modification [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:33:46.969: INFO: >>> kubeConfig: /tmp/kubeconfig-324782104
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:858
+[It] should update labels on modification [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating the pod
+Jul  2 13:33:51.854: INFO: Successfully updated pod "labelsupdate8c2576e5-7dfc-11e8-8e15-aefe7bc77cc2"
+[AfterEach] [sig-storage] Projected
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:33:53.884: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-jzm7k" for this suite.
+Jul  2 13:34:15.926: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:34:15.980: INFO: namespace: e2e-tests-projected-jzm7k, resource: bindings, ignored listing per whitelist
+Jul  2 13:34:16.021: INFO: namespace e2e-tests-projected-jzm7k deletion completed in 22.133176239s
+
+• [SLOW TEST:29.051 seconds]
+[sig-storage] Projected
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:34
+  should update labels on modification [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+[sig-api-machinery] Garbage collector 
+  should orphan RS created by deployment when deleteOptions.PropagationPolicy is Orphan [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-api-machinery] Garbage collector
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:34:16.021: INFO: >>> kubeConfig: /tmp/kubeconfig-324782104
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should orphan RS created by deployment when deleteOptions.PropagationPolicy is Orphan [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: create the deployment
+STEP: Wait for the Deployment to create new ReplicaSet
+STEP: delete the deployment
+STEP: wait for 30 seconds to see if the garbage collector mistakenly deletes the rs
+STEP: Gathering metrics
+W0702 13:34:46.655778      15 metrics_grabber.go:81] Master node is not registered. Grabbing metrics from Scheduler, ControllerManager and ClusterAutoscaler is disabled.
+Jul  2 13:34:46.655: INFO: For apiserver_request_count:
+For apiserver_request_latencies_summary:
+For etcd_helper_cache_entry_count:
+For etcd_helper_cache_hit_count:
+For etcd_helper_cache_miss_count:
+For etcd_request_cache_add_latencies_summary:
+For etcd_request_cache_get_latencies_summary:
+For etcd_request_latencies_summary:
+For garbage_collector_attempt_to_delete_queue_latency:
+For garbage_collector_attempt_to_delete_work_duration:
+For garbage_collector_attempt_to_orphan_queue_latency:
+For garbage_collector_attempt_to_orphan_work_duration:
+For garbage_collector_dirty_processing_latency_microseconds:
+For garbage_collector_event_processing_latency_microseconds:
+For garbage_collector_graph_changes_queue_latency:
+For garbage_collector_graph_changes_work_duration:
+For garbage_collector_orphan_processing_latency_microseconds:
+For namespace_queue_latency:
+For namespace_queue_latency_sum:
+For namespace_queue_latency_count:
+For namespace_retries:
+For namespace_work_duration:
+For namespace_work_duration_sum:
+For namespace_work_duration_count:
+For function_duration_seconds:
+For errors_total:
+For evicted_pods_total:
+
+[AfterEach] [sig-api-machinery] Garbage collector
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:34:46.655: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-gc-6rrkd" for this suite.
+Jul  2 13:34:52.694: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:34:52.805: INFO: namespace: e2e-tests-gc-6rrkd, resource: bindings, ignored listing per whitelist
+Jul  2 13:34:52.818: INFO: namespace e2e-tests-gc-6rrkd deletion completed in 6.158488861s
+
+• [SLOW TEST:36.797 seconds]
+[sig-api-machinery] Garbage collector
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apimachinery/framework.go:22
+  should orphan RS created by deployment when deleteOptions.PropagationPolicy is Orphan [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSSSS
+------------------------------
+[k8s.io] [sig-node] Events 
+  should be sent by kubelets and the scheduler about pods scheduling and running  [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [k8s.io] [sig-node] Events
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:34:52.818: INFO: >>> kubeConfig: /tmp/kubeconfig-324782104
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should be sent by kubelets and the scheduler about pods scheduling and running  [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: creating the pod
+STEP: submitting the pod to kubernetes
+STEP: verifying the pod is in kubernetes
+STEP: retrieving the pod
+&Pod{ObjectMeta:k8s_io_apimachinery_pkg_apis_meta_v1.ObjectMeta{Name:send-events-b35a9f7c-7dfc-11e8-8e15-aefe7bc77cc2,GenerateName:,Namespace:e2e-tests-events-j2f4n,SelfLink:/api/v1/namespaces/e2e-tests-events-j2f4n/pods/send-events-b35a9f7c-7dfc-11e8-8e15-aefe7bc77cc2,UID:b35c5f86-7dfc-11e8-bc8c-d657551927e5,ResourceVersion:7841,Generation:0,CreationTimestamp:2018-07-02 13:34:52 +0000 UTC,DeletionTimestamp:<nil>,DeletionGracePeriodSeconds:nil,Labels:map[string]string{name: foo,time: 909148888,},Annotations:map[string]string{cni.projectcalico.org/podIP: 100.96.1.99/32,},OwnerReferences:[],Finalizers:[],ClusterName:,Initializers:nil,},Spec:PodSpec{Volumes:[{default-token-jbb6c {nil nil nil nil nil SecretVolumeSource{SecretName:default-token-jbb6c,Items:[],DefaultMode:*420,Optional:nil,} nil nil nil nil nil nil nil nil nil nil nil nil nil nil nil nil nil nil nil nil nil}}],Containers:[{p gcr.io/kubernetes-e2e-test-images/serve-hostname-amd64:1.0 [] []  [{ 0 80 TCP }] [] [] {map[] map[]} [{default-token-jbb6c true /var/run/secrets/kubernetes.io/serviceaccount  <nil>}] [] nil nil nil /dev/termination-log File IfNotPresent nil false false false}],RestartPolicy:Always,TerminationGracePeriodSeconds:*30,ActiveDeadlineSeconds:nil,DNSPolicy:ClusterFirst,NodeSelector:map[string]string{},ServiceAccountName:default,DeprecatedServiceAccount:default,NodeName:shoot--core--confaz-worker-qfmi9-79968b77d9-kcr6j,HostNetwork:false,HostPID:false,HostIPC:false,SecurityContext:&PodSecurityContext{SELinuxOptions:nil,RunAsUser:nil,RunAsNonRoot:nil,SupplementalGroups:[],FSGroup:nil,RunAsGroup:nil,Sysctls:[],},ImagePullSecrets:[],Hostname:,Subdomain:,Affinity:nil,SchedulerName:default-scheduler,InitContainers:[],AutomountServiceAccountToken:nil,Tolerations:[{node.kubernetes.io/not-ready Exists  NoExecute 0xc421f47520} {node.kubernetes.io/unreachable Exists  NoExecute 0xc421f47540}],HostAliases:[],PriorityClassName:,Priority:nil,DNSConfig:nil,ShareProcessNamespace:nil,ReadinessGates:[],},Status:PodStatus{Phase:Running,Conditions:[{Initialized True 0001-01-01 00:00:00 +0000 UTC 2018-07-02 13:34:52 +0000 UTC  } {Ready True 0001-01-01 00:00:00 +0000 UTC 2018-07-02 13:34:55 +0000 UTC  } {ContainersReady True 0001-01-01 00:00:00 +0000 UTC 0001-01-01 00:00:00 +0000 UTC  } {PodScheduled True 0001-01-01 00:00:00 +0000 UTC 2018-07-02 13:34:52 +0000 UTC  }],Message:,Reason:,HostIP:10.250.0.5,PodIP:100.96.1.99,StartTime:2018-07-02 13:34:52 +0000 UTC,ContainerStatuses:[{p {nil ContainerStateRunning{StartedAt:2018-07-02 13:34:54 +0000 UTC,} nil} {nil nil nil} true 0 gcr.io/kubernetes-e2e-test-images/serve-hostname-amd64:1.0 docker-pullable://gcr.io/kubernetes-e2e-test-images/serve-hostname-amd64@sha256:2dd4032e98a0450d95a0ac71a5e465f542a900812d8c41bc6ca635aed1a5fc91 docker://6b6054e6c91fb02d0ca928ed028f1e771db8b4dcd52a01ffbccf33efc9b463bf}],QOSClass:BestEffort,InitContainerStatuses:[],NominatedNodeName:,},}
+STEP: checking for scheduler event about the pod
+Saw scheduler event for our pod.
+STEP: checking for kubelet event about the pod
+Saw kubelet event for our pod.
+STEP: deleting the pod
+[AfterEach] [k8s.io] [sig-node] Events
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:35:00.948: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-events-j2f4n" for this suite.
+Jul  2 13:35:22.997: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:35:23.192: INFO: namespace: e2e-tests-events-j2f4n, resource: bindings, ignored listing per whitelist
+Jul  2 13:35:23.195: INFO: namespace e2e-tests-events-j2f4n deletion completed in 22.208608771s
+
+• [SLOW TEST:30.377 seconds]
+[k8s.io] [sig-node] Events
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:679
+  should be sent by kubelets and the scheduler about pods scheduling and running  [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSS
+------------------------------
+[sig-storage] Downward API volume 
+  should update annotations on modification [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:35:23.195: INFO: >>> kubeConfig: /tmp/kubeconfig-324782104
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downwardapi_volume.go:38
+[It] should update annotations on modification [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating the pod
+Jul  2 13:35:28.030: INFO: Successfully updated pod "annotationupdatec579c744-7dfc-11e8-8e15-aefe7bc77cc2"
+[AfterEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:35:30.135: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-downward-api-ddpkt" for this suite.
+Jul  2 13:35:52.151: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:35:52.184: INFO: namespace: e2e-tests-downward-api-ddpkt, resource: bindings, ignored listing per whitelist
+Jul  2 13:35:52.305: INFO: namespace e2e-tests-downward-api-ddpkt deletion completed in 22.16507088s
+
+• [SLOW TEST:29.110 seconds]
+[sig-storage] Downward API volume
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downwardapi_volume.go:33
+  should update annotations on modification [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+S
+------------------------------
+[sig-storage] EmptyDir volumes 
+  should support (root,0666,tmpfs) [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-storage] EmptyDir volumes
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:35:52.305: INFO: >>> kubeConfig: /tmp/kubeconfig-324782104
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should support (root,0666,tmpfs) [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating a pod to test emptydir 0666 on tmpfs
+Jul  2 13:35:52.413: INFO: Waiting up to 5m0s for pod "pod-d6d05834-7dfc-11e8-8e15-aefe7bc77cc2" in namespace "e2e-tests-emptydir-ggsz6" to be "success or failure"
+Jul  2 13:35:52.421: INFO: Pod "pod-d6d05834-7dfc-11e8-8e15-aefe7bc77cc2": Phase="Pending", Reason="", readiness=false. Elapsed: 7.899831ms
+Jul  2 13:35:54.424: INFO: Pod "pod-d6d05834-7dfc-11e8-8e15-aefe7bc77cc2": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.011353995s
+STEP: Saw pod success
+Jul  2 13:35:54.424: INFO: Pod "pod-d6d05834-7dfc-11e8-8e15-aefe7bc77cc2" satisfied condition "success or failure"
+Jul  2 13:35:54.427: INFO: Trying to get logs from node shoot--core--confaz-worker-qfmi9-79968b77d9-kcr6j pod pod-d6d05834-7dfc-11e8-8e15-aefe7bc77cc2 container test-container: <nil>
+STEP: delete the pod
+Jul  2 13:35:54.452: INFO: Waiting for pod pod-d6d05834-7dfc-11e8-8e15-aefe7bc77cc2 to disappear
+Jul  2 13:35:54.458: INFO: Pod pod-d6d05834-7dfc-11e8-8e15-aefe7bc77cc2 no longer exists
+[AfterEach] [sig-storage] EmptyDir volumes
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:35:54.458: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-emptydir-ggsz6" for this suite.
+Jul  2 13:36:00.489: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:36:00.540: INFO: namespace: e2e-tests-emptydir-ggsz6, resource: bindings, ignored listing per whitelist
+Jul  2 13:36:00.586: INFO: namespace e2e-tests-emptydir-ggsz6 deletion completed in 6.119439345s
+
+• [SLOW TEST:8.281 seconds]
+[sig-storage] EmptyDir volumes
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/empty_dir.go:40
+  should support (root,0666,tmpfs) [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSSSSS
+------------------------------
+[sig-storage] Projected 
+  should be consumable from pods in volume with defaultMode set [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:36:00.587: INFO: >>> kubeConfig: /tmp/kubeconfig-324782104
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:858
+[It] should be consumable from pods in volume with defaultMode set [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating projection with secret that has name projected-secret-test-dbbf1e37-7dfc-11e8-8e15-aefe7bc77cc2
+STEP: Creating a pod to test consume secrets
+Jul  2 13:36:00.704: INFO: Waiting up to 5m0s for pod "pod-projected-secrets-dbbff2ad-7dfc-11e8-8e15-aefe7bc77cc2" in namespace "e2e-tests-projected-cz4zl" to be "success or failure"
+Jul  2 13:36:00.713: INFO: Pod "pod-projected-secrets-dbbff2ad-7dfc-11e8-8e15-aefe7bc77cc2": Phase="Pending", Reason="", readiness=false. Elapsed: 8.996932ms
+Jul  2 13:36:02.717: INFO: Pod "pod-projected-secrets-dbbff2ad-7dfc-11e8-8e15-aefe7bc77cc2": Phase="Pending", Reason="", readiness=false. Elapsed: 2.012995008s
+Jul  2 13:36:04.721: INFO: Pod "pod-projected-secrets-dbbff2ad-7dfc-11e8-8e15-aefe7bc77cc2": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.016594411s
+STEP: Saw pod success
+Jul  2 13:36:04.721: INFO: Pod "pod-projected-secrets-dbbff2ad-7dfc-11e8-8e15-aefe7bc77cc2" satisfied condition "success or failure"
+Jul  2 13:36:04.724: INFO: Trying to get logs from node shoot--core--confaz-worker-qfmi9-79968b77d9-kcr6j pod pod-projected-secrets-dbbff2ad-7dfc-11e8-8e15-aefe7bc77cc2 container projected-secret-volume-test: <nil>
+STEP: delete the pod
+Jul  2 13:36:04.769: INFO: Waiting for pod pod-projected-secrets-dbbff2ad-7dfc-11e8-8e15-aefe7bc77cc2 to disappear
+Jul  2 13:36:04.788: INFO: Pod pod-projected-secrets-dbbff2ad-7dfc-11e8-8e15-aefe7bc77cc2 no longer exists
+[AfterEach] [sig-storage] Projected
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:36:04.788: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-cz4zl" for this suite.
+Jul  2 13:36:10.809: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:36:10.924: INFO: namespace: e2e-tests-projected-cz4zl, resource: bindings, ignored listing per whitelist
+Jul  2 13:36:10.946: INFO: namespace e2e-tests-projected-cz4zl deletion completed in 6.154426311s
+
+• [SLOW TEST:10.360 seconds]
+[sig-storage] Projected
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:34
+  should be consumable from pods in volume with defaultMode set [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SS
+------------------------------
+[sig-storage] Secrets 
+  should be consumable from pods in volume with mappings [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-storage] Secrets
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:36:10.947: INFO: >>> kubeConfig: /tmp/kubeconfig-324782104
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should be consumable from pods in volume with mappings [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating secret with name secret-test-map-e1eb5aed-7dfc-11e8-8e15-aefe7bc77cc2
+STEP: Creating a pod to test consume secrets
+Jul  2 13:36:11.109: INFO: Waiting up to 5m0s for pod "pod-secrets-e1f5ce97-7dfc-11e8-8e15-aefe7bc77cc2" in namespace "e2e-tests-secrets-r7mlh" to be "success or failure"
+Jul  2 13:36:11.113: INFO: Pod "pod-secrets-e1f5ce97-7dfc-11e8-8e15-aefe7bc77cc2": Phase="Pending", Reason="", readiness=false. Elapsed: 4.302719ms
+Jul  2 13:36:13.117: INFO: Pod "pod-secrets-e1f5ce97-7dfc-11e8-8e15-aefe7bc77cc2": Phase="Pending", Reason="", readiness=false. Elapsed: 2.007709053s
+Jul  2 13:36:15.120: INFO: Pod "pod-secrets-e1f5ce97-7dfc-11e8-8e15-aefe7bc77cc2": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.011178944s
+STEP: Saw pod success
+Jul  2 13:36:15.120: INFO: Pod "pod-secrets-e1f5ce97-7dfc-11e8-8e15-aefe7bc77cc2" satisfied condition "success or failure"
+Jul  2 13:36:15.124: INFO: Trying to get logs from node shoot--core--confaz-worker-qfmi9-79968b77d9-kcr6j pod pod-secrets-e1f5ce97-7dfc-11e8-8e15-aefe7bc77cc2 container secret-volume-test: <nil>
+STEP: delete the pod
+Jul  2 13:36:15.160: INFO: Waiting for pod pod-secrets-e1f5ce97-7dfc-11e8-8e15-aefe7bc77cc2 to disappear
+Jul  2 13:36:15.172: INFO: Pod pod-secrets-e1f5ce97-7dfc-11e8-8e15-aefe7bc77cc2 no longer exists
+[AfterEach] [sig-storage] Secrets
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:36:15.172: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-secrets-r7mlh" for this suite.
+Jul  2 13:36:21.235: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:36:21.346: INFO: namespace: e2e-tests-secrets-r7mlh, resource: bindings, ignored listing per whitelist
+Jul  2 13:36:21.354: INFO: namespace e2e-tests-secrets-r7mlh deletion completed in 6.178716988s
+
+• [SLOW TEST:10.408 seconds]
+[sig-storage] Secrets
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/secrets_volume.go:33
+  should be consumable from pods in volume with mappings [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SS
+------------------------------
+[sig-storage] Projected 
+  should be consumable from pods in volume with mappings as non-root [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:36:21.354: INFO: >>> kubeConfig: /tmp/kubeconfig-324782104
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:858
+[It] should be consumable from pods in volume with mappings as non-root [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating configMap with name projected-configmap-test-volume-map-e8203187-7dfc-11e8-8e15-aefe7bc77cc2
+STEP: Creating a pod to test consume configMaps
+Jul  2 13:36:21.476: INFO: Waiting up to 5m0s for pod "pod-projected-configmaps-e821aebf-7dfc-11e8-8e15-aefe7bc77cc2" in namespace "e2e-tests-projected-xv9f6" to be "success or failure"
+Jul  2 13:36:21.491: INFO: Pod "pod-projected-configmaps-e821aebf-7dfc-11e8-8e15-aefe7bc77cc2": Phase="Pending", Reason="", readiness=false. Elapsed: 14.723658ms
+Jul  2 13:36:23.535: INFO: Pod "pod-projected-configmaps-e821aebf-7dfc-11e8-8e15-aefe7bc77cc2": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.059009381s
+STEP: Saw pod success
+Jul  2 13:36:23.535: INFO: Pod "pod-projected-configmaps-e821aebf-7dfc-11e8-8e15-aefe7bc77cc2" satisfied condition "success or failure"
+Jul  2 13:36:23.540: INFO: Trying to get logs from node shoot--core--confaz-worker-qfmi9-79968b77d9-kcr6j pod pod-projected-configmaps-e821aebf-7dfc-11e8-8e15-aefe7bc77cc2 container projected-configmap-volume-test: <nil>
+STEP: delete the pod
+Jul  2 13:36:23.568: INFO: Waiting for pod pod-projected-configmaps-e821aebf-7dfc-11e8-8e15-aefe7bc77cc2 to disappear
+Jul  2 13:36:23.576: INFO: Pod pod-projected-configmaps-e821aebf-7dfc-11e8-8e15-aefe7bc77cc2 no longer exists
+[AfterEach] [sig-storage] Projected
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:36:23.576: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-xv9f6" for this suite.
+Jul  2 13:36:29.592: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:36:29.721: INFO: namespace: e2e-tests-projected-xv9f6, resource: bindings, ignored listing per whitelist
+Jul  2 13:36:29.814: INFO: namespace e2e-tests-projected-xv9f6 deletion completed in 6.234840819s
+
+• [SLOW TEST:8.460 seconds]
+[sig-storage] Projected
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:34
+  should be consumable from pods in volume with mappings as non-root [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSSSSSSSSSSSSSSSSSSSS
+------------------------------
+[sig-storage] ConfigMap 
+  should be consumable from pods in volume with mappings and Item mode set [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-storage] ConfigMap
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:36:29.815: INFO: >>> kubeConfig: /tmp/kubeconfig-324782104
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should be consumable from pods in volume with mappings and Item mode set [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating configMap with name configmap-test-volume-map-ed2b3bab-7dfc-11e8-8e15-aefe7bc77cc2
+STEP: Creating a pod to test consume configMaps
+Jul  2 13:36:29.921: INFO: Waiting up to 5m0s for pod "pod-configmaps-ed2c9769-7dfc-11e8-8e15-aefe7bc77cc2" in namespace "e2e-tests-configmap-dh5gm" to be "success or failure"
+Jul  2 13:36:29.923: INFO: Pod "pod-configmaps-ed2c9769-7dfc-11e8-8e15-aefe7bc77cc2": Phase="Pending", Reason="", readiness=false. Elapsed: 2.46671ms
+Jul  2 13:36:31.969: INFO: Pod "pod-configmaps-ed2c9769-7dfc-11e8-8e15-aefe7bc77cc2": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.048317674s
+STEP: Saw pod success
+Jul  2 13:36:31.969: INFO: Pod "pod-configmaps-ed2c9769-7dfc-11e8-8e15-aefe7bc77cc2" satisfied condition "success or failure"
+Jul  2 13:36:31.972: INFO: Trying to get logs from node shoot--core--confaz-worker-qfmi9-79968b77d9-kcr6j pod pod-configmaps-ed2c9769-7dfc-11e8-8e15-aefe7bc77cc2 container configmap-volume-test: <nil>
+STEP: delete the pod
+Jul  2 13:36:32.000: INFO: Waiting for pod pod-configmaps-ed2c9769-7dfc-11e8-8e15-aefe7bc77cc2 to disappear
+Jul  2 13:36:32.009: INFO: Pod pod-configmaps-ed2c9769-7dfc-11e8-8e15-aefe7bc77cc2 no longer exists
+[AfterEach] [sig-storage] ConfigMap
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:36:32.010: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-configmap-dh5gm" for this suite.
+Jul  2 13:36:38.025: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:36:38.102: INFO: namespace: e2e-tests-configmap-dh5gm, resource: bindings, ignored listing per whitelist
+Jul  2 13:36:38.121: INFO: namespace e2e-tests-configmap-dh5gm deletion completed in 6.106609962s
+
+• [SLOW TEST:8.306 seconds]
+[sig-storage] ConfigMap
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/configmap_volume.go:32
+  should be consumable from pods in volume with mappings and Item mode set [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSSSS
+------------------------------
+[sig-storage] Projected 
+  should be consumable from pods in volume with mappings [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:36:38.122: INFO: >>> kubeConfig: /tmp/kubeconfig-324782104
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:858
+[It] should be consumable from pods in volume with mappings [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating projection with secret that has name projected-secret-test-map-f21eaf0c-7dfc-11e8-8e15-aefe7bc77cc2
+STEP: Creating a pod to test consume secrets
+Jul  2 13:36:38.227: INFO: Waiting up to 5m0s for pod "pod-projected-secrets-f21fffe1-7dfc-11e8-8e15-aefe7bc77cc2" in namespace "e2e-tests-projected-w5xvr" to be "success or failure"
+Jul  2 13:36:38.230: INFO: Pod "pod-projected-secrets-f21fffe1-7dfc-11e8-8e15-aefe7bc77cc2": Phase="Pending", Reason="", readiness=false. Elapsed: 3.000212ms
+Jul  2 13:36:40.255: INFO: Pod "pod-projected-secrets-f21fffe1-7dfc-11e8-8e15-aefe7bc77cc2": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.027316351s
+STEP: Saw pod success
+Jul  2 13:36:40.255: INFO: Pod "pod-projected-secrets-f21fffe1-7dfc-11e8-8e15-aefe7bc77cc2" satisfied condition "success or failure"
+Jul  2 13:36:40.257: INFO: Trying to get logs from node shoot--core--confaz-worker-qfmi9-79968b77d9-kcr6j pod pod-projected-secrets-f21fffe1-7dfc-11e8-8e15-aefe7bc77cc2 container projected-secret-volume-test: <nil>
+STEP: delete the pod
+Jul  2 13:36:40.276: INFO: Waiting for pod pod-projected-secrets-f21fffe1-7dfc-11e8-8e15-aefe7bc77cc2 to disappear
+Jul  2 13:36:40.284: INFO: Pod pod-projected-secrets-f21fffe1-7dfc-11e8-8e15-aefe7bc77cc2 no longer exists
+[AfterEach] [sig-storage] Projected
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:36:40.284: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-w5xvr" for this suite.
+Jul  2 13:36:46.309: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:36:46.389: INFO: namespace: e2e-tests-projected-w5xvr, resource: bindings, ignored listing per whitelist
+Jul  2 13:36:46.403: INFO: namespace e2e-tests-projected-w5xvr deletion completed in 6.113195349s
+
+• [SLOW TEST:8.281 seconds]
+[sig-storage] Projected
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:34
+  should be consumable from pods in volume with mappings [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSSSSSSS
+------------------------------
+[sig-network] Service endpoints latency 
+  should not be very high  [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-network] Service endpoints latency
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:36:46.403: INFO: >>> kubeConfig: /tmp/kubeconfig-324782104
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should not be very high  [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: creating replication controller svc-latency-rc in namespace e2e-tests-svc-latency-6r8bb
+I0702 13:36:46.507595      15 runners.go:177] Created replication controller with name: svc-latency-rc, namespace: e2e-tests-svc-latency-6r8bb, replica count: 1
+I0702 13:36:47.558006      15 runners.go:177] svc-latency-rc Pods: 1 out of 1 created, 0 running, 1 pending, 0 waiting, 0 inactive, 0 terminating, 0 unknown, 0 runningButNotReady 
+I0702 13:36:48.558171      15 runners.go:177] svc-latency-rc Pods: 1 out of 1 created, 1 running, 0 pending, 0 waiting, 0 inactive, 0 terminating, 0 unknown, 0 runningButNotReady 
+Jul  2 13:36:48.676: INFO: Created: latency-svc-qv428
+Jul  2 13:36:48.692: INFO: Got endpoints: latency-svc-qv428 [34.485545ms]
+Jul  2 13:36:48.713: INFO: Created: latency-svc-fk9rx
+Jul  2 13:36:48.753: INFO: Created: latency-svc-cdfxb
+Jul  2 13:36:48.758: INFO: Got endpoints: latency-svc-cdfxb [65.217172ms]
+Jul  2 13:36:48.758: INFO: Got endpoints: latency-svc-fk9rx [65.371373ms]
+Jul  2 13:36:48.768: INFO: Created: latency-svc-x852f
+Jul  2 13:36:48.780: INFO: Got endpoints: latency-svc-x852f [87.159764ms]
+Jul  2 13:36:48.804: INFO: Created: latency-svc-dxr7k
+Jul  2 13:36:48.823: INFO: Got endpoints: latency-svc-dxr7k [130.203644ms]
+Jul  2 13:36:48.844: INFO: Created: latency-svc-mltnx
+Jul  2 13:36:48.899: INFO: Got endpoints: latency-svc-mltnx [205.914261ms]
+Jul  2 13:36:48.900: INFO: Created: latency-svc-29gcv
+Jul  2 13:36:48.904: INFO: Got endpoints: latency-svc-29gcv [210.921182ms]
+Jul  2 13:36:48.917: INFO: Created: latency-svc-nh5xc
+Jul  2 13:36:48.928: INFO: Got endpoints: latency-svc-nh5xc [235.254184ms]
+Jul  2 13:36:48.940: INFO: Created: latency-svc-7bnlz
+Jul  2 13:36:48.958: INFO: Got endpoints: latency-svc-7bnlz [264.911207ms]
+Jul  2 13:36:48.979: INFO: Created: latency-svc-lj82t
+Jul  2 13:36:48.990: INFO: Got endpoints: latency-svc-lj82t [297.354043ms]
+Jul  2 13:36:49.039: INFO: Created: latency-svc-hbq2d
+Jul  2 13:36:49.041: INFO: Got endpoints: latency-svc-hbq2d [348.070054ms]
+Jul  2 13:36:49.058: INFO: Created: latency-svc-9tdzm
+Jul  2 13:36:49.071: INFO: Got endpoints: latency-svc-9tdzm [378.10488ms]
+Jul  2 13:36:49.083: INFO: Created: latency-svc-sfxcv
+Jul  2 13:36:49.104: INFO: Got endpoints: latency-svc-sfxcv [411.117318ms]
+Jul  2 13:36:49.124: INFO: Created: latency-svc-p9998
+Jul  2 13:36:49.136: INFO: Got endpoints: latency-svc-p9998 [442.677649ms]
+Jul  2 13:36:49.162: INFO: Created: latency-svc-8tjw7
+Jul  2 13:36:49.165: INFO: Got endpoints: latency-svc-8tjw7 [472.108872ms]
+Jul  2 13:36:49.181: INFO: Created: latency-svc-dflfh
+Jul  2 13:36:49.193: INFO: Got endpoints: latency-svc-dflfh [499.481687ms]
+Jul  2 13:36:49.212: INFO: Created: latency-svc-zt7v7
+Jul  2 13:36:49.232: INFO: Got endpoints: latency-svc-zt7v7 [474.496982ms]
+Jul  2 13:36:49.255: INFO: Created: latency-svc-jnhhj
+Jul  2 13:36:49.295: INFO: Got endpoints: latency-svc-jnhhj [537.564145ms]
+Jul  2 13:36:49.298: INFO: Created: latency-svc-tcqnw
+Jul  2 13:36:49.311: INFO: Got endpoints: latency-svc-tcqnw [531.334418ms]
+Jul  2 13:36:49.315: INFO: Created: latency-svc-jsxww
+Jul  2 13:36:49.318: INFO: Got endpoints: latency-svc-jsxww [495.379669ms]
+Jul  2 13:36:49.334: INFO: Created: latency-svc-gm5hl
+Jul  2 13:36:49.344: INFO: Got endpoints: latency-svc-gm5hl [445.53236ms]
+Jul  2 13:36:49.365: INFO: Created: latency-svc-hh7wb
+Jul  2 13:36:49.378: INFO: Got endpoints: latency-svc-hh7wb [473.693277ms]
+Jul  2 13:36:49.447: INFO: Created: latency-svc-sj5p7
+Jul  2 13:36:49.454: INFO: Got endpoints: latency-svc-sj5p7 [525.506593ms]
+Jul  2 13:36:49.470: INFO: Created: latency-svc-g45fz
+Jul  2 13:36:49.481: INFO: Got endpoints: latency-svc-g45fz [523.081083ms]
+Jul  2 13:36:49.494: INFO: Created: latency-svc-fxnvx
+Jul  2 13:36:49.514: INFO: Got endpoints: latency-svc-fxnvx [523.205183ms]
+Jul  2 13:36:49.534: INFO: Created: latency-svc-6ptct
+Jul  2 13:36:49.545: INFO: Got endpoints: latency-svc-6ptct [503.515002ms]
+Jul  2 13:36:49.574: INFO: Created: latency-svc-4trtm
+Jul  2 13:36:49.577: INFO: Got endpoints: latency-svc-4trtm [505.910811ms]
+Jul  2 13:36:49.607: INFO: Created: latency-svc-dpk7c
+Jul  2 13:36:49.619: INFO: Got endpoints: latency-svc-dpk7c [514.716248ms]
+Jul  2 13:36:49.635: INFO: Created: latency-svc-zcnxx
+Jul  2 13:36:49.653: INFO: Got endpoints: latency-svc-zcnxx [516.606256ms]
+Jul  2 13:36:49.672: INFO: Created: latency-svc-cv2xr
+Jul  2 13:36:49.699: INFO: Got endpoints: latency-svc-cv2xr [533.836528ms]
+Jul  2 13:36:49.702: INFO: Created: latency-svc-lxjm5
+Jul  2 13:36:49.705: INFO: Got endpoints: latency-svc-lxjm5 [512.576639ms]
+Jul  2 13:36:49.721: INFO: Created: latency-svc-8h9kb
+Jul  2 13:36:49.735: INFO: Got endpoints: latency-svc-8h9kb [502.348097ms]
+Jul  2 13:36:49.747: INFO: Created: latency-svc-fdphh
+Jul  2 13:36:49.765: INFO: Got endpoints: latency-svc-fdphh [469.329559ms]
+Jul  2 13:36:49.786: INFO: Created: latency-svc-6tggh
+Jul  2 13:36:49.880: INFO: Got endpoints: latency-svc-6tggh [568.884474ms]
+Jul  2 13:36:49.882: INFO: Created: latency-svc-kpqnp
+Jul  2 13:36:49.885: INFO: Got endpoints: latency-svc-kpqnp [566.080762ms]
+Jul  2 13:36:49.904: INFO: Created: latency-svc-vvrxf
+Jul  2 13:36:49.919: INFO: Created: latency-svc-5p4dg
+Jul  2 13:36:49.919: INFO: Got endpoints: latency-svc-vvrxf [574.137496ms]
+Jul  2 13:36:49.930: INFO: Got endpoints: latency-svc-5p4dg [552.314705ms]
+Jul  2 13:36:49.942: INFO: Created: latency-svc-8cwft
+Jul  2 13:36:50.044: INFO: Got endpoints: latency-svc-8cwft [590.343569ms]
+Jul  2 13:36:50.094: INFO: Created: latency-svc-vqmzf
+Jul  2 13:36:50.094: INFO: Got endpoints: latency-svc-vqmzf [612.574969ms]
+Jul  2 13:36:50.211: INFO: Created: latency-svc-qtn5s
+Jul  2 13:36:50.211: INFO: Created: latency-svc-42rsr
+Jul  2 13:36:50.211: INFO: Created: latency-svc-gsr5z
+Jul  2 13:36:50.211: INFO: Created: latency-svc-psx8k
+Jul  2 13:36:50.211: INFO: Created: latency-svc-l87pv
+Jul  2 13:36:50.211: INFO: Got endpoints: latency-svc-qtn5s [558.45466ms]
+Jul  2 13:36:50.211: INFO: Got endpoints: latency-svc-42rsr [697.374839ms]
+Jul  2 13:36:50.211: INFO: Got endpoints: latency-svc-gsr5z [666.592511ms]
+Jul  2 13:36:50.212: INFO: Got endpoints: latency-svc-psx8k [634.270675ms]
+Jul  2 13:36:50.212: INFO: Got endpoints: latency-svc-l87pv [592.410801ms]
+Jul  2 13:36:50.220: INFO: Created: latency-svc-qlrf5
+Jul  2 13:36:50.230: INFO: Got endpoints: latency-svc-qlrf5 [530.607146ms]
+Jul  2 13:36:50.242: INFO: Created: latency-svc-7t6v2
+Jul  2 13:36:50.261: INFO: Got endpoints: latency-svc-7t6v2 [555.511054ms]
+Jul  2 13:36:50.318: INFO: Created: latency-svc-lwxw4
+Jul  2 13:36:50.321: INFO: Got endpoints: latency-svc-lwxw4 [585.694088ms]
+Jul  2 13:36:50.366: INFO: Created: latency-svc-tfjm4
+Jul  2 13:36:50.378: INFO: Got endpoints: latency-svc-tfjm4 [613.242112ms]
+Jul  2 13:36:50.389: INFO: Created: latency-svc-d4l78
+Jul  2 13:36:50.401: INFO: Got endpoints: latency-svc-d4l78 [520.947129ms]
+Jul  2 13:36:50.415: INFO: Created: latency-svc-ntlmj
+Jul  2 13:36:50.452: INFO: Created: latency-svc-ht7qb
+Jul  2 13:36:50.453: INFO: Got endpoints: latency-svc-ntlmj [567.896933ms]
+Jul  2 13:36:50.454: INFO: Got endpoints: latency-svc-ht7qb [535.478397ms]
+Jul  2 13:36:50.471: INFO: Created: latency-svc-nsns9
+Jul  2 13:36:50.482: INFO: Got endpoints: latency-svc-nsns9 [551.422367ms]
+Jul  2 13:36:50.495: INFO: Created: latency-svc-2p6fc
+Jul  2 13:36:50.506: INFO: Got endpoints: latency-svc-2p6fc [461.405689ms]
+Jul  2 13:36:50.517: INFO: Created: latency-svc-hml8f
+Jul  2 13:36:50.529: INFO: Got endpoints: latency-svc-hml8f [434.816275ms]
+Jul  2 13:36:50.540: INFO: Created: latency-svc-m7zv5
+Jul  2 13:36:50.575: INFO: Got endpoints: latency-svc-m7zv5 [363.972969ms]
+Jul  2 13:36:50.576: INFO: Created: latency-svc-s77cd
+Jul  2 13:36:50.580: INFO: Got endpoints: latency-svc-s77cd [368.991591ms]
+Jul  2 13:36:50.598: INFO: Created: latency-svc-sx45r
+Jul  2 13:36:50.608: INFO: Got endpoints: latency-svc-sx45r [396.937411ms]
+Jul  2 13:36:50.618: INFO: Created: latency-svc-4qkft
+Jul  2 13:36:50.631: INFO: Got endpoints: latency-svc-4qkft [419.314008ms]
+Jul  2 13:36:50.642: INFO: Created: latency-svc-7lqv7
+Jul  2 13:36:50.654: INFO: Got endpoints: latency-svc-7lqv7 [442.155107ms]
+Jul  2 13:36:50.670: INFO: Created: latency-svc-hgjq8
+Jul  2 13:36:50.704: INFO: Got endpoints: latency-svc-hgjq8 [473.942144ms]
+Jul  2 13:36:50.706: INFO: Created: latency-svc-p6dj2
+Jul  2 13:36:50.709: INFO: Got endpoints: latency-svc-p6dj2 [448.374834ms]
+Jul  2 13:36:50.724: INFO: Created: latency-svc-4lcx6
+Jul  2 13:36:50.735: INFO: Got endpoints: latency-svc-4lcx6 [414.340587ms]
+Jul  2 13:36:50.748: INFO: Created: latency-svc-kfgz9
+Jul  2 13:36:50.759: INFO: Got endpoints: latency-svc-kfgz9 [381.236444ms]
+Jul  2 13:36:50.771: INFO: Created: latency-svc-wnf7p
+Jul  2 13:36:50.782: INFO: Got endpoints: latency-svc-wnf7p [381.037243ms]
+Jul  2 13:36:50.794: INFO: Created: latency-svc-psp55
+Jul  2 13:36:50.834: INFO: Got endpoints: latency-svc-psp55 [379.966039ms]
+Jul  2 13:36:50.845: INFO: Created: latency-svc-h9ps7
+Jul  2 13:36:50.857: INFO: Got endpoints: latency-svc-h9ps7 [404.050642ms]
+Jul  2 13:36:50.868: INFO: Created: latency-svc-2x5jl
+Jul  2 13:36:50.879: INFO: Got endpoints: latency-svc-2x5jl [397.819315ms]
+Jul  2 13:36:50.893: INFO: Created: latency-svc-pdxjw
+Jul  2 13:36:50.905: INFO: Got endpoints: latency-svc-pdxjw [398.83172ms]
+Jul  2 13:36:50.915: INFO: Created: latency-svc-xb575
+Jul  2 13:36:50.926: INFO: Got endpoints: latency-svc-xb575 [396.880011ms]
+Jul  2 13:36:50.984: INFO: Created: latency-svc-sqbtr
+Jul  2 13:36:50.988: INFO: Got endpoints: latency-svc-sqbtr [413.062781ms]
+Jul  2 13:36:51.001: INFO: Created: latency-svc-czq5l
+Jul  2 13:36:51.019: INFO: Got endpoints: latency-svc-czq5l [439.019993ms]
+Jul  2 13:36:51.049: INFO: Created: latency-svc-s5zt8
+Jul  2 13:36:51.058: INFO: Got endpoints: latency-svc-s5zt8 [449.589339ms]
+Jul  2 13:36:51.070: INFO: Created: latency-svc-6m8pg
+Jul  2 13:36:51.107: INFO: Got endpoints: latency-svc-6m8pg [476.181953ms]
+Jul  2 13:36:51.131: INFO: Created: latency-svc-89cmj
+Jul  2 13:36:51.142: INFO: Got endpoints: latency-svc-89cmj [488.058604ms]
+Jul  2 13:36:51.154: INFO: Created: latency-svc-wz22l
+Jul  2 13:36:51.166: INFO: Got endpoints: latency-svc-wz22l [462.354193ms]
+Jul  2 13:36:51.193: INFO: Created: latency-svc-76cvg
+Jul  2 13:36:51.204: INFO: Got endpoints: latency-svc-76cvg [494.755532ms]
+Jul  2 13:36:51.231: INFO: Created: latency-svc-pwhq7
+Jul  2 13:36:51.238: INFO: Got endpoints: latency-svc-pwhq7 [503.239269ms]
+Jul  2 13:36:51.269: INFO: Created: latency-svc-5nvjx
+Jul  2 13:36:51.280: INFO: Got endpoints: latency-svc-5nvjx [520.200041ms]
+Jul  2 13:36:51.292: INFO: Created: latency-svc-qv2sx
+Jul  2 13:36:51.304: INFO: Got endpoints: latency-svc-qv2sx [521.480147ms]
+Jul  2 13:36:51.316: INFO: Created: latency-svc-l8lmq
+Jul  2 13:36:51.327: INFO: Got endpoints: latency-svc-l8lmq [492.566022ms]
+Jul  2 13:36:51.377: INFO: Created: latency-svc-xws7t
+Jul  2 13:36:51.379: INFO: Got endpoints: latency-svc-xws7t [522.658751ms]
+Jul  2 13:36:51.395: INFO: Created: latency-svc-7nh7m
+Jul  2 13:36:51.407: INFO: Got endpoints: latency-svc-7nh7m [527.008469ms]
+Jul  2 13:36:51.417: INFO: Created: latency-svc-r9hh2
+Jul  2 13:36:51.437: INFO: Got endpoints: latency-svc-r9hh2 [532.075091ms]
+Jul  2 13:36:51.462: INFO: Created: latency-svc-x29zt
+Jul  2 13:36:51.524: INFO: Got endpoints: latency-svc-x29zt [598.123375ms]
+Jul  2 13:36:51.527: INFO: Created: latency-svc-rc9lc
+Jul  2 13:36:51.531: INFO: Got endpoints: latency-svc-rc9lc [543.057438ms]
+Jul  2 13:36:51.543: INFO: Created: latency-svc-w58w7
+Jul  2 13:36:51.555: INFO: Got endpoints: latency-svc-w58w7 [535.551005ms]
+Jul  2 13:36:51.570: INFO: Created: latency-svc-sr4nt
+Jul  2 13:36:51.589: INFO: Got endpoints: latency-svc-sr4nt [530.926385ms]
+Jul  2 13:36:51.609: INFO: Created: latency-svc-lrjwb
+Jul  2 13:36:51.622: INFO: Got endpoints: latency-svc-lrjwb [514.759616ms]
+Jul  2 13:36:51.650: INFO: Created: latency-svc-r5hdm
+Jul  2 13:36:51.655: INFO: Got endpoints: latency-svc-r5hdm [513.123809ms]
+Jul  2 13:36:51.665: INFO: Created: latency-svc-mmv4h
+Jul  2 13:36:51.703: INFO: Got endpoints: latency-svc-mmv4h [536.731911ms]
+Jul  2 13:36:51.703: INFO: Created: latency-svc-tpk6w
+Jul  2 13:36:51.727: INFO: Created: latency-svc-h9c82
+Jul  2 13:36:51.738: INFO: Got endpoints: latency-svc-tpk6w [534.101799ms]
+Jul  2 13:36:51.802: INFO: Created: latency-svc-l9vxq
+Jul  2 13:36:51.803: INFO: Got endpoints: latency-svc-h9c82 [564.49663ms]
+Jul  2 13:36:51.822: INFO: Created: latency-svc-2lqsn
+Jul  2 13:36:51.852: INFO: Got endpoints: latency-svc-l9vxq [572.546365ms]
+Jul  2 13:36:51.884: INFO: Got endpoints: latency-svc-2lqsn [580.366399ms]
+Jul  2 13:36:51.884: INFO: Created: latency-svc-c8stt
+Jul  2 13:36:51.938: INFO: Created: latency-svc-9tt4w
+Jul  2 13:36:51.945: INFO: Got endpoints: latency-svc-c8stt [617.76226ms]
+Jul  2 13:36:51.975: INFO: Created: latency-svc-n2hfq
+Jul  2 13:36:51.986: INFO: Got endpoints: latency-svc-9tt4w [606.910113ms]
+Jul  2 13:36:51.999: INFO: Created: latency-svc-kcd7d
+Jul  2 13:36:52.023: INFO: Created: latency-svc-phxh7
+Jul  2 13:36:52.033: INFO: Got endpoints: latency-svc-n2hfq [626.811898ms]
+Jul  2 13:36:52.058: INFO: Created: latency-svc-8p25x
+Jul  2 13:36:52.079: INFO: Created: latency-svc-zwgb5
+Jul  2 13:36:52.087: INFO: Got endpoints: latency-svc-kcd7d [650.690801ms]
+Jul  2 13:36:52.099: INFO: Created: latency-svc-6ktgk
+Jul  2 13:36:52.129: INFO: Created: latency-svc-lh7kh
+Jul  2 13:36:52.141: INFO: Got endpoints: latency-svc-phxh7 [616.861754ms]
+Jul  2 13:36:52.152: INFO: Created: latency-svc-9s68j
+Jul  2 13:36:52.199: INFO: Got endpoints: latency-svc-8p25x [668.084474ms]
+Jul  2 13:36:52.201: INFO: Created: latency-svc-lv6p8
+Jul  2 13:36:52.223: INFO: Created: latency-svc-xjbd7
+Jul  2 13:36:52.242: INFO: Got endpoints: latency-svc-zwgb5 [687.173157ms]
+Jul  2 13:36:52.243: INFO: Created: latency-svc-kvhcq
+Jul  2 13:36:52.268: INFO: Created: latency-svc-8fdmd
+Jul  2 13:36:52.348: INFO: Created: latency-svc-6qcrx
+Jul  2 13:36:52.349: INFO: Got endpoints: latency-svc-lh7kh [726.794426ms]
+Jul  2 13:36:52.349: INFO: Got endpoints: latency-svc-6ktgk [760.116769ms]
+Jul  2 13:36:52.379: INFO: Created: latency-svc-ngtk4
+Jul  2 13:36:52.398: INFO: Got endpoints: latency-svc-9s68j [743.478797ms]
+Jul  2 13:36:52.426: INFO: Created: latency-svc-5dkpn
+Jul  2 13:36:52.442: INFO: Got endpoints: latency-svc-lv6p8 [738.317375ms]
+Jul  2 13:36:52.442: INFO: Created: latency-svc-zxfcx
+Jul  2 13:36:52.479: INFO: Created: latency-svc-gdzsj
+Jul  2 13:36:52.484: INFO: Got endpoints: latency-svc-xjbd7 [745.770607ms]
+Jul  2 13:36:52.496: INFO: Created: latency-svc-sccfz
+Jul  2 13:36:52.518: INFO: Created: latency-svc-zqld6
+Jul  2 13:36:52.540: INFO: Got endpoints: latency-svc-kvhcq [736.971168ms]
+Jul  2 13:36:52.542: INFO: Created: latency-svc-fcfwf
+Jul  2 13:36:52.562: INFO: Created: latency-svc-wnh9j
+Jul  2 13:36:52.620: INFO: Got endpoints: latency-svc-8fdmd [767.293998ms]
+Jul  2 13:36:52.621: INFO: Created: latency-svc-47sd9
+Jul  2 13:36:52.635: INFO: Created: latency-svc-xnth5
+Jul  2 13:36:52.635: INFO: Got endpoints: latency-svc-6qcrx [750.832128ms]
+Jul  2 13:36:52.659: INFO: Created: latency-svc-lgzs6
+Jul  2 13:36:52.743: INFO: Got endpoints: latency-svc-5dkpn [756.773252ms]
+Jul  2 13:36:52.744: INFO: Got endpoints: latency-svc-ngtk4 [798.686233ms]
+Jul  2 13:36:52.744: INFO: Created: latency-svc-fhxhp
+Jul  2 13:36:52.757: INFO: Created: latency-svc-j2bzq
+Jul  2 13:36:52.780: INFO: Created: latency-svc-xthhg
+Jul  2 13:36:52.791: INFO: Got endpoints: latency-svc-zxfcx [757.980957ms]
+Jul  2 13:36:52.804: INFO: Created: latency-svc-frvm6
+Jul  2 13:36:52.827: INFO: Created: latency-svc-xpn47
+Jul  2 13:36:52.875: INFO: Got endpoints: latency-svc-gdzsj [787.681985ms]
+Jul  2 13:36:52.881: INFO: Got endpoints: latency-svc-sccfz [740.03848ms]
+Jul  2 13:36:52.885: INFO: Created: latency-svc-z44x9
+Jul  2 13:36:52.900: INFO: Created: latency-svc-m7xfq
+Jul  2 13:36:52.951: INFO: Got endpoints: latency-svc-zqld6 [751.876632ms]
+Jul  2 13:36:52.951: INFO: Created: latency-svc-g82sh
+Jul  2 13:36:53.038: INFO: Got endpoints: latency-svc-wnh9j [689.01116ms]
+Jul  2 13:36:53.038: INFO: Created: latency-svc-sgkqb
+Jul  2 13:36:53.038: INFO: Got endpoints: latency-svc-fcfwf [796.077521ms]
+Jul  2 13:36:53.070: INFO: Created: latency-svc-777tw
+Jul  2 13:36:53.085: INFO: Got endpoints: latency-svc-47sd9 [735.279459ms]
+Jul  2 13:36:53.176: INFO: Got endpoints: latency-svc-xnth5 [777.415839ms]
+Jul  2 13:36:53.176: INFO: Created: latency-svc-2pt7l
+Jul  2 13:36:53.192: INFO: Created: latency-svc-rn2kl
+Jul  2 13:36:53.192: INFO: Got endpoints: latency-svc-lgzs6 [750.595724ms]
+Jul  2 13:36:53.217: INFO: Created: latency-svc-bwjbv
+Jul  2 13:36:53.241: INFO: Got endpoints: latency-svc-fhxhp [756.909151ms]
+Jul  2 13:36:53.243: INFO: Created: latency-svc-lv7n6
+Jul  2 13:36:53.303: INFO: Created: latency-svc-jc5t6
+Jul  2 13:36:53.304: INFO: Got endpoints: latency-svc-j2bzq [764.152982ms]
+Jul  2 13:36:53.344: INFO: Got endpoints: latency-svc-xthhg [724.055009ms]
+Jul  2 13:36:53.345: INFO: Created: latency-svc-krfls
+Jul  2 13:36:53.373: INFO: Created: latency-svc-lqs2v
+Jul  2 13:36:53.390: INFO: Got endpoints: latency-svc-frvm6 [754.428339ms]
+Jul  2 13:36:53.398: INFO: Created: latency-svc-9zjh5
+Jul  2 13:36:53.446: INFO: Got endpoints: latency-svc-xpn47 [702.522615ms]
+Jul  2 13:36:53.448: INFO: Created: latency-svc-qmzgn
+Jul  2 13:36:53.471: INFO: Created: latency-svc-pm7kk
+Jul  2 13:36:53.482: INFO: Got endpoints: latency-svc-z44x9 [738.717071ms]
+Jul  2 13:36:53.515: INFO: Created: latency-svc-cfwx6
+Jul  2 13:36:53.535: INFO: Got endpoints: latency-svc-m7xfq [743.858893ms]
+Jul  2 13:36:53.599: INFO: Got endpoints: latency-svc-g82sh [724.106807ms]
+Jul  2 13:36:53.600: INFO: Created: latency-svc-272h6
+Jul  2 13:36:53.639: INFO: Created: latency-svc-dgs9b
+Jul  2 13:36:53.639: INFO: Got endpoints: latency-svc-sgkqb [757.940052ms]
+Jul  2 13:36:53.721: INFO: Got endpoints: latency-svc-777tw [769.578101ms]
+Jul  2 13:36:53.721: INFO: Created: latency-svc-747kl
+Jul  2 13:36:53.748: INFO: Got endpoints: latency-svc-2pt7l [709.308243ms]
+Jul  2 13:36:53.748: INFO: Created: latency-svc-bmxn2
+Jul  2 13:36:53.766: INFO: Created: latency-svc-c4zwd
+Jul  2 13:36:53.783: INFO: Got endpoints: latency-svc-rn2kl [744.826295ms]
+Jul  2 13:36:53.801: INFO: Created: latency-svc-rrqbd
+Jul  2 13:36:53.848: INFO: Got endpoints: latency-svc-bwjbv [763.936477ms]
+Jul  2 13:36:53.889: INFO: Got endpoints: latency-svc-lv7n6 [713.26516ms]
+Jul  2 13:36:53.890: INFO: Created: latency-svc-wkt8n
+Jul  2 13:36:53.928: INFO: Created: latency-svc-sbk9b
+Jul  2 13:36:53.940: INFO: Got endpoints: latency-svc-jc5t6 [747.843608ms]
+Jul  2 13:36:53.986: INFO: Got endpoints: latency-svc-krfls [744.872396ms]
+Jul  2 13:36:53.989: INFO: Created: latency-svc-ngk4x
+Jul  2 13:36:54.008: INFO: Created: latency-svc-6vdws
+Jul  2 13:36:54.030: INFO: Got endpoints: latency-svc-lqs2v [725.886214ms]
+Jul  2 13:36:54.066: INFO: Created: latency-svc-pdpkq
+Jul  2 13:36:54.080: INFO: Got endpoints: latency-svc-9zjh5 [736.634859ms]
+Jul  2 13:36:54.110: INFO: Created: latency-svc-cwjs5
+Jul  2 13:36:54.130: INFO: Got endpoints: latency-svc-qmzgn [740.069274ms]
+Jul  2 13:36:54.154: INFO: Created: latency-svc-j9qp7
+Jul  2 13:36:54.180: INFO: Got endpoints: latency-svc-pm7kk [733.901047ms]
+Jul  2 13:36:54.234: INFO: Got endpoints: latency-svc-cfwx6 [751.784823ms]
+Jul  2 13:36:54.234: INFO: Created: latency-svc-5lb2n
+Jul  2 13:36:54.261: INFO: Created: latency-svc-z6648
+Jul  2 13:36:54.280: INFO: Got endpoints: latency-svc-272h6 [744.17209ms]
+Jul  2 13:36:54.322: INFO: Created: latency-svc-m5mnz
+Jul  2 13:36:54.360: INFO: Got endpoints: latency-svc-dgs9b [760.241659ms]
+Jul  2 13:36:54.399: INFO: Created: latency-svc-7rbn6
+Jul  2 13:36:54.400: INFO: Got endpoints: latency-svc-747kl [760.941561ms]
+Jul  2 13:36:54.433: INFO: Got endpoints: latency-svc-bmxn2 [711.74265ms]
+Jul  2 13:36:54.433: INFO: Created: latency-svc-ghkd6
+Jul  2 13:36:54.487: INFO: Got endpoints: latency-svc-c4zwd [739.421669ms]
+Jul  2 13:36:54.537: INFO: Got endpoints: latency-svc-rrqbd [753.74243ms]
+Jul  2 13:36:54.537: INFO: Created: latency-svc-jwtw4
+Jul  2 13:36:54.579: INFO: Created: latency-svc-6j2lp
+Jul  2 13:36:54.634: INFO: Got endpoints: latency-svc-sbk9b [744.268388ms]
+Jul  2 13:36:54.634: INFO: Got endpoints: latency-svc-wkt8n [785.294864ms]
+Jul  2 13:36:54.636: INFO: Created: latency-svc-bcnhg
+Jul  2 13:36:54.656: INFO: Created: latency-svc-c2h7g
+Jul  2 13:36:54.681: INFO: Created: latency-svc-s2xp6
+Jul  2 13:36:54.681: INFO: Got endpoints: latency-svc-ngk4x [740.779272ms]
+Jul  2 13:36:54.709: INFO: Created: latency-svc-p6dfb
+Jul  2 13:36:54.730: INFO: Got endpoints: latency-svc-6vdws [743.768985ms]
+Jul  2 13:36:54.797: INFO: Got endpoints: latency-svc-pdpkq [767.106485ms]
+Jul  2 13:36:54.798: INFO: Created: latency-svc-llmqg
+Jul  2 13:36:54.832: INFO: Got endpoints: latency-svc-cwjs5 [751.600218ms]
+Jul  2 13:36:54.834: INFO: Created: latency-svc-cqdlh
+Jul  2 13:36:54.902: INFO: Got endpoints: latency-svc-j9qp7 [771.857306ms]
+Jul  2 13:36:54.902: INFO: Created: latency-svc-ntr95
+Jul  2 13:36:54.921: INFO: Created: latency-svc-nn767
+Jul  2 13:36:54.932: INFO: Got endpoints: latency-svc-5lb2n [751.95342ms]
+Jul  2 13:36:54.969: INFO: Created: latency-svc-wgsc5
+Jul  2 13:36:54.981: INFO: Got endpoints: latency-svc-z6648 [747.017599ms]
+Jul  2 13:36:55.000: INFO: Created: latency-svc-glgpw
+Jul  2 13:36:55.033: INFO: Got endpoints: latency-svc-m5mnz [753.476026ms]
+Jul  2 13:36:55.051: INFO: Created: latency-svc-hwj9p
+Jul  2 13:36:55.082: INFO: Got endpoints: latency-svc-7rbn6 [722.513594ms]
+Jul  2 13:36:55.106: INFO: Created: latency-svc-c7nwx
+Jul  2 13:36:55.130: INFO: Got endpoints: latency-svc-ghkd6 [730.581528ms]
+Jul  2 13:36:55.187: INFO: Created: latency-svc-24gzp
+Jul  2 13:36:55.193: INFO: Got endpoints: latency-svc-jwtw4 [760.549056ms]
+Jul  2 13:36:55.224: INFO: Created: latency-svc-wmxgp
+Jul  2 13:36:55.236: INFO: Got endpoints: latency-svc-6j2lp [748.731005ms]
+Jul  2 13:36:55.310: INFO: Got endpoints: latency-svc-bcnhg [773.132009ms]
+Jul  2 13:36:55.310: INFO: Created: latency-svc-csmqw
+Jul  2 13:36:55.331: INFO: Created: latency-svc-zpj9z
+Jul  2 13:36:55.341: INFO: Got endpoints: latency-svc-c2h7g [707.444927ms]
+Jul  2 13:36:55.360: INFO: Created: latency-svc-t6pnl
+Jul  2 13:36:55.381: INFO: Got endpoints: latency-svc-s2xp6 [746.546994ms]
+Jul  2 13:36:55.448: INFO: Got endpoints: latency-svc-p6dfb [767.325382ms]
+Jul  2 13:36:55.449: INFO: Created: latency-svc-cthng
+Jul  2 13:36:55.493: INFO: Created: latency-svc-s8hcq
+Jul  2 13:36:55.493: INFO: Got endpoints: latency-svc-llmqg [762.605263ms]
+Jul  2 13:36:55.517: INFO: Created: latency-svc-8w66v
+Jul  2 13:36:55.529: INFO: Got endpoints: latency-svc-cqdlh [732.406733ms]
+Jul  2 13:36:55.729: INFO: Created: latency-svc-7lg4j
+Jul  2 13:36:55.730: INFO: Got endpoints: latency-svc-nn767 [828.068341ms]
+Jul  2 13:36:55.730: INFO: Got endpoints: latency-svc-ntr95 [897.743339ms]
+Jul  2 13:36:55.730: INFO: Got endpoints: latency-svc-wgsc5 [798.457514ms]
+Jul  2 13:36:55.752: INFO: Got endpoints: latency-svc-glgpw [770.700295ms]
+Jul  2 13:36:55.776: INFO: Created: latency-svc-2fb7f
+Jul  2 13:36:55.791: INFO: Got endpoints: latency-svc-hwj9p [758.139041ms]
+Jul  2 13:36:55.799: INFO: Created: latency-svc-vqfcq
+Jul  2 13:36:55.822: INFO: Created: latency-svc-m9h7p
+Jul  2 13:36:55.872: INFO: Got endpoints: latency-svc-c7nwx [789.998278ms]
+Jul  2 13:36:55.874: INFO: Created: latency-svc-cbp8g
+Jul  2 13:36:55.881: INFO: Got endpoints: latency-svc-24gzp [750.289007ms]
+Jul  2 13:36:56.093: INFO: Got endpoints: latency-svc-wmxgp [899.595745ms]
+Jul  2 13:36:56.093: INFO: Created: latency-svc-szhmk
+Jul  2 13:36:56.094: INFO: Got endpoints: latency-svc-t6pnl [753.124919ms]
+Jul  2 13:36:56.095: INFO: Got endpoints: latency-svc-zpj9z [784.458553ms]
+Jul  2 13:36:56.095: INFO: Got endpoints: latency-svc-csmqw [858.793571ms]
+Jul  2 13:36:56.112: INFO: Created: latency-svc-dc9n5
+Jul  2 13:36:56.160: INFO: Got endpoints: latency-svc-cthng [779.792432ms]
+Jul  2 13:36:56.161: INFO: Created: latency-svc-zlz9s
+Jul  2 13:36:56.185: INFO: Got endpoints: latency-svc-s8hcq [736.772249ms]
+Jul  2 13:36:56.186: INFO: Created: latency-svc-gkk6x
+Jul  2 13:36:56.240: INFO: Got endpoints: latency-svc-8w66v [747.561494ms]
+Jul  2 13:36:56.242: INFO: Created: latency-svc-xwxc6
+Jul  2 13:36:56.265: INFO: Created: latency-svc-wvtlm
+Jul  2 13:36:56.287: INFO: Created: latency-svc-jnk7g
+Jul  2 13:36:56.288: INFO: Got endpoints: latency-svc-7lg4j [758.899942ms]
+Jul  2 13:36:56.311: INFO: Created: latency-svc-jxp9q
+Jul  2 13:36:56.346: INFO: Got endpoints: latency-svc-2fb7f [615.79783ms]
+Jul  2 13:36:56.361: INFO: Created: latency-svc-2vgsr
+Jul  2 13:36:56.396: INFO: Got endpoints: latency-svc-vqfcq [666.482247ms]
+Jul  2 13:36:56.397: INFO: Created: latency-svc-7cmvm
+Jul  2 13:36:56.421: INFO: Created: latency-svc-ffffw
+Jul  2 13:36:56.433: INFO: Got endpoints: latency-svc-m9h7p [702.5631ms]
+Jul  2 13:36:56.444: INFO: Created: latency-svc-4b9pn
+Jul  2 13:36:56.478: INFO: Created: latency-svc-8qxbs
+Jul  2 13:36:56.481: INFO: Got endpoints: latency-svc-cbp8g [729.143114ms]
+Jul  2 13:36:56.495: INFO: Created: latency-svc-llpzk
+Jul  2 13:36:56.730: INFO: Got endpoints: latency-svc-zlz9s [849.755527ms]
+Jul  2 13:36:56.730: INFO: Got endpoints: latency-svc-szhmk [939.187409ms]
+Jul  2 13:36:56.730: INFO: Got endpoints: latency-svc-dc9n5 [858.005962ms]
+Jul  2 13:36:56.731: INFO: Got endpoints: latency-svc-gkk6x [637.917322ms]
+Jul  2 13:36:56.731: INFO: Created: latency-svc-ftnk9
+Jul  2 13:36:56.732: INFO: Got endpoints: latency-svc-xwxc6 [637.34062ms]
+Jul  2 13:36:56.878: INFO: Got endpoints: latency-svc-jnk7g [783.593444ms]
+Jul  2 13:36:56.878: INFO: Got endpoints: latency-svc-wvtlm [783.723644ms]
+Jul  2 13:36:56.881: INFO: Got endpoints: latency-svc-jxp9q [720.524075ms]
+Jul  2 13:36:56.930: INFO: Got endpoints: latency-svc-2vgsr [744.290476ms]
+Jul  2 13:36:56.987: INFO: Got endpoints: latency-svc-7cmvm [747.037488ms]
+Jul  2 13:36:57.030: INFO: Got endpoints: latency-svc-ffffw [741.388964ms]
+Jul  2 13:36:57.080: INFO: Got endpoints: latency-svc-4b9pn [734.840035ms]
+Jul  2 13:36:57.130: INFO: Got endpoints: latency-svc-8qxbs [733.476829ms]
+Jul  2 13:36:57.181: INFO: Got endpoints: latency-svc-llpzk [747.646689ms]
+Jul  2 13:36:57.313: INFO: Got endpoints: latency-svc-ftnk9 [832.191449ms]
+Jul  2 13:36:57.313: INFO: Latencies: [65.217172ms 65.371373ms 87.159764ms 130.203644ms 205.914261ms 210.921182ms 235.254184ms 264.911207ms 297.354043ms 348.070054ms 363.972969ms 368.991591ms 378.10488ms 379.966039ms 381.037243ms 381.236444ms 396.880011ms 396.937411ms 397.819315ms 398.83172ms 404.050642ms 411.117318ms 413.062781ms 414.340587ms 419.314008ms 434.816275ms 439.019993ms 442.155107ms 442.677649ms 445.53236ms 448.374834ms 449.589339ms 461.405689ms 462.354193ms 469.329559ms 472.108872ms 473.693277ms 473.942144ms 474.496982ms 476.181953ms 488.058604ms 492.566022ms 494.755532ms 495.379669ms 499.481687ms 502.348097ms 503.239269ms 503.515002ms 505.910811ms 512.576639ms 513.123809ms 514.716248ms 514.759616ms 516.606256ms 520.200041ms 520.947129ms 521.480147ms 522.658751ms 523.081083ms 523.205183ms 525.506593ms 527.008469ms 530.607146ms 530.926385ms 531.334418ms 532.075091ms 533.836528ms 534.101799ms 535.478397ms 535.551005ms 536.731911ms 537.564145ms 543.057438ms 551.422367ms 552.314705ms 555.511054ms 558.45466ms 564.49663ms 566.080762ms 567.896933ms 568.884474ms 572.546365ms 574.137496ms 580.366399ms 585.694088ms 590.343569ms 592.410801ms 598.123375ms 606.910113ms 612.574969ms 613.242112ms 615.79783ms 616.861754ms 617.76226ms 626.811898ms 634.270675ms 637.34062ms 637.917322ms 650.690801ms 666.482247ms 666.592511ms 668.084474ms 687.173157ms 689.01116ms 697.374839ms 702.522615ms 702.5631ms 707.444927ms 709.308243ms 711.74265ms 713.26516ms 720.524075ms 722.513594ms 724.055009ms 724.106807ms 725.886214ms 726.794426ms 729.143114ms 730.581528ms 732.406733ms 733.476829ms 733.901047ms 734.840035ms 735.279459ms 736.634859ms 736.772249ms 736.971168ms 738.317375ms 738.717071ms 739.421669ms 740.03848ms 740.069274ms 740.779272ms 741.388964ms 743.478797ms 743.768985ms 743.858893ms 744.17209ms 744.268388ms 744.290476ms 744.826295ms 744.872396ms 745.770607ms 746.546994ms 747.017599ms 747.037488ms 747.561494ms 747.646689ms 747.843608ms 748.731005ms 750.289007ms 750.595724ms 750.832128ms 751.600218ms 751.784823ms 751.876632ms 751.95342ms 753.124919ms 753.476026ms 753.74243ms 754.428339ms 756.773252ms 756.909151ms 757.940052ms 757.980957ms 758.139041ms 758.899942ms 760.116769ms 760.241659ms 760.549056ms 760.941561ms 762.605263ms 763.936477ms 764.152982ms 767.106485ms 767.293998ms 767.325382ms 769.578101ms 770.700295ms 771.857306ms 773.132009ms 777.415839ms 779.792432ms 783.593444ms 783.723644ms 784.458553ms 785.294864ms 787.681985ms 789.998278ms 796.077521ms 798.457514ms 798.686233ms 828.068341ms 832.191449ms 849.755527ms 858.005962ms 858.793571ms 897.743339ms 899.595745ms 939.187409ms]
+Jul  2 13:36:57.314: INFO: 50 %ile: 666.592511ms
+Jul  2 13:36:57.314: INFO: 90 %ile: 773.132009ms
+Jul  2 13:36:57.314: INFO: 99 %ile: 899.595745ms
+Jul  2 13:36:57.314: INFO: Total sample count: 200
+[AfterEach] [sig-network] Service endpoints latency
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:36:57.314: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-svc-latency-6r8bb" for this suite.
+Jul  2 13:37:21.328: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:37:21.418: INFO: namespace: e2e-tests-svc-latency-6r8bb, resource: bindings, ignored listing per whitelist
+Jul  2 13:37:21.443: INFO: namespace e2e-tests-svc-latency-6r8bb deletion completed in 24.125329012s
+
+• [SLOW TEST:35.040 seconds]
+[sig-network] Service endpoints latency
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/network/framework.go:22
+  should not be very high  [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSS
+------------------------------
+[sig-api-machinery] ConfigMap 
+  should be consumable via the environment [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-api-machinery] ConfigMap
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:37:21.443: INFO: >>> kubeConfig: /tmp/kubeconfig-324782104
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should be consumable via the environment [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating configMap e2e-tests-configmap-sfrvc/configmap-test-0bf48031-7dfd-11e8-8e15-aefe7bc77cc2
+STEP: Creating a pod to test consume configMaps
+Jul  2 13:37:21.575: INFO: Waiting up to 5m0s for pod "pod-configmaps-0bf5fc77-7dfd-11e8-8e15-aefe7bc77cc2" in namespace "e2e-tests-configmap-sfrvc" to be "success or failure"
+Jul  2 13:37:21.585: INFO: Pod "pod-configmaps-0bf5fc77-7dfd-11e8-8e15-aefe7bc77cc2": Phase="Pending", Reason="", readiness=false. Elapsed: 9.618144ms
+Jul  2 13:37:23.589: INFO: Pod "pod-configmaps-0bf5fc77-7dfd-11e8-8e15-aefe7bc77cc2": Phase="Pending", Reason="", readiness=false. Elapsed: 2.013558886s
+Jul  2 13:37:25.595: INFO: Pod "pod-configmaps-0bf5fc77-7dfd-11e8-8e15-aefe7bc77cc2": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.019527457s
+STEP: Saw pod success
+Jul  2 13:37:25.595: INFO: Pod "pod-configmaps-0bf5fc77-7dfd-11e8-8e15-aefe7bc77cc2" satisfied condition "success or failure"
+Jul  2 13:37:25.597: INFO: Trying to get logs from node shoot--core--confaz-worker-qfmi9-79968b77d9-kcr6j pod pod-configmaps-0bf5fc77-7dfd-11e8-8e15-aefe7bc77cc2 container env-test: <nil>
+STEP: delete the pod
+Jul  2 13:37:25.621: INFO: Waiting for pod pod-configmaps-0bf5fc77-7dfd-11e8-8e15-aefe7bc77cc2 to disappear
+Jul  2 13:37:25.631: INFO: Pod pod-configmaps-0bf5fc77-7dfd-11e8-8e15-aefe7bc77cc2 no longer exists
+[AfterEach] [sig-api-machinery] ConfigMap
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:37:25.631: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-configmap-sfrvc" for this suite.
+Jul  2 13:37:31.645: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:37:31.682: INFO: namespace: e2e-tests-configmap-sfrvc, resource: bindings, ignored listing per whitelist
+Jul  2 13:37:31.817: INFO: namespace e2e-tests-configmap-sfrvc deletion completed in 6.182568139s
+
+• [SLOW TEST:10.374 seconds]
+[sig-api-machinery] ConfigMap
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/configmap.go:29
+  should be consumable via the environment [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+S
+------------------------------
+[sig-network] DNS 
+  should provide DNS for services  [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-network] DNS
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:37:31.817: INFO: >>> kubeConfig: /tmp/kubeconfig-324782104
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should provide DNS for services  [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating a test headless service
+STEP: Running these commands on wheezy: for i in `seq 1 600`; do test -n "$$(dig +notcp +noall +answer +search dns-test-service A)" && echo OK > /results/wheezy_udp@dns-test-service;test -n "$$(dig +tcp +noall +answer +search dns-test-service A)" && echo OK > /results/wheezy_tcp@dns-test-service;test -n "$$(dig +notcp +noall +answer +search dns-test-service.e2e-tests-dns-xp5v4 A)" && echo OK > /results/wheezy_udp@dns-test-service.e2e-tests-dns-xp5v4;test -n "$$(dig +tcp +noall +answer +search dns-test-service.e2e-tests-dns-xp5v4 A)" && echo OK > /results/wheezy_tcp@dns-test-service.e2e-tests-dns-xp5v4;test -n "$$(dig +notcp +noall +answer +search dns-test-service.e2e-tests-dns-xp5v4.svc A)" && echo OK > /results/wheezy_udp@dns-test-service.e2e-tests-dns-xp5v4.svc;test -n "$$(dig +tcp +noall +answer +search dns-test-service.e2e-tests-dns-xp5v4.svc A)" && echo OK > /results/wheezy_tcp@dns-test-service.e2e-tests-dns-xp5v4.svc;test -n "$$(dig +notcp +noall +answer +search _http._tcp.dns-test-service.e2e-tests-dns-xp5v4.svc SRV)" && echo OK > /results/wheezy_udp@_http._tcp.dns-test-service.e2e-tests-dns-xp5v4.svc;test -n "$$(dig +tcp +noall +answer +search _http._tcp.dns-test-service.e2e-tests-dns-xp5v4.svc SRV)" && echo OK > /results/wheezy_tcp@_http._tcp.dns-test-service.e2e-tests-dns-xp5v4.svc;test -n "$$(dig +notcp +noall +answer +search _http._tcp.test-service-2.e2e-tests-dns-xp5v4.svc SRV)" && echo OK > /results/wheezy_udp@_http._tcp.test-service-2.e2e-tests-dns-xp5v4.svc;test -n "$$(dig +tcp +noall +answer +search _http._tcp.test-service-2.e2e-tests-dns-xp5v4.svc SRV)" && echo OK > /results/wheezy_tcp@_http._tcp.test-service-2.e2e-tests-dns-xp5v4.svc;podARec=$$(hostname -i| awk -F. '{print $$1"-"$$2"-"$$3"-"$$4".e2e-tests-dns-xp5v4.pod.cluster.local"}');test -n "$$(dig +notcp +noall +answer +search $${podARec} A)" && echo OK > /results/wheezy_udp@PodARecord;test -n "$$(dig +tcp +noall +answer +search $${podARec} A)" && echo OK > /results/wheezy_tcp@PodARecord;test -n "$$(dig +notcp +noall +answer +search 77.246.64.100.in-addr.arpa. PTR)" && echo OK > /results/100.64.246.77_udp@PTR;test -n "$$(dig +tcp +noall +answer +search 77.246.64.100.in-addr.arpa. PTR)" && echo OK > /results/100.64.246.77_tcp@PTR;sleep 1; done
+
+STEP: Running these commands on jessie: for i in `seq 1 600`; do test -n "$$(dig +notcp +noall +answer +search dns-test-service A)" && echo OK > /results/jessie_udp@dns-test-service;test -n "$$(dig +tcp +noall +answer +search dns-test-service A)" && echo OK > /results/jessie_tcp@dns-test-service;test -n "$$(dig +notcp +noall +answer +search dns-test-service.e2e-tests-dns-xp5v4 A)" && echo OK > /results/jessie_udp@dns-test-service.e2e-tests-dns-xp5v4;test -n "$$(dig +tcp +noall +answer +search dns-test-service.e2e-tests-dns-xp5v4 A)" && echo OK > /results/jessie_tcp@dns-test-service.e2e-tests-dns-xp5v4;test -n "$$(dig +notcp +noall +answer +search dns-test-service.e2e-tests-dns-xp5v4.svc A)" && echo OK > /results/jessie_udp@dns-test-service.e2e-tests-dns-xp5v4.svc;test -n "$$(dig +tcp +noall +answer +search dns-test-service.e2e-tests-dns-xp5v4.svc A)" && echo OK > /results/jessie_tcp@dns-test-service.e2e-tests-dns-xp5v4.svc;test -n "$$(dig +notcp +noall +answer +search _http._tcp.dns-test-service.e2e-tests-dns-xp5v4.svc SRV)" && echo OK > /results/jessie_udp@_http._tcp.dns-test-service.e2e-tests-dns-xp5v4.svc;test -n "$$(dig +tcp +noall +answer +search _http._tcp.dns-test-service.e2e-tests-dns-xp5v4.svc SRV)" && echo OK > /results/jessie_tcp@_http._tcp.dns-test-service.e2e-tests-dns-xp5v4.svc;test -n "$$(dig +notcp +noall +answer +search _http._tcp.test-service-2.e2e-tests-dns-xp5v4.svc SRV)" && echo OK > /results/jessie_udp@_http._tcp.test-service-2.e2e-tests-dns-xp5v4.svc;test -n "$$(dig +tcp +noall +answer +search _http._tcp.test-service-2.e2e-tests-dns-xp5v4.svc SRV)" && echo OK > /results/jessie_tcp@_http._tcp.test-service-2.e2e-tests-dns-xp5v4.svc;podARec=$$(hostname -i| awk -F. '{print $$1"-"$$2"-"$$3"-"$$4".e2e-tests-dns-xp5v4.pod.cluster.local"}');test -n "$$(dig +notcp +noall +answer +search $${podARec} A)" && echo OK > /results/jessie_udp@PodARecord;test -n "$$(dig +tcp +noall +answer +search $${podARec} A)" && echo OK > /results/jessie_tcp@PodARecord;test -n "$$(dig +notcp +noall +answer +search 77.246.64.100.in-addr.arpa. PTR)" && echo OK > /results/100.64.246.77_udp@PTR;test -n "$$(dig +tcp +noall +answer +search 77.246.64.100.in-addr.arpa. PTR)" && echo OK > /results/100.64.246.77_tcp@PTR;sleep 1; done
+
+STEP: creating a pod to probe DNS
+STEP: submitting the pod to kubernetes
+STEP: retrieving the pod
+STEP: looking for the results for each expected name from probers
+Jul  2 13:37:47.901: INFO: DNS probes using dns-test-122c636c-7dfd-11e8-8e15-aefe7bc77cc2 succeeded
+
+STEP: deleting the pod
+STEP: deleting the test service
+STEP: deleting the test headless service
+[AfterEach] [sig-network] DNS
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:37:47.999: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-dns-xp5v4" for this suite.
+Jul  2 13:37:54.062: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:37:54.105: INFO: namespace: e2e-tests-dns-xp5v4, resource: bindings, ignored listing per whitelist
+Jul  2 13:37:54.227: INFO: namespace e2e-tests-dns-xp5v4 deletion completed in 6.223197472s
+
+• [SLOW TEST:22.410 seconds]
+[sig-network] DNS
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/network/framework.go:22
+  should provide DNS for services  [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSSSSSS
+------------------------------
+[sig-storage] Projected 
+  should be consumable from pods in volume with mappings and Item mode set [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:37:54.227: INFO: >>> kubeConfig: /tmp/kubeconfig-324782104
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:858
+[It] should be consumable from pods in volume with mappings and Item mode set [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating configMap with name projected-configmap-test-volume-map-1f80b51a-7dfd-11e8-8e15-aefe7bc77cc2
+STEP: Creating a pod to test consume configMaps
+Jul  2 13:37:54.372: INFO: Waiting up to 5m0s for pod "pod-projected-configmaps-1f817108-7dfd-11e8-8e15-aefe7bc77cc2" in namespace "e2e-tests-projected-tf8pr" to be "success or failure"
+Jul  2 13:37:54.385: INFO: Pod "pod-projected-configmaps-1f817108-7dfd-11e8-8e15-aefe7bc77cc2": Phase="Pending", Reason="", readiness=false. Elapsed: 13.034055ms
+Jul  2 13:37:56.389: INFO: Pod "pod-projected-configmaps-1f817108-7dfd-11e8-8e15-aefe7bc77cc2": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.016236755s
+STEP: Saw pod success
+Jul  2 13:37:56.389: INFO: Pod "pod-projected-configmaps-1f817108-7dfd-11e8-8e15-aefe7bc77cc2" satisfied condition "success or failure"
+Jul  2 13:37:56.392: INFO: Trying to get logs from node shoot--core--confaz-worker-qfmi9-79968b77d9-kcr6j pod pod-projected-configmaps-1f817108-7dfd-11e8-8e15-aefe7bc77cc2 container projected-configmap-volume-test: <nil>
+STEP: delete the pod
+Jul  2 13:37:56.429: INFO: Waiting for pod pod-projected-configmaps-1f817108-7dfd-11e8-8e15-aefe7bc77cc2 to disappear
+Jul  2 13:37:56.439: INFO: Pod pod-projected-configmaps-1f817108-7dfd-11e8-8e15-aefe7bc77cc2 no longer exists
+[AfterEach] [sig-storage] Projected
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:37:56.439: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-tf8pr" for this suite.
+Jul  2 13:38:02.455: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:38:02.498: INFO: namespace: e2e-tests-projected-tf8pr, resource: bindings, ignored listing per whitelist
+Jul  2 13:38:02.631: INFO: namespace e2e-tests-projected-tf8pr deletion completed in 6.18868272s
+
+• [SLOW TEST:8.404 seconds]
+[sig-storage] Projected
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:34
+  should be consumable from pods in volume with mappings and Item mode set [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSSSSSSSSSS
+------------------------------
+[sig-storage] ConfigMap 
+  should be consumable from pods in volume [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-storage] ConfigMap
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:38:02.631: INFO: >>> kubeConfig: /tmp/kubeconfig-324782104
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should be consumable from pods in volume [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating configMap with name configmap-test-volume-247d6ceb-7dfd-11e8-8e15-aefe7bc77cc2
+STEP: Creating a pod to test consume configMaps
+Jul  2 13:38:02.744: INFO: Waiting up to 5m0s for pod "pod-configmaps-24805684-7dfd-11e8-8e15-aefe7bc77cc2" in namespace "e2e-tests-configmap-h96v5" to be "success or failure"
+Jul  2 13:38:02.756: INFO: Pod "pod-configmaps-24805684-7dfd-11e8-8e15-aefe7bc77cc2": Phase="Pending", Reason="", readiness=false. Elapsed: 11.377044ms
+Jul  2 13:38:04.778: INFO: Pod "pod-configmaps-24805684-7dfd-11e8-8e15-aefe7bc77cc2": Phase="Pending", Reason="", readiness=false. Elapsed: 2.033270508s
+Jul  2 13:38:06.797: INFO: Pod "pod-configmaps-24805684-7dfd-11e8-8e15-aefe7bc77cc2": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.052857913s
+STEP: Saw pod success
+Jul  2 13:38:06.797: INFO: Pod "pod-configmaps-24805684-7dfd-11e8-8e15-aefe7bc77cc2" satisfied condition "success or failure"
+Jul  2 13:38:06.800: INFO: Trying to get logs from node shoot--core--confaz-worker-qfmi9-79968b77d9-kcr6j pod pod-configmaps-24805684-7dfd-11e8-8e15-aefe7bc77cc2 container configmap-volume-test: <nil>
+STEP: delete the pod
+Jul  2 13:38:06.870: INFO: Waiting for pod pod-configmaps-24805684-7dfd-11e8-8e15-aefe7bc77cc2 to disappear
+Jul  2 13:38:06.873: INFO: Pod pod-configmaps-24805684-7dfd-11e8-8e15-aefe7bc77cc2 no longer exists
+[AfterEach] [sig-storage] ConfigMap
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:38:06.873: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-configmap-h96v5" for this suite.
+Jul  2 13:38:12.894: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:38:12.901: INFO: namespace: e2e-tests-configmap-h96v5, resource: bindings, ignored listing per whitelist
+Jul  2 13:38:13.032: INFO: namespace e2e-tests-configmap-h96v5 deletion completed in 6.149503789s
+
+• [SLOW TEST:10.401 seconds]
+[sig-storage] ConfigMap
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/configmap_volume.go:32
+  should be consumable from pods in volume [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSSSSS
+------------------------------
+[k8s.io] Docker Containers 
+  should be able to override the image's default command and arguments [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [k8s.io] Docker Containers
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:38:13.032: INFO: >>> kubeConfig: /tmp/kubeconfig-324782104
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should be able to override the image's default command and arguments [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating a pod to test override all
+Jul  2 13:38:13.156: INFO: Waiting up to 5m0s for pod "client-containers-2ab41b2d-7dfd-11e8-8e15-aefe7bc77cc2" in namespace "e2e-tests-containers-l2v24" to be "success or failure"
+Jul  2 13:38:13.164: INFO: Pod "client-containers-2ab41b2d-7dfd-11e8-8e15-aefe7bc77cc2": Phase="Pending", Reason="", readiness=false. Elapsed: 8.252732ms
+Jul  2 13:38:15.168: INFO: Pod "client-containers-2ab41b2d-7dfd-11e8-8e15-aefe7bc77cc2": Phase="Pending", Reason="", readiness=false. Elapsed: 2.01170912s
+Jul  2 13:38:17.176: INFO: Pod "client-containers-2ab41b2d-7dfd-11e8-8e15-aefe7bc77cc2": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.020021943s
+STEP: Saw pod success
+Jul  2 13:38:17.176: INFO: Pod "client-containers-2ab41b2d-7dfd-11e8-8e15-aefe7bc77cc2" satisfied condition "success or failure"
+Jul  2 13:38:17.179: INFO: Trying to get logs from node shoot--core--confaz-worker-qfmi9-79968b77d9-kcr6j pod client-containers-2ab41b2d-7dfd-11e8-8e15-aefe7bc77cc2 container test-container: <nil>
+STEP: delete the pod
+Jul  2 13:38:17.222: INFO: Waiting for pod client-containers-2ab41b2d-7dfd-11e8-8e15-aefe7bc77cc2 to disappear
+Jul  2 13:38:17.229: INFO: Pod client-containers-2ab41b2d-7dfd-11e8-8e15-aefe7bc77cc2 no longer exists
+[AfterEach] [k8s.io] Docker Containers
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:38:17.229: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-containers-l2v24" for this suite.
+Jul  2 13:38:23.242: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:38:23.353: INFO: namespace: e2e-tests-containers-l2v24, resource: bindings, ignored listing per whitelist
+Jul  2 13:38:23.358: INFO: namespace e2e-tests-containers-l2v24 deletion completed in 6.125900229s
+
+• [SLOW TEST:10.325 seconds]
+[k8s.io] Docker Containers
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:679
+  should be able to override the image's default command and arguments [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSSS
+------------------------------
+[k8s.io] Pods 
+  should allow activeDeadlineSeconds to be updated [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [k8s.io] Pods
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:38:23.358: INFO: >>> kubeConfig: /tmp/kubeconfig-324782104
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [k8s.io] Pods
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/pods.go:127
+[It] should allow activeDeadlineSeconds to be updated [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: creating the pod
+STEP: submitting the pod to kubernetes
+STEP: verifying the pod is in kubernetes
+STEP: updating the pod
+Jul  2 13:38:28.235: INFO: Successfully updated pod "pod-update-activedeadlineseconds-30d86bed-7dfd-11e8-8e15-aefe7bc77cc2"
+Jul  2 13:38:28.235: INFO: Waiting up to 5m0s for pod "pod-update-activedeadlineseconds-30d86bed-7dfd-11e8-8e15-aefe7bc77cc2" in namespace "e2e-tests-pods-5q2ts" to be "terminated due to deadline exceeded"
+Jul  2 13:38:28.250: INFO: Pod "pod-update-activedeadlineseconds-30d86bed-7dfd-11e8-8e15-aefe7bc77cc2": Phase="Running", Reason="", readiness=true. Elapsed: 15.674862ms
+Jul  2 13:38:30.255: INFO: Pod "pod-update-activedeadlineseconds-30d86bed-7dfd-11e8-8e15-aefe7bc77cc2": Phase="Failed", Reason="DeadlineExceeded", readiness=false. Elapsed: 2.01985462s
+Jul  2 13:38:30.255: INFO: Pod "pod-update-activedeadlineseconds-30d86bed-7dfd-11e8-8e15-aefe7bc77cc2" satisfied condition "terminated due to deadline exceeded"
+[AfterEach] [k8s.io] Pods
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:38:30.255: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-pods-5q2ts" for this suite.
+Jul  2 13:38:36.330: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:38:36.525: INFO: namespace: e2e-tests-pods-5q2ts, resource: bindings, ignored listing per whitelist
+Jul  2 13:38:36.592: INFO: namespace e2e-tests-pods-5q2ts deletion completed in 6.333287263s
+
+• [SLOW TEST:13.234 seconds]
+[k8s.io] Pods
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:679
+  should allow activeDeadlineSeconds to be updated [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSSSSSS
+------------------------------
+[sig-storage] EmptyDir volumes 
+  should support (non-root,0644,default) [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-storage] EmptyDir volumes
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:38:36.592: INFO: >>> kubeConfig: /tmp/kubeconfig-324782104
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should support (non-root,0644,default) [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating a pod to test emptydir 0644 on node default medium
+Jul  2 13:38:36.782: INFO: Waiting up to 5m0s for pod "pod-38c9f527-7dfd-11e8-8e15-aefe7bc77cc2" in namespace "e2e-tests-emptydir-vkzxt" to be "success or failure"
+Jul  2 13:38:36.786: INFO: Pod "pod-38c9f527-7dfd-11e8-8e15-aefe7bc77cc2": Phase="Pending", Reason="", readiness=false. Elapsed: 4.133315ms
+Jul  2 13:38:38.790: INFO: Pod "pod-38c9f527-7dfd-11e8-8e15-aefe7bc77cc2": Phase="Pending", Reason="", readiness=false. Elapsed: 2.00772886s
+Jul  2 13:38:40.830: INFO: Pod "pod-38c9f527-7dfd-11e8-8e15-aefe7bc77cc2": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.047984898s
+STEP: Saw pod success
+Jul  2 13:38:40.830: INFO: Pod "pod-38c9f527-7dfd-11e8-8e15-aefe7bc77cc2" satisfied condition "success or failure"
+Jul  2 13:38:40.833: INFO: Trying to get logs from node shoot--core--confaz-worker-qfmi9-79968b77d9-kcr6j pod pod-38c9f527-7dfd-11e8-8e15-aefe7bc77cc2 container test-container: <nil>
+STEP: delete the pod
+Jul  2 13:38:40.865: INFO: Waiting for pod pod-38c9f527-7dfd-11e8-8e15-aefe7bc77cc2 to disappear
+Jul  2 13:38:40.889: INFO: Pod pod-38c9f527-7dfd-11e8-8e15-aefe7bc77cc2 no longer exists
+[AfterEach] [sig-storage] EmptyDir volumes
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:38:40.889: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-emptydir-vkzxt" for this suite.
+Jul  2 13:38:46.904: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:38:46.965: INFO: namespace: e2e-tests-emptydir-vkzxt, resource: bindings, ignored listing per whitelist
+Jul  2 13:38:47.001: INFO: namespace e2e-tests-emptydir-vkzxt deletion completed in 6.108382361s
+
+• [SLOW TEST:10.409 seconds]
+[sig-storage] EmptyDir volumes
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/empty_dir.go:40
+  should support (non-root,0644,default) [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSSSSSS
+------------------------------
+[sig-network] Proxy version v1 
+  should proxy through a service and a pod  [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] version v1
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:38:47.002: INFO: >>> kubeConfig: /tmp/kubeconfig-324782104
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should proxy through a service and a pod  [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: starting an echo server on multiple ports
+STEP: creating replication controller proxy-service-lbscg in namespace e2e-tests-proxy-vfx29
+I0702 13:38:47.158988      15 runners.go:177] Created replication controller with name: proxy-service-lbscg, namespace: e2e-tests-proxy-vfx29, replica count: 1
+I0702 13:38:48.209631      15 runners.go:177] proxy-service-lbscg Pods: 1 out of 1 created, 0 running, 1 pending, 0 waiting, 0 inactive, 0 terminating, 0 unknown, 0 runningButNotReady 
+I0702 13:38:49.209856      15 runners.go:177] proxy-service-lbscg Pods: 1 out of 1 created, 0 running, 1 pending, 0 waiting, 0 inactive, 0 terminating, 0 unknown, 0 runningButNotReady 
+I0702 13:38:50.210044      15 runners.go:177] proxy-service-lbscg Pods: 1 out of 1 created, 0 running, 1 pending, 0 waiting, 0 inactive, 0 terminating, 0 unknown, 0 runningButNotReady 
+I0702 13:38:51.233101      15 runners.go:177] proxy-service-lbscg Pods: 1 out of 1 created, 0 running, 0 pending, 0 waiting, 0 inactive, 0 terminating, 0 unknown, 1 runningButNotReady 
+I0702 13:38:52.233360      15 runners.go:177] proxy-service-lbscg Pods: 1 out of 1 created, 0 running, 0 pending, 0 waiting, 0 inactive, 0 terminating, 0 unknown, 1 runningButNotReady 
+I0702 13:38:53.233639      15 runners.go:177] proxy-service-lbscg Pods: 1 out of 1 created, 0 running, 0 pending, 0 waiting, 0 inactive, 0 terminating, 0 unknown, 1 runningButNotReady 
+I0702 13:38:54.233893      15 runners.go:177] proxy-service-lbscg Pods: 1 out of 1 created, 1 running, 0 pending, 0 waiting, 0 inactive, 0 terminating, 0 unknown, 0 runningButNotReady 
+Jul  2 13:38:54.236: INFO: setup took 7.145895695s, starting test cases
+STEP: running 16 cases, 20 attempts per case, 320 total attempts
+Jul  2 13:38:54.247: INFO: (0) /api/v1/namespaces/e2e-tests-proxy-vfx29/pods/http:proxy-service-lbscg-tnfcm:162/proxy/: bar (200; 10.759138ms)
+Jul  2 13:38:54.247: INFO: (0) /api/v1/namespaces/e2e-tests-proxy-vfx29/services/http:proxy-service-lbscg:portname1/proxy/: foo (200; 9.930535ms)
+Jul  2 13:38:54.247: INFO: (0) /api/v1/namespaces/e2e-tests-proxy-vfx29/services/proxy-service-lbscg:portname1/proxy/: foo (200; 10.789638ms)
+Jul  2 13:38:54.247: INFO: (0) /api/v1/namespaces/e2e-tests-proxy-vfx29/pods/proxy-service-lbscg-tnfcm:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-vfx29/pods/proxy-service-lbscg-tnfcm:1080/proxy/rewri... (200; 10.708837ms)
+Jul  2 13:38:54.263: INFO: (0) /api/v1/namespaces/e2e-tests-proxy-vfx29/pods/proxy-service-lbscg-tnfcm/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-vfx29/pods/proxy-service-lbscg-tnfcm/proxy/rewriteme"... (200; 26.154491ms)
+Jul  2 13:38:54.263: INFO: (0) /api/v1/namespaces/e2e-tests-proxy-vfx29/pods/http:proxy-service-lbscg-tnfcm:160/proxy/: foo (200; 26.420292ms)
+Jul  2 13:38:54.263: INFO: (0) /api/v1/namespaces/e2e-tests-proxy-vfx29/services/proxy-service-lbscg:portname2/proxy/: bar (200; 26.000392ms)
+Jul  2 13:38:54.263: INFO: (0) /api/v1/namespaces/e2e-tests-proxy-vfx29/pods/proxy-service-lbscg-tnfcm:160/proxy/: foo (200; 25.951891ms)
+Jul  2 13:38:54.264: INFO: (0) /api/v1/namespaces/e2e-tests-proxy-vfx29/pods/proxy-service-lbscg-tnfcm:162/proxy/: bar (200; 26.542393ms)
+Jul  2 13:38:54.264: INFO: (0) /api/v1/namespaces/e2e-tests-proxy-vfx29/services/http:proxy-service-lbscg:portname2/proxy/: bar (200; 27.007494ms)
+Jul  2 13:38:54.264: INFO: (0) /api/v1/namespaces/e2e-tests-proxy-vfx29/pods/http:proxy-service-lbscg-tnfcm:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-vfx29/pods/http:proxy-service-lbscg-tnfcm:1080/proxy/... (200; 26.422092ms)
+Jul  2 13:38:54.269: INFO: (0) /api/v1/namespaces/e2e-tests-proxy-vfx29/pods/https:proxy-service-lbscg-tnfcm:443/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-vfx29/pods/https:proxy-service-lbscg-tnfcm:443/proxy/... (200; 32.573614ms)
+Jul  2 13:38:54.269: INFO: (0) /api/v1/namespaces/e2e-tests-proxy-vfx29/services/https:proxy-service-lbscg:tlsportname1/proxy/: tls baz (200; 32.059313ms)
+Jul  2 13:38:54.269: INFO: (0) /api/v1/namespaces/e2e-tests-proxy-vfx29/pods/https:proxy-service-lbscg-tnfcm:460/proxy/: tls baz (200; 32.460314ms)
+Jul  2 13:38:54.270: INFO: (0) /api/v1/namespaces/e2e-tests-proxy-vfx29/services/https:proxy-service-lbscg:tlsportname2/proxy/: tls qux (200; 32.366213ms)
+Jul  2 13:38:54.270: INFO: (0) /api/v1/namespaces/e2e-tests-proxy-vfx29/pods/https:proxy-service-lbscg-tnfcm:462/proxy/: tls qux (200; 33.016316ms)
+Jul  2 13:38:54.276: INFO: (1) /api/v1/namespaces/e2e-tests-proxy-vfx29/pods/proxy-service-lbscg-tnfcm:160/proxy/: foo (200; 5.79732ms)
+Jul  2 13:38:54.276: INFO: (1) /api/v1/namespaces/e2e-tests-proxy-vfx29/pods/proxy-service-lbscg-tnfcm:162/proxy/: bar (200; 6.031221ms)
+Jul  2 13:38:54.276: INFO: (1) /api/v1/namespaces/e2e-tests-proxy-vfx29/pods/proxy-service-lbscg-tnfcm:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-vfx29/pods/proxy-service-lbscg-tnfcm:1080/proxy/rewri... (200; 5.87492ms)
+Jul  2 13:38:54.277: INFO: (1) /api/v1/namespaces/e2e-tests-proxy-vfx29/pods/https:proxy-service-lbscg-tnfcm:460/proxy/: tls baz (200; 6.874324ms)
+Jul  2 13:38:54.277: INFO: (1) /api/v1/namespaces/e2e-tests-proxy-vfx29/pods/https:proxy-service-lbscg-tnfcm:462/proxy/: tls qux (200; 6.556823ms)
+Jul  2 13:38:54.278: INFO: (1) /api/v1/namespaces/e2e-tests-proxy-vfx29/pods/http:proxy-service-lbscg-tnfcm:160/proxy/: foo (200; 7.470826ms)
+Jul  2 13:38:54.279: INFO: (1) /api/v1/namespaces/e2e-tests-proxy-vfx29/pods/http:proxy-service-lbscg-tnfcm:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-vfx29/pods/http:proxy-service-lbscg-tnfcm:1080/proxy/... (200; 8.983431ms)
+Jul  2 13:38:54.279: INFO: (1) /api/v1/namespaces/e2e-tests-proxy-vfx29/pods/proxy-service-lbscg-tnfcm/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-vfx29/pods/proxy-service-lbscg-tnfcm/proxy/rewriteme"... (200; 8.50203ms)
+Jul  2 13:38:54.279: INFO: (1) /api/v1/namespaces/e2e-tests-proxy-vfx29/pods/http:proxy-service-lbscg-tnfcm:162/proxy/: bar (200; 8.977332ms)
+Jul  2 13:38:54.280: INFO: (1) /api/v1/namespaces/e2e-tests-proxy-vfx29/pods/https:proxy-service-lbscg-tnfcm:443/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-vfx29/pods/https:proxy-service-lbscg-tnfcm:443/proxy/... (200; 8.825831ms)
+Jul  2 13:38:54.280: INFO: (1) /api/v1/namespaces/e2e-tests-proxy-vfx29/services/https:proxy-service-lbscg:tlsportname1/proxy/: tls baz (200; 9.466834ms)
+Jul  2 13:38:54.280: INFO: (1) /api/v1/namespaces/e2e-tests-proxy-vfx29/services/proxy-service-lbscg:portname1/proxy/: foo (200; 9.594934ms)
+Jul  2 13:38:54.281: INFO: (1) /api/v1/namespaces/e2e-tests-proxy-vfx29/services/https:proxy-service-lbscg:tlsportname2/proxy/: tls qux (200; 10.375336ms)
+Jul  2 13:38:54.320: INFO: (1) /api/v1/namespaces/e2e-tests-proxy-vfx29/services/http:proxy-service-lbscg:portname2/proxy/: bar (200; 49.601773ms)
+Jul  2 13:38:54.321: INFO: (1) /api/v1/namespaces/e2e-tests-proxy-vfx29/services/http:proxy-service-lbscg:portname1/proxy/: foo (200; 50.400677ms)
+Jul  2 13:38:54.320: INFO: (1) /api/v1/namespaces/e2e-tests-proxy-vfx29/services/proxy-service-lbscg:portname2/proxy/: bar (200; 50.495877ms)
+Jul  2 13:38:54.327: INFO: (2) /api/v1/namespaces/e2e-tests-proxy-vfx29/pods/http:proxy-service-lbscg-tnfcm:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-vfx29/pods/http:proxy-service-lbscg-tnfcm:1080/proxy/... (200; 5.89542ms)
+Jul  2 13:38:54.328: INFO: (2) /api/v1/namespaces/e2e-tests-proxy-vfx29/pods/proxy-service-lbscg-tnfcm:160/proxy/: foo (200; 7.133925ms)
+Jul  2 13:38:54.328: INFO: (2) /api/v1/namespaces/e2e-tests-proxy-vfx29/pods/http:proxy-service-lbscg-tnfcm:162/proxy/: bar (200; 7.304625ms)
+Jul  2 13:38:54.328: INFO: (2) /api/v1/namespaces/e2e-tests-proxy-vfx29/pods/proxy-service-lbscg-tnfcm:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-vfx29/pods/proxy-service-lbscg-tnfcm:1080/proxy/rewri... (200; 7.265925ms)
+Jul  2 13:38:54.329: INFO: (2) /api/v1/namespaces/e2e-tests-proxy-vfx29/pods/https:proxy-service-lbscg-tnfcm:462/proxy/: tls qux (200; 8.219529ms)
+Jul  2 13:38:54.330: INFO: (2) /api/v1/namespaces/e2e-tests-proxy-vfx29/pods/https:proxy-service-lbscg-tnfcm:443/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-vfx29/pods/https:proxy-service-lbscg-tnfcm:443/proxy/... (200; 8.776831ms)
+Jul  2 13:38:54.330: INFO: (2) /api/v1/namespaces/e2e-tests-proxy-vfx29/pods/proxy-service-lbscg-tnfcm/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-vfx29/pods/proxy-service-lbscg-tnfcm/proxy/rewriteme"... (200; 9.112131ms)
+Jul  2 13:38:54.330: INFO: (2) /api/v1/namespaces/e2e-tests-proxy-vfx29/pods/http:proxy-service-lbscg-tnfcm:160/proxy/: foo (200; 9.526033ms)
+Jul  2 13:38:54.331: INFO: (2) /api/v1/namespaces/e2e-tests-proxy-vfx29/pods/proxy-service-lbscg-tnfcm:162/proxy/: bar (200; 9.675934ms)
+Jul  2 13:38:54.331: INFO: (2) /api/v1/namespaces/e2e-tests-proxy-vfx29/pods/https:proxy-service-lbscg-tnfcm:460/proxy/: tls baz (200; 9.621633ms)
+Jul  2 13:38:54.331: INFO: (2) /api/v1/namespaces/e2e-tests-proxy-vfx29/services/https:proxy-service-lbscg:tlsportname1/proxy/: tls baz (200; 10.274136ms)
+Jul  2 13:38:54.331: INFO: (2) /api/v1/namespaces/e2e-tests-proxy-vfx29/services/http:proxy-service-lbscg:portname1/proxy/: foo (200; 9.944435ms)
+Jul  2 13:38:54.332: INFO: (2) /api/v1/namespaces/e2e-tests-proxy-vfx29/services/proxy-service-lbscg:portname2/proxy/: bar (200; 10.551137ms)
+Jul  2 13:38:54.332: INFO: (2) /api/v1/namespaces/e2e-tests-proxy-vfx29/services/https:proxy-service-lbscg:tlsportname2/proxy/: tls qux (200; 10.769438ms)
+Jul  2 13:38:54.332: INFO: (2) /api/v1/namespaces/e2e-tests-proxy-vfx29/services/proxy-service-lbscg:portname1/proxy/: foo (200; 11.118739ms)
+Jul  2 13:38:54.332: INFO: (2) /api/v1/namespaces/e2e-tests-proxy-vfx29/services/http:proxy-service-lbscg:portname2/proxy/: bar (200; 11.48584ms)
+Jul  2 13:38:54.342: INFO: (3) /api/v1/namespaces/e2e-tests-proxy-vfx29/services/https:proxy-service-lbscg:tlsportname1/proxy/: tls baz (200; 9.307832ms)
+Jul  2 13:38:54.342: INFO: (3) /api/v1/namespaces/e2e-tests-proxy-vfx29/pods/proxy-service-lbscg-tnfcm:160/proxy/: foo (200; 9.354833ms)
+Jul  2 13:38:54.342: INFO: (3) /api/v1/namespaces/e2e-tests-proxy-vfx29/pods/https:proxy-service-lbscg-tnfcm:460/proxy/: tls baz (200; 9.435433ms)
+Jul  2 13:38:54.342: INFO: (3) /api/v1/namespaces/e2e-tests-proxy-vfx29/pods/https:proxy-service-lbscg-tnfcm:462/proxy/: tls qux (200; 9.637334ms)
+Jul  2 13:38:54.344: INFO: (3) /api/v1/namespaces/e2e-tests-proxy-vfx29/services/https:proxy-service-lbscg:tlsportname2/proxy/: tls qux (200; 11.47054ms)
+Jul  2 13:38:54.345: INFO: (3) /api/v1/namespaces/e2e-tests-proxy-vfx29/pods/http:proxy-service-lbscg-tnfcm:162/proxy/: bar (200; 11.767141ms)
+Jul  2 13:38:54.345: INFO: (3) /api/v1/namespaces/e2e-tests-proxy-vfx29/pods/proxy-service-lbscg-tnfcm/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-vfx29/pods/proxy-service-lbscg-tnfcm/proxy/rewriteme"... (200; 12.153543ms)
+Jul  2 13:38:54.345: INFO: (3) /api/v1/namespaces/e2e-tests-proxy-vfx29/services/proxy-service-lbscg:portname1/proxy/: foo (200; 11.944641ms)
+Jul  2 13:38:54.345: INFO: (3) /api/v1/namespaces/e2e-tests-proxy-vfx29/pods/proxy-service-lbscg-tnfcm:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-vfx29/pods/proxy-service-lbscg-tnfcm:1080/proxy/rewri... (200; 11.890942ms)
+Jul  2 13:38:54.345: INFO: (3) /api/v1/namespaces/e2e-tests-proxy-vfx29/services/http:proxy-service-lbscg:portname2/proxy/: bar (200; 12.218743ms)
+Jul  2 13:38:54.345: INFO: (3) /api/v1/namespaces/e2e-tests-proxy-vfx29/services/http:proxy-service-lbscg:portname1/proxy/: foo (200; 12.301343ms)
+Jul  2 13:38:54.345: INFO: (3) /api/v1/namespaces/e2e-tests-proxy-vfx29/pods/http:proxy-service-lbscg-tnfcm:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-vfx29/pods/http:proxy-service-lbscg-tnfcm:1080/proxy/... (200; 12.259243ms)
+Jul  2 13:38:54.345: INFO: (3) /api/v1/namespaces/e2e-tests-proxy-vfx29/pods/https:proxy-service-lbscg-tnfcm:443/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-vfx29/pods/https:proxy-service-lbscg-tnfcm:443/proxy/... (200; 12.000542ms)
+Jul  2 13:38:54.385: INFO: (3) /api/v1/namespaces/e2e-tests-proxy-vfx29/services/proxy-service-lbscg:portname2/proxy/: bar (200; 52.658285ms)
+Jul  2 13:38:54.385: INFO: (3) /api/v1/namespaces/e2e-tests-proxy-vfx29/pods/proxy-service-lbscg-tnfcm:162/proxy/: bar (200; 52.618184ms)
+Jul  2 13:38:54.385: INFO: (3) /api/v1/namespaces/e2e-tests-proxy-vfx29/pods/http:proxy-service-lbscg-tnfcm:160/proxy/: foo (200; 52.546984ms)
+Jul  2 13:38:54.390: INFO: (4) /api/v1/namespaces/e2e-tests-proxy-vfx29/pods/proxy-service-lbscg-tnfcm:160/proxy/: foo (200; 4.871417ms)
+Jul  2 13:38:54.399: INFO: (4) /api/v1/namespaces/e2e-tests-proxy-vfx29/pods/proxy-service-lbscg-tnfcm/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-vfx29/pods/proxy-service-lbscg-tnfcm/proxy/rewriteme"... (200; 13.653748ms)
+Jul  2 13:38:54.400: INFO: (4) /api/v1/namespaces/e2e-tests-proxy-vfx29/services/proxy-service-lbscg:portname2/proxy/: bar (200; 13.947649ms)
+Jul  2 13:38:54.400: INFO: (4) /api/v1/namespaces/e2e-tests-proxy-vfx29/pods/https:proxy-service-lbscg-tnfcm:460/proxy/: tls baz (200; 14.14645ms)
+Jul  2 13:38:54.400: INFO: (4) /api/v1/namespaces/e2e-tests-proxy-vfx29/pods/https:proxy-service-lbscg-tnfcm:462/proxy/: tls qux (200; 13.830349ms)
+Jul  2 13:38:54.400: INFO: (4) /api/v1/namespaces/e2e-tests-proxy-vfx29/pods/http:proxy-service-lbscg-tnfcm:160/proxy/: foo (200; 13.883849ms)
+Jul  2 13:38:54.400: INFO: (4) /api/v1/namespaces/e2e-tests-proxy-vfx29/services/proxy-service-lbscg:portname1/proxy/: foo (200; 13.935849ms)
+Jul  2 13:38:54.400: INFO: (4) /api/v1/namespaces/e2e-tests-proxy-vfx29/pods/proxy-service-lbscg-tnfcm:162/proxy/: bar (200; 14.09025ms)
+Jul  2 13:38:54.400: INFO: (4) /api/v1/namespaces/e2e-tests-proxy-vfx29/pods/http:proxy-service-lbscg-tnfcm:162/proxy/: bar (200; 13.969449ms)
+Jul  2 13:38:54.400: INFO: (4) /api/v1/namespaces/e2e-tests-proxy-vfx29/pods/proxy-service-lbscg-tnfcm:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-vfx29/pods/proxy-service-lbscg-tnfcm:1080/proxy/rewri... (200; 13.963849ms)
+Jul  2 13:38:54.400: INFO: (4) /api/v1/namespaces/e2e-tests-proxy-vfx29/pods/https:proxy-service-lbscg-tnfcm:443/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-vfx29/pods/https:proxy-service-lbscg-tnfcm:443/proxy/... (200; 14.042649ms)
+Jul  2 13:38:54.400: INFO: (4) /api/v1/namespaces/e2e-tests-proxy-vfx29/services/https:proxy-service-lbscg:tlsportname2/proxy/: tls qux (200; 14.091749ms)
+Jul  2 13:38:54.400: INFO: (4) /api/v1/namespaces/e2e-tests-proxy-vfx29/services/https:proxy-service-lbscg:tlsportname1/proxy/: tls baz (200; 14.150049ms)
+Jul  2 13:38:54.400: INFO: (4) /api/v1/namespaces/e2e-tests-proxy-vfx29/services/http:proxy-service-lbscg:portname2/proxy/: bar (200; 13.981749ms)
+Jul  2 13:38:54.400: INFO: (4) /api/v1/namespaces/e2e-tests-proxy-vfx29/services/http:proxy-service-lbscg:portname1/proxy/: foo (200; 14.21685ms)
+Jul  2 13:38:54.400: INFO: (4) /api/v1/namespaces/e2e-tests-proxy-vfx29/pods/http:proxy-service-lbscg-tnfcm:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-vfx29/pods/http:proxy-service-lbscg-tnfcm:1080/proxy/... (200; 14.36295ms)
+Jul  2 13:38:54.406: INFO: (5) /api/v1/namespaces/e2e-tests-proxy-vfx29/pods/proxy-service-lbscg-tnfcm:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-vfx29/pods/proxy-service-lbscg-tnfcm:1080/proxy/rewri... (200; 5.68342ms)
+Jul  2 13:38:54.407: INFO: (5) /api/v1/namespaces/e2e-tests-proxy-vfx29/pods/https:proxy-service-lbscg-tnfcm:443/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-vfx29/pods/https:proxy-service-lbscg-tnfcm:443/proxy/... (200; 6.405423ms)
+Jul  2 13:38:54.407: INFO: (5) /api/v1/namespaces/e2e-tests-proxy-vfx29/pods/https:proxy-service-lbscg-tnfcm:460/proxy/: tls baz (200; 6.552023ms)
+Jul  2 13:38:54.407: INFO: (5) /api/v1/namespaces/e2e-tests-proxy-vfx29/pods/https:proxy-service-lbscg-tnfcm:462/proxy/: tls qux (200; 6.324422ms)
+Jul  2 13:38:54.407: INFO: (5) /api/v1/namespaces/e2e-tests-proxy-vfx29/pods/http:proxy-service-lbscg-tnfcm:160/proxy/: foo (200; 6.158222ms)
+Jul  2 13:38:54.407: INFO: (5) /api/v1/namespaces/e2e-tests-proxy-vfx29/pods/proxy-service-lbscg-tnfcm/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-vfx29/pods/proxy-service-lbscg-tnfcm/proxy/rewriteme"... (200; 6.103121ms)
+Jul  2 13:38:54.407: INFO: (5) /api/v1/namespaces/e2e-tests-proxy-vfx29/pods/http:proxy-service-lbscg-tnfcm:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-vfx29/pods/http:proxy-service-lbscg-tnfcm:1080/proxy/... (200; 6.178322ms)
+Jul  2 13:38:54.408: INFO: (5) /api/v1/namespaces/e2e-tests-proxy-vfx29/pods/proxy-service-lbscg-tnfcm:160/proxy/: foo (200; 7.255626ms)
+Jul  2 13:38:54.408: INFO: (5) /api/v1/namespaces/e2e-tests-proxy-vfx29/services/http:proxy-service-lbscg:portname2/proxy/: bar (200; 7.541826ms)
+Jul  2 13:38:54.408: INFO: (5) /api/v1/namespaces/e2e-tests-proxy-vfx29/pods/http:proxy-service-lbscg-tnfcm:162/proxy/: bar (200; 7.166925ms)
+Jul  2 13:38:54.409: INFO: (5) /api/v1/namespaces/e2e-tests-proxy-vfx29/services/proxy-service-lbscg:portname1/proxy/: foo (200; 8.205829ms)
+Jul  2 13:38:54.410: INFO: (5) /api/v1/namespaces/e2e-tests-proxy-vfx29/pods/proxy-service-lbscg-tnfcm:162/proxy/: bar (200; 9.317532ms)
+Jul  2 13:38:54.411: INFO: (5) /api/v1/namespaces/e2e-tests-proxy-vfx29/services/https:proxy-service-lbscg:tlsportname1/proxy/: tls baz (200; 10.043635ms)
+Jul  2 13:38:54.447: INFO: (5) /api/v1/namespaces/e2e-tests-proxy-vfx29/services/proxy-service-lbscg:portname2/proxy/: bar (200; 46.723064ms)
+Jul  2 13:38:54.447: INFO: (5) /api/v1/namespaces/e2e-tests-proxy-vfx29/services/http:proxy-service-lbscg:portname1/proxy/: foo (200; 46.550063ms)
+Jul  2 13:38:54.447: INFO: (5) /api/v1/namespaces/e2e-tests-proxy-vfx29/services/https:proxy-service-lbscg:tlsportname2/proxy/: tls qux (200; 47.515566ms)
+Jul  2 13:38:54.455: INFO: (6) /api/v1/namespaces/e2e-tests-proxy-vfx29/pods/proxy-service-lbscg-tnfcm/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-vfx29/pods/proxy-service-lbscg-tnfcm/proxy/rewriteme"... (200; 7.535827ms)
+Jul  2 13:38:54.457: INFO: (6) /api/v1/namespaces/e2e-tests-proxy-vfx29/pods/proxy-service-lbscg-tnfcm:162/proxy/: bar (200; 8.884731ms)
+Jul  2 13:38:54.457: INFO: (6) /api/v1/namespaces/e2e-tests-proxy-vfx29/pods/proxy-service-lbscg-tnfcm:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-vfx29/pods/proxy-service-lbscg-tnfcm:1080/proxy/rewri... (200; 8.62123ms)
+Jul  2 13:38:54.457: INFO: (6) /api/v1/namespaces/e2e-tests-proxy-vfx29/pods/https:proxy-service-lbscg-tnfcm:462/proxy/: tls qux (200; 8.641931ms)
+Jul  2 13:38:54.457: INFO: (6) /api/v1/namespaces/e2e-tests-proxy-vfx29/pods/http:proxy-service-lbscg-tnfcm:160/proxy/: foo (200; 8.881931ms)
+Jul  2 13:38:54.457: INFO: (6) /api/v1/namespaces/e2e-tests-proxy-vfx29/pods/proxy-service-lbscg-tnfcm:160/proxy/: foo (200; 9.710134ms)
+Jul  2 13:38:54.458: INFO: (6) /api/v1/namespaces/e2e-tests-proxy-vfx29/pods/https:proxy-service-lbscg-tnfcm:460/proxy/: tls baz (200; 10.037735ms)
+Jul  2 13:38:54.458: INFO: (6) /api/v1/namespaces/e2e-tests-proxy-vfx29/pods/http:proxy-service-lbscg-tnfcm:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-vfx29/pods/http:proxy-service-lbscg-tnfcm:1080/proxy/... (200; 10.222136ms)
+Jul  2 13:38:54.460: INFO: (6) /api/v1/namespaces/e2e-tests-proxy-vfx29/services/http:proxy-service-lbscg:portname2/proxy/: bar (200; 12.346543ms)
+Jul  2 13:38:54.461: INFO: (6) /api/v1/namespaces/e2e-tests-proxy-vfx29/services/https:proxy-service-lbscg:tlsportname1/proxy/: tls baz (200; 12.594744ms)
+Jul  2 13:38:54.461: INFO: (6) /api/v1/namespaces/e2e-tests-proxy-vfx29/services/http:proxy-service-lbscg:portname1/proxy/: foo (200; 12.330843ms)
+Jul  2 13:38:54.461: INFO: (6) /api/v1/namespaces/e2e-tests-proxy-vfx29/services/proxy-service-lbscg:portname1/proxy/: foo (200; 13.092346ms)
+Jul  2 13:38:54.461: INFO: (6) /api/v1/namespaces/e2e-tests-proxy-vfx29/services/https:proxy-service-lbscg:tlsportname2/proxy/: tls qux (200; 12.743244ms)
+Jul  2 13:38:54.461: INFO: (6) /api/v1/namespaces/e2e-tests-proxy-vfx29/services/proxy-service-lbscg:portname2/proxy/: bar (200; 12.814045ms)
+Jul  2 13:38:54.461: INFO: (6) /api/v1/namespaces/e2e-tests-proxy-vfx29/pods/https:proxy-service-lbscg-tnfcm:443/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-vfx29/pods/https:proxy-service-lbscg-tnfcm:443/proxy/... (200; 12.674845ms)
+Jul  2 13:38:54.504: INFO: (6) /api/v1/namespaces/e2e-tests-proxy-vfx29/pods/http:proxy-service-lbscg-tnfcm:162/proxy/: bar (200; 56.206597ms)
+Jul  2 13:38:54.512: INFO: (7) /api/v1/namespaces/e2e-tests-proxy-vfx29/pods/proxy-service-lbscg-tnfcm:160/proxy/: foo (200; 7.134225ms)
+Jul  2 13:38:54.512: INFO: (7) /api/v1/namespaces/e2e-tests-proxy-vfx29/pods/proxy-service-lbscg-tnfcm:162/proxy/: bar (200; 7.503627ms)
+Jul  2 13:38:54.512: INFO: (7) /api/v1/namespaces/e2e-tests-proxy-vfx29/pods/http:proxy-service-lbscg-tnfcm:160/proxy/: foo (200; 7.404026ms)
+Jul  2 13:38:54.512: INFO: (7) /api/v1/namespaces/e2e-tests-proxy-vfx29/pods/http:proxy-service-lbscg-tnfcm:162/proxy/: bar (200; 7.434026ms)
+Jul  2 13:38:54.513: INFO: (7) /api/v1/namespaces/e2e-tests-proxy-vfx29/pods/https:proxy-service-lbscg-tnfcm:443/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-vfx29/pods/https:proxy-service-lbscg-tnfcm:443/proxy/... (200; 7.944828ms)
+Jul  2 13:38:54.513: INFO: (7) /api/v1/namespaces/e2e-tests-proxy-vfx29/pods/proxy-service-lbscg-tnfcm:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-vfx29/pods/proxy-service-lbscg-tnfcm:1080/proxy/rewri... (200; 8.049429ms)
+Jul  2 13:38:54.513: INFO: (7) /api/v1/namespaces/e2e-tests-proxy-vfx29/pods/http:proxy-service-lbscg-tnfcm:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-vfx29/pods/http:proxy-service-lbscg-tnfcm:1080/proxy/... (200; 7.838227ms)
+Jul  2 13:38:54.513: INFO: (7) /api/v1/namespaces/e2e-tests-proxy-vfx29/pods/proxy-service-lbscg-tnfcm/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-vfx29/pods/proxy-service-lbscg-tnfcm/proxy/rewriteme"... (200; 7.971228ms)
+Jul  2 13:38:54.513: INFO: (7) /api/v1/namespaces/e2e-tests-proxy-vfx29/services/https:proxy-service-lbscg:tlsportname1/proxy/: tls baz (200; 8.233429ms)
+Jul  2 13:38:54.513: INFO: (7) /api/v1/namespaces/e2e-tests-proxy-vfx29/services/https:proxy-service-lbscg:tlsportname2/proxy/: tls qux (200; 8.231729ms)
+Jul  2 13:38:54.513: INFO: (7) /api/v1/namespaces/e2e-tests-proxy-vfx29/pods/https:proxy-service-lbscg-tnfcm:460/proxy/: tls baz (200; 8.374929ms)
+Jul  2 13:38:54.513: INFO: (7) /api/v1/namespaces/e2e-tests-proxy-vfx29/pods/https:proxy-service-lbscg-tnfcm:462/proxy/: tls qux (200; 8.334329ms)
+Jul  2 13:38:54.515: INFO: (7) /api/v1/namespaces/e2e-tests-proxy-vfx29/services/proxy-service-lbscg:portname1/proxy/: foo (200; 10.070535ms)
+Jul  2 13:38:54.516: INFO: (7) /api/v1/namespaces/e2e-tests-proxy-vfx29/services/http:proxy-service-lbscg:portname1/proxy/: foo (200; 11.230539ms)
+Jul  2 13:38:54.516: INFO: (7) /api/v1/namespaces/e2e-tests-proxy-vfx29/services/http:proxy-service-lbscg:portname2/proxy/: bar (200; 11.165039ms)
+Jul  2 13:38:54.516: INFO: (7) /api/v1/namespaces/e2e-tests-proxy-vfx29/services/proxy-service-lbscg:portname2/proxy/: bar (200; 11.358739ms)
+Jul  2 13:38:54.525: INFO: (8) /api/v1/namespaces/e2e-tests-proxy-vfx29/pods/https:proxy-service-lbscg-tnfcm:462/proxy/: tls qux (200; 8.39653ms)
+Jul  2 13:38:54.526: INFO: (8) /api/v1/namespaces/e2e-tests-proxy-vfx29/pods/https:proxy-service-lbscg-tnfcm:460/proxy/: tls baz (200; 9.575234ms)
+Jul  2 13:38:54.527: INFO: (8) /api/v1/namespaces/e2e-tests-proxy-vfx29/pods/http:proxy-service-lbscg-tnfcm:160/proxy/: foo (200; 10.081335ms)
+Jul  2 13:38:54.527: INFO: (8) /api/v1/namespaces/e2e-tests-proxy-vfx29/pods/proxy-service-lbscg-tnfcm:162/proxy/: bar (200; 9.546733ms)
+Jul  2 13:38:54.527: INFO: (8) /api/v1/namespaces/e2e-tests-proxy-vfx29/pods/http:proxy-service-lbscg-tnfcm:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-vfx29/pods/http:proxy-service-lbscg-tnfcm:1080/proxy/... (200; 9.346233ms)
+Jul  2 13:38:54.527: INFO: (8) /api/v1/namespaces/e2e-tests-proxy-vfx29/pods/proxy-service-lbscg-tnfcm:160/proxy/: foo (200; 9.735234ms)
+Jul  2 13:38:54.527: INFO: (8) /api/v1/namespaces/e2e-tests-proxy-vfx29/pods/https:proxy-service-lbscg-tnfcm:443/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-vfx29/pods/https:proxy-service-lbscg-tnfcm:443/proxy/... (200; 10.221236ms)
+Jul  2 13:38:54.527: INFO: (8) /api/v1/namespaces/e2e-tests-proxy-vfx29/pods/http:proxy-service-lbscg-tnfcm:162/proxy/: bar (200; 10.739738ms)
+Jul  2 13:38:54.527: INFO: (8) /api/v1/namespaces/e2e-tests-proxy-vfx29/pods/proxy-service-lbscg-tnfcm:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-vfx29/pods/proxy-service-lbscg-tnfcm:1080/proxy/rewri... (200; 10.434936ms)
+Jul  2 13:38:54.527: INFO: (8) /api/v1/namespaces/e2e-tests-proxy-vfx29/pods/proxy-service-lbscg-tnfcm/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-vfx29/pods/proxy-service-lbscg-tnfcm/proxy/rewriteme"... (200; 10.129535ms)
+Jul  2 13:38:54.528: INFO: (8) /api/v1/namespaces/e2e-tests-proxy-vfx29/services/https:proxy-service-lbscg:tlsportname1/proxy/: tls baz (200; 10.354237ms)
+Jul  2 13:38:54.528: INFO: (8) /api/v1/namespaces/e2e-tests-proxy-vfx29/services/https:proxy-service-lbscg:tlsportname2/proxy/: tls qux (200; 10.330336ms)
+Jul  2 13:38:54.528: INFO: (8) /api/v1/namespaces/e2e-tests-proxy-vfx29/services/proxy-service-lbscg:portname1/proxy/: foo (200; 11.492041ms)
+Jul  2 13:38:54.528: INFO: (8) /api/v1/namespaces/e2e-tests-proxy-vfx29/services/http:proxy-service-lbscg:portname1/proxy/: foo (200; 10.734838ms)
+Jul  2 13:38:54.528: INFO: (8) /api/v1/namespaces/e2e-tests-proxy-vfx29/services/proxy-service-lbscg:portname2/proxy/: bar (200; 10.973439ms)
+Jul  2 13:38:54.530: INFO: (8) /api/v1/namespaces/e2e-tests-proxy-vfx29/services/http:proxy-service-lbscg:portname2/proxy/: bar (200; 13.011545ms)
+Jul  2 13:38:54.538: INFO: (9) /api/v1/namespaces/e2e-tests-proxy-vfx29/services/proxy-service-lbscg:portname1/proxy/: foo (200; 7.859728ms)
+Jul  2 13:38:54.538: INFO: (9) /api/v1/namespaces/e2e-tests-proxy-vfx29/pods/https:proxy-service-lbscg-tnfcm:443/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-vfx29/pods/https:proxy-service-lbscg-tnfcm:443/proxy/... (200; 8.272629ms)
+Jul  2 13:38:54.538: INFO: (9) /api/v1/namespaces/e2e-tests-proxy-vfx29/pods/http:proxy-service-lbscg-tnfcm:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-vfx29/pods/http:proxy-service-lbscg-tnfcm:1080/proxy/... (200; 7.529927ms)
+Jul  2 13:38:54.538: INFO: (9) /api/v1/namespaces/e2e-tests-proxy-vfx29/pods/proxy-service-lbscg-tnfcm:162/proxy/: bar (200; 7.777527ms)
+Jul  2 13:38:54.539: INFO: (9) /api/v1/namespaces/e2e-tests-proxy-vfx29/services/https:proxy-service-lbscg:tlsportname2/proxy/: tls qux (200; 8.62473ms)
+Jul  2 13:38:54.539: INFO: (9) /api/v1/namespaces/e2e-tests-proxy-vfx29/pods/http:proxy-service-lbscg-tnfcm:160/proxy/: foo (200; 9.152132ms)
+Jul  2 13:38:54.539: INFO: (9) /api/v1/namespaces/e2e-tests-proxy-vfx29/pods/https:proxy-service-lbscg-tnfcm:460/proxy/: tls baz (200; 8.785731ms)
+Jul  2 13:38:54.539: INFO: (9) /api/v1/namespaces/e2e-tests-proxy-vfx29/pods/https:proxy-service-lbscg-tnfcm:462/proxy/: tls qux (200; 9.106531ms)
+Jul  2 13:38:54.539: INFO: (9) /api/v1/namespaces/e2e-tests-proxy-vfx29/services/http:proxy-service-lbscg:portname2/proxy/: bar (200; 8.848231ms)
+Jul  2 13:38:54.539: INFO: (9) /api/v1/namespaces/e2e-tests-proxy-vfx29/pods/proxy-service-lbscg-tnfcm/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-vfx29/pods/proxy-service-lbscg-tnfcm/proxy/rewriteme"... (200; 9.441033ms)
+Jul  2 13:38:54.539: INFO: (9) /api/v1/namespaces/e2e-tests-proxy-vfx29/pods/proxy-service-lbscg-tnfcm:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-vfx29/pods/proxy-service-lbscg-tnfcm:1080/proxy/rewri... (200; 9.001632ms)
+Jul  2 13:38:54.540: INFO: (9) /api/v1/namespaces/e2e-tests-proxy-vfx29/services/https:proxy-service-lbscg:tlsportname1/proxy/: tls baz (200; 10.456237ms)
+Jul  2 13:38:54.540: INFO: (9) /api/v1/namespaces/e2e-tests-proxy-vfx29/pods/http:proxy-service-lbscg-tnfcm:162/proxy/: bar (200; 9.521533ms)
+Jul  2 13:38:54.540: INFO: (9) /api/v1/namespaces/e2e-tests-proxy-vfx29/pods/proxy-service-lbscg-tnfcm:160/proxy/: foo (200; 9.501633ms)
+Jul  2 13:38:54.541: INFO: (9) /api/v1/namespaces/e2e-tests-proxy-vfx29/services/http:proxy-service-lbscg:portname1/proxy/: foo (200; 9.573034ms)
+Jul  2 13:38:54.541: INFO: (9) /api/v1/namespaces/e2e-tests-proxy-vfx29/services/proxy-service-lbscg:portname2/proxy/: bar (200; 10.082635ms)
+Jul  2 13:38:54.548: INFO: (10) /api/v1/namespaces/e2e-tests-proxy-vfx29/services/http:proxy-service-lbscg:portname2/proxy/: bar (200; 7.134225ms)
+Jul  2 13:38:54.549: INFO: (10) /api/v1/namespaces/e2e-tests-proxy-vfx29/pods/proxy-service-lbscg-tnfcm:162/proxy/: bar (200; 7.882428ms)
+Jul  2 13:38:54.549: INFO: (10) /api/v1/namespaces/e2e-tests-proxy-vfx29/pods/proxy-service-lbscg-tnfcm:160/proxy/: foo (200; 7.670427ms)
+Jul  2 13:38:54.549: INFO: (10) /api/v1/namespaces/e2e-tests-proxy-vfx29/pods/proxy-service-lbscg-tnfcm/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-vfx29/pods/proxy-service-lbscg-tnfcm/proxy/rewriteme"... (200; 7.745827ms)
+Jul  2 13:38:54.549: INFO: (10) /api/v1/namespaces/e2e-tests-proxy-vfx29/pods/http:proxy-service-lbscg-tnfcm:160/proxy/: foo (200; 8.384329ms)
+Jul  2 13:38:54.550: INFO: (10) /api/v1/namespaces/e2e-tests-proxy-vfx29/services/https:proxy-service-lbscg:tlsportname2/proxy/: tls qux (200; 8.48313ms)
+Jul  2 13:38:54.550: INFO: (10) /api/v1/namespaces/e2e-tests-proxy-vfx29/pods/https:proxy-service-lbscg-tnfcm:460/proxy/: tls baz (200; 8.41963ms)
+Jul  2 13:38:54.550: INFO: (10) /api/v1/namespaces/e2e-tests-proxy-vfx29/pods/http:proxy-service-lbscg-tnfcm:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-vfx29/pods/http:proxy-service-lbscg-tnfcm:1080/proxy/... (200; 8.51133ms)
+Jul  2 13:38:54.550: INFO: (10) /api/v1/namespaces/e2e-tests-proxy-vfx29/pods/https:proxy-service-lbscg-tnfcm:462/proxy/: tls qux (200; 8.36543ms)
+Jul  2 13:38:54.550: INFO: (10) /api/v1/namespaces/e2e-tests-proxy-vfx29/pods/proxy-service-lbscg-tnfcm:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-vfx29/pods/proxy-service-lbscg-tnfcm:1080/proxy/rewri... (200; 8.52053ms)
+Jul  2 13:38:54.550: INFO: (10) /api/v1/namespaces/e2e-tests-proxy-vfx29/services/https:proxy-service-lbscg:tlsportname1/proxy/: tls baz (200; 9.247032ms)
+Jul  2 13:38:54.551: INFO: (10) /api/v1/namespaces/e2e-tests-proxy-vfx29/pods/https:proxy-service-lbscg-tnfcm:443/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-vfx29/pods/https:proxy-service-lbscg-tnfcm:443/proxy/... (200; 9.214633ms)
+Jul  2 13:38:54.551: INFO: (10) /api/v1/namespaces/e2e-tests-proxy-vfx29/pods/http:proxy-service-lbscg-tnfcm:162/proxy/: bar (200; 9.622134ms)
+Jul  2 13:38:54.551: INFO: (10) /api/v1/namespaces/e2e-tests-proxy-vfx29/services/proxy-service-lbscg:portname1/proxy/: foo (200; 10.294636ms)
+Jul  2 13:38:54.551: INFO: (10) /api/v1/namespaces/e2e-tests-proxy-vfx29/services/proxy-service-lbscg:portname2/proxy/: bar (200; 10.076435ms)
+Jul  2 13:38:54.552: INFO: (10) /api/v1/namespaces/e2e-tests-proxy-vfx29/services/http:proxy-service-lbscg:portname1/proxy/: foo (200; 10.749038ms)
+Jul  2 13:38:54.612: INFO: (11) /api/v1/namespaces/e2e-tests-proxy-vfx29/pods/http:proxy-service-lbscg-tnfcm:160/proxy/: foo (200; 59.90101ms)
+Jul  2 13:38:54.613: INFO: (11) /api/v1/namespaces/e2e-tests-proxy-vfx29/pods/https:proxy-service-lbscg-tnfcm:443/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-vfx29/pods/https:proxy-service-lbscg-tnfcm:443/proxy/... (200; 60.161811ms)
+Jul  2 13:38:54.613: INFO: (11) /api/v1/namespaces/e2e-tests-proxy-vfx29/pods/proxy-service-lbscg-tnfcm:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-vfx29/pods/proxy-service-lbscg-tnfcm:1080/proxy/rewri... (200; 60.297011ms)
+Jul  2 13:38:54.613: INFO: (11) /api/v1/namespaces/e2e-tests-proxy-vfx29/pods/http:proxy-service-lbscg-tnfcm:162/proxy/: bar (200; 60.502712ms)
+Jul  2 13:38:54.613: INFO: (11) /api/v1/namespaces/e2e-tests-proxy-vfx29/pods/proxy-service-lbscg-tnfcm:162/proxy/: bar (200; 60.789713ms)
+Jul  2 13:38:54.613: INFO: (11) /api/v1/namespaces/e2e-tests-proxy-vfx29/pods/proxy-service-lbscg-tnfcm:160/proxy/: foo (200; 61.053314ms)
+Jul  2 13:38:54.613: INFO: (11) /api/v1/namespaces/e2e-tests-proxy-vfx29/pods/proxy-service-lbscg-tnfcm/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-vfx29/pods/proxy-service-lbscg-tnfcm/proxy/rewriteme"... (200; 61.135114ms)
+Jul  2 13:38:54.614: INFO: (11) /api/v1/namespaces/e2e-tests-proxy-vfx29/services/https:proxy-service-lbscg:tlsportname1/proxy/: tls baz (200; 61.760316ms)
+Jul  2 13:38:54.614: INFO: (11) /api/v1/namespaces/e2e-tests-proxy-vfx29/pods/https:proxy-service-lbscg-tnfcm:460/proxy/: tls baz (200; 61.655916ms)
+Jul  2 13:38:54.614: INFO: (11) /api/v1/namespaces/e2e-tests-proxy-vfx29/pods/http:proxy-service-lbscg-tnfcm:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-vfx29/pods/http:proxy-service-lbscg-tnfcm:1080/proxy/... (200; 61.592015ms)
+Jul  2 13:38:54.614: INFO: (11) /api/v1/namespaces/e2e-tests-proxy-vfx29/pods/https:proxy-service-lbscg-tnfcm:462/proxy/: tls qux (200; 61.997417ms)
+Jul  2 13:38:54.655: INFO: (11) /api/v1/namespaces/e2e-tests-proxy-vfx29/services/http:proxy-service-lbscg:portname2/proxy/: bar (200; 102.546059ms)
+Jul  2 13:38:54.655: INFO: (11) /api/v1/namespaces/e2e-tests-proxy-vfx29/services/https:proxy-service-lbscg:tlsportname2/proxy/: tls qux (200; 102.368858ms)
+Jul  2 13:38:54.655: INFO: (11) /api/v1/namespaces/e2e-tests-proxy-vfx29/services/http:proxy-service-lbscg:portname1/proxy/: foo (200; 102.532759ms)
+Jul  2 13:38:54.655: INFO: (11) /api/v1/namespaces/e2e-tests-proxy-vfx29/services/proxy-service-lbscg:portname1/proxy/: foo (200; 102.521759ms)
+Jul  2 13:38:54.655: INFO: (11) /api/v1/namespaces/e2e-tests-proxy-vfx29/services/proxy-service-lbscg:portname2/proxy/: bar (200; 102.68236ms)
+Jul  2 13:38:54.662: INFO: (12) /api/v1/namespaces/e2e-tests-proxy-vfx29/pods/http:proxy-service-lbscg-tnfcm:162/proxy/: bar (200; 5.79352ms)
+Jul  2 13:38:54.662: INFO: (12) /api/v1/namespaces/e2e-tests-proxy-vfx29/pods/proxy-service-lbscg-tnfcm:162/proxy/: bar (200; 6.164522ms)
+Jul  2 13:38:54.662: INFO: (12) /api/v1/namespaces/e2e-tests-proxy-vfx29/pods/https:proxy-service-lbscg-tnfcm:462/proxy/: tls qux (200; 6.769724ms)
+Jul  2 13:38:54.662: INFO: (12) /api/v1/namespaces/e2e-tests-proxy-vfx29/pods/proxy-service-lbscg-tnfcm:160/proxy/: foo (200; 6.442422ms)
+Jul  2 13:38:54.662: INFO: (12) /api/v1/namespaces/e2e-tests-proxy-vfx29/pods/http:proxy-service-lbscg-tnfcm:160/proxy/: foo (200; 5.87602ms)
+Jul  2 13:38:54.662: INFO: (12) /api/v1/namespaces/e2e-tests-proxy-vfx29/pods/proxy-service-lbscg-tnfcm:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-vfx29/pods/proxy-service-lbscg-tnfcm:1080/proxy/rewri... (200; 6.194521ms)
+Jul  2 13:38:54.662: INFO: (12) /api/v1/namespaces/e2e-tests-proxy-vfx29/pods/https:proxy-service-lbscg-tnfcm:460/proxy/: tls baz (200; 6.891124ms)
+Jul  2 13:38:54.662: INFO: (12) /api/v1/namespaces/e2e-tests-proxy-vfx29/pods/proxy-service-lbscg-tnfcm/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-vfx29/pods/proxy-service-lbscg-tnfcm/proxy/rewriteme"... (200; 6.993124ms)
+Jul  2 13:38:54.662: INFO: (12) /api/v1/namespaces/e2e-tests-proxy-vfx29/pods/http:proxy-service-lbscg-tnfcm:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-vfx29/pods/http:proxy-service-lbscg-tnfcm:1080/proxy/... (200; 6.483223ms)
+Jul  2 13:38:54.662: INFO: (12) /api/v1/namespaces/e2e-tests-proxy-vfx29/pods/https:proxy-service-lbscg-tnfcm:443/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-vfx29/pods/https:proxy-service-lbscg-tnfcm:443/proxy/... (200; 6.119521ms)
+Jul  2 13:38:54.664: INFO: (12) /api/v1/namespaces/e2e-tests-proxy-vfx29/services/proxy-service-lbscg:portname1/proxy/: foo (200; 8.248329ms)
+Jul  2 13:38:54.706: INFO: (12) /api/v1/namespaces/e2e-tests-proxy-vfx29/services/http:proxy-service-lbscg:portname2/proxy/: bar (200; 50.533277ms)
+Jul  2 13:38:54.706: INFO: (12) /api/v1/namespaces/e2e-tests-proxy-vfx29/services/https:proxy-service-lbscg:tlsportname1/proxy/: tls baz (200; 49.997875ms)
+Jul  2 13:38:54.706: INFO: (12) /api/v1/namespaces/e2e-tests-proxy-vfx29/services/http:proxy-service-lbscg:portname1/proxy/: foo (200; 50.078275ms)
+Jul  2 13:38:54.706: INFO: (12) /api/v1/namespaces/e2e-tests-proxy-vfx29/services/proxy-service-lbscg:portname2/proxy/: bar (200; 50.365377ms)
+Jul  2 13:38:54.706: INFO: (12) /api/v1/namespaces/e2e-tests-proxy-vfx29/services/https:proxy-service-lbscg:tlsportname2/proxy/: tls qux (200; 50.138475ms)
+Jul  2 13:38:54.762: INFO: (13) /api/v1/namespaces/e2e-tests-proxy-vfx29/pods/proxy-service-lbscg-tnfcm/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-vfx29/pods/proxy-service-lbscg-tnfcm/proxy/rewriteme"... (200; 55.755596ms)
+Jul  2 13:38:54.762: INFO: (13) /api/v1/namespaces/e2e-tests-proxy-vfx29/pods/proxy-service-lbscg-tnfcm:162/proxy/: bar (200; 55.687895ms)
+Jul  2 13:38:54.762: INFO: (13) /api/v1/namespaces/e2e-tests-proxy-vfx29/pods/http:proxy-service-lbscg-tnfcm:162/proxy/: bar (200; 55.661095ms)
+Jul  2 13:38:54.762: INFO: (13) /api/v1/namespaces/e2e-tests-proxy-vfx29/pods/proxy-service-lbscg-tnfcm:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-vfx29/pods/proxy-service-lbscg-tnfcm:1080/proxy/rewri... (200; 55.541095ms)
+Jul  2 13:38:54.762: INFO: (13) /api/v1/namespaces/e2e-tests-proxy-vfx29/pods/https:proxy-service-lbscg-tnfcm:443/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-vfx29/pods/https:proxy-service-lbscg-tnfcm:443/proxy/... (200; 56.259497ms)
+Jul  2 13:38:54.762: INFO: (13) /api/v1/namespaces/e2e-tests-proxy-vfx29/pods/https:proxy-service-lbscg-tnfcm:462/proxy/: tls qux (200; 55.771396ms)
+Jul  2 13:38:54.762: INFO: (13) /api/v1/namespaces/e2e-tests-proxy-vfx29/pods/http:proxy-service-lbscg-tnfcm:160/proxy/: foo (200; 55.750196ms)
+Jul  2 13:38:54.763: INFO: (13) /api/v1/namespaces/e2e-tests-proxy-vfx29/pods/http:proxy-service-lbscg-tnfcm:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-vfx29/pods/http:proxy-service-lbscg-tnfcm:1080/proxy/... (200; 56.694399ms)
+Jul  2 13:38:54.763: INFO: (13) /api/v1/namespaces/e2e-tests-proxy-vfx29/services/https:proxy-service-lbscg:tlsportname1/proxy/: tls baz (200; 56.876299ms)
+Jul  2 13:38:54.763: INFO: (13) /api/v1/namespaces/e2e-tests-proxy-vfx29/pods/https:proxy-service-lbscg-tnfcm:460/proxy/: tls baz (200; 57.075799ms)
+Jul  2 13:38:54.763: INFO: (13) /api/v1/namespaces/e2e-tests-proxy-vfx29/services/https:proxy-service-lbscg:tlsportname2/proxy/: tls qux (200; 57.308601ms)
+Jul  2 13:38:54.763: INFO: (13) /api/v1/namespaces/e2e-tests-proxy-vfx29/pods/proxy-service-lbscg-tnfcm:160/proxy/: foo (200; 57.0917ms)
+Jul  2 13:38:54.764: INFO: (13) /api/v1/namespaces/e2e-tests-proxy-vfx29/services/http:proxy-service-lbscg:portname1/proxy/: foo (200; 57.683902ms)
+Jul  2 13:38:54.764: INFO: (13) /api/v1/namespaces/e2e-tests-proxy-vfx29/services/proxy-service-lbscg:portname1/proxy/: foo (200; 58.109304ms)
+Jul  2 13:38:54.765: INFO: (13) /api/v1/namespaces/e2e-tests-proxy-vfx29/services/http:proxy-service-lbscg:portname2/proxy/: bar (200; 58.958407ms)
+Jul  2 13:38:54.765: INFO: (13) /api/v1/namespaces/e2e-tests-proxy-vfx29/services/proxy-service-lbscg:portname2/proxy/: bar (200; 58.826706ms)
+Jul  2 13:38:54.863: INFO: (14) /api/v1/namespaces/e2e-tests-proxy-vfx29/pods/http:proxy-service-lbscg-tnfcm:160/proxy/: foo (200; 98.241444ms)
+Jul  2 13:38:54.865: INFO: (14) /api/v1/namespaces/e2e-tests-proxy-vfx29/pods/proxy-service-lbscg-tnfcm/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-vfx29/pods/proxy-service-lbscg-tnfcm/proxy/rewriteme"... (200; 99.114247ms)
+Jul  2 13:38:54.865: INFO: (14) /api/v1/namespaces/e2e-tests-proxy-vfx29/pods/proxy-service-lbscg-tnfcm:160/proxy/: foo (200; 98.951646ms)
+Jul  2 13:38:54.865: INFO: (14) /api/v1/namespaces/e2e-tests-proxy-vfx29/pods/https:proxy-service-lbscg-tnfcm:443/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-vfx29/pods/https:proxy-service-lbscg-tnfcm:443/proxy/... (200; 98.767846ms)
+Jul  2 13:38:54.865: INFO: (14) /api/v1/namespaces/e2e-tests-proxy-vfx29/pods/http:proxy-service-lbscg-tnfcm:162/proxy/: bar (200; 99.297848ms)
+Jul  2 13:38:54.865: INFO: (14) /api/v1/namespaces/e2e-tests-proxy-vfx29/pods/proxy-service-lbscg-tnfcm:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-vfx29/pods/proxy-service-lbscg-tnfcm:1080/proxy/rewri... (200; 98.550245ms)
+Jul  2 13:38:54.865: INFO: (14) /api/v1/namespaces/e2e-tests-proxy-vfx29/pods/http:proxy-service-lbscg-tnfcm:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-vfx29/pods/http:proxy-service-lbscg-tnfcm:1080/proxy/... (200; 98.897747ms)
+Jul  2 13:38:54.865: INFO: (14) /api/v1/namespaces/e2e-tests-proxy-vfx29/pods/proxy-service-lbscg-tnfcm:162/proxy/: bar (200; 98.955847ms)
+Jul  2 13:38:54.865: INFO: (14) /api/v1/namespaces/e2e-tests-proxy-vfx29/pods/https:proxy-service-lbscg-tnfcm:460/proxy/: tls baz (200; 99.148747ms)
+Jul  2 13:38:54.865: INFO: (14) /api/v1/namespaces/e2e-tests-proxy-vfx29/pods/https:proxy-service-lbscg-tnfcm:462/proxy/: tls qux (200; 98.661246ms)
+Jul  2 13:38:54.866: INFO: (14) /api/v1/namespaces/e2e-tests-proxy-vfx29/services/proxy-service-lbscg:portname1/proxy/: foo (200; 100.048451ms)
+Jul  2 13:38:54.866: INFO: (14) /api/v1/namespaces/e2e-tests-proxy-vfx29/services/https:proxy-service-lbscg:tlsportname2/proxy/: tls qux (200; 100.125751ms)
+Jul  2 13:38:54.866: INFO: (14) /api/v1/namespaces/e2e-tests-proxy-vfx29/services/https:proxy-service-lbscg:tlsportname1/proxy/: tls baz (200; 100.312452ms)
+Jul  2 13:38:54.866: INFO: (14) /api/v1/namespaces/e2e-tests-proxy-vfx29/services/http:proxy-service-lbscg:portname1/proxy/: foo (200; 100.411152ms)
+Jul  2 13:38:54.866: INFO: (14) /api/v1/namespaces/e2e-tests-proxy-vfx29/services/proxy-service-lbscg:portname2/proxy/: bar (200; 100.747653ms)
+Jul  2 13:38:54.867: INFO: (14) /api/v1/namespaces/e2e-tests-proxy-vfx29/services/http:proxy-service-lbscg:portname2/proxy/: bar (200; 101.312855ms)
+Jul  2 13:38:54.875: INFO: (15) /api/v1/namespaces/e2e-tests-proxy-vfx29/pods/proxy-service-lbscg-tnfcm:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-vfx29/pods/proxy-service-lbscg-tnfcm:1080/proxy/rewri... (200; 7.737227ms)
+Jul  2 13:38:54.875: INFO: (15) /api/v1/namespaces/e2e-tests-proxy-vfx29/pods/proxy-service-lbscg-tnfcm:162/proxy/: bar (200; 7.163625ms)
+Jul  2 13:38:54.875: INFO: (15) /api/v1/namespaces/e2e-tests-proxy-vfx29/pods/http:proxy-service-lbscg-tnfcm:160/proxy/: foo (200; 7.807627ms)
+Jul  2 13:38:54.875: INFO: (15) /api/v1/namespaces/e2e-tests-proxy-vfx29/pods/https:proxy-service-lbscg-tnfcm:462/proxy/: tls qux (200; 7.642927ms)
+Jul  2 13:38:54.875: INFO: (15) /api/v1/namespaces/e2e-tests-proxy-vfx29/pods/https:proxy-service-lbscg-tnfcm:443/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-vfx29/pods/https:proxy-service-lbscg-tnfcm:443/proxy/... (200; 7.739927ms)
+Jul  2 13:38:54.875: INFO: (15) /api/v1/namespaces/e2e-tests-proxy-vfx29/pods/http:proxy-service-lbscg-tnfcm:162/proxy/: bar (200; 8.422929ms)
+Jul  2 13:38:54.877: INFO: (15) /api/v1/namespaces/e2e-tests-proxy-vfx29/pods/http:proxy-service-lbscg-tnfcm:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-vfx29/pods/http:proxy-service-lbscg-tnfcm:1080/proxy/... (200; 8.587131ms)
+Jul  2 13:38:54.877: INFO: (15) /api/v1/namespaces/e2e-tests-proxy-vfx29/services/proxy-service-lbscg:portname1/proxy/: foo (200; 9.799935ms)
+Jul  2 13:38:54.877: INFO: (15) /api/v1/namespaces/e2e-tests-proxy-vfx29/services/https:proxy-service-lbscg:tlsportname1/proxy/: tls baz (200; 8.842731ms)
+Jul  2 13:38:54.877: INFO: (15) /api/v1/namespaces/e2e-tests-proxy-vfx29/pods/https:proxy-service-lbscg-tnfcm:460/proxy/: tls baz (200; 9.195932ms)
+Jul  2 13:38:54.877: INFO: (15) /api/v1/namespaces/e2e-tests-proxy-vfx29/pods/proxy-service-lbscg-tnfcm/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-vfx29/pods/proxy-service-lbscg-tnfcm/proxy/rewriteme"... (200; 9.472833ms)
+Jul  2 13:38:54.877: INFO: (15) /api/v1/namespaces/e2e-tests-proxy-vfx29/services/https:proxy-service-lbscg:tlsportname2/proxy/: tls qux (200; 9.067432ms)
+Jul  2 13:38:54.878: INFO: (15) /api/v1/namespaces/e2e-tests-proxy-vfx29/services/http:proxy-service-lbscg:portname2/proxy/: bar (200; 10.727438ms)
+Jul  2 13:38:54.879: INFO: (15) /api/v1/namespaces/e2e-tests-proxy-vfx29/services/proxy-service-lbscg:portname2/proxy/: bar (200; 10.601737ms)
+Jul  2 13:38:54.879: INFO: (15) /api/v1/namespaces/e2e-tests-proxy-vfx29/pods/proxy-service-lbscg-tnfcm:160/proxy/: foo (200; 10.581437ms)
+Jul  2 13:38:54.879: INFO: (15) /api/v1/namespaces/e2e-tests-proxy-vfx29/services/http:proxy-service-lbscg:portname1/proxy/: foo (200; 10.558637ms)
+Jul  2 13:38:54.889: INFO: (16) /api/v1/namespaces/e2e-tests-proxy-vfx29/pods/http:proxy-service-lbscg-tnfcm:160/proxy/: foo (200; 10.141935ms)
+Jul  2 13:38:54.889: INFO: (16) /api/v1/namespaces/e2e-tests-proxy-vfx29/pods/proxy-service-lbscg-tnfcm/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-vfx29/pods/proxy-service-lbscg-tnfcm/proxy/rewriteme"... (200; 9.949234ms)
+Jul  2 13:38:54.889: INFO: (16) /api/v1/namespaces/e2e-tests-proxy-vfx29/pods/proxy-service-lbscg-tnfcm:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-vfx29/pods/proxy-service-lbscg-tnfcm:1080/proxy/rewri... (200; 10.224135ms)
+Jul  2 13:38:54.889: INFO: (16) /api/v1/namespaces/e2e-tests-proxy-vfx29/pods/http:proxy-service-lbscg-tnfcm:162/proxy/: bar (200; 10.377236ms)
+Jul  2 13:38:54.890: INFO: (16) /api/v1/namespaces/e2e-tests-proxy-vfx29/services/https:proxy-service-lbscg:tlsportname2/proxy/: tls qux (200; 9.789434ms)
+Jul  2 13:38:54.890: INFO: (16) /api/v1/namespaces/e2e-tests-proxy-vfx29/pods/proxy-service-lbscg-tnfcm:162/proxy/: bar (200; 9.984435ms)
+Jul  2 13:38:54.890: INFO: (16) /api/v1/namespaces/e2e-tests-proxy-vfx29/services/proxy-service-lbscg:portname1/proxy/: foo (200; 10.693138ms)
+Jul  2 13:38:54.890: INFO: (16) /api/v1/namespaces/e2e-tests-proxy-vfx29/pods/http:proxy-service-lbscg-tnfcm:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-vfx29/pods/http:proxy-service-lbscg-tnfcm:1080/proxy/... (200; 9.853935ms)
+Jul  2 13:38:54.890: INFO: (16) /api/v1/namespaces/e2e-tests-proxy-vfx29/pods/https:proxy-service-lbscg-tnfcm:443/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-vfx29/pods/https:proxy-service-lbscg-tnfcm:443/proxy/... (200; 10.552937ms)
+Jul  2 13:38:54.890: INFO: (16) /api/v1/namespaces/e2e-tests-proxy-vfx29/pods/proxy-service-lbscg-tnfcm:160/proxy/: foo (200; 10.709338ms)
+Jul  2 13:38:54.890: INFO: (16) /api/v1/namespaces/e2e-tests-proxy-vfx29/pods/https:proxy-service-lbscg-tnfcm:460/proxy/: tls baz (200; 10.856138ms)
+Jul  2 13:38:54.890: INFO: (16) /api/v1/namespaces/e2e-tests-proxy-vfx29/services/https:proxy-service-lbscg:tlsportname1/proxy/: tls baz (200; 10.564837ms)
+Jul  2 13:38:54.890: INFO: (16) /api/v1/namespaces/e2e-tests-proxy-vfx29/pods/https:proxy-service-lbscg-tnfcm:462/proxy/: tls qux (200; 11.086339ms)
+Jul  2 13:38:54.890: INFO: (16) /api/v1/namespaces/e2e-tests-proxy-vfx29/services/proxy-service-lbscg:portname2/proxy/: bar (200; 10.856638ms)
+Jul  2 13:38:54.928: INFO: (16) /api/v1/namespaces/e2e-tests-proxy-vfx29/services/http:proxy-service-lbscg:portname2/proxy/: bar (200; 49.233673ms)
+Jul  2 13:38:54.928: INFO: (16) /api/v1/namespaces/e2e-tests-proxy-vfx29/services/http:proxy-service-lbscg:portname1/proxy/: foo (200; 48.884471ms)
+Jul  2 13:38:54.936: INFO: (17) /api/v1/namespaces/e2e-tests-proxy-vfx29/pods/http:proxy-service-lbscg-tnfcm:160/proxy/: foo (200; 7.566126ms)
+Jul  2 13:38:54.936: INFO: (17) /api/v1/namespaces/e2e-tests-proxy-vfx29/pods/proxy-service-lbscg-tnfcm:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-vfx29/pods/proxy-service-lbscg-tnfcm:1080/proxy/rewri... (200; 7.647526ms)
+Jul  2 13:38:54.936: INFO: (17) /api/v1/namespaces/e2e-tests-proxy-vfx29/pods/https:proxy-service-lbscg-tnfcm:462/proxy/: tls qux (200; 7.513427ms)
+Jul  2 13:38:54.936: INFO: (17) /api/v1/namespaces/e2e-tests-proxy-vfx29/pods/https:proxy-service-lbscg-tnfcm:443/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-vfx29/pods/https:proxy-service-lbscg-tnfcm:443/proxy/... (200; 7.579727ms)
+Jul  2 13:38:54.938: INFO: (17) /api/v1/namespaces/e2e-tests-proxy-vfx29/services/https:proxy-service-lbscg:tlsportname1/proxy/: tls baz (200; 8.180529ms)
+Jul  2 13:38:54.939: INFO: (17) /api/v1/namespaces/e2e-tests-proxy-vfx29/pods/proxy-service-lbscg-tnfcm/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-vfx29/pods/proxy-service-lbscg-tnfcm/proxy/rewriteme"... (200; 9.835634ms)
+Jul  2 13:38:54.939: INFO: (17) /api/v1/namespaces/e2e-tests-proxy-vfx29/pods/http:proxy-service-lbscg-tnfcm:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-vfx29/pods/http:proxy-service-lbscg-tnfcm:1080/proxy/... (200; 9.395633ms)
+Jul  2 13:38:54.939: INFO: (17) /api/v1/namespaces/e2e-tests-proxy-vfx29/pods/proxy-service-lbscg-tnfcm:160/proxy/: foo (200; 9.776734ms)
+Jul  2 13:38:54.939: INFO: (17) /api/v1/namespaces/e2e-tests-proxy-vfx29/services/http:proxy-service-lbscg:portname2/proxy/: bar (200; 10.060036ms)
+Jul  2 13:38:54.939: INFO: (17) /api/v1/namespaces/e2e-tests-proxy-vfx29/pods/http:proxy-service-lbscg-tnfcm:162/proxy/: bar (200; 10.476437ms)
+Jul  2 13:38:54.939: INFO: (17) /api/v1/namespaces/e2e-tests-proxy-vfx29/services/https:proxy-service-lbscg:tlsportname2/proxy/: tls qux (200; 9.644134ms)
+Jul  2 13:38:54.939: INFO: (17) /api/v1/namespaces/e2e-tests-proxy-vfx29/services/http:proxy-service-lbscg:portname1/proxy/: foo (200; 9.871534ms)
+Jul  2 13:38:54.939: INFO: (17) /api/v1/namespaces/e2e-tests-proxy-vfx29/pods/https:proxy-service-lbscg-tnfcm:460/proxy/: tls baz (200; 10.154735ms)
+Jul  2 13:38:54.940: INFO: (17) /api/v1/namespaces/e2e-tests-proxy-vfx29/services/proxy-service-lbscg:portname2/proxy/: bar (200; 10.438537ms)
+Jul  2 13:38:54.940: INFO: (17) /api/v1/namespaces/e2e-tests-proxy-vfx29/pods/proxy-service-lbscg-tnfcm:162/proxy/: bar (200; 10.745138ms)
+Jul  2 13:38:54.940: INFO: (17) /api/v1/namespaces/e2e-tests-proxy-vfx29/services/proxy-service-lbscg:portname1/proxy/: foo (200; 11.358439ms)
+Jul  2 13:38:54.954: INFO: (18) /api/v1/namespaces/e2e-tests-proxy-vfx29/pods/https:proxy-service-lbscg-tnfcm:460/proxy/: tls baz (200; 13.252447ms)
+Jul  2 13:38:54.954: INFO: (18) /api/v1/namespaces/e2e-tests-proxy-vfx29/pods/proxy-service-lbscg-tnfcm/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-vfx29/pods/proxy-service-lbscg-tnfcm/proxy/rewriteme"... (200; 13.359247ms)
+Jul  2 13:38:54.954: INFO: (18) /api/v1/namespaces/e2e-tests-proxy-vfx29/pods/https:proxy-service-lbscg-tnfcm:443/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-vfx29/pods/https:proxy-service-lbscg-tnfcm:443/proxy/... (200; 13.528047ms)
+Jul  2 13:38:54.954: INFO: (18) /api/v1/namespaces/e2e-tests-proxy-vfx29/pods/http:proxy-service-lbscg-tnfcm:162/proxy/: bar (200; 12.977045ms)
+Jul  2 13:38:54.954: INFO: (18) /api/v1/namespaces/e2e-tests-proxy-vfx29/pods/https:proxy-service-lbscg-tnfcm:462/proxy/: tls qux (200; 13.927049ms)
+Jul  2 13:38:54.954: INFO: (18) /api/v1/namespaces/e2e-tests-proxy-vfx29/services/http:proxy-service-lbscg:portname2/proxy/: bar (200; 13.540147ms)
+Jul  2 13:38:54.954: INFO: (18) /api/v1/namespaces/e2e-tests-proxy-vfx29/pods/http:proxy-service-lbscg-tnfcm:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-vfx29/pods/http:proxy-service-lbscg-tnfcm:1080/proxy/... (200; 14.130649ms)
+Jul  2 13:38:54.954: INFO: (18) /api/v1/namespaces/e2e-tests-proxy-vfx29/pods/proxy-service-lbscg-tnfcm:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-vfx29/pods/proxy-service-lbscg-tnfcm:1080/proxy/rewri... (200; 13.810848ms)
+Jul  2 13:38:54.954: INFO: (18) /api/v1/namespaces/e2e-tests-proxy-vfx29/services/proxy-service-lbscg:portname1/proxy/: foo (200; 13.907648ms)
+Jul  2 13:38:54.955: INFO: (18) /api/v1/namespaces/e2e-tests-proxy-vfx29/services/https:proxy-service-lbscg:tlsportname2/proxy/: tls qux (200; 13.613747ms)
+Jul  2 13:38:54.956: INFO: (18) /api/v1/namespaces/e2e-tests-proxy-vfx29/pods/proxy-service-lbscg-tnfcm:160/proxy/: foo (200; 14.643951ms)
+Jul  2 13:38:54.956: INFO: (18) /api/v1/namespaces/e2e-tests-proxy-vfx29/pods/http:proxy-service-lbscg-tnfcm:160/proxy/: foo (200; 15.158353ms)
+Jul  2 13:38:54.956: INFO: (18) /api/v1/namespaces/e2e-tests-proxy-vfx29/services/https:proxy-service-lbscg:tlsportname1/proxy/: tls baz (200; 14.28765ms)
+Jul  2 13:38:54.956: INFO: (18) /api/v1/namespaces/e2e-tests-proxy-vfx29/pods/proxy-service-lbscg-tnfcm:162/proxy/: bar (200; 14.998753ms)
+Jul  2 13:38:54.956: INFO: (18) /api/v1/namespaces/e2e-tests-proxy-vfx29/services/proxy-service-lbscg:portname2/proxy/: bar (200; 15.203253ms)
+Jul  2 13:38:54.959: INFO: (18) /api/v1/namespaces/e2e-tests-proxy-vfx29/services/http:proxy-service-lbscg:portname1/proxy/: foo (200; 17.698262ms)
+Jul  2 13:38:54.966: INFO: (19) /api/v1/namespaces/e2e-tests-proxy-vfx29/pods/proxy-service-lbscg-tnfcm:162/proxy/: bar (200; 6.915725ms)
+Jul  2 13:38:54.966: INFO: (19) /api/v1/namespaces/e2e-tests-proxy-vfx29/pods/https:proxy-service-lbscg-tnfcm:443/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-vfx29/pods/https:proxy-service-lbscg-tnfcm:443/proxy/... (200; 6.887824ms)
+Jul  2 13:38:54.967: INFO: (19) /api/v1/namespaces/e2e-tests-proxy-vfx29/pods/proxy-service-lbscg-tnfcm:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-vfx29/pods/proxy-service-lbscg-tnfcm:1080/proxy/rewri... (200; 6.587423ms)
+Jul  2 13:38:54.967: INFO: (19) /api/v1/namespaces/e2e-tests-proxy-vfx29/pods/http:proxy-service-lbscg-tnfcm:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-vfx29/pods/http:proxy-service-lbscg-tnfcm:1080/proxy/... (200; 6.937324ms)
+Jul  2 13:38:54.967: INFO: (19) /api/v1/namespaces/e2e-tests-proxy-vfx29/services/http:proxy-service-lbscg:portname1/proxy/: foo (200; 7.241825ms)
+Jul  2 13:38:54.967: INFO: (19) /api/v1/namespaces/e2e-tests-proxy-vfx29/pods/https:proxy-service-lbscg-tnfcm:462/proxy/: tls qux (200; 6.925625ms)
+Jul  2 13:38:54.967: INFO: (19) /api/v1/namespaces/e2e-tests-proxy-vfx29/pods/http:proxy-service-lbscg-tnfcm:162/proxy/: bar (200; 6.859724ms)
+Jul  2 13:38:54.967: INFO: (19) /api/v1/namespaces/e2e-tests-proxy-vfx29/services/https:proxy-service-lbscg:tlsportname2/proxy/: tls qux (200; 7.470026ms)
+Jul  2 13:38:54.967: INFO: (19) /api/v1/namespaces/e2e-tests-proxy-vfx29/pods/http:proxy-service-lbscg-tnfcm:160/proxy/: foo (200; 7.102525ms)
+Jul  2 13:38:54.967: INFO: (19) /api/v1/namespaces/e2e-tests-proxy-vfx29/services/https:proxy-service-lbscg:tlsportname1/proxy/: tls baz (200; 7.632127ms)
+Jul  2 13:38:54.968: INFO: (19) /api/v1/namespaces/e2e-tests-proxy-vfx29/services/http:proxy-service-lbscg:portname2/proxy/: bar (200; 8.47053ms)
+Jul  2 13:38:54.969: INFO: (19) /api/v1/namespaces/e2e-tests-proxy-vfx29/pods/proxy-service-lbscg-tnfcm/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-vfx29/pods/proxy-service-lbscg-tnfcm/proxy/rewriteme"... (200; 9.022232ms)
+Jul  2 13:38:54.969: INFO: (19) /api/v1/namespaces/e2e-tests-proxy-vfx29/pods/https:proxy-service-lbscg-tnfcm:460/proxy/: tls baz (200; 8.954232ms)
+Jul  2 13:38:54.969: INFO: (19) /api/v1/namespaces/e2e-tests-proxy-vfx29/pods/proxy-service-lbscg-tnfcm:160/proxy/: foo (200; 9.035731ms)
+Jul  2 13:38:54.969: INFO: (19) /api/v1/namespaces/e2e-tests-proxy-vfx29/services/proxy-service-lbscg:portname1/proxy/: foo (200; 9.435633ms)
+Jul  2 13:38:54.969: INFO: (19) /api/v1/namespaces/e2e-tests-proxy-vfx29/services/proxy-service-lbscg:portname2/proxy/: bar (200; 9.321832ms)
+STEP: deleting { ReplicationController} proxy-service-lbscg in namespace e2e-tests-proxy-vfx29, will wait for the garbage collector to delete the pods
+Jul  2 13:38:55.030: INFO: Deleting { ReplicationController} proxy-service-lbscg took: 6.578523ms
+Jul  2 13:38:55.133: INFO: Terminating { ReplicationController} proxy-service-lbscg pods took: 103.306661ms
+[AfterEach] version v1
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:38:57.533: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-proxy-vfx29" for this suite.
+Jul  2 13:39:03.565: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:39:03.594: INFO: namespace: e2e-tests-proxy-vfx29, resource: bindings, ignored listing per whitelist
+Jul  2 13:39:03.661: INFO: namespace e2e-tests-proxy-vfx29 deletion completed in 6.122627164s
+
+• [SLOW TEST:16.660 seconds]
+[sig-network] Proxy
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/network/framework.go:22
+  version v1
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/network/proxy.go:56
+    should proxy through a service and a pod  [Conformance]
+    /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSS
+------------------------------
+[k8s.io] [sig-node] PreStop 
+  should call prestop when killing a pod  [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [k8s.io] [sig-node] PreStop
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:39:03.661: INFO: >>> kubeConfig: /tmp/kubeconfig-324782104
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should call prestop when killing a pod  [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating server pod server in namespace e2e-tests-prestop-8nbb8
+STEP: Waiting for pods to come up.
+STEP: Creating tester pod tester in namespace e2e-tests-prestop-8nbb8
+STEP: Deleting pre-stop pod
+Jul  2 13:39:19.028: INFO: Saw: {
+	"Hostname": "server",
+	"Sent": null,
+	"Received": {
+		"prestop": 1
+	},
+	"Errors": null,
+	"Log": [
+		"default/nettest has 0 endpoints ([]), which is less than 8 as expected. Waiting for all endpoints to come up.",
+		"default/nettest has 0 endpoints ([]), which is less than 8 as expected. Waiting for all endpoints to come up.",
+		"default/nettest has 0 endpoints ([]), which is less than 8 as expected. Waiting for all endpoints to come up."
+	],
+	"StillContactingPeers": true
+}
+STEP: Deleting the server pod
+[AfterEach] [k8s.io] [sig-node] PreStop
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:39:19.033: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-prestop-8nbb8" for this suite.
+Jul  2 13:39:57.053: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:39:57.152: INFO: namespace: e2e-tests-prestop-8nbb8, resource: bindings, ignored listing per whitelist
+Jul  2 13:39:57.212: INFO: namespace e2e-tests-prestop-8nbb8 deletion completed in 38.169674471s
+
+• [SLOW TEST:53.551 seconds]
+[k8s.io] [sig-node] PreStop
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:679
+  should call prestop when killing a pod  [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSSSSSSSSSSSSS
+------------------------------
+[k8s.io] Docker Containers 
+  should be able to override the image's default arguments (docker cmd) [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [k8s.io] Docker Containers
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:39:57.213: INFO: >>> kubeConfig: /tmp/kubeconfig-324782104
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should be able to override the image's default arguments (docker cmd) [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating a pod to test override arguments
+Jul  2 13:39:57.319: INFO: Waiting up to 5m0s for pod "client-containers-68c9f100-7dfd-11e8-8e15-aefe7bc77cc2" in namespace "e2e-tests-containers-jgtt7" to be "success or failure"
+Jul  2 13:39:57.323: INFO: Pod "client-containers-68c9f100-7dfd-11e8-8e15-aefe7bc77cc2": Phase="Pending", Reason="", readiness=false. Elapsed: 3.994412ms
+Jul  2 13:39:59.327: INFO: Pod "client-containers-68c9f100-7dfd-11e8-8e15-aefe7bc77cc2": Phase="Pending", Reason="", readiness=false. Elapsed: 2.007568984s
+Jul  2 13:40:01.330: INFO: Pod "client-containers-68c9f100-7dfd-11e8-8e15-aefe7bc77cc2": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.010567788s
+STEP: Saw pod success
+Jul  2 13:40:01.330: INFO: Pod "client-containers-68c9f100-7dfd-11e8-8e15-aefe7bc77cc2" satisfied condition "success or failure"
+Jul  2 13:40:01.332: INFO: Trying to get logs from node shoot--core--confaz-worker-qfmi9-79968b77d9-kcr6j pod client-containers-68c9f100-7dfd-11e8-8e15-aefe7bc77cc2 container test-container: <nil>
+STEP: delete the pod
+Jul  2 13:40:01.351: INFO: Waiting for pod client-containers-68c9f100-7dfd-11e8-8e15-aefe7bc77cc2 to disappear
+Jul  2 13:40:01.364: INFO: Pod client-containers-68c9f100-7dfd-11e8-8e15-aefe7bc77cc2 no longer exists
+[AfterEach] [k8s.io] Docker Containers
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:40:01.364: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-containers-jgtt7" for this suite.
+Jul  2 13:40:07.379: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:40:07.441: INFO: namespace: e2e-tests-containers-jgtt7, resource: bindings, ignored listing per whitelist
+Jul  2 13:40:07.515: INFO: namespace e2e-tests-containers-jgtt7 deletion completed in 6.147679005s
+
+• [SLOW TEST:10.302 seconds]
+[k8s.io] Docker Containers
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:679
+  should be able to override the image's default arguments (docker cmd) [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSSSSS
+------------------------------
+[sig-storage] Projected 
+  should be consumable from pods in volume with mappings and Item Mode set [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:40:07.515: INFO: >>> kubeConfig: /tmp/kubeconfig-324782104
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:858
+[It] should be consumable from pods in volume with mappings and Item Mode set [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating projection with secret that has name projected-secret-test-map-6eed1d4c-7dfd-11e8-8e15-aefe7bc77cc2
+STEP: Creating a pod to test consume secrets
+Jul  2 13:40:07.625: INFO: Waiting up to 5m0s for pod "pod-projected-secrets-6eeea94e-7dfd-11e8-8e15-aefe7bc77cc2" in namespace "e2e-tests-projected-98sh7" to be "success or failure"
+Jul  2 13:40:07.628: INFO: Pod "pod-projected-secrets-6eeea94e-7dfd-11e8-8e15-aefe7bc77cc2": Phase="Pending", Reason="", readiness=false. Elapsed: 2.96971ms
+Jul  2 13:40:09.631: INFO: Pod "pod-projected-secrets-6eeea94e-7dfd-11e8-8e15-aefe7bc77cc2": Phase="Pending", Reason="", readiness=false. Elapsed: 2.006260635s
+Jul  2 13:40:11.635: INFO: Pod "pod-projected-secrets-6eeea94e-7dfd-11e8-8e15-aefe7bc77cc2": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.009557655s
+STEP: Saw pod success
+Jul  2 13:40:11.635: INFO: Pod "pod-projected-secrets-6eeea94e-7dfd-11e8-8e15-aefe7bc77cc2" satisfied condition "success or failure"
+Jul  2 13:40:11.637: INFO: Trying to get logs from node shoot--core--confaz-worker-qfmi9-79968b77d9-kcr6j pod pod-projected-secrets-6eeea94e-7dfd-11e8-8e15-aefe7bc77cc2 container projected-secret-volume-test: <nil>
+STEP: delete the pod
+Jul  2 13:40:11.666: INFO: Waiting for pod pod-projected-secrets-6eeea94e-7dfd-11e8-8e15-aefe7bc77cc2 to disappear
+Jul  2 13:40:11.669: INFO: Pod pod-projected-secrets-6eeea94e-7dfd-11e8-8e15-aefe7bc77cc2 no longer exists
+[AfterEach] [sig-storage] Projected
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:40:11.669: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-98sh7" for this suite.
+Jul  2 13:40:17.685: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:40:17.822: INFO: namespace: e2e-tests-projected-98sh7, resource: bindings, ignored listing per whitelist
+Jul  2 13:40:17.839: INFO: namespace e2e-tests-projected-98sh7 deletion completed in 6.16620373s
+
+• [SLOW TEST:10.324 seconds]
+[sig-storage] Projected
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:34
+  should be consumable from pods in volume with mappings and Item Mode set [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSSSSSSSSSSSSSS
+------------------------------
+[sig-storage] Secrets 
+  should be consumable from pods in volume as non-root with defaultMode and fsGroup set [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-storage] Secrets
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:40:17.840: INFO: >>> kubeConfig: /tmp/kubeconfig-324782104
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should be consumable from pods in volume as non-root with defaultMode and fsGroup set [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating secret with name secret-test-7515ba3d-7dfd-11e8-8e15-aefe7bc77cc2
+STEP: Creating a pod to test consume secrets
+Jul  2 13:40:17.944: INFO: Waiting up to 5m0s for pod "pod-secrets-7516384e-7dfd-11e8-8e15-aefe7bc77cc2" in namespace "e2e-tests-secrets-pqrds" to be "success or failure"
+Jul  2 13:40:17.953: INFO: Pod "pod-secrets-7516384e-7dfd-11e8-8e15-aefe7bc77cc2": Phase="Pending", Reason="", readiness=false. Elapsed: 9.170733ms
+Jul  2 13:40:19.958: INFO: Pod "pod-secrets-7516384e-7dfd-11e8-8e15-aefe7bc77cc2": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.013597448s
+STEP: Saw pod success
+Jul  2 13:40:19.958: INFO: Pod "pod-secrets-7516384e-7dfd-11e8-8e15-aefe7bc77cc2" satisfied condition "success or failure"
+Jul  2 13:40:19.962: INFO: Trying to get logs from node shoot--core--confaz-worker-qfmi9-79968b77d9-kcr6j pod pod-secrets-7516384e-7dfd-11e8-8e15-aefe7bc77cc2 container secret-volume-test: <nil>
+STEP: delete the pod
+Jul  2 13:40:19.998: INFO: Waiting for pod pod-secrets-7516384e-7dfd-11e8-8e15-aefe7bc77cc2 to disappear
+Jul  2 13:40:20.033: INFO: Pod pod-secrets-7516384e-7dfd-11e8-8e15-aefe7bc77cc2 no longer exists
+[AfterEach] [sig-storage] Secrets
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:40:20.033: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-secrets-pqrds" for this suite.
+Jul  2 13:40:26.074: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:40:26.087: INFO: namespace: e2e-tests-secrets-pqrds, resource: bindings, ignored listing per whitelist
+Jul  2 13:40:26.175: INFO: namespace e2e-tests-secrets-pqrds deletion completed in 6.136104675s
+
+• [SLOW TEST:8.335 seconds]
+[sig-storage] Secrets
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/secrets_volume.go:33
+  should be consumable from pods in volume as non-root with defaultMode and fsGroup set [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+[sig-storage] ConfigMap 
+  should be consumable from pods in volume with defaultMode set [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-storage] ConfigMap
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:40:26.175: INFO: >>> kubeConfig: /tmp/kubeconfig-324782104
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should be consumable from pods in volume with defaultMode set [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating configMap with name configmap-test-volume-7a10c1ca-7dfd-11e8-8e15-aefe7bc77cc2
+STEP: Creating a pod to test consume configMaps
+Jul  2 13:40:26.307: INFO: Waiting up to 5m0s for pod "pod-configmaps-7a126419-7dfd-11e8-8e15-aefe7bc77cc2" in namespace "e2e-tests-configmap-zc4fg" to be "success or failure"
+Jul  2 13:40:26.313: INFO: Pod "pod-configmaps-7a126419-7dfd-11e8-8e15-aefe7bc77cc2": Phase="Pending", Reason="", readiness=false. Elapsed: 5.19952ms
+Jul  2 13:40:28.316: INFO: Pod "pod-configmaps-7a126419-7dfd-11e8-8e15-aefe7bc77cc2": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.0091166s
+STEP: Saw pod success
+Jul  2 13:40:28.316: INFO: Pod "pod-configmaps-7a126419-7dfd-11e8-8e15-aefe7bc77cc2" satisfied condition "success or failure"
+Jul  2 13:40:28.319: INFO: Trying to get logs from node shoot--core--confaz-worker-qfmi9-79968b77d9-kcr6j pod pod-configmaps-7a126419-7dfd-11e8-8e15-aefe7bc77cc2 container configmap-volume-test: <nil>
+STEP: delete the pod
+Jul  2 13:40:28.339: INFO: Waiting for pod pod-configmaps-7a126419-7dfd-11e8-8e15-aefe7bc77cc2 to disappear
+Jul  2 13:40:28.343: INFO: Pod pod-configmaps-7a126419-7dfd-11e8-8e15-aefe7bc77cc2 no longer exists
+[AfterEach] [sig-storage] ConfigMap
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:40:28.343: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-configmap-zc4fg" for this suite.
+Jul  2 13:40:34.368: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:40:34.377: INFO: namespace: e2e-tests-configmap-zc4fg, resource: bindings, ignored listing per whitelist
+Jul  2 13:40:34.538: INFO: namespace e2e-tests-configmap-zc4fg deletion completed in 6.182940508s
+
+• [SLOW TEST:8.363 seconds]
+[sig-storage] ConfigMap
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/configmap_volume.go:32
+  should be consumable from pods in volume with defaultMode set [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSSSSSSSSSSSSSSSSSSSS
+------------------------------
+[sig-api-machinery] Garbage collector 
+  should delete pods created by rc when not orphaning [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-api-machinery] Garbage collector
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:40:34.538: INFO: >>> kubeConfig: /tmp/kubeconfig-324782104
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should delete pods created by rc when not orphaning [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: create the rc
+STEP: delete the rc
+STEP: wait for all pods to be garbage collected
+STEP: Gathering metrics
+W0702 13:40:44.769033      15 metrics_grabber.go:81] Master node is not registered. Grabbing metrics from Scheduler, ControllerManager and ClusterAutoscaler is disabled.
+Jul  2 13:40:44.769: INFO: For apiserver_request_count:
+For apiserver_request_latencies_summary:
+For etcd_helper_cache_entry_count:
+For etcd_helper_cache_hit_count:
+For etcd_helper_cache_miss_count:
+For etcd_request_cache_add_latencies_summary:
+For etcd_request_cache_get_latencies_summary:
+For etcd_request_latencies_summary:
+For garbage_collector_attempt_to_delete_queue_latency:
+For garbage_collector_attempt_to_delete_work_duration:
+For garbage_collector_attempt_to_orphan_queue_latency:
+For garbage_collector_attempt_to_orphan_work_duration:
+For garbage_collector_dirty_processing_latency_microseconds:
+For garbage_collector_event_processing_latency_microseconds:
+For garbage_collector_graph_changes_queue_latency:
+For garbage_collector_graph_changes_work_duration:
+For garbage_collector_orphan_processing_latency_microseconds:
+For namespace_queue_latency:
+For namespace_queue_latency_sum:
+For namespace_queue_latency_count:
+For namespace_retries:
+For namespace_work_duration:
+For namespace_work_duration_sum:
+For namespace_work_duration_count:
+For function_duration_seconds:
+For errors_total:
+For evicted_pods_total:
+
+[AfterEach] [sig-api-machinery] Garbage collector
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:40:44.769: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-gc-br74m" for this suite.
+Jul  2 13:40:50.787: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:40:50.869: INFO: namespace: e2e-tests-gc-br74m, resource: bindings, ignored listing per whitelist
+Jul  2 13:40:50.926: INFO: namespace e2e-tests-gc-br74m deletion completed in 6.153079825s
+
+• [SLOW TEST:16.388 seconds]
+[sig-api-machinery] Garbage collector
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apimachinery/framework.go:22
+  should delete pods created by rc when not orphaning [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSSS
+------------------------------
+[k8s.io] Docker Containers 
+  should be able to override the image's default command (docker entrypoint) [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [k8s.io] Docker Containers
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:40:50.926: INFO: >>> kubeConfig: /tmp/kubeconfig-324782104
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should be able to override the image's default command (docker entrypoint) [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating a pod to test override command
+Jul  2 13:40:51.048: INFO: Waiting up to 5m0s for pod "client-containers-88d0756e-7dfd-11e8-8e15-aefe7bc77cc2" in namespace "e2e-tests-containers-dddg5" to be "success or failure"
+Jul  2 13:40:51.051: INFO: Pod "client-containers-88d0756e-7dfd-11e8-8e15-aefe7bc77cc2": Phase="Pending", Reason="", readiness=false. Elapsed: 3.351215ms
+Jul  2 13:40:53.055: INFO: Pod "client-containers-88d0756e-7dfd-11e8-8e15-aefe7bc77cc2": Phase="Pending", Reason="", readiness=false. Elapsed: 2.007306216s
+Jul  2 13:40:55.060: INFO: Pod "client-containers-88d0756e-7dfd-11e8-8e15-aefe7bc77cc2": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.012326811s
+STEP: Saw pod success
+Jul  2 13:40:55.060: INFO: Pod "client-containers-88d0756e-7dfd-11e8-8e15-aefe7bc77cc2" satisfied condition "success or failure"
+Jul  2 13:40:55.063: INFO: Trying to get logs from node shoot--core--confaz-worker-qfmi9-79968b77d9-kcr6j pod client-containers-88d0756e-7dfd-11e8-8e15-aefe7bc77cc2 container test-container: <nil>
+STEP: delete the pod
+Jul  2 13:40:55.091: INFO: Waiting for pod client-containers-88d0756e-7dfd-11e8-8e15-aefe7bc77cc2 to disappear
+Jul  2 13:40:55.101: INFO: Pod client-containers-88d0756e-7dfd-11e8-8e15-aefe7bc77cc2 no longer exists
+[AfterEach] [k8s.io] Docker Containers
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:40:55.101: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-containers-dddg5" for this suite.
+Jul  2 13:41:01.123: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:41:01.182: INFO: namespace: e2e-tests-containers-dddg5, resource: bindings, ignored listing per whitelist
+Jul  2 13:41:01.219: INFO: namespace e2e-tests-containers-dddg5 deletion completed in 6.110227135s
+
+• [SLOW TEST:10.293 seconds]
+[k8s.io] Docker Containers
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:679
+  should be able to override the image's default command (docker entrypoint) [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSSS
+------------------------------
+[sig-storage] Secrets 
+  optional updates should be reflected in volume [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-storage] Secrets
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:41:01.219: INFO: >>> kubeConfig: /tmp/kubeconfig-324782104
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] optional updates should be reflected in volume [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating secret with name s-test-opt-del-8ef35d67-7dfd-11e8-8e15-aefe7bc77cc2
+STEP: Creating secret with name s-test-opt-upd-8ef35d90-7dfd-11e8-8e15-aefe7bc77cc2
+STEP: Creating the pod
+STEP: Deleting secret s-test-opt-del-8ef35d67-7dfd-11e8-8e15-aefe7bc77cc2
+STEP: Updating secret s-test-opt-upd-8ef35d90-7dfd-11e8-8e15-aefe7bc77cc2
+STEP: Creating secret with name s-test-opt-create-8ef35da0-7dfd-11e8-8e15-aefe7bc77cc2
+STEP: waiting to observe update in volume
+[AfterEach] [sig-storage] Secrets
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:42:17.009: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-secrets-rvwqt" for this suite.
+Jul  2 13:42:39.030: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:42:39.096: INFO: namespace: e2e-tests-secrets-rvwqt, resource: bindings, ignored listing per whitelist
+Jul  2 13:42:39.121: INFO: namespace e2e-tests-secrets-rvwqt deletion completed in 22.108648022s
+
+• [SLOW TEST:97.902 seconds]
+[sig-storage] Secrets
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/secrets_volume.go:33
+  optional updates should be reflected in volume [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSSSSS
+------------------------------
+[sig-storage] Projected 
+  should project all components that make up the projection API [Projection][NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:42:39.122: INFO: >>> kubeConfig: /tmp/kubeconfig-324782104
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:858
+[It] should project all components that make up the projection API [Projection][NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating configMap with name configmap-projected-all-test-volume-c94ed529-7dfd-11e8-8e15-aefe7bc77cc2
+STEP: Creating secret with name secret-projected-all-test-volume-c94ed512-7dfd-11e8-8e15-aefe7bc77cc2
+STEP: Creating a pod to test Check all projections for projected volume plugin
+Jul  2 13:42:39.259: INFO: Waiting up to 5m0s for pod "projected-volume-c94ed4ea-7dfd-11e8-8e15-aefe7bc77cc2" in namespace "e2e-tests-projected-vcdhb" to be "success or failure"
+Jul  2 13:42:39.266: INFO: Pod "projected-volume-c94ed4ea-7dfd-11e8-8e15-aefe7bc77cc2": Phase="Pending", Reason="", readiness=false. Elapsed: 7.269625ms
+Jul  2 13:42:41.269: INFO: Pod "projected-volume-c94ed4ea-7dfd-11e8-8e15-aefe7bc77cc2": Phase="Pending", Reason="", readiness=false. Elapsed: 2.010182496s
+Jul  2 13:42:43.272: INFO: Pod "projected-volume-c94ed4ea-7dfd-11e8-8e15-aefe7bc77cc2": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.013300395s
+STEP: Saw pod success
+Jul  2 13:42:43.272: INFO: Pod "projected-volume-c94ed4ea-7dfd-11e8-8e15-aefe7bc77cc2" satisfied condition "success or failure"
+Jul  2 13:42:43.276: INFO: Trying to get logs from node shoot--core--confaz-worker-qfmi9-79968b77d9-kcr6j pod projected-volume-c94ed4ea-7dfd-11e8-8e15-aefe7bc77cc2 container projected-all-volume-test: <nil>
+STEP: delete the pod
+Jul  2 13:42:43.307: INFO: Waiting for pod projected-volume-c94ed4ea-7dfd-11e8-8e15-aefe7bc77cc2 to disappear
+Jul  2 13:42:43.323: INFO: Pod projected-volume-c94ed4ea-7dfd-11e8-8e15-aefe7bc77cc2 no longer exists
+[AfterEach] [sig-storage] Projected
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:42:43.323: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-vcdhb" for this suite.
+Jul  2 13:42:49.348: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:42:49.357: INFO: namespace: e2e-tests-projected-vcdhb, resource: bindings, ignored listing per whitelist
+Jul  2 13:42:49.466: INFO: namespace e2e-tests-projected-vcdhb deletion completed in 6.13816081s
+
+• [SLOW TEST:10.345 seconds]
+[sig-storage] Projected
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:34
+  should project all components that make up the projection API [Projection][NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSSSS
+------------------------------
+[sig-api-machinery] Watchers 
+  should be able to start watching from a specific resource version [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-api-machinery] Watchers
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:42:49.467: INFO: >>> kubeConfig: /tmp/kubeconfig-324782104
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should be able to start watching from a specific resource version [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: creating a new configmap
+STEP: modifying the configmap once
+STEP: modifying the configmap a second time
+STEP: deleting the configmap
+STEP: creating a watch on configmaps from the resource version returned by the first update
+STEP: Expecting to observe notifications for all changes to the configmap after the first update
+Jul  2 13:42:49.611: INFO: Got : MODIFIED &ConfigMap{ObjectMeta:k8s_io_apimachinery_pkg_apis_meta_v1.ObjectMeta{Name:e2e-watch-test-resource-version,GenerateName:,Namespace:e2e-tests-watch-4dk2s,SelfLink:/api/v1/namespaces/e2e-tests-watch-4dk2s/configmaps/e2e-watch-test-resource-version,UID:cf78a884-7dfd-11e8-bc8c-d657551927e5,ResourceVersion:10528,Generation:0,CreationTimestamp:2018-07-02 13:42:49 +0000 UTC,DeletionTimestamp:<nil>,DeletionGracePeriodSeconds:nil,Labels:map[string]string{watch-this-configmap: from-resource-version,},Annotations:map[string]string{},OwnerReferences:[],Finalizers:[],ClusterName:,Initializers:nil,},Data:map[string]string{mutation: 2,},BinaryData:map[string][]byte{},}
+Jul  2 13:42:49.612: INFO: Got : DELETED &ConfigMap{ObjectMeta:k8s_io_apimachinery_pkg_apis_meta_v1.ObjectMeta{Name:e2e-watch-test-resource-version,GenerateName:,Namespace:e2e-tests-watch-4dk2s,SelfLink:/api/v1/namespaces/e2e-tests-watch-4dk2s/configmaps/e2e-watch-test-resource-version,UID:cf78a884-7dfd-11e8-bc8c-d657551927e5,ResourceVersion:10529,Generation:0,CreationTimestamp:2018-07-02 13:42:49 +0000 UTC,DeletionTimestamp:<nil>,DeletionGracePeriodSeconds:nil,Labels:map[string]string{watch-this-configmap: from-resource-version,},Annotations:map[string]string{},OwnerReferences:[],Finalizers:[],ClusterName:,Initializers:nil,},Data:map[string]string{mutation: 2,},BinaryData:map[string][]byte{},}
+[AfterEach] [sig-api-machinery] Watchers
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:42:49.612: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-watch-4dk2s" for this suite.
+Jul  2 13:42:55.644: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:42:55.719: INFO: namespace: e2e-tests-watch-4dk2s, resource: bindings, ignored listing per whitelist
+Jul  2 13:42:55.800: INFO: namespace e2e-tests-watch-4dk2s deletion completed in 6.184476197s
+
+• [SLOW TEST:6.333 seconds]
+[sig-api-machinery] Watchers
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apimachinery/framework.go:22
+  should be able to start watching from a specific resource version [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+[sig-storage] Projected 
+  should provide node allocatable (cpu) as default cpu limit if the limit is not set [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:42:55.801: INFO: >>> kubeConfig: /tmp/kubeconfig-324782104
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:858
+[It] should provide node allocatable (cpu) as default cpu limit if the limit is not set [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating a pod to test downward API volume plugin
+Jul  2 13:42:55.915: INFO: Waiting up to 5m0s for pod "downwardapi-volume-d33cc1c7-7dfd-11e8-8e15-aefe7bc77cc2" in namespace "e2e-tests-projected-d879g" to be "success or failure"
+Jul  2 13:42:55.928: INFO: Pod "downwardapi-volume-d33cc1c7-7dfd-11e8-8e15-aefe7bc77cc2": Phase="Pending", Reason="", readiness=false. Elapsed: 12.971752ms
+Jul  2 13:42:57.963: INFO: Pod "downwardapi-volume-d33cc1c7-7dfd-11e8-8e15-aefe7bc77cc2": Phase="Pending", Reason="", readiness=false. Elapsed: 2.047796092s
+Jul  2 13:42:59.967: INFO: Pod "downwardapi-volume-d33cc1c7-7dfd-11e8-8e15-aefe7bc77cc2": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.051641464s
+STEP: Saw pod success
+Jul  2 13:42:59.967: INFO: Pod "downwardapi-volume-d33cc1c7-7dfd-11e8-8e15-aefe7bc77cc2" satisfied condition "success or failure"
+Jul  2 13:42:59.970: INFO: Trying to get logs from node shoot--core--confaz-worker-qfmi9-79968b77d9-kcr6j pod downwardapi-volume-d33cc1c7-7dfd-11e8-8e15-aefe7bc77cc2 container client-container: <nil>
+STEP: delete the pod
+Jul  2 13:43:00.001: INFO: Waiting for pod downwardapi-volume-d33cc1c7-7dfd-11e8-8e15-aefe7bc77cc2 to disappear
+Jul  2 13:43:00.011: INFO: Pod downwardapi-volume-d33cc1c7-7dfd-11e8-8e15-aefe7bc77cc2 no longer exists
+[AfterEach] [sig-storage] Projected
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:43:00.011: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-d879g" for this suite.
+Jul  2 13:43:06.037: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:43:06.166: INFO: namespace: e2e-tests-projected-d879g, resource: bindings, ignored listing per whitelist
+Jul  2 13:43:06.244: INFO: namespace e2e-tests-projected-d879g deletion completed in 6.223473814s
+
+• [SLOW TEST:10.443 seconds]
+[sig-storage] Projected
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:34
+  should provide node allocatable (cpu) as default cpu limit if the limit is not set [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSSSSSSSS
+------------------------------
+[sig-storage] ConfigMap 
+  should be consumable from pods in volume as non-root [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-storage] ConfigMap
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:43:06.244: INFO: >>> kubeConfig: /tmp/kubeconfig-324782104
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should be consumable from pods in volume as non-root [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating configMap with name configmap-test-volume-d9805c9d-7dfd-11e8-8e15-aefe7bc77cc2
+STEP: Creating a pod to test consume configMaps
+Jul  2 13:43:06.422: INFO: Waiting up to 5m0s for pod "pod-configmaps-d981c960-7dfd-11e8-8e15-aefe7bc77cc2" in namespace "e2e-tests-configmap-5rrw7" to be "success or failure"
+Jul  2 13:43:06.425: INFO: Pod "pod-configmaps-d981c960-7dfd-11e8-8e15-aefe7bc77cc2": Phase="Pending", Reason="", readiness=false. Elapsed: 3.474713ms
+Jul  2 13:43:08.431: INFO: Pod "pod-configmaps-d981c960-7dfd-11e8-8e15-aefe7bc77cc2": Phase="Pending", Reason="", readiness=false. Elapsed: 2.008955073s
+Jul  2 13:43:10.435: INFO: Pod "pod-configmaps-d981c960-7dfd-11e8-8e15-aefe7bc77cc2": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.012830538s
+STEP: Saw pod success
+Jul  2 13:43:10.435: INFO: Pod "pod-configmaps-d981c960-7dfd-11e8-8e15-aefe7bc77cc2" satisfied condition "success or failure"
+Jul  2 13:43:10.438: INFO: Trying to get logs from node shoot--core--confaz-worker-qfmi9-79968b77d9-kcr6j pod pod-configmaps-d981c960-7dfd-11e8-8e15-aefe7bc77cc2 container configmap-volume-test: <nil>
+STEP: delete the pod
+Jul  2 13:43:10.460: INFO: Waiting for pod pod-configmaps-d981c960-7dfd-11e8-8e15-aefe7bc77cc2 to disappear
+Jul  2 13:43:10.463: INFO: Pod pod-configmaps-d981c960-7dfd-11e8-8e15-aefe7bc77cc2 no longer exists
+[AfterEach] [sig-storage] ConfigMap
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:43:10.463: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-configmap-5rrw7" for this suite.
+Jul  2 13:43:16.530: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:43:16.596: INFO: namespace: e2e-tests-configmap-5rrw7, resource: bindings, ignored listing per whitelist
+Jul  2 13:43:16.627: INFO: namespace e2e-tests-configmap-5rrw7 deletion completed in 6.161041646s
+
+• [SLOW TEST:10.383 seconds]
+[sig-storage] ConfigMap
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/configmap_volume.go:32
+  should be consumable from pods in volume as non-root [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSS
+------------------------------
+[sig-storage] Downward API volume 
+  should provide node allocatable (memory) as default memory limit if the limit is not set [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:43:16.627: INFO: >>> kubeConfig: /tmp/kubeconfig-324782104
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downwardapi_volume.go:38
+[It] should provide node allocatable (memory) as default memory limit if the limit is not set [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating a pod to test downward API volume plugin
+Jul  2 13:43:16.749: INFO: Waiting up to 5m0s for pod "downwardapi-volume-dfa7d5ba-7dfd-11e8-8e15-aefe7bc77cc2" in namespace "e2e-tests-downward-api-9xvms" to be "success or failure"
+Jul  2 13:43:16.753: INFO: Pod "downwardapi-volume-dfa7d5ba-7dfd-11e8-8e15-aefe7bc77cc2": Phase="Pending", Reason="", readiness=false. Elapsed: 3.818411ms
+Jul  2 13:43:18.756: INFO: Pod "downwardapi-volume-dfa7d5ba-7dfd-11e8-8e15-aefe7bc77cc2": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.00754844s
+STEP: Saw pod success
+Jul  2 13:43:18.756: INFO: Pod "downwardapi-volume-dfa7d5ba-7dfd-11e8-8e15-aefe7bc77cc2" satisfied condition "success or failure"
+Jul  2 13:43:18.759: INFO: Trying to get logs from node shoot--core--confaz-worker-qfmi9-79968b77d9-kcr6j pod downwardapi-volume-dfa7d5ba-7dfd-11e8-8e15-aefe7bc77cc2 container client-container: <nil>
+STEP: delete the pod
+Jul  2 13:43:18.795: INFO: Waiting for pod downwardapi-volume-dfa7d5ba-7dfd-11e8-8e15-aefe7bc77cc2 to disappear
+Jul  2 13:43:18.802: INFO: Pod downwardapi-volume-dfa7d5ba-7dfd-11e8-8e15-aefe7bc77cc2 no longer exists
+[AfterEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:43:18.802: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-downward-api-9xvms" for this suite.
+Jul  2 13:43:24.838: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:43:24.890: INFO: namespace: e2e-tests-downward-api-9xvms, resource: bindings, ignored listing per whitelist
+Jul  2 13:43:24.961: INFO: namespace e2e-tests-downward-api-9xvms deletion completed in 6.148279025s
+
+• [SLOW TEST:8.335 seconds]
+[sig-storage] Downward API volume
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downwardapi_volume.go:33
+  should provide node allocatable (memory) as default memory limit if the limit is not set [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSSSSSSSSSSSS
+------------------------------
+[sig-apps] Daemon set [Serial] 
+  should run and stop simple daemon [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-apps] Daemon set [Serial]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:43:24.962: INFO: >>> kubeConfig: /tmp/kubeconfig-324782104
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-apps] Daemon set [Serial]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/daemon_set.go:99
+[It] should run and stop simple daemon [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating simple DaemonSet "daemon-set"
+STEP: Check that daemon pods launch on every node of the cluster.
+Jul  2 13:43:25.092: INFO: Number of nodes with available pods: 0
+Jul  2 13:43:25.092: INFO: Node shoot--core--confaz-worker-qfmi9-79968b77d9-24hm4 is running more than one daemon pod
+Jul  2 13:43:26.099: INFO: Number of nodes with available pods: 0
+Jul  2 13:43:26.099: INFO: Node shoot--core--confaz-worker-qfmi9-79968b77d9-24hm4 is running more than one daemon pod
+Jul  2 13:43:27.098: INFO: Number of nodes with available pods: 2
+Jul  2 13:43:27.098: INFO: Number of running nodes: 2, number of available pods: 2
+STEP: Stop a daemon pod, check that the daemon pod is revived.
+Jul  2 13:43:27.128: INFO: Number of nodes with available pods: 1
+Jul  2 13:43:27.128: INFO: Node shoot--core--confaz-worker-qfmi9-79968b77d9-kcr6j is running more than one daemon pod
+Jul  2 13:43:28.136: INFO: Number of nodes with available pods: 1
+Jul  2 13:43:28.136: INFO: Node shoot--core--confaz-worker-qfmi9-79968b77d9-kcr6j is running more than one daemon pod
+Jul  2 13:43:29.136: INFO: Number of nodes with available pods: 1
+Jul  2 13:43:29.136: INFO: Node shoot--core--confaz-worker-qfmi9-79968b77d9-kcr6j is running more than one daemon pod
+Jul  2 13:43:30.136: INFO: Number of nodes with available pods: 1
+Jul  2 13:43:30.136: INFO: Node shoot--core--confaz-worker-qfmi9-79968b77d9-kcr6j is running more than one daemon pod
+Jul  2 13:43:31.135: INFO: Number of nodes with available pods: 1
+Jul  2 13:43:31.135: INFO: Node shoot--core--confaz-worker-qfmi9-79968b77d9-kcr6j is running more than one daemon pod
+Jul  2 13:43:32.136: INFO: Number of nodes with available pods: 2
+Jul  2 13:43:32.136: INFO: Number of running nodes: 2, number of available pods: 2
+[AfterEach] [sig-apps] Daemon set [Serial]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/daemon_set.go:65
+STEP: Deleting DaemonSet "daemon-set"
+STEP: deleting {extensions DaemonSet} daemon-set in namespace e2e-tests-daemonsets-8vmv6, will wait for the garbage collector to delete the pods
+Jul  2 13:43:32.205: INFO: Deleting {extensions DaemonSet} daemon-set took: 7.239228ms
+Jul  2 13:43:32.305: INFO: Terminating {extensions DaemonSet} daemon-set pods took: 100.160588ms
+Jul  2 13:43:39.208: INFO: Number of nodes with available pods: 0
+Jul  2 13:43:39.208: INFO: Number of running nodes: 0, number of available pods: 0
+Jul  2 13:43:39.211: INFO: daemonset: {"kind":"DaemonSetList","apiVersion":"apps/v1","metadata":{"selfLink":"/apis/apps/v1/namespaces/e2e-tests-daemonsets-8vmv6/daemonsets","resourceVersion":"10724"},"items":null}
+
+Jul  2 13:43:39.214: INFO: pods: {"kind":"PodList","apiVersion":"v1","metadata":{"selfLink":"/api/v1/namespaces/e2e-tests-daemonsets-8vmv6/pods","resourceVersion":"10724"},"items":null}
+
+[AfterEach] [sig-apps] Daemon set [Serial]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:43:39.222: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-daemonsets-8vmv6" for this suite.
+Jul  2 13:43:45.238: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:43:45.281: INFO: namespace: e2e-tests-daemonsets-8vmv6, resource: bindings, ignored listing per whitelist
+Jul  2 13:43:45.348: INFO: namespace e2e-tests-daemonsets-8vmv6 deletion completed in 6.123164378s
+
+• [SLOW TEST:20.386 seconds]
+[sig-apps] Daemon set [Serial]
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/framework.go:22
+  should run and stop simple daemon [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSS
+------------------------------
+[sig-storage] Projected 
+  should be consumable in multiple volumes in a pod [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:43:45.348: INFO: >>> kubeConfig: /tmp/kubeconfig-324782104
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:858
+[It] should be consumable in multiple volumes in a pod [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating secret with name projected-secret-test-f0c3fea4-7dfd-11e8-8e15-aefe7bc77cc2
+STEP: Creating a pod to test consume secrets
+Jul  2 13:43:45.487: INFO: Waiting up to 5m0s for pod "pod-projected-secrets-f0ca6374-7dfd-11e8-8e15-aefe7bc77cc2" in namespace "e2e-tests-projected-6c4jv" to be "success or failure"
+Jul  2 13:43:45.496: INFO: Pod "pod-projected-secrets-f0ca6374-7dfd-11e8-8e15-aefe7bc77cc2": Phase="Pending", Reason="", readiness=false. Elapsed: 9.013031ms
+Jul  2 13:43:47.501: INFO: Pod "pod-projected-secrets-f0ca6374-7dfd-11e8-8e15-aefe7bc77cc2": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.013990671s
+STEP: Saw pod success
+Jul  2 13:43:47.501: INFO: Pod "pod-projected-secrets-f0ca6374-7dfd-11e8-8e15-aefe7bc77cc2" satisfied condition "success or failure"
+Jul  2 13:43:47.503: INFO: Trying to get logs from node shoot--core--confaz-worker-qfmi9-79968b77d9-kcr6j pod pod-projected-secrets-f0ca6374-7dfd-11e8-8e15-aefe7bc77cc2 container secret-volume-test: <nil>
+STEP: delete the pod
+Jul  2 13:43:47.532: INFO: Waiting for pod pod-projected-secrets-f0ca6374-7dfd-11e8-8e15-aefe7bc77cc2 to disappear
+Jul  2 13:43:47.545: INFO: Pod pod-projected-secrets-f0ca6374-7dfd-11e8-8e15-aefe7bc77cc2 no longer exists
+[AfterEach] [sig-storage] Projected
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:43:47.545: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-6c4jv" for this suite.
+Jul  2 13:43:53.560: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:43:53.600: INFO: namespace: e2e-tests-projected-6c4jv, resource: bindings, ignored listing per whitelist
+Jul  2 13:43:53.660: INFO: namespace e2e-tests-projected-6c4jv deletion completed in 6.110468672s
+
+• [SLOW TEST:8.312 seconds]
+[sig-storage] Projected
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:34
+  should be consumable in multiple volumes in a pod [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+[k8s.io] Variable Expansion 
+  should allow composing env vars into new env vars [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [k8s.io] Variable Expansion
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:43:53.660: INFO: >>> kubeConfig: /tmp/kubeconfig-324782104
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should allow composing env vars into new env vars [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating a pod to test env composition
+Jul  2 13:43:53.769: INFO: Waiting up to 5m0s for pod "var-expansion-f5b82e46-7dfd-11e8-8e15-aefe7bc77cc2" in namespace "e2e-tests-var-expansion-699mg" to be "success or failure"
+Jul  2 13:43:53.773: INFO: Pod "var-expansion-f5b82e46-7dfd-11e8-8e15-aefe7bc77cc2": Phase="Pending", Reason="", readiness=false. Elapsed: 3.810113ms
+Jul  2 13:43:55.776: INFO: Pod "var-expansion-f5b82e46-7dfd-11e8-8e15-aefe7bc77cc2": Phase="Pending", Reason="", readiness=false. Elapsed: 2.007333541s
+Jul  2 13:43:57.780: INFO: Pod "var-expansion-f5b82e46-7dfd-11e8-8e15-aefe7bc77cc2": Phase="Pending", Reason="", readiness=false. Elapsed: 4.011365615s
+Jul  2 13:43:59.784: INFO: Pod "var-expansion-f5b82e46-7dfd-11e8-8e15-aefe7bc77cc2": Phase="Succeeded", Reason="", readiness=false. Elapsed: 6.014529303s
+STEP: Saw pod success
+Jul  2 13:43:59.784: INFO: Pod "var-expansion-f5b82e46-7dfd-11e8-8e15-aefe7bc77cc2" satisfied condition "success or failure"
+Jul  2 13:43:59.786: INFO: Trying to get logs from node shoot--core--confaz-worker-qfmi9-79968b77d9-kcr6j pod var-expansion-f5b82e46-7dfd-11e8-8e15-aefe7bc77cc2 container dapi-container: <nil>
+STEP: delete the pod
+Jul  2 13:43:59.806: INFO: Waiting for pod var-expansion-f5b82e46-7dfd-11e8-8e15-aefe7bc77cc2 to disappear
+Jul  2 13:43:59.819: INFO: Pod var-expansion-f5b82e46-7dfd-11e8-8e15-aefe7bc77cc2 no longer exists
+[AfterEach] [k8s.io] Variable Expansion
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:43:59.822: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-var-expansion-699mg" for this suite.
+Jul  2 13:44:05.847: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:44:05.961: INFO: namespace: e2e-tests-var-expansion-699mg, resource: bindings, ignored listing per whitelist
+Jul  2 13:44:05.964: INFO: namespace e2e-tests-var-expansion-699mg deletion completed in 6.135169099s
+
+• [SLOW TEST:12.304 seconds]
+[k8s.io] Variable Expansion
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:679
+  should allow composing env vars into new env vars [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSSSSSSSSSSS
+------------------------------
+[k8s.io] [sig-node] Pods Extended [k8s.io] Pods Set QOS Class 
+  should be submitted and removed  [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [k8s.io] [sig-node] Pods Extended
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:44:05.965: INFO: >>> kubeConfig: /tmp/kubeconfig-324782104
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [k8s.io] Pods Set QOS Class
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/node/pods.go:199
+[It] should be submitted and removed  [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: creating the pod
+STEP: submitting the pod to kubernetes
+STEP: verifying QOS class is set on the pod
+[AfterEach] [k8s.io] [sig-node] Pods Extended
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:44:06.123: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-pods-qlmmb" for this suite.
+Jul  2 13:44:28.142: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:44:28.175: INFO: namespace: e2e-tests-pods-qlmmb, resource: bindings, ignored listing per whitelist
+Jul  2 13:44:28.240: INFO: namespace e2e-tests-pods-qlmmb deletion completed in 22.110756445s
+
+• [SLOW TEST:22.275 seconds]
+[k8s.io] [sig-node] Pods Extended
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:679
+  [k8s.io] Pods Set QOS Class
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:679
+    should be submitted and removed  [Conformance]
+    /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SS
+------------------------------
+[sig-network] Proxy version v1 
+  should proxy logs on node with explicit kubelet port using proxy subresource  [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] version v1
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:44:28.240: INFO: >>> kubeConfig: /tmp/kubeconfig-324782104
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should proxy logs on node with explicit kubelet port using proxy subresource  [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+Jul  2 13:44:28.401: INFO: (0) /api/v1/nodes/shoot--core--confaz-worker-qfmi9-79968b77d9-24hm4:10250/proxy/logs/: <pre>
+<a href="azure/">azure/</a>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<... (200; 12.614249ms)
+Jul  2 13:44:28.445: INFO: (1) /api/v1/nodes/shoot--core--confaz-worker-qfmi9-79968b77d9-24hm4:10250/proxy/logs/: <pre>
+<a href="azure/">azure/</a>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<... (200; 43.973772ms)
+Jul  2 13:44:28.451: INFO: (2) /api/v1/nodes/shoot--core--confaz-worker-qfmi9-79968b77d9-24hm4:10250/proxy/logs/: <pre>
+<a href="azure/">azure/</a>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<... (200; 5.892423ms)
+Jul  2 13:44:28.457: INFO: (3) /api/v1/nodes/shoot--core--confaz-worker-qfmi9-79968b77d9-24hm4:10250/proxy/logs/: <pre>
+<a href="azure/">azure/</a>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<... (200; 5.876623ms)
+Jul  2 13:44:28.464: INFO: (4) /api/v1/nodes/shoot--core--confaz-worker-qfmi9-79968b77d9-24hm4:10250/proxy/logs/: <pre>
+<a href="azure/">azure/</a>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<... (200; 6.505726ms)
+Jul  2 13:44:28.469: INFO: (5) /api/v1/nodes/shoot--core--confaz-worker-qfmi9-79968b77d9-24hm4:10250/proxy/logs/: <pre>
+<a href="azure/">azure/</a>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<... (200; 5.627622ms)
+Jul  2 13:44:28.482: INFO: (6) /api/v1/nodes/shoot--core--confaz-worker-qfmi9-79968b77d9-24hm4:10250/proxy/logs/: <pre>
+<a href="azure/">azure/</a>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<... (200; 12.425849ms)
+Jul  2 13:44:28.563: INFO: (7) /api/v1/nodes/shoot--core--confaz-worker-qfmi9-79968b77d9-24hm4:10250/proxy/logs/: <pre>
+<a href="azure/">azure/</a>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<... (200; 81.036217ms)
+Jul  2 13:44:28.571: INFO: (8) /api/v1/nodes/shoot--core--confaz-worker-qfmi9-79968b77d9-24hm4:10250/proxy/logs/: <pre>
+<a href="azure/">azure/</a>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<... (200; 8.395233ms)
+Jul  2 13:44:28.577: INFO: (9) /api/v1/nodes/shoot--core--confaz-worker-qfmi9-79968b77d9-24hm4:10250/proxy/logs/: <pre>
+<a href="azure/">azure/</a>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<... (200; 5.612522ms)
+Jul  2 13:44:28.663: INFO: (10) /api/v1/nodes/shoot--core--confaz-worker-qfmi9-79968b77d9-24hm4:10250/proxy/logs/: <pre>
+<a href="azure/">azure/</a>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<... (200; 85.487334ms)
+Jul  2 13:44:28.667: INFO: (11) /api/v1/nodes/shoot--core--confaz-worker-qfmi9-79968b77d9-24hm4:10250/proxy/logs/: <pre>
+<a href="azure/">azure/</a>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<... (200; 4.663818ms)
+Jul  2 13:44:28.672: INFO: (12) /api/v1/nodes/shoot--core--confaz-worker-qfmi9-79968b77d9-24hm4:10250/proxy/logs/: <pre>
+<a href="azure/">azure/</a>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<... (200; 4.189617ms)
+Jul  2 13:44:28.676: INFO: (13) /api/v1/nodes/shoot--core--confaz-worker-qfmi9-79968b77d9-24hm4:10250/proxy/logs/: <pre>
+<a href="azure/">azure/</a>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<... (200; 4.106216ms)
+Jul  2 13:44:28.680: INFO: (14) /api/v1/nodes/shoot--core--confaz-worker-qfmi9-79968b77d9-24hm4:10250/proxy/logs/: <pre>
+<a href="azure/">azure/</a>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<... (200; 3.661314ms)
+Jul  2 13:44:28.684: INFO: (15) /api/v1/nodes/shoot--core--confaz-worker-qfmi9-79968b77d9-24hm4:10250/proxy/logs/: <pre>
+<a href="azure/">azure/</a>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<... (200; 3.948515ms)
+Jul  2 13:44:28.688: INFO: (16) /api/v1/nodes/shoot--core--confaz-worker-qfmi9-79968b77d9-24hm4:10250/proxy/logs/: <pre>
+<a href="azure/">azure/</a>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<... (200; 4.068516ms)
+Jul  2 13:44:28.692: INFO: (17) /api/v1/nodes/shoot--core--confaz-worker-qfmi9-79968b77d9-24hm4:10250/proxy/logs/: <pre>
+<a href="azure/">azure/</a>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<... (200; 3.812015ms)
+Jul  2 13:44:28.696: INFO: (18) /api/v1/nodes/shoot--core--confaz-worker-qfmi9-79968b77d9-24hm4:10250/proxy/logs/: <pre>
+<a href="azure/">azure/</a>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<... (200; 4.562618ms)
+Jul  2 13:44:28.700: INFO: (19) /api/v1/nodes/shoot--core--confaz-worker-qfmi9-79968b77d9-24hm4:10250/proxy/logs/: <pre>
+<a href="azure/">azure/</a>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<... (200; 3.675014ms)
+[AfterEach] version v1
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:44:28.700: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-proxy-b954k" for this suite.
+Jul  2 13:44:34.765: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:44:34.810: INFO: namespace: e2e-tests-proxy-b954k, resource: bindings, ignored listing per whitelist
+Jul  2 13:44:34.859: INFO: namespace e2e-tests-proxy-b954k deletion completed in 6.155998607s
+
+• [SLOW TEST:6.619 seconds]
+[sig-network] Proxy
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/network/framework.go:22
+  version v1
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/network/proxy.go:56
+    should proxy logs on node with explicit kubelet port using proxy subresource  [Conformance]
+    /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSSSSSS
+------------------------------
+[sig-api-machinery] Garbage collector 
+  should delete RS created by deployment when not orphaning [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-api-machinery] Garbage collector
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:44:34.860: INFO: >>> kubeConfig: /tmp/kubeconfig-324782104
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should delete RS created by deployment when not orphaning [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: create the deployment
+STEP: Wait for the Deployment to create new ReplicaSet
+STEP: delete the deployment
+STEP: wait for all rs to be garbage collected
+STEP: expected 0 rs, got 1 rs
+STEP: expected 0 Pods, got 2 Pods
+STEP: Gathering metrics
+W0702 13:44:36.140087      15 metrics_grabber.go:81] Master node is not registered. Grabbing metrics from Scheduler, ControllerManager and ClusterAutoscaler is disabled.
+Jul  2 13:44:36.140: INFO: For apiserver_request_count:
+For apiserver_request_latencies_summary:
+For etcd_helper_cache_entry_count:
+For etcd_helper_cache_hit_count:
+For etcd_helper_cache_miss_count:
+For etcd_request_cache_add_latencies_summary:
+For etcd_request_cache_get_latencies_summary:
+For etcd_request_latencies_summary:
+For garbage_collector_attempt_to_delete_queue_latency:
+For garbage_collector_attempt_to_delete_work_duration:
+For garbage_collector_attempt_to_orphan_queue_latency:
+For garbage_collector_attempt_to_orphan_work_duration:
+For garbage_collector_dirty_processing_latency_microseconds:
+For garbage_collector_event_processing_latency_microseconds:
+For garbage_collector_graph_changes_queue_latency:
+For garbage_collector_graph_changes_work_duration:
+For garbage_collector_orphan_processing_latency_microseconds:
+For namespace_queue_latency:
+For namespace_queue_latency_sum:
+For namespace_queue_latency_count:
+For namespace_retries:
+For namespace_work_duration:
+For namespace_work_duration_sum:
+For namespace_work_duration_count:
+For function_duration_seconds:
+For errors_total:
+For evicted_pods_total:
+
+[AfterEach] [sig-api-machinery] Garbage collector
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:44:36.140: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-gc-scrsv" for this suite.
+Jul  2 13:44:42.163: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:44:42.179: INFO: namespace: e2e-tests-gc-scrsv, resource: bindings, ignored listing per whitelist
+Jul  2 13:44:42.339: INFO: namespace e2e-tests-gc-scrsv deletion completed in 6.194390367s
+
+• [SLOW TEST:7.479 seconds]
+[sig-api-machinery] Garbage collector
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apimachinery/framework.go:22
+  should delete RS created by deployment when not orphaning [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSSS
+------------------------------
+[k8s.io] Pods 
+  should contain environment variables for services [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [k8s.io] Pods
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:44:42.339: INFO: >>> kubeConfig: /tmp/kubeconfig-324782104
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [k8s.io] Pods
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/pods.go:127
+[It] should contain environment variables for services [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+Jul  2 13:44:46.515: INFO: Waiting up to 5m0s for pod "client-envvars-152a1ea1-7dfe-11e8-8e15-aefe7bc77cc2" in namespace "e2e-tests-pods-jthtt" to be "success or failure"
+Jul  2 13:44:46.539: INFO: Pod "client-envvars-152a1ea1-7dfe-11e8-8e15-aefe7bc77cc2": Phase="Pending", Reason="", readiness=false. Elapsed: 23.343579ms
+Jul  2 13:44:48.631: INFO: Pod "client-envvars-152a1ea1-7dfe-11e8-8e15-aefe7bc77cc2": Phase="Pending", Reason="", readiness=false. Elapsed: 2.115683368s
+Jul  2 13:44:50.763: INFO: Pod "client-envvars-152a1ea1-7dfe-11e8-8e15-aefe7bc77cc2": Phase="Pending", Reason="", readiness=false. Elapsed: 4.24750262s
+Jul  2 13:44:52.768: INFO: Pod "client-envvars-152a1ea1-7dfe-11e8-8e15-aefe7bc77cc2": Phase="Succeeded", Reason="", readiness=false. Elapsed: 6.252308327s
+STEP: Saw pod success
+Jul  2 13:44:52.768: INFO: Pod "client-envvars-152a1ea1-7dfe-11e8-8e15-aefe7bc77cc2" satisfied condition "success or failure"
+Jul  2 13:44:52.770: INFO: Trying to get logs from node shoot--core--confaz-worker-qfmi9-79968b77d9-kcr6j pod client-envvars-152a1ea1-7dfe-11e8-8e15-aefe7bc77cc2 container env3cont: <nil>
+STEP: delete the pod
+Jul  2 13:44:52.798: INFO: Waiting for pod client-envvars-152a1ea1-7dfe-11e8-8e15-aefe7bc77cc2 to disappear
+Jul  2 13:44:52.811: INFO: Pod client-envvars-152a1ea1-7dfe-11e8-8e15-aefe7bc77cc2 no longer exists
+[AfterEach] [k8s.io] Pods
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:44:52.812: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-pods-jthtt" for this suite.
+Jul  2 13:45:14.826: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:45:14.917: INFO: namespace: e2e-tests-pods-jthtt, resource: bindings, ignored listing per whitelist
+Jul  2 13:45:14.930: INFO: namespace e2e-tests-pods-jthtt deletion completed in 22.11557277s
+
+• [SLOW TEST:32.592 seconds]
+[k8s.io] Pods
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:679
+  should contain environment variables for services [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSS
+------------------------------
+[sig-network] Services 
+  should provide secure master service  [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-network] Services
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:45:14.931: INFO: >>> kubeConfig: /tmp/kubeconfig-324782104
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-network] Services
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/network/service.go:83
+[It] should provide secure master service  [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[AfterEach] [sig-network] Services
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:45:15.056: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-services-kd867" for this suite.
+Jul  2 13:45:21.073: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:45:21.147: INFO: namespace: e2e-tests-services-kd867, resource: bindings, ignored listing per whitelist
+Jul  2 13:45:21.167: INFO: namespace e2e-tests-services-kd867 deletion completed in 6.108121349s
+[AfterEach] [sig-network] Services
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/network/service.go:88
+
+• [SLOW TEST:6.236 seconds]
+[sig-network] Services
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/network/framework.go:22
+  should provide secure master service  [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSSSS
+------------------------------
+[sig-scheduling] SchedulerPredicates [Serial] 
+  validates that NodeSelector is respected if matching  [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-scheduling] SchedulerPredicates [Serial]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:45:21.167: INFO: >>> kubeConfig: /tmp/kubeconfig-324782104
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-scheduling] SchedulerPredicates [Serial]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/scheduling/predicates.go:79
+Jul  2 13:45:21.258: INFO: Waiting up to 1m0s for all nodes to be ready
+Jul  2 13:46:21.277: INFO: Waiting for terminating namespaces to be deleted...
+Jul  2 13:46:21.330: INFO: Waiting up to 5m0s for all pods (need at least 0) in namespace 'kube-system' to be running and ready
+Jul  2 13:46:21.342: INFO: 14 / 14 pods in namespace 'kube-system' are running and ready (0 seconds elapsed)
+Jul  2 13:46:21.342: INFO: expected 8 pod replicas in namespace 'kube-system', 8 are Running and Ready.
+Jul  2 13:46:21.345: INFO: Waiting for pods to enter Success, but no pods in "kube-system" match label map[name:e2e-image-puller]
+Jul  2 13:46:21.345: INFO: 
+Logging pods the kubelet thinks is on node shoot--core--confaz-worker-qfmi9-79968b77d9-24hm4 before test
+Jul  2 13:46:21.355: INFO: addons-nginx-ingress-nginx-ingress-k8s-backend-7b5569797f-vs48p from kube-system started at 2018-07-02 12:51:50 +0000 UTC (1 container statuses recorded)
+Jul  2 13:46:21.355: INFO: 	Container nginx-ingress-nginx-ingress-k8s-backend ready: true, restart count 0
+Jul  2 13:46:21.355: INFO: kube-dns-9c4dfc4fb-wvnfk from kube-system started at 2018-07-02 12:51:50 +0000 UTC (3 container statuses recorded)
+Jul  2 13:46:21.355: INFO: 	Container dnsmasq ready: true, restart count 0
+Jul  2 13:46:21.355: INFO: 	Container kubedns ready: true, restart count 0
+Jul  2 13:46:21.355: INFO: 	Container sidecar ready: true, restart count 0
+Jul  2 13:46:21.355: INFO: addons-kubernetes-dashboard-5486b968b7-9bgvq from kube-system started at 2018-07-02 12:51:50 +0000 UTC (1 container statuses recorded)
+Jul  2 13:46:21.355: INFO: 	Container main ready: true, restart count 0
+Jul  2 13:46:21.355: INFO: node-exporter-fzzjt from kube-system started at 2018-07-02 12:51:19 +0000 UTC (1 container statuses recorded)
+Jul  2 13:46:21.355: INFO: 	Container node-exporter ready: true, restart count 0
+Jul  2 13:46:21.355: INFO: kube-dns-autoscaler-6dd4765967-wxfns from kube-system started at 2018-07-02 12:51:50 +0000 UTC (1 container statuses recorded)
+Jul  2 13:46:21.355: INFO: 	Container autoscaler ready: true, restart count 0
+Jul  2 13:46:21.355: INFO: addons-nginx-ingress-controller-79bfb57974-gxmr9 from kube-system started at 2018-07-02 12:51:50 +0000 UTC (1 container statuses recorded)
+Jul  2 13:46:21.355: INFO: 	Container nginx-ingress-controller ready: true, restart count 0
+Jul  2 13:46:21.356: INFO: kube-dns-9c4dfc4fb-68s88 from kube-system started at 2018-07-02 12:52:17 +0000 UTC (3 container statuses recorded)
+Jul  2 13:46:21.356: INFO: 	Container dnsmasq ready: true, restart count 0
+Jul  2 13:46:21.356: INFO: 	Container kubedns ready: true, restart count 0
+Jul  2 13:46:21.356: INFO: 	Container sidecar ready: true, restart count 0
+Jul  2 13:46:21.356: INFO: calico-node-vzzmk from kube-system started at 2018-07-02 12:51:19 +0000 UTC (2 container statuses recorded)
+Jul  2 13:46:21.356: INFO: 	Container calico-node ready: true, restart count 0
+Jul  2 13:46:21.356: INFO: 	Container install-cni ready: true, restart count 0
+Jul  2 13:46:21.356: INFO: kube-proxy-9j7qk from kube-system started at 2018-07-02 12:51:19 +0000 UTC (1 container statuses recorded)
+Jul  2 13:46:21.356: INFO: 	Container kube-proxy ready: true, restart count 0
+Jul  2 13:46:21.356: INFO: vpn-shoot-dd669f8bb-vs6qw from kube-system started at 2018-07-02 12:51:50 +0000 UTC (1 container statuses recorded)
+Jul  2 13:46:21.356: INFO: 	Container vpn-shoot ready: true, restart count 0
+Jul  2 13:46:21.356: INFO: addons-heapster-e3b0c-64455ddddb-4nqxw from kube-system started at 2018-07-02 12:51:50 +0000 UTC (2 container statuses recorded)
+Jul  2 13:46:21.356: INFO: 	Container heapster ready: true, restart count 0
+Jul  2 13:46:21.356: INFO: 	Container heapster-nanny ready: true, restart count 0
+Jul  2 13:46:21.356: INFO: 
+Logging pods the kubelet thinks is on node shoot--core--confaz-worker-qfmi9-79968b77d9-kcr6j before test
+Jul  2 13:46:21.366: INFO: kube-proxy-f5qqz from kube-system started at 2018-07-02 12:51:49 +0000 UTC (1 container statuses recorded)
+Jul  2 13:46:21.366: INFO: 	Container kube-proxy ready: true, restart count 0
+Jul  2 13:46:21.366: INFO: sonobuoy-e2e-job-23e7c281ee4e4e5d from sonobuoy started at 2018-07-02 12:54:29 +0000 UTC (2 container statuses recorded)
+Jul  2 13:46:21.366: INFO: 	Container e2e ready: true, restart count 0
+Jul  2 13:46:21.366: INFO: 	Container sonobuoy-worker ready: true, restart count 0
+Jul  2 13:46:21.366: INFO: node-exporter-wh8n7 from kube-system started at 2018-07-02 12:51:49 +0000 UTC (1 container statuses recorded)
+Jul  2 13:46:21.366: INFO: 	Container node-exporter ready: true, restart count 0
+Jul  2 13:46:21.366: INFO: calico-node-77jff from kube-system started at 2018-07-02 12:51:49 +0000 UTC (2 container statuses recorded)
+Jul  2 13:46:21.366: INFO: 	Container calico-node ready: true, restart count 0
+Jul  2 13:46:21.366: INFO: 	Container install-cni ready: true, restart count 0
+Jul  2 13:46:21.366: INFO: sonobuoy from sonobuoy started at 2018-07-02 12:54:15 +0000 UTC (1 container statuses recorded)
+Jul  2 13:46:21.366: INFO: 	Container kube-sonobuoy ready: true, restart count 0
+[It] validates that NodeSelector is respected if matching  [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Trying to launch a pod without a label to get a node which can launch it.
+STEP: Explicitly delete pod here to free the resource it takes.
+STEP: Trying to apply a random label on the found node.
+STEP: verifying the node has the label kubernetes.io/e2e-501f3b12-7dfe-11e8-8e15-aefe7bc77cc2 42
+STEP: Trying to relaunch the pod, now with labels.
+STEP: removing the label kubernetes.io/e2e-501f3b12-7dfe-11e8-8e15-aefe7bc77cc2 off the node shoot--core--confaz-worker-qfmi9-79968b77d9-kcr6j
+STEP: verifying the node doesn't have the label kubernetes.io/e2e-501f3b12-7dfe-11e8-8e15-aefe7bc77cc2
+[AfterEach] [sig-scheduling] SchedulerPredicates [Serial]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:46:29.477: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-sched-pred-274jb" for this suite.
+Jul  2 13:46:51.550: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:46:51.677: INFO: namespace: e2e-tests-sched-pred-274jb, resource: bindings, ignored listing per whitelist
+Jul  2 13:46:51.681: INFO: namespace e2e-tests-sched-pred-274jb deletion completed in 22.20002541s
+[AfterEach] [sig-scheduling] SchedulerPredicates [Serial]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/scheduling/predicates.go:70
+
+• [SLOW TEST:90.514 seconds]
+[sig-scheduling] SchedulerPredicates [Serial]
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/scheduling/framework.go:22
+  validates that NodeSelector is respected if matching  [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSSSSSSSSSSSSSS
+------------------------------
+[sig-storage] Secrets 
+  should be consumable from pods in volume with mappings and Item Mode set [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-storage] Secrets
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:46:51.681: INFO: >>> kubeConfig: /tmp/kubeconfig-324782104
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should be consumable from pods in volume with mappings and Item Mode set [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating secret with name secret-test-map-5fd5cc1b-7dfe-11e8-8e15-aefe7bc77cc2
+STEP: Creating a pod to test consume secrets
+Jul  2 13:46:51.797: INFO: Waiting up to 5m0s for pod "pod-secrets-5fd75511-7dfe-11e8-8e15-aefe7bc77cc2" in namespace "e2e-tests-secrets-8l8m6" to be "success or failure"
+Jul  2 13:46:51.801: INFO: Pod "pod-secrets-5fd75511-7dfe-11e8-8e15-aefe7bc77cc2": Phase="Pending", Reason="", readiness=false. Elapsed: 4.026914ms
+Jul  2 13:46:53.804: INFO: Pod "pod-secrets-5fd75511-7dfe-11e8-8e15-aefe7bc77cc2": Phase="Pending", Reason="", readiness=false. Elapsed: 2.007209726s
+Jul  2 13:46:55.807: INFO: Pod "pod-secrets-5fd75511-7dfe-11e8-8e15-aefe7bc77cc2": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.01067757s
+STEP: Saw pod success
+Jul  2 13:46:55.807: INFO: Pod "pod-secrets-5fd75511-7dfe-11e8-8e15-aefe7bc77cc2" satisfied condition "success or failure"
+Jul  2 13:46:55.810: INFO: Trying to get logs from node shoot--core--confaz-worker-qfmi9-79968b77d9-kcr6j pod pod-secrets-5fd75511-7dfe-11e8-8e15-aefe7bc77cc2 container secret-volume-test: <nil>
+STEP: delete the pod
+Jul  2 13:46:55.888: INFO: Waiting for pod pod-secrets-5fd75511-7dfe-11e8-8e15-aefe7bc77cc2 to disappear
+Jul  2 13:46:55.901: INFO: Pod pod-secrets-5fd75511-7dfe-11e8-8e15-aefe7bc77cc2 no longer exists
+[AfterEach] [sig-storage] Secrets
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:46:55.901: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-secrets-8l8m6" for this suite.
+Jul  2 13:47:01.917: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:47:02.016: INFO: namespace: e2e-tests-secrets-8l8m6, resource: bindings, ignored listing per whitelist
+Jul  2 13:47:02.070: INFO: namespace e2e-tests-secrets-8l8m6 deletion completed in 6.165338487s
+
+• [SLOW TEST:10.389 seconds]
+[sig-storage] Secrets
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/secrets_volume.go:33
+  should be consumable from pods in volume with mappings and Item Mode set [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+[k8s.io] Probing container 
+  should have monotonically increasing restart count [Slow][NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [k8s.io] Probing container
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:47:02.071: INFO: >>> kubeConfig: /tmp/kubeconfig-324782104
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [k8s.io] Probing container
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/container_probe.go:48
+[It] should have monotonically increasing restart count [Slow][NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating pod liveness-http in namespace e2e-tests-container-probe-7rqwt
+Jul  2 13:47:06.250: INFO: Started pod liveness-http in namespace e2e-tests-container-probe-7rqwt
+STEP: checking the pod's current state and verifying that restartCount is present
+Jul  2 13:47:06.266: INFO: Initial restart count of pod liveness-http is 0
+Jul  2 13:47:26.356: INFO: Restart count of pod e2e-tests-container-probe-7rqwt/liveness-http is now 1 (20.090566232s elapsed)
+Jul  2 13:47:46.449: INFO: Restart count of pod e2e-tests-container-probe-7rqwt/liveness-http is now 2 (40.183071008s elapsed)
+Jul  2 13:48:06.676: INFO: Restart count of pod e2e-tests-container-probe-7rqwt/liveness-http is now 3 (1m0.410761824s elapsed)
+Jul  2 13:48:26.749: INFO: Restart count of pod e2e-tests-container-probe-7rqwt/liveness-http is now 4 (1m20.483555937s elapsed)
+Jul  2 13:49:27.257: INFO: Restart count of pod e2e-tests-container-probe-7rqwt/liveness-http is now 5 (2m20.991036481s elapsed)
+STEP: deleting the pod
+[AfterEach] [k8s.io] Probing container
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:49:27.279: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-container-probe-7rqwt" for this suite.
+Jul  2 13:49:33.308: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:49:33.392: INFO: namespace: e2e-tests-container-probe-7rqwt, resource: bindings, ignored listing per whitelist
+Jul  2 13:49:33.413: INFO: namespace e2e-tests-container-probe-7rqwt deletion completed in 6.120283013s
+
+• [SLOW TEST:151.342 seconds]
+[k8s.io] Probing container
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:679
+  should have monotonically increasing restart count [Slow][NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSSSSSSSS
+------------------------------
+[sig-apps] ReplicationController 
+  should serve a basic image on each replica with a public image  [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-apps] ReplicationController
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:49:33.414: INFO: >>> kubeConfig: /tmp/kubeconfig-324782104
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should serve a basic image on each replica with a public image  [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating replication controller my-hostname-basic-c03cf1c3-7dfe-11e8-8e15-aefe7bc77cc2
+Jul  2 13:49:33.560: INFO: Pod name my-hostname-basic-c03cf1c3-7dfe-11e8-8e15-aefe7bc77cc2: Found 0 pods out of 1
+Jul  2 13:49:38.564: INFO: Pod name my-hostname-basic-c03cf1c3-7dfe-11e8-8e15-aefe7bc77cc2: Found 1 pods out of 1
+Jul  2 13:49:38.564: INFO: Ensuring all pods for ReplicationController "my-hostname-basic-c03cf1c3-7dfe-11e8-8e15-aefe7bc77cc2" are running
+Jul  2 13:49:38.567: INFO: Pod "my-hostname-basic-c03cf1c3-7dfe-11e8-8e15-aefe7bc77cc2-nbxtr" is running (conditions: [{Type:Initialized Status:True LastProbeTime:0001-01-01 00:00:00 +0000 UTC LastTransitionTime:2018-07-02 13:49:33 +0000 UTC Reason: Message:} {Type:Ready Status:True LastProbeTime:0001-01-01 00:00:00 +0000 UTC LastTransitionTime:2018-07-02 13:49:35 +0000 UTC Reason: Message:} {Type:ContainersReady Status:True LastProbeTime:0001-01-01 00:00:00 +0000 UTC LastTransitionTime:0001-01-01 00:00:00 +0000 UTC Reason: Message:} {Type:PodScheduled Status:True LastProbeTime:0001-01-01 00:00:00 +0000 UTC LastTransitionTime:2018-07-02 13:49:33 +0000 UTC Reason: Message:}])
+Jul  2 13:49:38.567: INFO: Trying to dial the pod
+Jul  2 13:49:43.718: INFO: Controller my-hostname-basic-c03cf1c3-7dfe-11e8-8e15-aefe7bc77cc2: Got expected result from replica 1 [my-hostname-basic-c03cf1c3-7dfe-11e8-8e15-aefe7bc77cc2-nbxtr]: "my-hostname-basic-c03cf1c3-7dfe-11e8-8e15-aefe7bc77cc2-nbxtr", 1 of 1 required successes so far
+[AfterEach] [sig-apps] ReplicationController
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:49:43.718: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-replication-controller-9jb8r" for this suite.
+Jul  2 13:49:49.734: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:49:49.864: INFO: namespace: e2e-tests-replication-controller-9jb8r, resource: bindings, ignored listing per whitelist
+Jul  2 13:49:49.930: INFO: namespace e2e-tests-replication-controller-9jb8r deletion completed in 6.208349963s
+
+• [SLOW TEST:16.517 seconds]
+[sig-apps] ReplicationController
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/framework.go:22
+  should serve a basic image on each replica with a public image  [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSSSS
+------------------------------
+[sig-api-machinery] Watchers 
+  should be able to restart watching from the last resource version observed by the previous watch [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-api-machinery] Watchers
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:49:49.931: INFO: >>> kubeConfig: /tmp/kubeconfig-324782104
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should be able to restart watching from the last resource version observed by the previous watch [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: creating a watch on configmaps
+STEP: creating a new configmap
+STEP: modifying the configmap once
+STEP: closing the watch once it receives two notifications
+Jul  2 13:49:50.056: INFO: Got : ADDED &ConfigMap{ObjectMeta:k8s_io_apimachinery_pkg_apis_meta_v1.ObjectMeta{Name:e2e-watch-test-watch-closed,GenerateName:,Namespace:e2e-tests-watch-wtrvt,SelfLink:/api/v1/namespaces/e2e-tests-watch-wtrvt/configmaps/e2e-watch-test-watch-closed,UID:ca16766e-7dfe-11e8-bc8c-d657551927e5,ResourceVersion:11698,Generation:0,CreationTimestamp:2018-07-02 13:49:50 +0000 UTC,DeletionTimestamp:<nil>,DeletionGracePeriodSeconds:nil,Labels:map[string]string{watch-this-configmap: watch-closed-and-restarted,},Annotations:map[string]string{},OwnerReferences:[],Finalizers:[],ClusterName:,Initializers:nil,},Data:map[string]string{},BinaryData:map[string][]byte{},}
+Jul  2 13:49:50.056: INFO: Got : MODIFIED &ConfigMap{ObjectMeta:k8s_io_apimachinery_pkg_apis_meta_v1.ObjectMeta{Name:e2e-watch-test-watch-closed,GenerateName:,Namespace:e2e-tests-watch-wtrvt,SelfLink:/api/v1/namespaces/e2e-tests-watch-wtrvt/configmaps/e2e-watch-test-watch-closed,UID:ca16766e-7dfe-11e8-bc8c-d657551927e5,ResourceVersion:11699,Generation:0,CreationTimestamp:2018-07-02 13:49:50 +0000 UTC,DeletionTimestamp:<nil>,DeletionGracePeriodSeconds:nil,Labels:map[string]string{watch-this-configmap: watch-closed-and-restarted,},Annotations:map[string]string{},OwnerReferences:[],Finalizers:[],ClusterName:,Initializers:nil,},Data:map[string]string{mutation: 1,},BinaryData:map[string][]byte{},}
+STEP: modifying the configmap a second time, while the watch is closed
+STEP: creating a new watch on configmaps from the last resource version observed by the first watch
+STEP: deleting the configmap
+STEP: Expecting to observe notifications for all changes to the configmap since the first watch closed
+Jul  2 13:49:50.090: INFO: Got : MODIFIED &ConfigMap{ObjectMeta:k8s_io_apimachinery_pkg_apis_meta_v1.ObjectMeta{Name:e2e-watch-test-watch-closed,GenerateName:,Namespace:e2e-tests-watch-wtrvt,SelfLink:/api/v1/namespaces/e2e-tests-watch-wtrvt/configmaps/e2e-watch-test-watch-closed,UID:ca16766e-7dfe-11e8-bc8c-d657551927e5,ResourceVersion:11700,Generation:0,CreationTimestamp:2018-07-02 13:49:50 +0000 UTC,DeletionTimestamp:<nil>,DeletionGracePeriodSeconds:nil,Labels:map[string]string{watch-this-configmap: watch-closed-and-restarted,},Annotations:map[string]string{},OwnerReferences:[],Finalizers:[],ClusterName:,Initializers:nil,},Data:map[string]string{mutation: 2,},BinaryData:map[string][]byte{},}
+Jul  2 13:49:50.091: INFO: Got : DELETED &ConfigMap{ObjectMeta:k8s_io_apimachinery_pkg_apis_meta_v1.ObjectMeta{Name:e2e-watch-test-watch-closed,GenerateName:,Namespace:e2e-tests-watch-wtrvt,SelfLink:/api/v1/namespaces/e2e-tests-watch-wtrvt/configmaps/e2e-watch-test-watch-closed,UID:ca16766e-7dfe-11e8-bc8c-d657551927e5,ResourceVersion:11701,Generation:0,CreationTimestamp:2018-07-02 13:49:50 +0000 UTC,DeletionTimestamp:<nil>,DeletionGracePeriodSeconds:nil,Labels:map[string]string{watch-this-configmap: watch-closed-and-restarted,},Annotations:map[string]string{},OwnerReferences:[],Finalizers:[],ClusterName:,Initializers:nil,},Data:map[string]string{mutation: 2,},BinaryData:map[string][]byte{},}
+[AfterEach] [sig-api-machinery] Watchers
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:49:50.091: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-watch-wtrvt" for this suite.
+Jul  2 13:49:56.107: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:49:56.207: INFO: namespace: e2e-tests-watch-wtrvt, resource: bindings, ignored listing per whitelist
+Jul  2 13:49:56.281: INFO: namespace e2e-tests-watch-wtrvt deletion completed in 6.18644169s
+
+• [SLOW TEST:6.351 seconds]
+[sig-api-machinery] Watchers
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apimachinery/framework.go:22
+  should be able to restart watching from the last resource version observed by the previous watch [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+[sig-storage] EmptyDir volumes 
+  should support (root,0644,default) [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-storage] EmptyDir volumes
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:49:56.281: INFO: >>> kubeConfig: /tmp/kubeconfig-324782104
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should support (root,0644,default) [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating a pod to test emptydir 0644 on node default medium
+Jul  2 13:49:56.414: INFO: Waiting up to 5m0s for pod "pod-cde11763-7dfe-11e8-8e15-aefe7bc77cc2" in namespace "e2e-tests-emptydir-2zzmf" to be "success or failure"
+Jul  2 13:49:56.417: INFO: Pod "pod-cde11763-7dfe-11e8-8e15-aefe7bc77cc2": Phase="Pending", Reason="", readiness=false. Elapsed: 2.67351ms
+Jul  2 13:49:58.430: INFO: Pod "pod-cde11763-7dfe-11e8-8e15-aefe7bc77cc2": Phase="Pending", Reason="", readiness=false. Elapsed: 2.016235847s
+Jul  2 13:50:00.434: INFO: Pod "pod-cde11763-7dfe-11e8-8e15-aefe7bc77cc2": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.019491534s
+STEP: Saw pod success
+Jul  2 13:50:00.434: INFO: Pod "pod-cde11763-7dfe-11e8-8e15-aefe7bc77cc2" satisfied condition "success or failure"
+Jul  2 13:50:00.436: INFO: Trying to get logs from node shoot--core--confaz-worker-qfmi9-79968b77d9-kcr6j pod pod-cde11763-7dfe-11e8-8e15-aefe7bc77cc2 container test-container: <nil>
+STEP: delete the pod
+Jul  2 13:50:00.476: INFO: Waiting for pod pod-cde11763-7dfe-11e8-8e15-aefe7bc77cc2 to disappear
+Jul  2 13:50:00.507: INFO: Pod pod-cde11763-7dfe-11e8-8e15-aefe7bc77cc2 no longer exists
+[AfterEach] [sig-storage] EmptyDir volumes
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:50:00.507: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-emptydir-2zzmf" for this suite.
+Jul  2 13:50:06.565: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:50:06.673: INFO: namespace: e2e-tests-emptydir-2zzmf, resource: bindings, ignored listing per whitelist
+Jul  2 13:50:06.688: INFO: namespace e2e-tests-emptydir-2zzmf deletion completed in 6.154499801s
+
+• [SLOW TEST:10.407 seconds]
+[sig-storage] EmptyDir volumes
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/empty_dir.go:40
+  should support (root,0644,default) [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+[sig-api-machinery] Downward API 
+  should provide pod name, namespace and IP address as env vars [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-api-machinery] Downward API
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:50:06.688: INFO: >>> kubeConfig: /tmp/kubeconfig-324782104
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should provide pod name, namespace and IP address as env vars [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating a pod to test downward api env vars
+Jul  2 13:50:06.820: INFO: Waiting up to 5m0s for pod "downward-api-d4147f4b-7dfe-11e8-8e15-aefe7bc77cc2" in namespace "e2e-tests-downward-api-pjkwf" to be "success or failure"
+Jul  2 13:50:06.822: INFO: Pod "downward-api-d4147f4b-7dfe-11e8-8e15-aefe7bc77cc2": Phase="Pending", Reason="", readiness=false. Elapsed: 2.409908ms
+Jul  2 13:50:08.863: INFO: Pod "downward-api-d4147f4b-7dfe-11e8-8e15-aefe7bc77cc2": Phase="Pending", Reason="", readiness=false. Elapsed: 2.043440482s
+Jul  2 13:50:10.933: INFO: Pod "downward-api-d4147f4b-7dfe-11e8-8e15-aefe7bc77cc2": Phase="Pending", Reason="", readiness=false. Elapsed: 4.112909584s
+Jul  2 13:50:12.937: INFO: Pod "downward-api-d4147f4b-7dfe-11e8-8e15-aefe7bc77cc2": Phase="Succeeded", Reason="", readiness=false. Elapsed: 6.116793237s
+STEP: Saw pod success
+Jul  2 13:50:12.937: INFO: Pod "downward-api-d4147f4b-7dfe-11e8-8e15-aefe7bc77cc2" satisfied condition "success or failure"
+Jul  2 13:50:12.939: INFO: Trying to get logs from node shoot--core--confaz-worker-qfmi9-79968b77d9-kcr6j pod downward-api-d4147f4b-7dfe-11e8-8e15-aefe7bc77cc2 container dapi-container: <nil>
+STEP: delete the pod
+Jul  2 13:50:12.969: INFO: Waiting for pod downward-api-d4147f4b-7dfe-11e8-8e15-aefe7bc77cc2 to disappear
+Jul  2 13:50:12.988: INFO: Pod downward-api-d4147f4b-7dfe-11e8-8e15-aefe7bc77cc2 no longer exists
+[AfterEach] [sig-api-machinery] Downward API
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:50:12.988: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-downward-api-pjkwf" for this suite.
+Jul  2 13:50:19.007: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:50:19.084: INFO: namespace: e2e-tests-downward-api-pjkwf, resource: bindings, ignored listing per whitelist
+Jul  2 13:50:19.110: INFO: namespace e2e-tests-downward-api-pjkwf deletion completed in 6.114648053s
+
+• [SLOW TEST:12.422 seconds]
+[sig-api-machinery] Downward API
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downward_api.go:37
+  should provide pod name, namespace and IP address as env vars [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+S
+------------------------------
+[k8s.io] Probing container 
+  should be restarted with a /healthz http liveness probe [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [k8s.io] Probing container
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:50:19.111: INFO: >>> kubeConfig: /tmp/kubeconfig-324782104
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [k8s.io] Probing container
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/container_probe.go:48
+[It] should be restarted with a /healthz http liveness probe [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating pod liveness-http in namespace e2e-tests-container-probe-qwlxn
+Jul  2 13:50:21.270: INFO: Started pod liveness-http in namespace e2e-tests-container-probe-qwlxn
+STEP: checking the pod's current state and verifying that restartCount is present
+Jul  2 13:50:21.273: INFO: Initial restart count of pod liveness-http is 0
+Jul  2 13:50:45.362: INFO: Restart count of pod e2e-tests-container-probe-qwlxn/liveness-http is now 1 (24.088908498s elapsed)
+STEP: deleting the pod
+[AfterEach] [k8s.io] Probing container
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:50:45.373: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-container-probe-qwlxn" for this suite.
+Jul  2 13:50:51.444: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:50:51.592: INFO: namespace: e2e-tests-container-probe-qwlxn, resource: bindings, ignored listing per whitelist
+Jul  2 13:50:51.635: INFO: namespace e2e-tests-container-probe-qwlxn deletion completed in 6.25871051s
+
+• [SLOW TEST:32.525 seconds]
+[k8s.io] Probing container
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:679
+  should be restarted with a /healthz http liveness probe [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSSSS
+------------------------------
+[sig-storage] EmptyDir volumes 
+  should support (root,0644,tmpfs) [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-storage] EmptyDir volumes
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:50:51.636: INFO: >>> kubeConfig: /tmp/kubeconfig-324782104
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should support (root,0644,tmpfs) [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating a pod to test emptydir 0644 on tmpfs
+Jul  2 13:50:51.773: INFO: Waiting up to 5m0s for pod "pod-eedfda0d-7dfe-11e8-8e15-aefe7bc77cc2" in namespace "e2e-tests-emptydir-xrjzr" to be "success or failure"
+Jul  2 13:50:51.792: INFO: Pod "pod-eedfda0d-7dfe-11e8-8e15-aefe7bc77cc2": Phase="Pending", Reason="", readiness=false. Elapsed: 19.000265ms
+Jul  2 13:50:53.795: INFO: Pod "pod-eedfda0d-7dfe-11e8-8e15-aefe7bc77cc2": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.021982162s
+STEP: Saw pod success
+Jul  2 13:50:53.795: INFO: Pod "pod-eedfda0d-7dfe-11e8-8e15-aefe7bc77cc2" satisfied condition "success or failure"
+Jul  2 13:50:53.798: INFO: Trying to get logs from node shoot--core--confaz-worker-qfmi9-79968b77d9-kcr6j pod pod-eedfda0d-7dfe-11e8-8e15-aefe7bc77cc2 container test-container: <nil>
+STEP: delete the pod
+Jul  2 13:50:53.832: INFO: Waiting for pod pod-eedfda0d-7dfe-11e8-8e15-aefe7bc77cc2 to disappear
+Jul  2 13:50:53.841: INFO: Pod pod-eedfda0d-7dfe-11e8-8e15-aefe7bc77cc2 no longer exists
+[AfterEach] [sig-storage] EmptyDir volumes
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:50:53.841: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-emptydir-xrjzr" for this suite.
+Jul  2 13:50:59.858: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:50:59.888: INFO: namespace: e2e-tests-emptydir-xrjzr, resource: bindings, ignored listing per whitelist
+Jul  2 13:50:59.947: INFO: namespace e2e-tests-emptydir-xrjzr deletion completed in 6.102529516s
+
+• [SLOW TEST:8.311 seconds]
+[sig-storage] EmptyDir volumes
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/empty_dir.go:40
+  should support (root,0644,tmpfs) [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSSSSSSSSSSSSSSSS
+------------------------------
+[sig-apps] StatefulSet [k8s.io] Basic StatefulSet functionality [StatefulSetBasic] 
+  Burst scaling should run to completion even with unhealthy pods [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-apps] StatefulSet
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:50:59.947: INFO: >>> kubeConfig: /tmp/kubeconfig-324782104
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-apps] StatefulSet
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/statefulset.go:57
+[BeforeEach] [k8s.io] Basic StatefulSet functionality [StatefulSetBasic]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/statefulset.go:72
+STEP: Creating service test in namespace e2e-tests-statefulset-72pwn
+[It] Burst scaling should run to completion even with unhealthy pods [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating stateful set ss in namespace e2e-tests-statefulset-72pwn
+STEP: Waiting until all stateful set ss replicas will be running in namespace e2e-tests-statefulset-72pwn
+Jul  2 13:51:00.056: INFO: Found 0 stateful pods, waiting for 1
+Jul  2 13:51:10.060: INFO: Waiting for pod ss-0 to enter Running - Ready=true, currently Running - Ready=true
+STEP: Confirming that stateful set scale up will not halt with unhealthy stateful pod
+Jul  2 13:51:10.068: INFO: Running '/usr/local/bin/kubectl --kubeconfig=/tmp/kubeconfig-324782104 exec --namespace=e2e-tests-statefulset-72pwn ss-0 -- /bin/sh -c mv -v /usr/share/nginx/html/index.html /tmp/ || true'
+Jul  2 13:51:10.540: INFO: stderr: ""
+Jul  2 13:51:10.540: INFO: stdout: "'/usr/share/nginx/html/index.html' -> '/tmp/index.html'\n"
+Jul  2 13:51:10.540: INFO: stdout of mv -v /usr/share/nginx/html/index.html /tmp/ || true on ss-0: '/usr/share/nginx/html/index.html' -> '/tmp/index.html'
+
+Jul  2 13:51:10.544: INFO: Waiting for pod ss-0 to enter Running - Ready=false, currently Running - Ready=true
+Jul  2 13:51:20.549: INFO: Waiting for pod ss-0 to enter Running - Ready=false, currently Running - Ready=false
+Jul  2 13:51:20.549: INFO: Waiting for statefulset status.replicas updated to 0
+Jul  2 13:51:20.560: INFO: POD   NODE                                               PHASE    GRACE  CONDITIONS
+Jul  2 13:51:20.560: INFO: ss-0  shoot--core--confaz-worker-qfmi9-79968b77d9-kcr6j  Running         [{Initialized True 0001-01-01 00:00:00 +0000 UTC 2018-07-02 13:51:00 +0000 UTC  } {Ready False 0001-01-01 00:00:00 +0000 UTC 2018-07-02 13:51:10 +0000 UTC ContainersNotReady containers with unready status: [nginx]} {ContainersReady False 0001-01-01 00:00:00 +0000 UTC 0001-01-01 00:00:00 +0000 UTC ContainersNotReady containers with unready status: [nginx]} {PodScheduled True 0001-01-01 00:00:00 +0000 UTC 2018-07-02 13:51:00 +0000 UTC  }]
+Jul  2 13:51:20.560: INFO: 
+Jul  2 13:51:20.560: INFO: StatefulSet ss has not reached scale 3, at 1
+Jul  2 13:51:21.565: INFO: Verifying statefulset ss doesn't scale past 3 for another 8.996724592s
+Jul  2 13:51:22.569: INFO: Verifying statefulset ss doesn't scale past 3 for another 7.991980234s
+Jul  2 13:51:23.574: INFO: Verifying statefulset ss doesn't scale past 3 for another 6.988074748s
+Jul  2 13:51:24.577: INFO: Verifying statefulset ss doesn't scale past 3 for another 5.983678303s
+Jul  2 13:51:25.581: INFO: Verifying statefulset ss doesn't scale past 3 for another 4.980264544s
+Jul  2 13:51:26.585: INFO: Verifying statefulset ss doesn't scale past 3 for another 3.975975187s
+Jul  2 13:51:27.597: INFO: Verifying statefulset ss doesn't scale past 3 for another 2.971773736s
+Jul  2 13:51:28.601: INFO: Verifying statefulset ss doesn't scale past 3 for another 1.960466365s
+Jul  2 13:51:29.634: INFO: Verifying statefulset ss doesn't scale past 3 for another 956.598727ms
+STEP: Scaling up stateful set ss to 3 replicas and waiting until all of them will be running in namespace e2e-tests-statefulset-72pwn
+Jul  2 13:51:30.638: INFO: Running '/usr/local/bin/kubectl --kubeconfig=/tmp/kubeconfig-324782104 exec --namespace=e2e-tests-statefulset-72pwn ss-0 -- /bin/sh -c mv -v /tmp/index.html /usr/share/nginx/html/ || true'
+Jul  2 13:51:31.180: INFO: stderr: ""
+Jul  2 13:51:31.180: INFO: stdout: "'/tmp/index.html' -> '/usr/share/nginx/html/index.html'\n"
+Jul  2 13:51:31.180: INFO: stdout of mv -v /tmp/index.html /usr/share/nginx/html/ || true on ss-0: '/tmp/index.html' -> '/usr/share/nginx/html/index.html'
+
+Jul  2 13:51:31.180: INFO: Running '/usr/local/bin/kubectl --kubeconfig=/tmp/kubeconfig-324782104 exec --namespace=e2e-tests-statefulset-72pwn ss-1 -- /bin/sh -c mv -v /tmp/index.html /usr/share/nginx/html/ || true'
+Jul  2 13:51:31.663: INFO: stderr: "mv: cannot stat '/tmp/index.html': No such file or directory\n"
+Jul  2 13:51:31.663: INFO: stdout: ""
+Jul  2 13:51:31.663: INFO: stdout of mv -v /tmp/index.html /usr/share/nginx/html/ || true on ss-1: 
+Jul  2 13:51:31.663: INFO: Running '/usr/local/bin/kubectl --kubeconfig=/tmp/kubeconfig-324782104 exec --namespace=e2e-tests-statefulset-72pwn ss-2 -- /bin/sh -c mv -v /tmp/index.html /usr/share/nginx/html/ || true'
+Jul  2 13:51:32.216: INFO: stderr: "mv: cannot stat '/tmp/index.html': No such file or directory\n"
+Jul  2 13:51:32.216: INFO: stdout: ""
+Jul  2 13:51:32.216: INFO: stdout of mv -v /tmp/index.html /usr/share/nginx/html/ || true on ss-2: 
+Jul  2 13:51:32.221: INFO: Waiting for pod ss-0 to enter Running - Ready=true, currently Running - Ready=true
+Jul  2 13:51:32.221: INFO: Waiting for pod ss-1 to enter Running - Ready=true, currently Running - Ready=true
+Jul  2 13:51:32.221: INFO: Waiting for pod ss-2 to enter Running - Ready=true, currently Running - Ready=true
+STEP: Scale down will not halt with unhealthy stateful pod
+Jul  2 13:51:32.226: INFO: Running '/usr/local/bin/kubectl --kubeconfig=/tmp/kubeconfig-324782104 exec --namespace=e2e-tests-statefulset-72pwn ss-0 -- /bin/sh -c mv -v /usr/share/nginx/html/index.html /tmp/ || true'
+Jul  2 13:51:32.684: INFO: stderr: ""
+Jul  2 13:51:32.684: INFO: stdout: "'/usr/share/nginx/html/index.html' -> '/tmp/index.html'\n"
+Jul  2 13:51:32.684: INFO: stdout of mv -v /usr/share/nginx/html/index.html /tmp/ || true on ss-0: '/usr/share/nginx/html/index.html' -> '/tmp/index.html'
+
+Jul  2 13:51:32.684: INFO: Running '/usr/local/bin/kubectl --kubeconfig=/tmp/kubeconfig-324782104 exec --namespace=e2e-tests-statefulset-72pwn ss-1 -- /bin/sh -c mv -v /usr/share/nginx/html/index.html /tmp/ || true'
+Jul  2 13:51:33.262: INFO: stderr: ""
+Jul  2 13:51:33.262: INFO: stdout: "'/usr/share/nginx/html/index.html' -> '/tmp/index.html'\n"
+Jul  2 13:51:33.262: INFO: stdout of mv -v /usr/share/nginx/html/index.html /tmp/ || true on ss-1: '/usr/share/nginx/html/index.html' -> '/tmp/index.html'
+
+Jul  2 13:51:33.262: INFO: Running '/usr/local/bin/kubectl --kubeconfig=/tmp/kubeconfig-324782104 exec --namespace=e2e-tests-statefulset-72pwn ss-2 -- /bin/sh -c mv -v /usr/share/nginx/html/index.html /tmp/ || true'
+Jul  2 13:51:33.708: INFO: stderr: ""
+Jul  2 13:51:33.708: INFO: stdout: "'/usr/share/nginx/html/index.html' -> '/tmp/index.html'\n"
+Jul  2 13:51:33.708: INFO: stdout of mv -v /usr/share/nginx/html/index.html /tmp/ || true on ss-2: '/usr/share/nginx/html/index.html' -> '/tmp/index.html'
+
+Jul  2 13:51:33.708: INFO: Waiting for statefulset status.replicas updated to 0
+Jul  2 13:51:33.766: INFO: Waiting for stateful set status.readyReplicas to become 0, currently 2
+Jul  2 13:51:43.774: INFO: Waiting for pod ss-0 to enter Running - Ready=false, currently Running - Ready=false
+Jul  2 13:51:43.774: INFO: Waiting for pod ss-1 to enter Running - Ready=false, currently Running - Ready=false
+Jul  2 13:51:43.774: INFO: Waiting for pod ss-2 to enter Running - Ready=false, currently Running - Ready=false
+Jul  2 13:51:43.786: INFO: POD   NODE                                               PHASE    GRACE  CONDITIONS
+Jul  2 13:51:43.786: INFO: ss-0  shoot--core--confaz-worker-qfmi9-79968b77d9-kcr6j  Running         [{Initialized True 0001-01-01 00:00:00 +0000 UTC 2018-07-02 13:51:00 +0000 UTC  } {Ready False 0001-01-01 00:00:00 +0000 UTC 2018-07-02 13:51:32 +0000 UTC ContainersNotReady containers with unready status: [nginx]} {ContainersReady False 0001-01-01 00:00:00 +0000 UTC 0001-01-01 00:00:00 +0000 UTC ContainersNotReady containers with unready status: [nginx]} {PodScheduled True 0001-01-01 00:00:00 +0000 UTC 2018-07-02 13:51:00 +0000 UTC  }]
+Jul  2 13:51:43.786: INFO: ss-1  shoot--core--confaz-worker-qfmi9-79968b77d9-24hm4  Running         [{Initialized True 0001-01-01 00:00:00 +0000 UTC 2018-07-02 13:51:20 +0000 UTC  } {Ready False 0001-01-01 00:00:00 +0000 UTC 2018-07-02 13:51:34 +0000 UTC ContainersNotReady containers with unready status: [nginx]} {ContainersReady False 0001-01-01 00:00:00 +0000 UTC 0001-01-01 00:00:00 +0000 UTC ContainersNotReady containers with unready status: [nginx]} {PodScheduled True 0001-01-01 00:00:00 +0000 UTC 2018-07-02 13:51:20 +0000 UTC  }]
+Jul  2 13:51:43.786: INFO: ss-2  shoot--core--confaz-worker-qfmi9-79968b77d9-kcr6j  Running         [{Initialized True 0001-01-01 00:00:00 +0000 UTC 2018-07-02 13:51:20 +0000 UTC  } {Ready False 0001-01-01 00:00:00 +0000 UTC 2018-07-02 13:51:34 +0000 UTC ContainersNotReady containers with unready status: [nginx]} {ContainersReady False 0001-01-01 00:00:00 +0000 UTC 0001-01-01 00:00:00 +0000 UTC ContainersNotReady containers with unready status: [nginx]} {PodScheduled True 0001-01-01 00:00:00 +0000 UTC 2018-07-02 13:51:20 +0000 UTC  }]
+Jul  2 13:51:43.786: INFO: 
+Jul  2 13:51:43.786: INFO: StatefulSet ss has not reached scale 0, at 3
+Jul  2 13:51:44.801: INFO: POD   NODE                                               PHASE    GRACE  CONDITIONS
+Jul  2 13:51:44.801: INFO: ss-0  shoot--core--confaz-worker-qfmi9-79968b77d9-kcr6j  Running  30s    [{Initialized True 0001-01-01 00:00:00 +0000 UTC 2018-07-02 13:51:00 +0000 UTC  } {Ready False 0001-01-01 00:00:00 +0000 UTC 2018-07-02 13:51:32 +0000 UTC ContainersNotReady containers with unready status: [nginx]} {ContainersReady False 0001-01-01 00:00:00 +0000 UTC 0001-01-01 00:00:00 +0000 UTC ContainersNotReady containers with unready status: [nginx]} {PodScheduled True 0001-01-01 00:00:00 +0000 UTC 2018-07-02 13:51:00 +0000 UTC  }]
+Jul  2 13:51:44.801: INFO: ss-1  shoot--core--confaz-worker-qfmi9-79968b77d9-24hm4  Running  30s    [{Initialized True 0001-01-01 00:00:00 +0000 UTC 2018-07-02 13:51:20 +0000 UTC  } {Ready False 0001-01-01 00:00:00 +0000 UTC 2018-07-02 13:51:34 +0000 UTC ContainersNotReady containers with unready status: [nginx]} {ContainersReady False 0001-01-01 00:00:00 +0000 UTC 0001-01-01 00:00:00 +0000 UTC ContainersNotReady containers with unready status: [nginx]} {PodScheduled True 0001-01-01 00:00:00 +0000 UTC 2018-07-02 13:51:20 +0000 UTC  }]
+Jul  2 13:51:44.802: INFO: ss-2  shoot--core--confaz-worker-qfmi9-79968b77d9-kcr6j  Running  30s    [{Initialized True 0001-01-01 00:00:00 +0000 UTC 2018-07-02 13:51:20 +0000 UTC  } {Ready False 0001-01-01 00:00:00 +0000 UTC 2018-07-02 13:51:34 +0000 UTC ContainersNotReady containers with unready status: [nginx]} {ContainersReady False 0001-01-01 00:00:00 +0000 UTC 0001-01-01 00:00:00 +0000 UTC ContainersNotReady containers with unready status: [nginx]} {PodScheduled True 0001-01-01 00:00:00 +0000 UTC 2018-07-02 13:51:20 +0000 UTC  }]
+Jul  2 13:51:44.802: INFO: 
+Jul  2 13:51:44.802: INFO: StatefulSet ss has not reached scale 0, at 3
+Jul  2 13:51:45.806: INFO: POD   NODE                                               PHASE    GRACE  CONDITIONS
+Jul  2 13:51:45.806: INFO: ss-1  shoot--core--confaz-worker-qfmi9-79968b77d9-24hm4  Pending  30s    [{Initialized True 0001-01-01 00:00:00 +0000 UTC 2018-07-02 13:51:20 +0000 UTC  } {Ready False 0001-01-01 00:00:00 +0000 UTC 2018-07-02 13:51:34 +0000 UTC ContainersNotReady containers with unready status: [nginx]} {ContainersReady False 0001-01-01 00:00:00 +0000 UTC 0001-01-01 00:00:00 +0000 UTC ContainersNotReady containers with unready status: [nginx]} {PodScheduled True 0001-01-01 00:00:00 +0000 UTC 2018-07-02 13:51:20 +0000 UTC  }]
+Jul  2 13:51:45.806: INFO: 
+Jul  2 13:51:45.806: INFO: StatefulSet ss has not reached scale 0, at 1
+Jul  2 13:51:46.810: INFO: POD   NODE                                               PHASE    GRACE  CONDITIONS
+Jul  2 13:51:46.810: INFO: ss-1  shoot--core--confaz-worker-qfmi9-79968b77d9-24hm4  Pending  30s    [{Initialized True 0001-01-01 00:00:00 +0000 UTC 2018-07-02 13:51:20 +0000 UTC  } {Ready False 0001-01-01 00:00:00 +0000 UTC 2018-07-02 13:51:34 +0000 UTC ContainersNotReady containers with unready status: [nginx]} {ContainersReady False 0001-01-01 00:00:00 +0000 UTC 0001-01-01 00:00:00 +0000 UTC ContainersNotReady containers with unready status: [nginx]} {PodScheduled True 0001-01-01 00:00:00 +0000 UTC 2018-07-02 13:51:20 +0000 UTC  }]
+Jul  2 13:51:46.810: INFO: 
+Jul  2 13:51:46.810: INFO: StatefulSet ss has not reached scale 0, at 1
+Jul  2 13:51:47.865: INFO: POD   NODE                                               PHASE    GRACE  CONDITIONS
+Jul  2 13:51:47.865: INFO: ss-1  shoot--core--confaz-worker-qfmi9-79968b77d9-24hm4  Pending  30s    [{Initialized True 0001-01-01 00:00:00 +0000 UTC 2018-07-02 13:51:20 +0000 UTC  } {Ready False 0001-01-01 00:00:00 +0000 UTC 2018-07-02 13:51:34 +0000 UTC ContainersNotReady containers with unready status: [nginx]} {ContainersReady False 0001-01-01 00:00:00 +0000 UTC 0001-01-01 00:00:00 +0000 UTC ContainersNotReady containers with unready status: [nginx]} {PodScheduled True 0001-01-01 00:00:00 +0000 UTC 2018-07-02 13:51:20 +0000 UTC  }]
+Jul  2 13:51:47.865: INFO: 
+Jul  2 13:51:47.865: INFO: StatefulSet ss has not reached scale 0, at 1
+Jul  2 13:51:48.869: INFO: POD   NODE                                               PHASE    GRACE  CONDITIONS
+Jul  2 13:51:48.869: INFO: ss-1  shoot--core--confaz-worker-qfmi9-79968b77d9-24hm4  Pending  30s    [{Initialized True 0001-01-01 00:00:00 +0000 UTC 2018-07-02 13:51:20 +0000 UTC  } {Ready False 0001-01-01 00:00:00 +0000 UTC 2018-07-02 13:51:34 +0000 UTC ContainersNotReady containers with unready status: [nginx]} {ContainersReady False 0001-01-01 00:00:00 +0000 UTC 0001-01-01 00:00:00 +0000 UTC ContainersNotReady containers with unready status: [nginx]} {PodScheduled True 0001-01-01 00:00:00 +0000 UTC 2018-07-02 13:51:20 +0000 UTC  }]
+Jul  2 13:51:48.869: INFO: 
+Jul  2 13:51:48.869: INFO: StatefulSet ss has not reached scale 0, at 1
+Jul  2 13:51:49.873: INFO: Verifying statefulset ss doesn't scale past 0 for another 3.912040163s
+Jul  2 13:51:50.888: INFO: Verifying statefulset ss doesn't scale past 0 for another 2.907728664s
+Jul  2 13:51:51.893: INFO: Verifying statefulset ss doesn't scale past 0 for another 1.892430336s
+Jul  2 13:51:52.896: INFO: Verifying statefulset ss doesn't scale past 0 for another 888.223746ms
+STEP: Scaling down stateful set ss to 0 replicas and waiting until none of pods will run in namespacee2e-tests-statefulset-72pwn
+Jul  2 13:51:53.902: INFO: Scaling statefulset ss to 0
+Jul  2 13:51:53.912: INFO: Waiting for statefulset status.replicas updated to 0
+[AfterEach] [k8s.io] Basic StatefulSet functionality [StatefulSetBasic]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/statefulset.go:83
+Jul  2 13:51:53.915: INFO: Deleting all statefulset in ns e2e-tests-statefulset-72pwn
+Jul  2 13:51:53.918: INFO: Scaling statefulset ss to 0
+Jul  2 13:51:53.926: INFO: Waiting for statefulset status.replicas updated to 0
+Jul  2 13:51:53.929: INFO: Deleting statefulset ss
+[AfterEach] [sig-apps] StatefulSet
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:51:53.956: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-statefulset-72pwn" for this suite.
+Jul  2 13:52:02.030: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:52:02.131: INFO: namespace: e2e-tests-statefulset-72pwn, resource: bindings, ignored listing per whitelist
+Jul  2 13:52:02.139: INFO: namespace e2e-tests-statefulset-72pwn deletion completed in 8.17995006s
+
+• [SLOW TEST:62.192 seconds]
+[sig-apps] StatefulSet
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/framework.go:22
+  [k8s.io] Basic StatefulSet functionality [StatefulSetBasic]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:679
+    Burst scaling should run to completion even with unhealthy pods [Conformance]
+    /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSSSSSSSSSS
+------------------------------
+[sig-storage] Secrets 
+  should be consumable from pods in volume with defaultMode set [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-storage] Secrets
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:52:02.139: INFO: >>> kubeConfig: /tmp/kubeconfig-324782104
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should be consumable from pods in volume with defaultMode set [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating secret with name secret-test-18e2a6e0-7dff-11e8-8e15-aefe7bc77cc2
+STEP: Creating a pod to test consume secrets
+Jul  2 13:52:02.266: INFO: Waiting up to 5m0s for pod "pod-secrets-18e486bb-7dff-11e8-8e15-aefe7bc77cc2" in namespace "e2e-tests-secrets-pdvgw" to be "success or failure"
+Jul  2 13:52:02.270: INFO: Pod "pod-secrets-18e486bb-7dff-11e8-8e15-aefe7bc77cc2": Phase="Pending", Reason="", readiness=false. Elapsed: 4.797114ms
+Jul  2 13:52:04.273: INFO: Pod "pod-secrets-18e486bb-7dff-11e8-8e15-aefe7bc77cc2": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.007849537s
+STEP: Saw pod success
+Jul  2 13:52:04.273: INFO: Pod "pod-secrets-18e486bb-7dff-11e8-8e15-aefe7bc77cc2" satisfied condition "success or failure"
+Jul  2 13:52:04.276: INFO: Trying to get logs from node shoot--core--confaz-worker-qfmi9-79968b77d9-kcr6j pod pod-secrets-18e486bb-7dff-11e8-8e15-aefe7bc77cc2 container secret-volume-test: <nil>
+STEP: delete the pod
+Jul  2 13:52:04.307: INFO: Waiting for pod pod-secrets-18e486bb-7dff-11e8-8e15-aefe7bc77cc2 to disappear
+Jul  2 13:52:04.319: INFO: Pod pod-secrets-18e486bb-7dff-11e8-8e15-aefe7bc77cc2 no longer exists
+[AfterEach] [sig-storage] Secrets
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:52:04.319: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-secrets-pdvgw" for this suite.
+Jul  2 13:52:10.335: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:52:10.373: INFO: namespace: e2e-tests-secrets-pdvgw, resource: bindings, ignored listing per whitelist
+Jul  2 13:52:10.503: INFO: namespace e2e-tests-secrets-pdvgw deletion completed in 6.180284646s
+
+• [SLOW TEST:8.364 seconds]
+[sig-storage] Secrets
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/secrets_volume.go:33
+  should be consumable from pods in volume with defaultMode set [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+[sig-storage] Projected 
+  should update annotations on modification [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:52:10.503: INFO: >>> kubeConfig: /tmp/kubeconfig-324782104
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:858
+[It] should update annotations on modification [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating the pod
+Jul  2 13:52:13.181: INFO: Successfully updated pod "annotationupdate1de03e1a-7dff-11e8-8e15-aefe7bc77cc2"
+[AfterEach] [sig-storage] Projected
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:52:15.247: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-pnvgx" for this suite.
+Jul  2 13:52:39.270: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:52:39.307: INFO: namespace: e2e-tests-projected-pnvgx, resource: bindings, ignored listing per whitelist
+Jul  2 13:52:39.378: INFO: namespace e2e-tests-projected-pnvgx deletion completed in 24.126973418s
+
+• [SLOW TEST:28.875 seconds]
+[sig-storage] Projected
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:34
+  should update annotations on modification [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SS
+------------------------------
+[sig-storage] Projected 
+  should be consumable from pods in volume with defaultMode set [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:52:39.378: INFO: >>> kubeConfig: /tmp/kubeconfig-324782104
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:858
+[It] should be consumable from pods in volume with defaultMode set [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating configMap with name projected-configmap-test-volume-2f17155b-7dff-11e8-8e15-aefe7bc77cc2
+STEP: Creating a pod to test consume configMaps
+Jul  2 13:52:39.512: INFO: Waiting up to 5m0s for pod "pod-projected-configmaps-2f188b35-7dff-11e8-8e15-aefe7bc77cc2" in namespace "e2e-tests-projected-2d7d2" to be "success or failure"
+Jul  2 13:52:39.516: INFO: Pod "pod-projected-configmaps-2f188b35-7dff-11e8-8e15-aefe7bc77cc2": Phase="Pending", Reason="", readiness=false. Elapsed: 3.542014ms
+Jul  2 13:52:41.519: INFO: Pod "pod-projected-configmaps-2f188b35-7dff-11e8-8e15-aefe7bc77cc2": Phase="Pending", Reason="", readiness=false. Elapsed: 2.006872395s
+Jul  2 13:52:43.523: INFO: Pod "pod-projected-configmaps-2f188b35-7dff-11e8-8e15-aefe7bc77cc2": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.010571862s
+STEP: Saw pod success
+Jul  2 13:52:43.523: INFO: Pod "pod-projected-configmaps-2f188b35-7dff-11e8-8e15-aefe7bc77cc2" satisfied condition "success or failure"
+Jul  2 13:52:43.526: INFO: Trying to get logs from node shoot--core--confaz-worker-qfmi9-79968b77d9-kcr6j pod pod-projected-configmaps-2f188b35-7dff-11e8-8e15-aefe7bc77cc2 container projected-configmap-volume-test: <nil>
+STEP: delete the pod
+Jul  2 13:52:43.560: INFO: Waiting for pod pod-projected-configmaps-2f188b35-7dff-11e8-8e15-aefe7bc77cc2 to disappear
+Jul  2 13:52:43.570: INFO: Pod pod-projected-configmaps-2f188b35-7dff-11e8-8e15-aefe7bc77cc2 no longer exists
+[AfterEach] [sig-storage] Projected
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:52:43.571: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-2d7d2" for this suite.
+Jul  2 13:52:49.587: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:52:49.733: INFO: namespace: e2e-tests-projected-2d7d2, resource: bindings, ignored listing per whitelist
+Jul  2 13:52:49.898: INFO: namespace e2e-tests-projected-2d7d2 deletion completed in 6.324102861s
+
+• [SLOW TEST:10.520 seconds]
+[sig-storage] Projected
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:34
+  should be consumable from pods in volume with defaultMode set [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSSS
+------------------------------
+[sig-api-machinery] CustomResourceDefinition resources Simple CustomResourceDefinition 
+  creating/deleting custom resource definition objects works  [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-api-machinery] CustomResourceDefinition resources
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:52:49.898: INFO: >>> kubeConfig: /tmp/kubeconfig-324782104
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] creating/deleting custom resource definition objects works  [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+Jul  2 13:52:50.006: INFO: >>> kubeConfig: /tmp/kubeconfig-324782104
+[AfterEach] [sig-api-machinery] CustomResourceDefinition resources
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:52:51.146: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-custom-resource-definition-pch9r" for this suite.
+Jul  2 13:52:57.161: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:52:57.199: INFO: namespace: e2e-tests-custom-resource-definition-pch9r, resource: bindings, ignored listing per whitelist
+Jul  2 13:52:57.251: INFO: namespace e2e-tests-custom-resource-definition-pch9r deletion completed in 6.101021327s
+
+• [SLOW TEST:7.352 seconds]
+[sig-api-machinery] CustomResourceDefinition resources
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apimachinery/framework.go:22
+  Simple CustomResourceDefinition
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apimachinery/custom_resource_definition.go:35
+    creating/deleting custom resource definition objects works  [Conformance]
+    /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSSSSSSSS
+------------------------------
+[sig-storage] Secrets 
+  should be consumable from pods in volume [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-storage] Secrets
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:52:57.251: INFO: >>> kubeConfig: /tmp/kubeconfig-324782104
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should be consumable from pods in volume [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating secret with name secret-test-39b8ac0b-7dff-11e8-8e15-aefe7bc77cc2
+STEP: Creating a pod to test consume secrets
+Jul  2 13:52:57.354: INFO: Waiting up to 5m0s for pod "pod-secrets-39bafca1-7dff-11e8-8e15-aefe7bc77cc2" in namespace "e2e-tests-secrets-khsr9" to be "success or failure"
+Jul  2 13:52:57.370: INFO: Pod "pod-secrets-39bafca1-7dff-11e8-8e15-aefe7bc77cc2": Phase="Pending", Reason="", readiness=false. Elapsed: 15.366254ms
+Jul  2 13:52:59.374: INFO: Pod "pod-secrets-39bafca1-7dff-11e8-8e15-aefe7bc77cc2": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.019067571s
+STEP: Saw pod success
+Jul  2 13:52:59.374: INFO: Pod "pod-secrets-39bafca1-7dff-11e8-8e15-aefe7bc77cc2" satisfied condition "success or failure"
+Jul  2 13:52:59.376: INFO: Trying to get logs from node shoot--core--confaz-worker-qfmi9-79968b77d9-kcr6j pod pod-secrets-39bafca1-7dff-11e8-8e15-aefe7bc77cc2 container secret-volume-test: <nil>
+STEP: delete the pod
+Jul  2 13:52:59.468: INFO: Waiting for pod pod-secrets-39bafca1-7dff-11e8-8e15-aefe7bc77cc2 to disappear
+Jul  2 13:52:59.475: INFO: Pod pod-secrets-39bafca1-7dff-11e8-8e15-aefe7bc77cc2 no longer exists
+[AfterEach] [sig-storage] Secrets
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:52:59.475: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-secrets-khsr9" for this suite.
+Jul  2 13:53:05.514: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:53:05.758: INFO: namespace: e2e-tests-secrets-khsr9, resource: bindings, ignored listing per whitelist
+Jul  2 13:53:05.766: INFO: namespace e2e-tests-secrets-khsr9 deletion completed in 6.287423909s
+
+• [SLOW TEST:8.515 seconds]
+[sig-storage] Secrets
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/secrets_volume.go:33
+  should be consumable from pods in volume [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSSSSSSSSSSSSSSS
+------------------------------
+[sig-storage] EmptyDir volumes 
+  should support (root,0777,default) [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-storage] EmptyDir volumes
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:53:05.766: INFO: >>> kubeConfig: /tmp/kubeconfig-324782104
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should support (root,0777,default) [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating a pod to test emptydir 0777 on node default medium
+Jul  2 13:53:05.907: INFO: Waiting up to 5m0s for pod "pod-3ed04636-7dff-11e8-8e15-aefe7bc77cc2" in namespace "e2e-tests-emptydir-jtcrp" to be "success or failure"
+Jul  2 13:53:05.920: INFO: Pod "pod-3ed04636-7dff-11e8-8e15-aefe7bc77cc2": Phase="Pending", Reason="", readiness=false. Elapsed: 12.947044ms
+Jul  2 13:53:07.931: INFO: Pod "pod-3ed04636-7dff-11e8-8e15-aefe7bc77cc2": Phase="Pending", Reason="", readiness=false. Elapsed: 2.023438261s
+Jul  2 13:53:09.934: INFO: Pod "pod-3ed04636-7dff-11e8-8e15-aefe7bc77cc2": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.026724148s
+STEP: Saw pod success
+Jul  2 13:53:09.934: INFO: Pod "pod-3ed04636-7dff-11e8-8e15-aefe7bc77cc2" satisfied condition "success or failure"
+Jul  2 13:53:09.937: INFO: Trying to get logs from node shoot--core--confaz-worker-qfmi9-79968b77d9-kcr6j pod pod-3ed04636-7dff-11e8-8e15-aefe7bc77cc2 container test-container: <nil>
+STEP: delete the pod
+Jul  2 13:53:09.977: INFO: Waiting for pod pod-3ed04636-7dff-11e8-8e15-aefe7bc77cc2 to disappear
+Jul  2 13:53:09.988: INFO: Pod pod-3ed04636-7dff-11e8-8e15-aefe7bc77cc2 no longer exists
+[AfterEach] [sig-storage] EmptyDir volumes
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:53:09.988: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-emptydir-jtcrp" for this suite.
+Jul  2 13:53:16.039: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:53:16.088: INFO: namespace: e2e-tests-emptydir-jtcrp, resource: bindings, ignored listing per whitelist
+Jul  2 13:53:16.145: INFO: namespace e2e-tests-emptydir-jtcrp deletion completed in 6.154149888s
+
+• [SLOW TEST:10.379 seconds]
+[sig-storage] EmptyDir volumes
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/empty_dir.go:40
+  should support (root,0777,default) [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSSSSSS
+------------------------------
+[sig-storage] Downward API volume 
+  should update labels on modification [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:53:16.145: INFO: >>> kubeConfig: /tmp/kubeconfig-324782104
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downwardapi_volume.go:38
+[It] should update labels on modification [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating the pod
+Jul  2 13:53:20.858: INFO: Successfully updated pod "labelsupdate4509036b-7dff-11e8-8e15-aefe7bc77cc2"
+[AfterEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:53:22.892: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-downward-api-9lh72" for this suite.
+Jul  2 13:53:44.907: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:53:44.917: INFO: namespace: e2e-tests-downward-api-9lh72, resource: bindings, ignored listing per whitelist
+Jul  2 13:53:45.035: INFO: namespace e2e-tests-downward-api-9lh72 deletion completed in 22.138819694s
+
+• [SLOW TEST:28.889 seconds]
+[sig-storage] Downward API volume
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downwardapi_volume.go:33
+  should update labels on modification [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSS
+------------------------------
+[sig-api-machinery] Garbage collector 
+  should orphan pods created by rc if delete options say so [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-api-machinery] Garbage collector
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:53:45.035: INFO: >>> kubeConfig: /tmp/kubeconfig-324782104
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should orphan pods created by rc if delete options say so [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: create the rc
+STEP: delete the rc
+STEP: wait for the rc to be deleted
+STEP: wait for 30 seconds to see if the garbage collector mistakenly deletes the pods
+STEP: Gathering metrics
+W0702 13:54:25.189843      15 metrics_grabber.go:81] Master node is not registered. Grabbing metrics from Scheduler, ControllerManager and ClusterAutoscaler is disabled.
+Jul  2 13:54:25.189: INFO: For apiserver_request_count:
+For apiserver_request_latencies_summary:
+For etcd_helper_cache_entry_count:
+For etcd_helper_cache_hit_count:
+For etcd_helper_cache_miss_count:
+For etcd_request_cache_add_latencies_summary:
+For etcd_request_cache_get_latencies_summary:
+For etcd_request_latencies_summary:
+For garbage_collector_attempt_to_delete_queue_latency:
+For garbage_collector_attempt_to_delete_work_duration:
+For garbage_collector_attempt_to_orphan_queue_latency:
+For garbage_collector_attempt_to_orphan_work_duration:
+For garbage_collector_dirty_processing_latency_microseconds:
+For garbage_collector_event_processing_latency_microseconds:
+For garbage_collector_graph_changes_queue_latency:
+For garbage_collector_graph_changes_work_duration:
+For garbage_collector_orphan_processing_latency_microseconds:
+For namespace_queue_latency:
+For namespace_queue_latency_sum:
+For namespace_queue_latency_count:
+For namespace_retries:
+For namespace_work_duration:
+For namespace_work_duration_sum:
+For namespace_work_duration_count:
+For function_duration_seconds:
+For errors_total:
+For evicted_pods_total:
+
+[AfterEach] [sig-api-machinery] Garbage collector
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:54:25.189: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-gc-68htz" for this suite.
+Jul  2 13:54:33.206: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:54:33.283: INFO: namespace: e2e-tests-gc-68htz, resource: bindings, ignored listing per whitelist
+Jul  2 13:54:33.307: INFO: namespace e2e-tests-gc-68htz deletion completed in 8.114688136s
+
+• [SLOW TEST:48.273 seconds]
+[sig-api-machinery] Garbage collector
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apimachinery/framework.go:22
+  should orphan pods created by rc if delete options say so [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SS
+------------------------------
+[sig-storage] ConfigMap 
+  should be consumable from pods in volume with mappings [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-storage] ConfigMap
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:54:33.308: INFO: >>> kubeConfig: /tmp/kubeconfig-324782104
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should be consumable from pods in volume with mappings [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating configMap with name configmap-test-volume-map-7306cac1-7dff-11e8-8e15-aefe7bc77cc2
+STEP: Creating a pod to test consume configMaps
+Jul  2 13:54:33.491: INFO: Waiting up to 5m0s for pod "pod-configmaps-730758cf-7dff-11e8-8e15-aefe7bc77cc2" in namespace "e2e-tests-configmap-8z8kc" to be "success or failure"
+Jul  2 13:54:33.502: INFO: Pod "pod-configmaps-730758cf-7dff-11e8-8e15-aefe7bc77cc2": Phase="Pending", Reason="", readiness=false. Elapsed: 10.459136ms
+Jul  2 13:54:35.576: INFO: Pod "pod-configmaps-730758cf-7dff-11e8-8e15-aefe7bc77cc2": Phase="Pending", Reason="", readiness=false. Elapsed: 2.084675241s
+Jul  2 13:54:37.579: INFO: Pod "pod-configmaps-730758cf-7dff-11e8-8e15-aefe7bc77cc2": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.088193257s
+STEP: Saw pod success
+Jul  2 13:54:37.580: INFO: Pod "pod-configmaps-730758cf-7dff-11e8-8e15-aefe7bc77cc2" satisfied condition "success or failure"
+Jul  2 13:54:37.582: INFO: Trying to get logs from node shoot--core--confaz-worker-qfmi9-79968b77d9-kcr6j pod pod-configmaps-730758cf-7dff-11e8-8e15-aefe7bc77cc2 container configmap-volume-test: <nil>
+STEP: delete the pod
+Jul  2 13:54:37.681: INFO: Waiting for pod pod-configmaps-730758cf-7dff-11e8-8e15-aefe7bc77cc2 to disappear
+Jul  2 13:54:37.691: INFO: Pod pod-configmaps-730758cf-7dff-11e8-8e15-aefe7bc77cc2 no longer exists
+[AfterEach] [sig-storage] ConfigMap
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:54:37.691: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-configmap-8z8kc" for this suite.
+Jul  2 13:54:43.707: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:54:43.771: INFO: namespace: e2e-tests-configmap-8z8kc, resource: bindings, ignored listing per whitelist
+Jul  2 13:54:43.811: INFO: namespace e2e-tests-configmap-8z8kc deletion completed in 6.115895225s
+
+• [SLOW TEST:10.502 seconds]
+[sig-storage] ConfigMap
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/configmap_volume.go:32
+  should be consumable from pods in volume with mappings [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSSSSSSSSSSSSSSSSS
+------------------------------
+[sig-storage] Projected 
+  should be consumable from pods in volume as non-root with defaultMode and fsGroup set [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:54:43.811: INFO: >>> kubeConfig: /tmp/kubeconfig-324782104
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:858
+[It] should be consumable from pods in volume as non-root with defaultMode and fsGroup set [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating projection with secret that has name projected-secret-test-7949cfbe-7dff-11e8-8e15-aefe7bc77cc2
+STEP: Creating a pod to test consume secrets
+Jul  2 13:54:43.990: INFO: Waiting up to 5m0s for pod "pod-projected-secrets-794a49e7-7dff-11e8-8e15-aefe7bc77cc2" in namespace "e2e-tests-projected-jx5pl" to be "success or failure"
+Jul  2 13:54:44.026: INFO: Pod "pod-projected-secrets-794a49e7-7dff-11e8-8e15-aefe7bc77cc2": Phase="Pending", Reason="", readiness=false. Elapsed: 36.005314ms
+Jul  2 13:54:46.030: INFO: Pod "pod-projected-secrets-794a49e7-7dff-11e8-8e15-aefe7bc77cc2": Phase="Pending", Reason="", readiness=false. Elapsed: 2.040076238s
+Jul  2 13:54:48.034: INFO: Pod "pod-projected-secrets-794a49e7-7dff-11e8-8e15-aefe7bc77cc2": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.043766783s
+STEP: Saw pod success
+Jul  2 13:54:48.034: INFO: Pod "pod-projected-secrets-794a49e7-7dff-11e8-8e15-aefe7bc77cc2" satisfied condition "success or failure"
+Jul  2 13:54:48.036: INFO: Trying to get logs from node shoot--core--confaz-worker-qfmi9-79968b77d9-kcr6j pod pod-projected-secrets-794a49e7-7dff-11e8-8e15-aefe7bc77cc2 container projected-secret-volume-test: <nil>
+STEP: delete the pod
+Jul  2 13:54:48.151: INFO: Waiting for pod pod-projected-secrets-794a49e7-7dff-11e8-8e15-aefe7bc77cc2 to disappear
+Jul  2 13:54:48.184: INFO: Pod pod-projected-secrets-794a49e7-7dff-11e8-8e15-aefe7bc77cc2 no longer exists
+[AfterEach] [sig-storage] Projected
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:54:48.185: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-jx5pl" for this suite.
+Jul  2 13:54:54.230: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:54:54.349: INFO: namespace: e2e-tests-projected-jx5pl, resource: bindings, ignored listing per whitelist
+Jul  2 13:54:54.354: INFO: namespace e2e-tests-projected-jx5pl deletion completed in 6.166671685s
+
+• [SLOW TEST:10.543 seconds]
+[sig-storage] Projected
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:34
+  should be consumable from pods in volume as non-root with defaultMode and fsGroup set [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSS
+------------------------------
+[sig-storage] EmptyDir volumes 
+  should support (non-root,0666,default) [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-storage] EmptyDir volumes
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:54:54.355: INFO: >>> kubeConfig: /tmp/kubeconfig-324782104
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should support (non-root,0666,default) [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating a pod to test emptydir 0666 on node default medium
+Jul  2 13:54:54.458: INFO: Waiting up to 5m0s for pod "pod-7f865ef0-7dff-11e8-8e15-aefe7bc77cc2" in namespace "e2e-tests-emptydir-7wtzf" to be "success or failure"
+Jul  2 13:54:54.460: INFO: Pod "pod-7f865ef0-7dff-11e8-8e15-aefe7bc77cc2": Phase="Pending", Reason="", readiness=false. Elapsed: 2.067808ms
+Jul  2 13:54:56.466: INFO: Pod "pod-7f865ef0-7dff-11e8-8e15-aefe7bc77cc2": Phase="Pending", Reason="", readiness=false. Elapsed: 2.008042687s
+Jul  2 13:54:58.470: INFO: Pod "pod-7f865ef0-7dff-11e8-8e15-aefe7bc77cc2": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.011966674s
+STEP: Saw pod success
+Jul  2 13:54:58.470: INFO: Pod "pod-7f865ef0-7dff-11e8-8e15-aefe7bc77cc2" satisfied condition "success or failure"
+Jul  2 13:54:58.473: INFO: Trying to get logs from node shoot--core--confaz-worker-qfmi9-79968b77d9-kcr6j pod pod-7f865ef0-7dff-11e8-8e15-aefe7bc77cc2 container test-container: <nil>
+STEP: delete the pod
+Jul  2 13:54:58.502: INFO: Waiting for pod pod-7f865ef0-7dff-11e8-8e15-aefe7bc77cc2 to disappear
+Jul  2 13:54:58.513: INFO: Pod pod-7f865ef0-7dff-11e8-8e15-aefe7bc77cc2 no longer exists
+[AfterEach] [sig-storage] EmptyDir volumes
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:54:58.513: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-emptydir-7wtzf" for this suite.
+Jul  2 13:55:04.558: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:55:04.569: INFO: namespace: e2e-tests-emptydir-7wtzf, resource: bindings, ignored listing per whitelist
+Jul  2 13:55:04.691: INFO: namespace e2e-tests-emptydir-7wtzf deletion completed in 6.174110777s
+
+• [SLOW TEST:10.336 seconds]
+[sig-storage] EmptyDir volumes
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/empty_dir.go:40
+  should support (non-root,0666,default) [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSS
+------------------------------
+[sig-apps] StatefulSet [k8s.io] Basic StatefulSet functionality [StatefulSetBasic] 
+  Should recreate evicted statefulset [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-apps] StatefulSet
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:55:04.691: INFO: >>> kubeConfig: /tmp/kubeconfig-324782104
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-apps] StatefulSet
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/statefulset.go:57
+[BeforeEach] [k8s.io] Basic StatefulSet functionality [StatefulSetBasic]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/statefulset.go:72
+STEP: Creating service test in namespace e2e-tests-statefulset-nthz4
+[It] Should recreate evicted statefulset [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Looking for a node to schedule stateful set and pod
+STEP: Creating pod with conflicting port in namespace e2e-tests-statefulset-nthz4
+STEP: Creating statefulset with conflicting port in namespace e2e-tests-statefulset-nthz4
+STEP: Waiting until pod test-pod will start running in namespace e2e-tests-statefulset-nthz4
+STEP: Waiting until stateful pod ss-0 will be recreated and deleted at least once in namespace e2e-tests-statefulset-nthz4
+Jul  2 13:55:08.833: INFO: Observed stateful pod in namespace: e2e-tests-statefulset-nthz4, name: ss-0, uid: 87c0bf7e-7dff-11e8-bc8c-d657551927e5, status phase: Pending. Waiting for statefulset controller to delete.
+Jul  2 13:55:08.891: INFO: Observed stateful pod in namespace: e2e-tests-statefulset-nthz4, name: ss-0, uid: 87c0bf7e-7dff-11e8-bc8c-d657551927e5, status phase: Failed. Waiting for statefulset controller to delete.
+Jul  2 13:55:08.931: INFO: Observed stateful pod in namespace: e2e-tests-statefulset-nthz4, name: ss-0, uid: 87c0bf7e-7dff-11e8-bc8c-d657551927e5, status phase: Failed. Waiting for statefulset controller to delete.
+Jul  2 13:55:08.958: INFO: Observed delete event for stateful pod ss-0 in namespace e2e-tests-statefulset-nthz4
+STEP: Removing pod with conflicting port in namespace e2e-tests-statefulset-nthz4
+STEP: Waiting when stateful pod ss-0 will be recreated in namespace e2e-tests-statefulset-nthz4 and will be in running state
+[AfterEach] [k8s.io] Basic StatefulSet functionality [StatefulSetBasic]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/statefulset.go:83
+Jul  2 13:55:13.025: INFO: Deleting all statefulset in ns e2e-tests-statefulset-nthz4
+Jul  2 13:55:13.031: INFO: Scaling statefulset ss to 0
+Jul  2 13:55:23.050: INFO: Waiting for statefulset status.replicas updated to 0
+Jul  2 13:55:23.053: INFO: Deleting statefulset ss
+[AfterEach] [sig-apps] StatefulSet
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:55:23.067: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-statefulset-nthz4" for this suite.
+Jul  2 13:55:29.260: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:55:29.411: INFO: namespace: e2e-tests-statefulset-nthz4, resource: bindings, ignored listing per whitelist
+Jul  2 13:55:29.430: INFO: namespace e2e-tests-statefulset-nthz4 deletion completed in 6.357495214s
+
+• [SLOW TEST:24.739 seconds]
+[sig-apps] StatefulSet
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/framework.go:22
+  [k8s.io] Basic StatefulSet functionality [StatefulSetBasic]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:679
+    Should recreate evicted statefulset [Conformance]
+    /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSSSSSSSSSSSS
+------------------------------
+[sig-storage] Downward API volume 
+  should provide node allocatable (cpu) as default cpu limit if the limit is not set [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:55:29.430: INFO: >>> kubeConfig: /tmp/kubeconfig-324782104
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downwardapi_volume.go:38
+[It] should provide node allocatable (cpu) as default cpu limit if the limit is not set [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating a pod to test downward API volume plugin
+Jul  2 13:55:29.546: INFO: Waiting up to 5m0s for pod "downwardapi-volume-9470a5b2-7dff-11e8-8e15-aefe7bc77cc2" in namespace "e2e-tests-downward-api-nfkkk" to be "success or failure"
+Jul  2 13:55:29.558: INFO: Pod "downwardapi-volume-9470a5b2-7dff-11e8-8e15-aefe7bc77cc2": Phase="Pending", Reason="", readiness=false. Elapsed: 12.713245ms
+Jul  2 13:55:31.563: INFO: Pod "downwardapi-volume-9470a5b2-7dff-11e8-8e15-aefe7bc77cc2": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.017617287s
+STEP: Saw pod success
+Jul  2 13:55:31.564: INFO: Pod "downwardapi-volume-9470a5b2-7dff-11e8-8e15-aefe7bc77cc2" satisfied condition "success or failure"
+Jul  2 13:55:31.566: INFO: Trying to get logs from node shoot--core--confaz-worker-qfmi9-79968b77d9-kcr6j pod downwardapi-volume-9470a5b2-7dff-11e8-8e15-aefe7bc77cc2 container client-container: <nil>
+STEP: delete the pod
+Jul  2 13:55:31.587: INFO: Waiting for pod downwardapi-volume-9470a5b2-7dff-11e8-8e15-aefe7bc77cc2 to disappear
+Jul  2 13:55:31.598: INFO: Pod downwardapi-volume-9470a5b2-7dff-11e8-8e15-aefe7bc77cc2 no longer exists
+[AfterEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:55:31.598: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-downward-api-nfkkk" for this suite.
+Jul  2 13:55:37.631: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:55:37.653: INFO: namespace: e2e-tests-downward-api-nfkkk, resource: bindings, ignored listing per whitelist
+Jul  2 13:55:37.734: INFO: namespace e2e-tests-downward-api-nfkkk deletion completed in 6.128263166s
+
+• [SLOW TEST:8.304 seconds]
+[sig-storage] Downward API volume
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downwardapi_volume.go:33
+  should provide node allocatable (cpu) as default cpu limit if the limit is not set [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+[sig-network] Services 
+  should serve multiport endpoints from pods  [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-network] Services
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:55:37.734: INFO: >>> kubeConfig: /tmp/kubeconfig-324782104
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-network] Services
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/network/service.go:83
+[It] should serve multiport endpoints from pods  [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: creating service multi-endpoint-test in namespace e2e-tests-services-2w4f2
+STEP: waiting up to 3m0s for service multi-endpoint-test in namespace e2e-tests-services-2w4f2 to expose endpoints map[]
+Jul  2 13:55:37.858: INFO: Get endpoints failed (3.151811ms elapsed, ignoring for 5s): endpoints "multi-endpoint-test" not found
+Jul  2 13:55:38.861: INFO: successfully validated that service multi-endpoint-test in namespace e2e-tests-services-2w4f2 exposes endpoints map[] (1.006473284s elapsed)
+STEP: Creating pod pod1 in namespace e2e-tests-services-2w4f2
+STEP: waiting up to 3m0s for service multi-endpoint-test in namespace e2e-tests-services-2w4f2 to expose endpoints map[pod1:[100]]
+Jul  2 13:55:41.975: INFO: successfully validated that service multi-endpoint-test in namespace e2e-tests-services-2w4f2 exposes endpoints map[pod1:[100]] (3.107414281s elapsed)
+STEP: Creating pod pod2 in namespace e2e-tests-services-2w4f2
+STEP: waiting up to 3m0s for service multi-endpoint-test in namespace e2e-tests-services-2w4f2 to expose endpoints map[pod1:[100] pod2:[101]]
+Jul  2 13:55:44.072: INFO: successfully validated that service multi-endpoint-test in namespace e2e-tests-services-2w4f2 exposes endpoints map[pod1:[100] pod2:[101]] (2.039335383s elapsed)
+STEP: Deleting pod pod1 in namespace e2e-tests-services-2w4f2
+STEP: waiting up to 3m0s for service multi-endpoint-test in namespace e2e-tests-services-2w4f2 to expose endpoints map[pod2:[101]]
+Jul  2 13:55:44.110: INFO: successfully validated that service multi-endpoint-test in namespace e2e-tests-services-2w4f2 exposes endpoints map[pod2:[101]] (21.981271ms elapsed)
+STEP: Deleting pod pod2 in namespace e2e-tests-services-2w4f2
+STEP: waiting up to 3m0s for service multi-endpoint-test in namespace e2e-tests-services-2w4f2 to expose endpoints map[]
+Jul  2 13:55:44.119: INFO: successfully validated that service multi-endpoint-test in namespace e2e-tests-services-2w4f2 exposes endpoints map[] (3.537411ms elapsed)
+[AfterEach] [sig-network] Services
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:55:44.149: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-services-2w4f2" for this suite.
+Jul  2 13:55:50.173: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:55:50.257: INFO: namespace: e2e-tests-services-2w4f2, resource: bindings, ignored listing per whitelist
+Jul  2 13:55:50.320: INFO: namespace e2e-tests-services-2w4f2 deletion completed in 6.163730368s
+[AfterEach] [sig-network] Services
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/network/service.go:88
+
+• [SLOW TEST:12.585 seconds]
+[sig-network] Services
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/network/framework.go:22
+  should serve multiport endpoints from pods  [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSSSSSSSSS
+------------------------------
+[sig-storage] Downward API volume 
+  should provide container's cpu request [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:55:50.320: INFO: >>> kubeConfig: /tmp/kubeconfig-324782104
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downwardapi_volume.go:38
+[It] should provide container's cpu request [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating a pod to test downward API volume plugin
+Jul  2 13:55:50.452: INFO: Waiting up to 5m0s for pod "downwardapi-volume-a0e2e40f-7dff-11e8-8e15-aefe7bc77cc2" in namespace "e2e-tests-downward-api-8p2q6" to be "success or failure"
+Jul  2 13:55:50.455: INFO: Pod "downwardapi-volume-a0e2e40f-7dff-11e8-8e15-aefe7bc77cc2": Phase="Pending", Reason="", readiness=false. Elapsed: 3.023709ms
+Jul  2 13:55:52.461: INFO: Pod "downwardapi-volume-a0e2e40f-7dff-11e8-8e15-aefe7bc77cc2": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.008918686s
+STEP: Saw pod success
+Jul  2 13:55:52.461: INFO: Pod "downwardapi-volume-a0e2e40f-7dff-11e8-8e15-aefe7bc77cc2" satisfied condition "success or failure"
+Jul  2 13:55:52.464: INFO: Trying to get logs from node shoot--core--confaz-worker-qfmi9-79968b77d9-kcr6j pod downwardapi-volume-a0e2e40f-7dff-11e8-8e15-aefe7bc77cc2 container client-container: <nil>
+STEP: delete the pod
+Jul  2 13:55:52.485: INFO: Waiting for pod downwardapi-volume-a0e2e40f-7dff-11e8-8e15-aefe7bc77cc2 to disappear
+Jul  2 13:55:52.497: INFO: Pod downwardapi-volume-a0e2e40f-7dff-11e8-8e15-aefe7bc77cc2 no longer exists
+[AfterEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:55:52.497: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-downward-api-8p2q6" for this suite.
+Jul  2 13:55:58.512: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:55:58.586: INFO: namespace: e2e-tests-downward-api-8p2q6, resource: bindings, ignored listing per whitelist
+Jul  2 13:55:58.657: INFO: namespace e2e-tests-downward-api-8p2q6 deletion completed in 6.156009637s
+
+• [SLOW TEST:8.337 seconds]
+[sig-storage] Downward API volume
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downwardapi_volume.go:33
+  should provide container's cpu request [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSSSSSS
+------------------------------
+[k8s.io] Pods 
+  should get a host IP [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [k8s.io] Pods
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:55:58.657: INFO: >>> kubeConfig: /tmp/kubeconfig-324782104
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [k8s.io] Pods
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/pods.go:127
+[It] should get a host IP [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: creating pod
+Jul  2 13:56:02.869: INFO: Pod pod-hostip-a5dab954-7dff-11e8-8e15-aefe7bc77cc2 has hostIP: 10.250.0.5
+[AfterEach] [k8s.io] Pods
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:56:02.869: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-pods-j89qd" for this suite.
+Jul  2 13:56:24.943: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:56:24.967: INFO: namespace: e2e-tests-pods-j89qd, resource: bindings, ignored listing per whitelist
+Jul  2 13:56:25.048: INFO: namespace e2e-tests-pods-j89qd deletion completed in 22.115408038s
+
+• [SLOW TEST:26.390 seconds]
+[k8s.io] Pods
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:679
+  should get a host IP [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+S
+------------------------------
+[sig-storage] Downward API volume 
+  should provide container's cpu limit [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:56:25.048: INFO: >>> kubeConfig: /tmp/kubeconfig-324782104
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downwardapi_volume.go:38
+[It] should provide container's cpu limit [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating a pod to test downward API volume plugin
+Jul  2 13:56:25.190: INFO: Waiting up to 5m0s for pod "downwardapi-volume-b59c3b68-7dff-11e8-8e15-aefe7bc77cc2" in namespace "e2e-tests-downward-api-mrpgz" to be "success or failure"
+Jul  2 13:56:25.202: INFO: Pod "downwardapi-volume-b59c3b68-7dff-11e8-8e15-aefe7bc77cc2": Phase="Pending", Reason="", readiness=false. Elapsed: 12.035035ms
+Jul  2 13:56:27.231: INFO: Pod "downwardapi-volume-b59c3b68-7dff-11e8-8e15-aefe7bc77cc2": Phase="Pending", Reason="", readiness=false. Elapsed: 2.040793029s
+Jul  2 13:56:29.234: INFO: Pod "downwardapi-volume-b59c3b68-7dff-11e8-8e15-aefe7bc77cc2": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.043960463s
+STEP: Saw pod success
+Jul  2 13:56:29.234: INFO: Pod "downwardapi-volume-b59c3b68-7dff-11e8-8e15-aefe7bc77cc2" satisfied condition "success or failure"
+Jul  2 13:56:29.237: INFO: Trying to get logs from node shoot--core--confaz-worker-qfmi9-79968b77d9-kcr6j pod downwardapi-volume-b59c3b68-7dff-11e8-8e15-aefe7bc77cc2 container client-container: <nil>
+STEP: delete the pod
+Jul  2 13:56:29.268: INFO: Waiting for pod downwardapi-volume-b59c3b68-7dff-11e8-8e15-aefe7bc77cc2 to disappear
+Jul  2 13:56:29.275: INFO: Pod downwardapi-volume-b59c3b68-7dff-11e8-8e15-aefe7bc77cc2 no longer exists
+[AfterEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:56:29.275: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-downward-api-mrpgz" for this suite.
+Jul  2 13:56:35.288: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:56:35.434: INFO: namespace: e2e-tests-downward-api-mrpgz, resource: bindings, ignored listing per whitelist
+Jul  2 13:56:35.450: INFO: namespace e2e-tests-downward-api-mrpgz deletion completed in 6.172729943s
+
+• [SLOW TEST:10.402 seconds]
+[sig-storage] Downward API volume
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downwardapi_volume.go:33
+  should provide container's cpu limit [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSSSS
+------------------------------
+[sig-storage] Projected 
+  updates should be reflected in volume [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:56:35.451: INFO: >>> kubeConfig: /tmp/kubeconfig-324782104
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:858
+[It] updates should be reflected in volume [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating projection with configMap that has name projected-configmap-test-upd-bbc9ed89-7dff-11e8-8e15-aefe7bc77cc2
+STEP: Creating the pod
+STEP: Updating configmap projected-configmap-test-upd-bbc9ed89-7dff-11e8-8e15-aefe7bc77cc2
+STEP: waiting to observe update in volume
+[AfterEach] [sig-storage] Projected
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:56:39.775: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-ssx9f" for this suite.
+Jul  2 13:57:01.863: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:57:01.952: INFO: namespace: e2e-tests-projected-ssx9f, resource: bindings, ignored listing per whitelist
+Jul  2 13:57:02.109: INFO: namespace e2e-tests-projected-ssx9f deletion completed in 22.330290805s
+
+• [SLOW TEST:26.659 seconds]
+[sig-storage] Projected
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:34
+  updates should be reflected in volume [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+[sig-storage] EmptyDir volumes 
+  should support (root,0666,default) [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-storage] EmptyDir volumes
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:57:02.110: INFO: >>> kubeConfig: /tmp/kubeconfig-324782104
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should support (root,0666,default) [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating a pod to test emptydir 0666 on node default medium
+Jul  2 13:57:02.272: INFO: Waiting up to 5m0s for pod "pod-cbb18573-7dff-11e8-8e15-aefe7bc77cc2" in namespace "e2e-tests-emptydir-vhlhc" to be "success or failure"
+Jul  2 13:57:02.282: INFO: Pod "pod-cbb18573-7dff-11e8-8e15-aefe7bc77cc2": Phase="Pending", Reason="", readiness=false. Elapsed: 9.281433ms
+Jul  2 13:57:04.333: INFO: Pod "pod-cbb18573-7dff-11e8-8e15-aefe7bc77cc2": Phase="Pending", Reason="", readiness=false. Elapsed: 2.061086658s
+Jul  2 13:57:06.337: INFO: Pod "pod-cbb18573-7dff-11e8-8e15-aefe7bc77cc2": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.065173414s
+STEP: Saw pod success
+Jul  2 13:57:06.337: INFO: Pod "pod-cbb18573-7dff-11e8-8e15-aefe7bc77cc2" satisfied condition "success or failure"
+Jul  2 13:57:06.341: INFO: Trying to get logs from node shoot--core--confaz-worker-qfmi9-79968b77d9-kcr6j pod pod-cbb18573-7dff-11e8-8e15-aefe7bc77cc2 container test-container: <nil>
+STEP: delete the pod
+Jul  2 13:57:06.375: INFO: Waiting for pod pod-cbb18573-7dff-11e8-8e15-aefe7bc77cc2 to disappear
+Jul  2 13:57:06.384: INFO: Pod pod-cbb18573-7dff-11e8-8e15-aefe7bc77cc2 no longer exists
+[AfterEach] [sig-storage] EmptyDir volumes
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:57:06.384: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-emptydir-vhlhc" for this suite.
+Jul  2 13:57:12.427: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:57:12.475: INFO: namespace: e2e-tests-emptydir-vhlhc, resource: bindings, ignored listing per whitelist
+Jul  2 13:57:12.526: INFO: namespace e2e-tests-emptydir-vhlhc deletion completed in 6.122641409s
+
+• [SLOW TEST:10.416 seconds]
+[sig-storage] EmptyDir volumes
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/empty_dir.go:40
+  should support (root,0666,default) [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSSSSS
+------------------------------
+[sig-storage] Downward API volume 
+  should set mode on item file [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:57:12.526: INFO: >>> kubeConfig: /tmp/kubeconfig-324782104
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downwardapi_volume.go:38
+[It] should set mode on item file [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating a pod to test downward API volume plugin
+Jul  2 13:57:12.633: INFO: Waiting up to 5m0s for pod "downwardapi-volume-d1e23aca-7dff-11e8-8e15-aefe7bc77cc2" in namespace "e2e-tests-downward-api-hdp97" to be "success or failure"
+Jul  2 13:57:12.636: INFO: Pod "downwardapi-volume-d1e23aca-7dff-11e8-8e15-aefe7bc77cc2": Phase="Pending", Reason="", readiness=false. Elapsed: 2.454608ms
+Jul  2 13:57:14.704: INFO: Pod "downwardapi-volume-d1e23aca-7dff-11e8-8e15-aefe7bc77cc2": Phase="Pending", Reason="", readiness=false. Elapsed: 2.070492366s
+Jul  2 13:57:16.707: INFO: Pod "downwardapi-volume-d1e23aca-7dff-11e8-8e15-aefe7bc77cc2": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.073857228s
+STEP: Saw pod success
+Jul  2 13:57:16.707: INFO: Pod "downwardapi-volume-d1e23aca-7dff-11e8-8e15-aefe7bc77cc2" satisfied condition "success or failure"
+Jul  2 13:57:16.714: INFO: Trying to get logs from node shoot--core--confaz-worker-qfmi9-79968b77d9-kcr6j pod downwardapi-volume-d1e23aca-7dff-11e8-8e15-aefe7bc77cc2 container client-container: <nil>
+STEP: delete the pod
+Jul  2 13:57:16.753: INFO: Waiting for pod downwardapi-volume-d1e23aca-7dff-11e8-8e15-aefe7bc77cc2 to disappear
+Jul  2 13:57:16.766: INFO: Pod downwardapi-volume-d1e23aca-7dff-11e8-8e15-aefe7bc77cc2 no longer exists
+[AfterEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:57:16.776: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-downward-api-hdp97" for this suite.
+Jul  2 13:57:22.790: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:57:22.913: INFO: namespace: e2e-tests-downward-api-hdp97, resource: bindings, ignored listing per whitelist
+Jul  2 13:57:22.913: INFO: namespace e2e-tests-downward-api-hdp97 deletion completed in 6.134005396s
+
+• [SLOW TEST:10.387 seconds]
+[sig-storage] Downward API volume
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downwardapi_volume.go:33
+  should set mode on item file [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+S
+------------------------------
+[k8s.io] Probing container 
+  with readiness probe that fails should never be ready and never restart [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [k8s.io] Probing container
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:57:22.913: INFO: >>> kubeConfig: /tmp/kubeconfig-324782104
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [k8s.io] Probing container
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/container_probe.go:48
+[It] with readiness probe that fails should never be ready and never restart [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[AfterEach] [k8s.io] Probing container
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:58:23.014: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-container-probe-7tvjs" for this suite.
+Jul  2 13:58:45.130: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:58:45.169: INFO: namespace: e2e-tests-container-probe-7tvjs, resource: bindings, ignored listing per whitelist
+Jul  2 13:58:45.246: INFO: namespace e2e-tests-container-probe-7tvjs deletion completed in 22.228127063s
+
+• [SLOW TEST:82.333 seconds]
+[k8s.io] Probing container
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:679
+  with readiness probe that fails should never be ready and never restart [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSS
+------------------------------
+[sig-api-machinery] Secrets 
+  should be consumable from pods in env vars [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-api-machinery] Secrets
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:58:45.247: INFO: >>> kubeConfig: /tmp/kubeconfig-324782104
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should be consumable from pods in env vars [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating secret with name secret-test-0927780e-7e00-11e8-8e15-aefe7bc77cc2
+STEP: Creating a pod to test consume secrets
+Jul  2 13:58:45.365: INFO: Waiting up to 5m0s for pod "pod-secrets-0927f469-7e00-11e8-8e15-aefe7bc77cc2" in namespace "e2e-tests-secrets-wm7vk" to be "success or failure"
+Jul  2 13:58:45.374: INFO: Pod "pod-secrets-0927f469-7e00-11e8-8e15-aefe7bc77cc2": Phase="Pending", Reason="", readiness=false. Elapsed: 9.128432ms
+Jul  2 13:58:47.377: INFO: Pod "pod-secrets-0927f469-7e00-11e8-8e15-aefe7bc77cc2": Phase="Pending", Reason="", readiness=false. Elapsed: 2.012384657s
+Jul  2 13:58:49.389: INFO: Pod "pod-secrets-0927f469-7e00-11e8-8e15-aefe7bc77cc2": Phase="Pending", Reason="", readiness=false. Elapsed: 4.024235641s
+Jul  2 13:58:51.392: INFO: Pod "pod-secrets-0927f469-7e00-11e8-8e15-aefe7bc77cc2": Phase="Succeeded", Reason="", readiness=false. Elapsed: 6.027616986s
+STEP: Saw pod success
+Jul  2 13:58:51.392: INFO: Pod "pod-secrets-0927f469-7e00-11e8-8e15-aefe7bc77cc2" satisfied condition "success or failure"
+Jul  2 13:58:51.395: INFO: Trying to get logs from node shoot--core--confaz-worker-qfmi9-79968b77d9-kcr6j pod pod-secrets-0927f469-7e00-11e8-8e15-aefe7bc77cc2 container secret-env-test: <nil>
+STEP: delete the pod
+Jul  2 13:58:51.415: INFO: Waiting for pod pod-secrets-0927f469-7e00-11e8-8e15-aefe7bc77cc2 to disappear
+Jul  2 13:58:51.418: INFO: Pod pod-secrets-0927f469-7e00-11e8-8e15-aefe7bc77cc2 no longer exists
+[AfterEach] [sig-api-machinery] Secrets
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:58:51.418: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-secrets-wm7vk" for this suite.
+Jul  2 13:58:57.464: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:58:57.542: INFO: namespace: e2e-tests-secrets-wm7vk, resource: bindings, ignored listing per whitelist
+Jul  2 13:58:57.570: INFO: namespace e2e-tests-secrets-wm7vk deletion completed in 6.148830426s
+
+• [SLOW TEST:12.324 seconds]
+[sig-api-machinery] Secrets
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/secrets.go:30
+  should be consumable from pods in env vars [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSS
+------------------------------
+[sig-network] Services 
+  should serve a basic endpoint from pods  [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-network] Services
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:58:57.571: INFO: >>> kubeConfig: /tmp/kubeconfig-324782104
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-network] Services
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/network/service.go:83
+[It] should serve a basic endpoint from pods  [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: creating service endpoint-test2 in namespace e2e-tests-services-djhf2
+STEP: waiting up to 3m0s for service endpoint-test2 in namespace e2e-tests-services-djhf2 to expose endpoints map[]
+Jul  2 13:58:57.715: INFO: Get endpoints failed (10.159834ms elapsed, ignoring for 5s): endpoints "endpoint-test2" not found
+Jul  2 13:58:58.718: INFO: successfully validated that service endpoint-test2 in namespace e2e-tests-services-djhf2 exposes endpoints map[] (1.013773999s elapsed)
+STEP: Creating pod pod1 in namespace e2e-tests-services-djhf2
+STEP: waiting up to 3m0s for service endpoint-test2 in namespace e2e-tests-services-djhf2 to expose endpoints map[pod1:[80]]
+Jul  2 13:59:00.790: INFO: successfully validated that service endpoint-test2 in namespace e2e-tests-services-djhf2 exposes endpoints map[pod1:[80]] (2.065309194s elapsed)
+STEP: Creating pod pod2 in namespace e2e-tests-services-djhf2
+STEP: waiting up to 3m0s for service endpoint-test2 in namespace e2e-tests-services-djhf2 to expose endpoints map[pod1:[80] pod2:[80]]
+Jul  2 13:59:03.885: INFO: successfully validated that service endpoint-test2 in namespace e2e-tests-services-djhf2 exposes endpoints map[pod1:[80] pod2:[80]] (3.089461996s elapsed)
+STEP: Deleting pod pod1 in namespace e2e-tests-services-djhf2
+STEP: waiting up to 3m0s for service endpoint-test2 in namespace e2e-tests-services-djhf2 to expose endpoints map[pod2:[80]]
+Jul  2 13:59:04.933: INFO: successfully validated that service endpoint-test2 in namespace e2e-tests-services-djhf2 exposes endpoints map[pod2:[80]] (1.032629883s elapsed)
+STEP: Deleting pod pod2 in namespace e2e-tests-services-djhf2
+STEP: waiting up to 3m0s for service endpoint-test2 in namespace e2e-tests-services-djhf2 to expose endpoints map[]
+Jul  2 13:59:05.946: INFO: successfully validated that service endpoint-test2 in namespace e2e-tests-services-djhf2 exposes endpoints map[] (1.006003292s elapsed)
+[AfterEach] [sig-network] Services
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:59:05.980: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-services-djhf2" for this suite.
+Jul  2 13:59:12.006: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:59:12.072: INFO: namespace: e2e-tests-services-djhf2, resource: bindings, ignored listing per whitelist
+Jul  2 13:59:12.097: INFO: namespace e2e-tests-services-djhf2 deletion completed in 6.104931201s
+[AfterEach] [sig-network] Services
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/network/service.go:88
+
+• [SLOW TEST:14.527 seconds]
+[sig-network] Services
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/network/framework.go:22
+  should serve a basic endpoint from pods  [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SS
+------------------------------
+[sig-api-machinery] Downward API 
+  should provide host IP as an env var [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-api-machinery] Downward API
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:59:12.097: INFO: >>> kubeConfig: /tmp/kubeconfig-324782104
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should provide host IP as an env var [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating a pod to test downward api env vars
+Jul  2 13:59:12.193: INFO: Waiting up to 5m0s for pod "downward-api-19262396-7e00-11e8-8e15-aefe7bc77cc2" in namespace "e2e-tests-downward-api-qnmb9" to be "success or failure"
+Jul  2 13:59:12.196: INFO: Pod "downward-api-19262396-7e00-11e8-8e15-aefe7bc77cc2": Phase="Pending", Reason="", readiness=false. Elapsed: 3.267111ms
+Jul  2 13:59:14.200: INFO: Pod "downward-api-19262396-7e00-11e8-8e15-aefe7bc77cc2": Phase="Pending", Reason="", readiness=false. Elapsed: 2.006816383s
+Jul  2 13:59:16.203: INFO: Pod "downward-api-19262396-7e00-11e8-8e15-aefe7bc77cc2": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.010587599s
+STEP: Saw pod success
+Jul  2 13:59:16.203: INFO: Pod "downward-api-19262396-7e00-11e8-8e15-aefe7bc77cc2" satisfied condition "success or failure"
+Jul  2 13:59:16.206: INFO: Trying to get logs from node shoot--core--confaz-worker-qfmi9-79968b77d9-kcr6j pod downward-api-19262396-7e00-11e8-8e15-aefe7bc77cc2 container dapi-container: <nil>
+STEP: delete the pod
+Jul  2 13:59:16.229: INFO: Waiting for pod downward-api-19262396-7e00-11e8-8e15-aefe7bc77cc2 to disappear
+Jul  2 13:59:16.237: INFO: Pod downward-api-19262396-7e00-11e8-8e15-aefe7bc77cc2 no longer exists
+[AfterEach] [sig-api-machinery] Downward API
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:59:16.240: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-downward-api-qnmb9" for this suite.
+Jul  2 13:59:22.259: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:59:22.318: INFO: namespace: e2e-tests-downward-api-qnmb9, resource: bindings, ignored listing per whitelist
+Jul  2 13:59:22.385: INFO: namespace e2e-tests-downward-api-qnmb9 deletion completed in 6.139122109s
+
+• [SLOW TEST:10.287 seconds]
+[sig-api-machinery] Downward API
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downward_api.go:37
+  should provide host IP as an env var [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SS
+------------------------------
+[sig-apps] Daemon set [Serial] 
+  should update pod when spec was updated and update strategy is RollingUpdate [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-apps] Daemon set [Serial]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:59:22.385: INFO: >>> kubeConfig: /tmp/kubeconfig-324782104
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-apps] Daemon set [Serial]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/daemon_set.go:99
+[It] should update pod when spec was updated and update strategy is RollingUpdate [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+Jul  2 13:59:22.486: INFO: Creating simple daemon set daemon-set
+STEP: Check that daemon pods launch on every node of the cluster.
+Jul  2 13:59:22.521: INFO: Number of nodes with available pods: 0
+Jul  2 13:59:22.521: INFO: Node shoot--core--confaz-worker-qfmi9-79968b77d9-24hm4 is running more than one daemon pod
+Jul  2 13:59:23.538: INFO: Number of nodes with available pods: 0
+Jul  2 13:59:23.538: INFO: Node shoot--core--confaz-worker-qfmi9-79968b77d9-24hm4 is running more than one daemon pod
+Jul  2 13:59:24.529: INFO: Number of nodes with available pods: 2
+Jul  2 13:59:24.529: INFO: Number of running nodes: 2, number of available pods: 2
+STEP: Update daemon pods image.
+STEP: Check that daemon pods images are updated.
+Jul  2 13:59:24.545: INFO: Wrong image for pod: daemon-set-4jkd8. Expected: gcr.io/kubernetes-e2e-test-images/redis-amd64:1.0, got: gcr.io/kubernetes-e2e-test-images/serve-hostname-amd64:1.0.
+Jul  2 13:59:24.545: INFO: Wrong image for pod: daemon-set-snws6. Expected: gcr.io/kubernetes-e2e-test-images/redis-amd64:1.0, got: gcr.io/kubernetes-e2e-test-images/serve-hostname-amd64:1.0.
+Jul  2 13:59:25.555: INFO: Wrong image for pod: daemon-set-4jkd8. Expected: gcr.io/kubernetes-e2e-test-images/redis-amd64:1.0, got: gcr.io/kubernetes-e2e-test-images/serve-hostname-amd64:1.0.
+Jul  2 13:59:25.555: INFO: Wrong image for pod: daemon-set-snws6. Expected: gcr.io/kubernetes-e2e-test-images/redis-amd64:1.0, got: gcr.io/kubernetes-e2e-test-images/serve-hostname-amd64:1.0.
+Jul  2 13:59:26.553: INFO: Wrong image for pod: daemon-set-4jkd8. Expected: gcr.io/kubernetes-e2e-test-images/redis-amd64:1.0, got: gcr.io/kubernetes-e2e-test-images/serve-hostname-amd64:1.0.
+Jul  2 13:59:26.553: INFO: Pod daemon-set-4jkd8 is not available
+Jul  2 13:59:26.553: INFO: Wrong image for pod: daemon-set-snws6. Expected: gcr.io/kubernetes-e2e-test-images/redis-amd64:1.0, got: gcr.io/kubernetes-e2e-test-images/serve-hostname-amd64:1.0.
+Jul  2 13:59:27.576: INFO: Wrong image for pod: daemon-set-4jkd8. Expected: gcr.io/kubernetes-e2e-test-images/redis-amd64:1.0, got: gcr.io/kubernetes-e2e-test-images/serve-hostname-amd64:1.0.
+Jul  2 13:59:27.576: INFO: Pod daemon-set-4jkd8 is not available
+Jul  2 13:59:27.576: INFO: Wrong image for pod: daemon-set-snws6. Expected: gcr.io/kubernetes-e2e-test-images/redis-amd64:1.0, got: gcr.io/kubernetes-e2e-test-images/serve-hostname-amd64:1.0.
+Jul  2 13:59:28.553: INFO: Wrong image for pod: daemon-set-snws6. Expected: gcr.io/kubernetes-e2e-test-images/redis-amd64:1.0, got: gcr.io/kubernetes-e2e-test-images/serve-hostname-amd64:1.0.
+Jul  2 13:59:28.553: INFO: Pod daemon-set-wcr8k is not available
+Jul  2 13:59:29.553: INFO: Wrong image for pod: daemon-set-snws6. Expected: gcr.io/kubernetes-e2e-test-images/redis-amd64:1.0, got: gcr.io/kubernetes-e2e-test-images/serve-hostname-amd64:1.0.
+Jul  2 13:59:29.553: INFO: Pod daemon-set-wcr8k is not available
+Jul  2 13:59:30.554: INFO: Wrong image for pod: daemon-set-snws6. Expected: gcr.io/kubernetes-e2e-test-images/redis-amd64:1.0, got: gcr.io/kubernetes-e2e-test-images/serve-hostname-amd64:1.0.
+Jul  2 13:59:30.554: INFO: Pod daemon-set-wcr8k is not available
+Jul  2 13:59:31.555: INFO: Wrong image for pod: daemon-set-snws6. Expected: gcr.io/kubernetes-e2e-test-images/redis-amd64:1.0, got: gcr.io/kubernetes-e2e-test-images/serve-hostname-amd64:1.0.
+Jul  2 13:59:31.555: INFO: Pod daemon-set-snws6 is not available
+Jul  2 13:59:32.553: INFO: Wrong image for pod: daemon-set-snws6. Expected: gcr.io/kubernetes-e2e-test-images/redis-amd64:1.0, got: gcr.io/kubernetes-e2e-test-images/serve-hostname-amd64:1.0.
+Jul  2 13:59:32.553: INFO: Pod daemon-set-snws6 is not available
+Jul  2 13:59:33.554: INFO: Wrong image for pod: daemon-set-snws6. Expected: gcr.io/kubernetes-e2e-test-images/redis-amd64:1.0, got: gcr.io/kubernetes-e2e-test-images/serve-hostname-amd64:1.0.
+Jul  2 13:59:33.554: INFO: Pod daemon-set-snws6 is not available
+Jul  2 13:59:34.553: INFO: Wrong image for pod: daemon-set-snws6. Expected: gcr.io/kubernetes-e2e-test-images/redis-amd64:1.0, got: gcr.io/kubernetes-e2e-test-images/serve-hostname-amd64:1.0.
+Jul  2 13:59:34.553: INFO: Pod daemon-set-snws6 is not available
+Jul  2 13:59:35.554: INFO: Wrong image for pod: daemon-set-snws6. Expected: gcr.io/kubernetes-e2e-test-images/redis-amd64:1.0, got: gcr.io/kubernetes-e2e-test-images/serve-hostname-amd64:1.0.
+Jul  2 13:59:35.554: INFO: Pod daemon-set-snws6 is not available
+Jul  2 13:59:36.593: INFO: Wrong image for pod: daemon-set-snws6. Expected: gcr.io/kubernetes-e2e-test-images/redis-amd64:1.0, got: gcr.io/kubernetes-e2e-test-images/serve-hostname-amd64:1.0.
+Jul  2 13:59:36.593: INFO: Pod daemon-set-snws6 is not available
+Jul  2 13:59:37.566: INFO: Wrong image for pod: daemon-set-snws6. Expected: gcr.io/kubernetes-e2e-test-images/redis-amd64:1.0, got: gcr.io/kubernetes-e2e-test-images/serve-hostname-amd64:1.0.
+Jul  2 13:59:37.566: INFO: Pod daemon-set-snws6 is not available
+Jul  2 13:59:38.553: INFO: Wrong image for pod: daemon-set-snws6. Expected: gcr.io/kubernetes-e2e-test-images/redis-amd64:1.0, got: gcr.io/kubernetes-e2e-test-images/serve-hostname-amd64:1.0.
+Jul  2 13:59:38.553: INFO: Pod daemon-set-snws6 is not available
+Jul  2 13:59:39.631: INFO: Pod daemon-set-fkft8 is not available
+STEP: Check that daemon pods are still running on every node of the cluster.
+Jul  2 13:59:39.642: INFO: Number of nodes with available pods: 1
+Jul  2 13:59:39.642: INFO: Node shoot--core--confaz-worker-qfmi9-79968b77d9-24hm4 is running more than one daemon pod
+Jul  2 13:59:40.648: INFO: Number of nodes with available pods: 1
+Jul  2 13:59:40.648: INFO: Node shoot--core--confaz-worker-qfmi9-79968b77d9-24hm4 is running more than one daemon pod
+Jul  2 13:59:41.673: INFO: Number of nodes with available pods: 1
+Jul  2 13:59:41.673: INFO: Node shoot--core--confaz-worker-qfmi9-79968b77d9-24hm4 is running more than one daemon pod
+Jul  2 13:59:42.670: INFO: Number of nodes with available pods: 1
+Jul  2 13:59:42.670: INFO: Node shoot--core--confaz-worker-qfmi9-79968b77d9-24hm4 is running more than one daemon pod
+Jul  2 13:59:43.731: INFO: Number of nodes with available pods: 2
+Jul  2 13:59:43.731: INFO: Number of running nodes: 2, number of available pods: 2
+[AfterEach] [sig-apps] Daemon set [Serial]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/daemon_set.go:65
+STEP: Deleting DaemonSet "daemon-set"
+STEP: deleting {extensions DaemonSet} daemon-set in namespace e2e-tests-daemonsets-st97n, will wait for the garbage collector to delete the pods
+Jul  2 13:59:43.807: INFO: Deleting {extensions DaemonSet} daemon-set took: 5.816021ms
+Jul  2 13:59:43.907: INFO: Terminating {extensions DaemonSet} daemon-set pods took: 100.491367ms
+Jul  2 13:59:49.211: INFO: Number of nodes with available pods: 0
+Jul  2 13:59:49.211: INFO: Number of running nodes: 0, number of available pods: 0
+Jul  2 13:59:49.213: INFO: daemonset: {"kind":"DaemonSetList","apiVersion":"apps/v1","metadata":{"selfLink":"/apis/apps/v1/namespaces/e2e-tests-daemonsets-st97n/daemonsets","resourceVersion":"13721"},"items":null}
+
+Jul  2 13:59:49.216: INFO: pods: {"kind":"PodList","apiVersion":"v1","metadata":{"selfLink":"/api/v1/namespaces/e2e-tests-daemonsets-st97n/pods","resourceVersion":"13721"},"items":null}
+
+[AfterEach] [sig-apps] Daemon set [Serial]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:59:49.225: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-daemonsets-st97n" for this suite.
+Jul  2 13:59:55.247: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:59:55.311: INFO: namespace: e2e-tests-daemonsets-st97n, resource: bindings, ignored listing per whitelist
+Jul  2 13:59:55.360: INFO: namespace e2e-tests-daemonsets-st97n deletion completed in 6.13169047s
+
+• [SLOW TEST:32.975 seconds]
+[sig-apps] Daemon set [Serial]
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/framework.go:22
+  should update pod when spec was updated and update strategy is RollingUpdate [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+S
+------------------------------
+[sig-storage] EmptyDir volumes 
+  should support (non-root,0777,tmpfs) [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-storage] EmptyDir volumes
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:59:55.360: INFO: >>> kubeConfig: /tmp/kubeconfig-324782104
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should support (non-root,0777,tmpfs) [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating a pod to test emptydir 0777 on tmpfs
+Jul  2 13:59:55.507: INFO: Waiting up to 5m0s for pod "pod-32f5b695-7e00-11e8-8e15-aefe7bc77cc2" in namespace "e2e-tests-emptydir-q8gc8" to be "success or failure"
+Jul  2 13:59:55.514: INFO: Pod "pod-32f5b695-7e00-11e8-8e15-aefe7bc77cc2": Phase="Pending", Reason="", readiness=false. Elapsed: 6.537918ms
+Jul  2 13:59:57.564: INFO: Pod "pod-32f5b695-7e00-11e8-8e15-aefe7bc77cc2": Phase="Pending", Reason="", readiness=false. Elapsed: 2.056549078s
+Jul  2 13:59:59.594: INFO: Pod "pod-32f5b695-7e00-11e8-8e15-aefe7bc77cc2": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.086680975s
+STEP: Saw pod success
+Jul  2 13:59:59.594: INFO: Pod "pod-32f5b695-7e00-11e8-8e15-aefe7bc77cc2" satisfied condition "success or failure"
+Jul  2 13:59:59.596: INFO: Trying to get logs from node shoot--core--confaz-worker-qfmi9-79968b77d9-kcr6j pod pod-32f5b695-7e00-11e8-8e15-aefe7bc77cc2 container test-container: <nil>
+STEP: delete the pod
+Jul  2 13:59:59.646: INFO: Waiting for pod pod-32f5b695-7e00-11e8-8e15-aefe7bc77cc2 to disappear
+Jul  2 13:59:59.658: INFO: Pod pod-32f5b695-7e00-11e8-8e15-aefe7bc77cc2 no longer exists
+[AfterEach] [sig-storage] EmptyDir volumes
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:59:59.658: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-emptydir-q8gc8" for this suite.
+Jul  2 14:00:05.679: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 14:00:05.800: INFO: namespace: e2e-tests-emptydir-q8gc8, resource: bindings, ignored listing per whitelist
+Jul  2 14:00:05.815: INFO: namespace e2e-tests-emptydir-q8gc8 deletion completed in 6.147068995s
+
+• [SLOW TEST:10.456 seconds]
+[sig-storage] EmptyDir volumes
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/empty_dir.go:40
+  should support (non-root,0777,tmpfs) [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SS
+------------------------------
+[sig-storage] Projected 
+  optional updates should be reflected in volume [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 14:00:05.817: INFO: >>> kubeConfig: /tmp/kubeconfig-324782104
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:858
+[It] optional updates should be reflected in volume [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating secret with name s-test-opt-del-392cd345-7e00-11e8-8e15-aefe7bc77cc2
+STEP: Creating secret with name s-test-opt-upd-392cd37b-7e00-11e8-8e15-aefe7bc77cc2
+STEP: Creating the pod
+STEP: Deleting secret s-test-opt-del-392cd345-7e00-11e8-8e15-aefe7bc77cc2
+STEP: Updating secret s-test-opt-upd-392cd37b-7e00-11e8-8e15-aefe7bc77cc2
+STEP: Creating secret with name s-test-opt-create-392cd38f-7e00-11e8-8e15-aefe7bc77cc2
+STEP: waiting to observe update in volume
+[AfterEach] [sig-storage] Projected
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 14:01:21.497: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-q6mwj" for this suite.
+Jul  2 14:01:43.530: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 14:01:43.616: INFO: namespace: e2e-tests-projected-q6mwj, resource: bindings, ignored listing per whitelist
+Jul  2 14:01:43.662: INFO: namespace e2e-tests-projected-q6mwj deletion completed in 22.161287504s
+
+• [SLOW TEST:97.846 seconds]
+[sig-storage] Projected
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:34
+  optional updates should be reflected in volume [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSSS
+------------------------------
+[sig-storage] ConfigMap 
+  should be consumable in multiple volumes in the same pod [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-storage] ConfigMap
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 14:01:43.663: INFO: >>> kubeConfig: /tmp/kubeconfig-324782104
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should be consumable in multiple volumes in the same pod [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating configMap with name configmap-test-volume-737e05cb-7e00-11e8-8e15-aefe7bc77cc2
+STEP: Creating a pod to test consume configMaps
+Jul  2 14:01:43.770: INFO: Waiting up to 5m0s for pod "pod-configmaps-737e9a5c-7e00-11e8-8e15-aefe7bc77cc2" in namespace "e2e-tests-configmap-knqq9" to be "success or failure"
+Jul  2 14:01:43.782: INFO: Pod "pod-configmaps-737e9a5c-7e00-11e8-8e15-aefe7bc77cc2": Phase="Pending", Reason="", readiness=false. Elapsed: 12.31685ms
+Jul  2 14:01:45.786: INFO: Pod "pod-configmaps-737e9a5c-7e00-11e8-8e15-aefe7bc77cc2": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.015939583s
+STEP: Saw pod success
+Jul  2 14:01:45.786: INFO: Pod "pod-configmaps-737e9a5c-7e00-11e8-8e15-aefe7bc77cc2" satisfied condition "success or failure"
+Jul  2 14:01:45.794: INFO: Trying to get logs from node shoot--core--confaz-worker-qfmi9-79968b77d9-kcr6j pod pod-configmaps-737e9a5c-7e00-11e8-8e15-aefe7bc77cc2 container configmap-volume-test: <nil>
+STEP: delete the pod
+Jul  2 14:01:45.864: INFO: Waiting for pod pod-configmaps-737e9a5c-7e00-11e8-8e15-aefe7bc77cc2 to disappear
+Jul  2 14:01:45.867: INFO: Pod pod-configmaps-737e9a5c-7e00-11e8-8e15-aefe7bc77cc2 no longer exists
+[AfterEach] [sig-storage] ConfigMap
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 14:01:45.867: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-configmap-knqq9" for this suite.
+Jul  2 14:01:51.930: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 14:01:51.938: INFO: namespace: e2e-tests-configmap-knqq9, resource: bindings, ignored listing per whitelist
+Jul  2 14:01:52.039: INFO: namespace e2e-tests-configmap-knqq9 deletion completed in 6.16912322s
+
+• [SLOW TEST:8.377 seconds]
+[sig-storage] ConfigMap
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/configmap_volume.go:32
+  should be consumable in multiple volumes in the same pod [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+S
+------------------------------
+[sig-api-machinery] Downward API 
+  should provide default limits.cpu/memory from node allocatable [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-api-machinery] Downward API
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 14:01:52.040: INFO: >>> kubeConfig: /tmp/kubeconfig-324782104
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should provide default limits.cpu/memory from node allocatable [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating a pod to test downward api env vars
+Jul  2 14:01:52.139: INFO: Waiting up to 5m0s for pod "downward-api-787ba4d8-7e00-11e8-8e15-aefe7bc77cc2" in namespace "e2e-tests-downward-api-8tqtz" to be "success or failure"
+Jul  2 14:01:52.143: INFO: Pod "downward-api-787ba4d8-7e00-11e8-8e15-aefe7bc77cc2": Phase="Pending", Reason="", readiness=false. Elapsed: 3.948014ms
+Jul  2 14:01:54.150: INFO: Pod "downward-api-787ba4d8-7e00-11e8-8e15-aefe7bc77cc2": Phase="Pending", Reason="", readiness=false. Elapsed: 2.011061807s
+Jul  2 14:01:56.154: INFO: Pod "downward-api-787ba4d8-7e00-11e8-8e15-aefe7bc77cc2": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.014927472s
+STEP: Saw pod success
+Jul  2 14:01:56.154: INFO: Pod "downward-api-787ba4d8-7e00-11e8-8e15-aefe7bc77cc2" satisfied condition "success or failure"
+Jul  2 14:01:56.156: INFO: Trying to get logs from node shoot--core--confaz-worker-qfmi9-79968b77d9-kcr6j pod downward-api-787ba4d8-7e00-11e8-8e15-aefe7bc77cc2 container dapi-container: <nil>
+STEP: delete the pod
+Jul  2 14:01:56.175: INFO: Waiting for pod downward-api-787ba4d8-7e00-11e8-8e15-aefe7bc77cc2 to disappear
+Jul  2 14:01:56.183: INFO: Pod downward-api-787ba4d8-7e00-11e8-8e15-aefe7bc77cc2 no longer exists
+[AfterEach] [sig-api-machinery] Downward API
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 14:01:56.183: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-downward-api-8tqtz" for this suite.
+Jul  2 14:02:02.198: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 14:02:02.249: INFO: namespace: e2e-tests-downward-api-8tqtz, resource: bindings, ignored listing per whitelist
+Jul  2 14:02:02.288: INFO: namespace e2e-tests-downward-api-8tqtz deletion completed in 6.101896473s
+
+• [SLOW TEST:10.249 seconds]
+[sig-api-machinery] Downward API
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downward_api.go:37
+  should provide default limits.cpu/memory from node allocatable [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSS
+------------------------------
+[sig-storage] Downward API volume 
+  should provide container's memory limit [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 14:02:02.289: INFO: >>> kubeConfig: /tmp/kubeconfig-324782104
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downwardapi_volume.go:38
+[It] should provide container's memory limit [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating a pod to test downward API volume plugin
+Jul  2 14:02:02.397: INFO: Waiting up to 5m0s for pod "downwardapi-volume-7e983472-7e00-11e8-8e15-aefe7bc77cc2" in namespace "e2e-tests-downward-api-sxjhs" to be "success or failure"
+Jul  2 14:02:02.402: INFO: Pod "downwardapi-volume-7e983472-7e00-11e8-8e15-aefe7bc77cc2": Phase="Pending", Reason="", readiness=false. Elapsed: 4.475715ms
+Jul  2 14:02:04.430: INFO: Pod "downwardapi-volume-7e983472-7e00-11e8-8e15-aefe7bc77cc2": Phase="Pending", Reason="", readiness=false. Elapsed: 2.03307403s
+Jul  2 14:02:06.531: INFO: Pod "downwardapi-volume-7e983472-7e00-11e8-8e15-aefe7bc77cc2": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.133447278s
+STEP: Saw pod success
+Jul  2 14:02:06.531: INFO: Pod "downwardapi-volume-7e983472-7e00-11e8-8e15-aefe7bc77cc2" satisfied condition "success or failure"
+Jul  2 14:02:06.533: INFO: Trying to get logs from node shoot--core--confaz-worker-qfmi9-79968b77d9-kcr6j pod downwardapi-volume-7e983472-7e00-11e8-8e15-aefe7bc77cc2 container client-container: <nil>
+STEP: delete the pod
+Jul  2 14:02:06.570: INFO: Waiting for pod downwardapi-volume-7e983472-7e00-11e8-8e15-aefe7bc77cc2 to disappear
+Jul  2 14:02:06.582: INFO: Pod downwardapi-volume-7e983472-7e00-11e8-8e15-aefe7bc77cc2 no longer exists
+[AfterEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 14:02:06.582: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-downward-api-sxjhs" for this suite.
+Jul  2 14:02:12.622: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 14:02:12.774: INFO: namespace: e2e-tests-downward-api-sxjhs, resource: bindings, ignored listing per whitelist
+Jul  2 14:02:12.783: INFO: namespace e2e-tests-downward-api-sxjhs deletion completed in 6.196901617s
+
+• [SLOW TEST:10.494 seconds]
+[sig-storage] Downward API volume
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downwardapi_volume.go:33
+  should provide container's memory limit [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSSSSSSSSS
+------------------------------
+[sig-api-machinery] Downward API 
+  should provide pod UID as env vars [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-api-machinery] Downward API
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 14:02:12.784: INFO: >>> kubeConfig: /tmp/kubeconfig-324782104
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should provide pod UID as env vars [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating a pod to test downward api env vars
+Jul  2 14:02:12.925: INFO: Waiting up to 5m0s for pod "downward-api-84db410e-7e00-11e8-8e15-aefe7bc77cc2" in namespace "e2e-tests-downward-api-djhpk" to be "success or failure"
+Jul  2 14:02:12.929: INFO: Pod "downward-api-84db410e-7e00-11e8-8e15-aefe7bc77cc2": Phase="Pending", Reason="", readiness=false. Elapsed: 3.728113ms
+Jul  2 14:02:14.932: INFO: Pod "downward-api-84db410e-7e00-11e8-8e15-aefe7bc77cc2": Phase="Pending", Reason="", readiness=false. Elapsed: 2.006772354s
+Jul  2 14:02:16.935: INFO: Pod "downward-api-84db410e-7e00-11e8-8e15-aefe7bc77cc2": Phase="Pending", Reason="", readiness=false. Elapsed: 4.010262172s
+Jul  2 14:02:18.938: INFO: Pod "downward-api-84db410e-7e00-11e8-8e15-aefe7bc77cc2": Phase="Succeeded", Reason="", readiness=false. Elapsed: 6.0136486s
+STEP: Saw pod success
+Jul  2 14:02:18.938: INFO: Pod "downward-api-84db410e-7e00-11e8-8e15-aefe7bc77cc2" satisfied condition "success or failure"
+Jul  2 14:02:18.941: INFO: Trying to get logs from node shoot--core--confaz-worker-qfmi9-79968b77d9-kcr6j pod downward-api-84db410e-7e00-11e8-8e15-aefe7bc77cc2 container dapi-container: <nil>
+STEP: delete the pod
+Jul  2 14:02:19.012: INFO: Waiting for pod downward-api-84db410e-7e00-11e8-8e15-aefe7bc77cc2 to disappear
+Jul  2 14:02:19.021: INFO: Pod downward-api-84db410e-7e00-11e8-8e15-aefe7bc77cc2 no longer exists
+[AfterEach] [sig-api-machinery] Downward API
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 14:02:19.021: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-downward-api-djhpk" for this suite.
+Jul  2 14:02:25.042: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 14:02:25.063: INFO: namespace: e2e-tests-downward-api-djhpk, resource: bindings, ignored listing per whitelist
+Jul  2 14:02:25.140: INFO: namespace e2e-tests-downward-api-djhpk deletion completed in 6.114717131s
+
+• [SLOW TEST:12.356 seconds]
+[sig-api-machinery] Downward API
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downward_api.go:37
+  should provide pod UID as env vars [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSSSSS
+------------------------------
+[sig-api-machinery] Watchers 
+  should observe an object deletion if it stops meeting the requirements of the selector [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-api-machinery] Watchers
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 14:02:25.140: INFO: >>> kubeConfig: /tmp/kubeconfig-324782104
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should observe an object deletion if it stops meeting the requirements of the selector [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: creating a watch on configmaps with a certain label
+STEP: creating a new configmap
+STEP: modifying the configmap once
+STEP: changing the label value of the configmap
+STEP: Expecting to observe a delete notification for the watched object
+Jul  2 14:02:25.305: INFO: Got : ADDED &ConfigMap{ObjectMeta:k8s_io_apimachinery_pkg_apis_meta_v1.ObjectMeta{Name:e2e-watch-test-label-changed,GenerateName:,Namespace:e2e-tests-watch-l8cs2,SelfLink:/api/v1/namespaces/e2e-tests-watch-l8cs2/configmaps/e2e-watch-test-label-changed,UID:8c3bb3c5-7e00-11e8-bc8c-d657551927e5,ResourceVersion:14154,Generation:0,CreationTimestamp:2018-07-02 14:02:25 +0000 UTC,DeletionTimestamp:<nil>,DeletionGracePeriodSeconds:nil,Labels:map[string]string{watch-this-configmap: label-changed-and-restored,},Annotations:map[string]string{},OwnerReferences:[],Finalizers:[],ClusterName:,Initializers:nil,},Data:map[string]string{},BinaryData:map[string][]byte{},}
+Jul  2 14:02:25.305: INFO: Got : MODIFIED &ConfigMap{ObjectMeta:k8s_io_apimachinery_pkg_apis_meta_v1.ObjectMeta{Name:e2e-watch-test-label-changed,GenerateName:,Namespace:e2e-tests-watch-l8cs2,SelfLink:/api/v1/namespaces/e2e-tests-watch-l8cs2/configmaps/e2e-watch-test-label-changed,UID:8c3bb3c5-7e00-11e8-bc8c-d657551927e5,ResourceVersion:14155,Generation:0,CreationTimestamp:2018-07-02 14:02:25 +0000 UTC,DeletionTimestamp:<nil>,DeletionGracePeriodSeconds:nil,Labels:map[string]string{watch-this-configmap: label-changed-and-restored,},Annotations:map[string]string{},OwnerReferences:[],Finalizers:[],ClusterName:,Initializers:nil,},Data:map[string]string{mutation: 1,},BinaryData:map[string][]byte{},}
+Jul  2 14:02:25.305: INFO: Got : DELETED &ConfigMap{ObjectMeta:k8s_io_apimachinery_pkg_apis_meta_v1.ObjectMeta{Name:e2e-watch-test-label-changed,GenerateName:,Namespace:e2e-tests-watch-l8cs2,SelfLink:/api/v1/namespaces/e2e-tests-watch-l8cs2/configmaps/e2e-watch-test-label-changed,UID:8c3bb3c5-7e00-11e8-bc8c-d657551927e5,ResourceVersion:14156,Generation:0,CreationTimestamp:2018-07-02 14:02:25 +0000 UTC,DeletionTimestamp:<nil>,DeletionGracePeriodSeconds:nil,Labels:map[string]string{watch-this-configmap: label-changed-and-restored,},Annotations:map[string]string{},OwnerReferences:[],Finalizers:[],ClusterName:,Initializers:nil,},Data:map[string]string{mutation: 1,},BinaryData:map[string][]byte{},}
+STEP: modifying the configmap a second time
+STEP: Expecting not to observe a notification because the object no longer meets the selector's requirements
+STEP: changing the label value of the configmap back
+STEP: modifying the configmap a third time
+STEP: deleting the configmap
+STEP: Expecting to observe an add notification for the watched object when the label value was restored
+Jul  2 14:02:35.354: INFO: Got : ADDED &ConfigMap{ObjectMeta:k8s_io_apimachinery_pkg_apis_meta_v1.ObjectMeta{Name:e2e-watch-test-label-changed,GenerateName:,Namespace:e2e-tests-watch-l8cs2,SelfLink:/api/v1/namespaces/e2e-tests-watch-l8cs2/configmaps/e2e-watch-test-label-changed,UID:8c3bb3c5-7e00-11e8-bc8c-d657551927e5,ResourceVersion:14179,Generation:0,CreationTimestamp:2018-07-02 14:02:25 +0000 UTC,DeletionTimestamp:<nil>,DeletionGracePeriodSeconds:nil,Labels:map[string]string{watch-this-configmap: label-changed-and-restored,},Annotations:map[string]string{},OwnerReferences:[],Finalizers:[],ClusterName:,Initializers:nil,},Data:map[string]string{mutation: 2,},BinaryData:map[string][]byte{},}
+Jul  2 14:02:35.354: INFO: Got : MODIFIED &ConfigMap{ObjectMeta:k8s_io_apimachinery_pkg_apis_meta_v1.ObjectMeta{Name:e2e-watch-test-label-changed,GenerateName:,Namespace:e2e-tests-watch-l8cs2,SelfLink:/api/v1/namespaces/e2e-tests-watch-l8cs2/configmaps/e2e-watch-test-label-changed,UID:8c3bb3c5-7e00-11e8-bc8c-d657551927e5,ResourceVersion:14180,Generation:0,CreationTimestamp:2018-07-02 14:02:25 +0000 UTC,DeletionTimestamp:<nil>,DeletionGracePeriodSeconds:nil,Labels:map[string]string{watch-this-configmap: label-changed-and-restored,},Annotations:map[string]string{},OwnerReferences:[],Finalizers:[],ClusterName:,Initializers:nil,},Data:map[string]string{mutation: 3,},BinaryData:map[string][]byte{},}
+Jul  2 14:02:35.354: INFO: Got : DELETED &ConfigMap{ObjectMeta:k8s_io_apimachinery_pkg_apis_meta_v1.ObjectMeta{Name:e2e-watch-test-label-changed,GenerateName:,Namespace:e2e-tests-watch-l8cs2,SelfLink:/api/v1/namespaces/e2e-tests-watch-l8cs2/configmaps/e2e-watch-test-label-changed,UID:8c3bb3c5-7e00-11e8-bc8c-d657551927e5,ResourceVersion:14181,Generation:0,CreationTimestamp:2018-07-02 14:02:25 +0000 UTC,DeletionTimestamp:<nil>,DeletionGracePeriodSeconds:nil,Labels:map[string]string{watch-this-configmap: label-changed-and-restored,},Annotations:map[string]string{},OwnerReferences:[],Finalizers:[],ClusterName:,Initializers:nil,},Data:map[string]string{mutation: 3,},BinaryData:map[string][]byte{},}
+[AfterEach] [sig-api-machinery] Watchers
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 14:02:35.354: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-watch-l8cs2" for this suite.
+Jul  2 14:02:41.375: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 14:02:41.468: INFO: namespace: e2e-tests-watch-l8cs2, resource: bindings, ignored listing per whitelist
+Jul  2 14:02:41.510: INFO: namespace e2e-tests-watch-l8cs2 deletion completed in 6.146470221s
+
+• [SLOW TEST:16.370 seconds]
+[sig-api-machinery] Watchers
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apimachinery/framework.go:22
+  should observe an object deletion if it stops meeting the requirements of the selector [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+[k8s.io] Probing container 
+  should be restarted with a exec "cat /tmp/health" liveness probe [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [k8s.io] Probing container
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 14:02:41.510: INFO: >>> kubeConfig: /tmp/kubeconfig-324782104
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [k8s.io] Probing container
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/container_probe.go:48
+[It] should be restarted with a exec "cat /tmp/health" liveness probe [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating pod liveness-exec in namespace e2e-tests-container-probe-wb2gl
+Jul  2 14:02:47.621: INFO: Started pod liveness-exec in namespace e2e-tests-container-probe-wb2gl
+STEP: checking the pod's current state and verifying that restartCount is present
+Jul  2 14:02:47.624: INFO: Initial restart count of pod liveness-exec is 0
+Jul  2 14:03:35.943: INFO: Restart count of pod e2e-tests-container-probe-wb2gl/liveness-exec is now 1 (48.318892351s elapsed)
+STEP: deleting the pod
+[AfterEach] [k8s.io] Probing container
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 14:03:35.953: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-container-probe-wb2gl" for this suite.
+Jul  2 14:03:41.975: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 14:03:42.007: INFO: namespace: e2e-tests-container-probe-wb2gl, resource: bindings, ignored listing per whitelist
+Jul  2 14:03:42.076: INFO: namespace e2e-tests-container-probe-wb2gl deletion completed in 6.118948051s
+
+• [SLOW TEST:60.566 seconds]
+[k8s.io] Probing container
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:679
+  should be restarted with a exec "cat /tmp/health" liveness probe [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSSSSSSSS
+------------------------------
+[sig-storage] Projected 
+  should be consumable from pods in volume as non-root [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 14:03:42.077: INFO: >>> kubeConfig: /tmp/kubeconfig-324782104
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:858
+[It] should be consumable from pods in volume as non-root [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating configMap with name projected-configmap-test-volume-ba170c7d-7e00-11e8-8e15-aefe7bc77cc2
+STEP: Creating a pod to test consume configMaps
+Jul  2 14:03:42.207: INFO: Waiting up to 5m0s for pod "pod-projected-configmaps-ba178aa3-7e00-11e8-8e15-aefe7bc77cc2" in namespace "e2e-tests-projected-frhtj" to be "success or failure"
+Jul  2 14:03:42.221: INFO: Pod "pod-projected-configmaps-ba178aa3-7e00-11e8-8e15-aefe7bc77cc2": Phase="Pending", Reason="", readiness=false. Elapsed: 13.43584ms
+Jul  2 14:03:44.225: INFO: Pod "pod-projected-configmaps-ba178aa3-7e00-11e8-8e15-aefe7bc77cc2": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.017725958s
+STEP: Saw pod success
+Jul  2 14:03:44.225: INFO: Pod "pod-projected-configmaps-ba178aa3-7e00-11e8-8e15-aefe7bc77cc2" satisfied condition "success or failure"
+Jul  2 14:03:44.229: INFO: Trying to get logs from node shoot--core--confaz-worker-qfmi9-79968b77d9-kcr6j pod pod-projected-configmaps-ba178aa3-7e00-11e8-8e15-aefe7bc77cc2 container projected-configmap-volume-test: <nil>
+STEP: delete the pod
+Jul  2 14:03:44.286: INFO: Waiting for pod pod-projected-configmaps-ba178aa3-7e00-11e8-8e15-aefe7bc77cc2 to disappear
+Jul  2 14:03:44.327: INFO: Pod pod-projected-configmaps-ba178aa3-7e00-11e8-8e15-aefe7bc77cc2 no longer exists
+[AfterEach] [sig-storage] Projected
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 14:03:44.327: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-frhtj" for this suite.
+Jul  2 14:03:50.451: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 14:03:50.552: INFO: namespace: e2e-tests-projected-frhtj, resource: bindings, ignored listing per whitelist
+Jul  2 14:03:50.609: INFO: namespace e2e-tests-projected-frhtj deletion completed in 6.252711879s
+
+• [SLOW TEST:8.533 seconds]
+[sig-storage] Projected
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:34
+  should be consumable from pods in volume as non-root [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+[sig-scheduling] SchedulerPredicates [Serial] 
+  validates resource limits of pods that are allowed to run  [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-scheduling] SchedulerPredicates [Serial]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 14:03:50.609: INFO: >>> kubeConfig: /tmp/kubeconfig-324782104
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-scheduling] SchedulerPredicates [Serial]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/scheduling/predicates.go:79
+Jul  2 14:03:50.708: INFO: Waiting up to 1m0s for all nodes to be ready
+Jul  2 14:04:50.731: INFO: Waiting for terminating namespaces to be deleted...
+Jul  2 14:04:50.737: INFO: Waiting up to 5m0s for all pods (need at least 0) in namespace 'kube-system' to be running and ready
+Jul  2 14:04:50.749: INFO: 14 / 14 pods in namespace 'kube-system' are running and ready (0 seconds elapsed)
+Jul  2 14:04:50.749: INFO: expected 8 pod replicas in namespace 'kube-system', 8 are Running and Ready.
+Jul  2 14:04:50.753: INFO: Waiting for pods to enter Success, but no pods in "kube-system" match label map[name:e2e-image-puller]
+Jul  2 14:04:50.753: INFO: 
+Logging pods the kubelet thinks is on node shoot--core--confaz-worker-qfmi9-79968b77d9-24hm4 before test
+Jul  2 14:04:50.764: INFO: vpn-shoot-dd669f8bb-vs6qw from kube-system started at 2018-07-02 12:51:50 +0000 UTC (1 container statuses recorded)
+Jul  2 14:04:50.764: INFO: 	Container vpn-shoot ready: true, restart count 0
+Jul  2 14:04:50.764: INFO: kube-dns-9c4dfc4fb-68s88 from kube-system started at 2018-07-02 12:52:17 +0000 UTC (3 container statuses recorded)
+Jul  2 14:04:50.764: INFO: 	Container dnsmasq ready: true, restart count 0
+Jul  2 14:04:50.764: INFO: 	Container kubedns ready: true, restart count 0
+Jul  2 14:04:50.764: INFO: 	Container sidecar ready: true, restart count 0
+Jul  2 14:04:50.764: INFO: calico-node-vzzmk from kube-system started at 2018-07-02 12:51:19 +0000 UTC (2 container statuses recorded)
+Jul  2 14:04:50.764: INFO: 	Container calico-node ready: true, restart count 0
+Jul  2 14:04:50.764: INFO: 	Container install-cni ready: true, restart count 0
+Jul  2 14:04:50.764: INFO: kube-proxy-9j7qk from kube-system started at 2018-07-02 12:51:19 +0000 UTC (1 container statuses recorded)
+Jul  2 14:04:50.764: INFO: 	Container kube-proxy ready: true, restart count 0
+Jul  2 14:04:50.764: INFO: addons-heapster-e3b0c-64455ddddb-4nqxw from kube-system started at 2018-07-02 12:51:50 +0000 UTC (2 container statuses recorded)
+Jul  2 14:04:50.764: INFO: 	Container heapster ready: true, restart count 0
+Jul  2 14:04:50.764: INFO: 	Container heapster-nanny ready: true, restart count 0
+Jul  2 14:04:50.764: INFO: addons-kubernetes-dashboard-5486b968b7-9bgvq from kube-system started at 2018-07-02 12:51:50 +0000 UTC (1 container statuses recorded)
+Jul  2 14:04:50.764: INFO: 	Container main ready: true, restart count 0
+Jul  2 14:04:50.764: INFO: addons-nginx-ingress-nginx-ingress-k8s-backend-7b5569797f-vs48p from kube-system started at 2018-07-02 12:51:50 +0000 UTC (1 container statuses recorded)
+Jul  2 14:04:50.764: INFO: 	Container nginx-ingress-nginx-ingress-k8s-backend ready: true, restart count 0
+Jul  2 14:04:50.764: INFO: kube-dns-9c4dfc4fb-wvnfk from kube-system started at 2018-07-02 12:51:50 +0000 UTC (3 container statuses recorded)
+Jul  2 14:04:50.764: INFO: 	Container dnsmasq ready: true, restart count 0
+Jul  2 14:04:50.764: INFO: 	Container kubedns ready: true, restart count 0
+Jul  2 14:04:50.764: INFO: 	Container sidecar ready: true, restart count 0
+Jul  2 14:04:50.764: INFO: addons-nginx-ingress-controller-79bfb57974-gxmr9 from kube-system started at 2018-07-02 12:51:50 +0000 UTC (1 container statuses recorded)
+Jul  2 14:04:50.764: INFO: 	Container nginx-ingress-controller ready: true, restart count 0
+Jul  2 14:04:50.764: INFO: node-exporter-fzzjt from kube-system started at 2018-07-02 12:51:19 +0000 UTC (1 container statuses recorded)
+Jul  2 14:04:50.764: INFO: 	Container node-exporter ready: true, restart count 0
+Jul  2 14:04:50.764: INFO: kube-dns-autoscaler-6dd4765967-wxfns from kube-system started at 2018-07-02 12:51:50 +0000 UTC (1 container statuses recorded)
+Jul  2 14:04:50.764: INFO: 	Container autoscaler ready: true, restart count 0
+Jul  2 14:04:50.764: INFO: 
+Logging pods the kubelet thinks is on node shoot--core--confaz-worker-qfmi9-79968b77d9-kcr6j before test
+Jul  2 14:04:50.773: INFO: node-exporter-wh8n7 from kube-system started at 2018-07-02 12:51:49 +0000 UTC (1 container statuses recorded)
+Jul  2 14:04:50.773: INFO: 	Container node-exporter ready: true, restart count 0
+Jul  2 14:04:50.773: INFO: calico-node-77jff from kube-system started at 2018-07-02 12:51:49 +0000 UTC (2 container statuses recorded)
+Jul  2 14:04:50.773: INFO: 	Container calico-node ready: true, restart count 0
+Jul  2 14:04:50.773: INFO: 	Container install-cni ready: true, restart count 0
+Jul  2 14:04:50.773: INFO: sonobuoy from sonobuoy started at 2018-07-02 12:54:15 +0000 UTC (1 container statuses recorded)
+Jul  2 14:04:50.773: INFO: 	Container kube-sonobuoy ready: true, restart count 0
+Jul  2 14:04:50.773: INFO: kube-proxy-f5qqz from kube-system started at 2018-07-02 12:51:49 +0000 UTC (1 container statuses recorded)
+Jul  2 14:04:50.773: INFO: 	Container kube-proxy ready: true, restart count 0
+Jul  2 14:04:50.773: INFO: sonobuoy-e2e-job-23e7c281ee4e4e5d from sonobuoy started at 2018-07-02 12:54:29 +0000 UTC (2 container statuses recorded)
+Jul  2 14:04:50.773: INFO: 	Container e2e ready: true, restart count 0
+Jul  2 14:04:50.773: INFO: 	Container sonobuoy-worker ready: true, restart count 0
+[It] validates resource limits of pods that are allowed to run  [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: verifying the node has the label node shoot--core--confaz-worker-qfmi9-79968b77d9-24hm4
+STEP: verifying the node has the label node shoot--core--confaz-worker-qfmi9-79968b77d9-kcr6j
+Jul  2 14:04:50.822: INFO: Pod addons-heapster-e3b0c-64455ddddb-4nqxw requesting resource cpu=50m on Node shoot--core--confaz-worker-qfmi9-79968b77d9-24hm4
+Jul  2 14:04:50.822: INFO: Pod addons-kubernetes-dashboard-5486b968b7-9bgvq requesting resource cpu=50m on Node shoot--core--confaz-worker-qfmi9-79968b77d9-24hm4
+Jul  2 14:04:50.822: INFO: Pod addons-nginx-ingress-controller-79bfb57974-gxmr9 requesting resource cpu=100m on Node shoot--core--confaz-worker-qfmi9-79968b77d9-24hm4
+Jul  2 14:04:50.822: INFO: Pod addons-nginx-ingress-nginx-ingress-k8s-backend-7b5569797f-vs48p requesting resource cpu=0m on Node shoot--core--confaz-worker-qfmi9-79968b77d9-24hm4
+Jul  2 14:04:50.822: INFO: Pod calico-node-77jff requesting resource cpu=250m on Node shoot--core--confaz-worker-qfmi9-79968b77d9-kcr6j
+Jul  2 14:04:50.822: INFO: Pod calico-node-vzzmk requesting resource cpu=250m on Node shoot--core--confaz-worker-qfmi9-79968b77d9-24hm4
+Jul  2 14:04:50.822: INFO: Pod kube-dns-9c4dfc4fb-68s88 requesting resource cpu=260m on Node shoot--core--confaz-worker-qfmi9-79968b77d9-24hm4
+Jul  2 14:04:50.822: INFO: Pod kube-dns-9c4dfc4fb-wvnfk requesting resource cpu=260m on Node shoot--core--confaz-worker-qfmi9-79968b77d9-24hm4
+Jul  2 14:04:50.822: INFO: Pod kube-dns-autoscaler-6dd4765967-wxfns requesting resource cpu=20m on Node shoot--core--confaz-worker-qfmi9-79968b77d9-24hm4
+Jul  2 14:04:50.822: INFO: Pod kube-proxy-9j7qk requesting resource cpu=50m on Node shoot--core--confaz-worker-qfmi9-79968b77d9-24hm4
+Jul  2 14:04:50.822: INFO: Pod kube-proxy-f5qqz requesting resource cpu=50m on Node shoot--core--confaz-worker-qfmi9-79968b77d9-kcr6j
+Jul  2 14:04:50.822: INFO: Pod node-exporter-fzzjt requesting resource cpu=10m on Node shoot--core--confaz-worker-qfmi9-79968b77d9-24hm4
+Jul  2 14:04:50.822: INFO: Pod node-exporter-wh8n7 requesting resource cpu=10m on Node shoot--core--confaz-worker-qfmi9-79968b77d9-kcr6j
+Jul  2 14:04:50.822: INFO: Pod vpn-shoot-dd669f8bb-vs6qw requesting resource cpu=100m on Node shoot--core--confaz-worker-qfmi9-79968b77d9-24hm4
+Jul  2 14:04:50.822: INFO: Pod sonobuoy requesting resource cpu=0m on Node shoot--core--confaz-worker-qfmi9-79968b77d9-kcr6j
+Jul  2 14:04:50.822: INFO: Pod sonobuoy-e2e-job-23e7c281ee4e4e5d requesting resource cpu=0m on Node shoot--core--confaz-worker-qfmi9-79968b77d9-kcr6j
+STEP: Starting Pods to consume most of the cluster CPU.
+STEP: Creating another pod that requires unavailable amount of CPU.
+STEP: Considering event: 
+Type = [Normal], Name = [filler-pod-e2fe6f8c-7e00-11e8-8e15-aefe7bc77cc2.153d92490e23501d], Reason = [Scheduled], Message = [Successfully assigned e2e-tests-sched-pred-p9jlc/filler-pod-e2fe6f8c-7e00-11e8-8e15-aefe7bc77cc2 to shoot--core--confaz-worker-qfmi9-79968b77d9-24hm4]
+STEP: Considering event: 
+Type = [Normal], Name = [filler-pod-e2fe6f8c-7e00-11e8-8e15-aefe7bc77cc2.153d924949e34bca], Reason = [Pulled], Message = [Container image "k8s.gcr.io/pause:3.1" already present on machine]
+STEP: Considering event: 
+Type = [Normal], Name = [filler-pod-e2fe6f8c-7e00-11e8-8e15-aefe7bc77cc2.153d924950be2c8d], Reason = [Created], Message = [Created container]
+STEP: Considering event: 
+Type = [Normal], Name = [filler-pod-e2fe6f8c-7e00-11e8-8e15-aefe7bc77cc2.153d924966d56fdc], Reason = [Started], Message = [Started container]
+STEP: Considering event: 
+Type = [Normal], Name = [filler-pod-e2ffa2b9-7e00-11e8-8e15-aefe7bc77cc2.153d924910d02e4e], Reason = [Scheduled], Message = [Successfully assigned e2e-tests-sched-pred-p9jlc/filler-pod-e2ffa2b9-7e00-11e8-8e15-aefe7bc77cc2 to shoot--core--confaz-worker-qfmi9-79968b77d9-kcr6j]
+STEP: Considering event: 
+Type = [Normal], Name = [filler-pod-e2ffa2b9-7e00-11e8-8e15-aefe7bc77cc2.153d92494ca33860], Reason = [Pulled], Message = [Container image "k8s.gcr.io/pause:3.1" already present on machine]
+STEP: Considering event: 
+Type = [Normal], Name = [filler-pod-e2ffa2b9-7e00-11e8-8e15-aefe7bc77cc2.153d9249548d5507], Reason = [Created], Message = [Created container]
+STEP: Considering event: 
+Type = [Normal], Name = [filler-pod-e2ffa2b9-7e00-11e8-8e15-aefe7bc77cc2.153d92495fad57bb], Reason = [Started], Message = [Started container]
+STEP: Considering event: 
+Type = [Warning], Name = [additional-pod.153d924a01ead799], Reason = [FailedScheduling], Message = [0/2 nodes are available: 2 Insufficient cpu.]
+STEP: removing the label node off the node shoot--core--confaz-worker-qfmi9-79968b77d9-24hm4
+STEP: verifying the node doesn't have the label node
+STEP: removing the label node off the node shoot--core--confaz-worker-qfmi9-79968b77d9-kcr6j
+STEP: verifying the node doesn't have the label node
+[AfterEach] [sig-scheduling] SchedulerPredicates [Serial]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 14:04:56.000: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-sched-pred-p9jlc" for this suite.
+Jul  2 14:05:18.066: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 14:05:18.143: INFO: namespace: e2e-tests-sched-pred-p9jlc, resource: bindings, ignored listing per whitelist
+Jul  2 14:05:18.229: INFO: namespace e2e-tests-sched-pred-p9jlc deletion completed in 22.224754994s
+[AfterEach] [sig-scheduling] SchedulerPredicates [Serial]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/scheduling/predicates.go:70
+
+• [SLOW TEST:87.619 seconds]
+[sig-scheduling] SchedulerPredicates [Serial]
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/scheduling/framework.go:22
+  validates resource limits of pods that are allowed to run  [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSJul  2 14:05:18.229: INFO: Running AfterSuite actions on all node
+Jul  2 14:05:18.229: INFO: Running AfterSuite actions on node 1
+Jul  2 14:05:18.229: INFO: Skipping dumping logs from cluster
+
+Ran 143 of 998 Specs in 4226.682 seconds
+SUCCESS! -- 143 Passed | 0 Failed | 0 Pending | 855 Skipped PASS
+
+Ginkgo ran 1 suite in 1h10m27.045351017s
+Test Suite Passed

--- a/v1.11/gardener-azure/junit_01.xml
+++ b/v1.11/gardener-azure/junit_01.xml
@@ -1,0 +1,2711 @@
+<?xml version="1.0" encoding="UTF-8"?>
+  <testsuite tests="143" failures="0" time="4226.681568083">
+      <testcase name="[sig-storage] EmptyDir volumes should support (non-root,0666,tmpfs) [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="10.655756758999999"></testcase>
+      <testcase name="[sig-storage] GCP Volumes GlusterFS should be mountable" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Probing container should *not* be restarted with a exec &#34;cat /tmp/health&#34; liveness probe [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="259.892548101"></testcase>
+      <testcase name="[sig-network] Loadbalancing: L7 GCE [Slow] [Feature:NEG] should conform to Ingress spec" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] DNS should provide DNS for pods for Hostname and Subdomain" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: gce-localssd-scsi-fs] [Serial] Set fsGroup for local volume should not set different fsGroups for two pods simultaneously" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] ConfigMap should be consumable from pods in volume with mappings as non-root [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="10.358532657"></testcase>
+      <testcase name="[k8s.io] [sig-node] Mount propagation should propagate mounts to the host" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: gce-localssd-scsi-fs] [Serial] One pod requesting one prebound PVC should be able to mount volume and write from pod1" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] KubeletManagedEtcHosts should test kubelet managed /etc/hosts file [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="48.472595008"></testcase>
+      <testcase name="[sig-ui] Kubernetes Dashboard should check that the kubernetes-dashboard instance is alive" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scalability] Load capacity [Feature:ManualPerformance] should be able to handle 30 pods per node { ReplicationController} with 0 secrets, 0 configmaps and 2 daemons" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: tmpfs] Set fsGroup for local volume should set fsGroup for one pod" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] SchedulerPredicates [Serial] validates that NodeAffinity is respected if not matching" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Network Partition [Disruptive] [Slow] [k8s.io] Pods should return to running and ready state after network partition is healed All pods on the unreachable node should be marked as NotReady upon the node turn NotReady AND all pods should be mark back to Ready when the node get back to Ready before pod eviction timeout" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: dir-bindmounted] Set fsGroup for local volume should not set different fsGroups for two pods simultaneously" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Projected should provide node allocatable (memory) as default memory limit if the limit is not set [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="8.459678407"></testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gluster] should support non-existent path" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: block] [Feature:BlockVolume] Set fsGroup for local volume should set same fsGroup for two pods simultaneously" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] ConfigMap should be consumable via environment variable [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="12.363946203"></testcase>
+      <testcase name="[sig-apps] Deployment deployment reaping should cascade to its replica sets and pods" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PVC Protection Verify &#34;immediate&#34; deletion of a PVC that is not in active use by a pod" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volume plugin streaming [Slow] Ceph-RBD [Feature:Volumes] should write files of various sizes, verify size, validate content" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Networking Granular Checks: Pods should function for node-pod communication: udp [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="47.528905094"></testcase>
+      <testcase name="[sig-api-machinery] Garbage collector should not delete dependents that have both valid owner and owner that&#39;s waiting for dependents to be deleted [Conformance]" classname="Kubernetes e2e suite" time="16.474595029"></testcase>
+      <testcase name="[sig-apps] Deployment RecreateDeployment should delete old pods and create new ones" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Services should work after restarting apiserver [Disruptive]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath Atomic writer volumes should support subpaths with configmap pod with mountPath of existing file" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] [Serial] Volume metrics PVController should create none metrics for pvc controller before creating any PV or PVC" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Kubectl apply should apply a new configuration to an existing RC" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Cluster size autoscaler scalability [Slow] should scale down underutilized nodes [Feature:ClusterAutoscalerScalability4]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: nfs] should fail for new directories when readOnly specified in the volumeSource" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-instrumentation] Cluster level logging implemented by Stackdriver should ingest events" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Services should be able to change the type from NodePort to ExternalName" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Pods should be updated [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="25.063060351"></testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Kubectl apply apply set/view last-applied" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: emptyDir] should support restarting containers using file as subpath [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Networking Granular Checks: Services [Slow] should function for endpoint-Service: http" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Networking should provide unchanging, static URL paths for kubernetes api services" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cluster-lifecycle] [Feature:BootstrapTokens] should not delete the token secret when the secret is not expired" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: hostPathSymlink] should fail for new directories when readOnly specified in the volumeSource" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Daemon set [Serial] should retry creating failed daemon pods [Conformance]" classname="Kubernetes e2e suite" time="24.502685499000002"></testcase>
+      <testcase name="[sig-apps] Daemon set [Serial] should run and stop complex daemon [Conformance]" classname="Kubernetes e2e suite" time="24.589785153"></testcase>
+      <testcase name="[sig-apps] CronJob should not emit unexpected warnings" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [sig-node] Security Context [Feature:SecurityContext] should support seccomp alpha runtime/default annotation [Feature:Seccomp]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] Should scale down GPU pool from 1 [GpuType:nvidia-tesla-v100] [Feature:ClusterSizeAutoscalingGpu]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] Shouldn&#39;t perform scale up operation and should list unhealthy status if most of the cluster is broken[Feature:ClusterSizeAutoscalingScaleUp]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-auth] ServiceAccounts should allow opting out of API token automount  [Conformance]" classname="Kubernetes e2e suite" time="24.990181326"></testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] should create new node if there is no node for node selector [Feature:ClusterSizeAutoscalingScaleWithNAP]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Node Unregister [Feature:vsphere] [Slow] [Disruptive] node unregister" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl Port forwarding [k8s.io] With a server listening on 0.0.0.0 [k8s.io] that expects a client request should support a client that connects, sends DATA, and disconnects" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Deployment deployment should support rollback" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volume Disk Size [Feature:vsphere] verify dynamically provisioned pv using storageclass with an invalid disk size fails" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cluster-lifecycle] Nodes [Disruptive] Resize [Slow] should be able to delete nodes" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] GKE local SSD [Feature:GKELocalSSD] should write and read from node local SSD [Feature:GKELocalSSD]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gcePDPVC] should support non-existent path" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Downward API volume should provide podname as non-root with fsgroup and defaultMode [NodeFeature:FSGroup]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] CronJob should delete successful finished jobs with limit of one successful job" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [Feature:Example] [k8s.io] RethinkDB should create and stop rethinkdb servers" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] StatefulSet [k8s.io] Deploy clustered applications [Feature:StatefulSet] [Slow] should creating a working redis cluster" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] EmptyDir volumes should support (non-root,0777,default) [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="10.400980547"></testcase>
+      <testcase name="[sig-storage] Dynamic Provisioning DynamicProvisioner should provision storage with non-default reclaim policy Retain" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] ResourceQuota should create a ResourceQuota and capture the life of a replication controller." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: tmpfs] Set fsGroup for local volume should not set different fsGroups for two pods simultaneously" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Projected should be consumable from pods in volume [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="10.484932773"></testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gcePDPartitioned] should support non-existent path" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Pods should be submitted and removed [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="19.446913851"></testcase>
+      <testcase name="[sig-apps] Network Partition [Disruptive] [Slow] [k8s.io] [ReplicationController] should recreate pods scheduled on the unreachable node AND allow scheduling of pods on a node after it rejoins the cluster" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Garbage collector should keep the rc around until all its pods are deleted if the deleteOptions says so [Conformance]" classname="Kubernetes e2e suite" time="12.32172958"></testcase>
+      <testcase name="[sig-network] Loadbalancing: L7 GCE [Slow] [Feature:kubemci] should remove clusters as expected" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-instrumentation] [Feature:PrometheusMonitoring] Prometheus should successfully scrape all targets" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] HostPath should give a volume the correct mode [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="10.30358364"></testcase>
+      <testcase name="[sig-network] Networking IPerf IPv6 [Experimental] [Feature:Networking-IPv6] [Slow] [Feature:Networking-Performance] should transfer ~ 1GB onto the service endpoint 1 servers (maximum of 1 clients)" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] ServiceLoadBalancer [Feature:ServiceLoadBalancer] should support simple GET on Ingress ips" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Projected should provide container&#39;s memory request [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="8.398510163"></testcase>
+      <testcase name="[k8s.io] [Feature:Example] [k8s.io] Spark should start spark master, driver and workers" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Services should only allow access from service loadbalancer source ranges [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] StatefulSet [k8s.io] Deploy clustered applications [Feature:StatefulSet] [Slow] should creating a working zookeeper cluster" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] SchedulerPredicates [Serial] validates that taints-tolerations is respected if not matching" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: nfsPVC] should support readOnly file specified in the volumeMount" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] NFSPersistentVolumes[Disruptive][Flaky] when kubelet restarts Should test that a volume mounted to a pod that is deleted while the kubelet is down unmounts when the kubelet returns." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Namespaces [Serial] should always delete fast (ALL of 100 namespaces in 150 seconds) [Feature:ComprehensiveNamespaceDraining]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-auth] ServiceAccounts should mount an API token into pods  [Conformance]" classname="Kubernetes e2e suite" time="19.26378739"></testcase>
+      <testcase name="[sig-scheduling] SchedulerPredicates [Serial] validates MaxPods limit number of pods that are allowed to run [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PVC Protection Verify that PVC in active use by a pod is not removed immediately" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Daemon set [Serial] should rollback without unnecessary restarts [Conformance]" classname="Kubernetes e2e suite" time="6.395427134">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-instrumentation] [Feature:PrometheusMonitoring] Prometheus should scrape metrics from annotated services." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: dir-link-bindmounted] One pod requesting one prebound PVC should be able to mount volume and write from pod1" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: nfsPVC] should support restarting containers using file as subpath [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [sig-node] Kubelet [Serial] [Slow] [k8s.io] [sig-node] regular resource usage tracking resource tracking for 100 pods per node" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: blockfs] Two pods mounting a local volume one after the other should be able to write from pod1 and read from pod2" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] stateful Upgrade [Feature:StatefulUpgrade] [k8s.io] stateful upgrade should maintain a functioning cluster" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] vsphere cloud provider stress [Feature:vsphere] vsphere stress tests" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-service-catalog] [Feature:PodPreset] PodPreset should not modify the pod on conflict" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Initializers [Feature:Initializers] will be set to nil if a patch removes the last pending initializer" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] [HPA] Horizontal pod autoscaling (scale resource: Custom Metrics from Stackdriver) should scale down with External Metric with target average value from Stackdriver [Feature:CustomMetricsAutoscaling]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gluster] should support existing directory" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Flexvolumes [Disruptive] should install plugin without kubelet restart" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] EmptyDir volumes volume on tmpfs should have the correct mode [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="8.272084355"></testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Kubectl expose should create services for rc  [Conformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] shouldn&#39;t trigger additional scale-ups during processing scale-up [Feature:ClusterSizeAutoscalingScaleUp]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Probing container should be restarted with a docker exec liveness probe with timeout " classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] [Feature:PerformanceDNS] Should answer DNS query for maximum number of services per cluster" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] ResourceQuota should create a ResourceQuota and capture the life of a pod." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Garbage collector should support cascading deletion of custom resources" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] EmptyDir volumes should support (non-root,0644,tmpfs) [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="8.325255255"></testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] should be able to scale down by draining system pods with pdb[Feature:ClusterSizeAutoscalingScaleDown]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: emptyDir] should unmount if pod is gracefully deleted while kubelet is down [Disruptive][Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: dir-link-bindmounted] Two pods mounting a local volume one after the other should be able to write from pod1 and read from pod2" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Deployment test Deployment ReplicaSet orphaning and adoption regarding controllerRef" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: gce-localssd-scsi-fs] [Serial] Set fsGroup for local volume should set same fsGroup for two pods simultaneously" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Job should run a job to completion when tasks succeed" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Variable Expansion should allow substituting values in a container&#39;s args [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="10.364655046"></testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: emptyDir] should support existing single file" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] should add node to the particular mig [Feature:ClusterSizeAutoscalingScaleUp]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Projected should be consumable from pods in volume as non-root with FSGroup [NodeFeature:FSGroup]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Downward API volume should provide podname only [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="9.434213802"></testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: gce-localssd-scsi-fs] [Serial] Two pods mounting a local volume one after the other should be able to write from pod1 and read from pod2" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gluster] should support file as subpath" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Services should have session affinity work for LoadBalancer service with ESIPP off [Slow] [DisabledForLargeClusters]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes:vsphere should test that deleting the Namespace of a PVC and Pod causes the successful detach of vsphere volume" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] Multi-AZ Cluster Volumes [sig-storage] should schedule pods in the same zones as statically provisioned PVs" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Storage Policy Based Volume Provisioning [Feature:vsphere] verify VSAN storage capability with valid hostFailuresToTolerate and cacheReservation values is honored for dynamically provisioned pvc using storageclass" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: emptyDir] should fail if subpath directory is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Network should set TCP CLOSE_WAIT timeout" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Kubectl logs should be able to retrieve and filter logs  [Conformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: nfs] should fail if subpath file is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: nfs] should unmount if pod is force deleted while kubelet is down [Disruptive][Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: dir-link-bindmounted] Set fsGroup for local volume should set different fsGroup for second pod if first pod is deleted" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Servers with support for Table transformation should return pod details" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Networking Granular Checks: Services [Slow] should function for node-Service: http" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] [HPA] Horizontal pod autoscaling (scale resource: CPU) [sig-autoscaling] ReplicationController light Should scale from 1 pod to 2 pods" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [sig-node] Security Context [Feature:SecurityContext] should support volume SELinux relabeling" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] should increase cluster size if pods are pending due to host port conflict [Feature:ClusterSizeAutoscalingScaleUp]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: blockfs] Set fsGroup for local volume should set same fsGroup for two pods simultaneously" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] [HPA] Horizontal pod autoscaling (scale resource: Custom Metrics from Stackdriver) should scale down with External Metric with target value from Stackdriver [Feature:CustomMetricsAutoscaling]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] ResourceQuota should create a ResourceQuota and capture the life of a secret." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Ephemeralstorage When pod refers to non-existent ephemeral storage should allow deletion of pod with invalid volume : projected" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Services [Feature:GCEAlphaFeature][Slow] should be able to create and tear down a standard-tier load balancer [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Networking Granular Checks: Pods should function for node-pod communication: http [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="47.065708444"></testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: tmpfs] Set fsGroup for local volume should set different fsGroup for second pod if first pod is deleted" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: dir-link-bindmounted] One pod requesting one prebound PVC should be able to mount volume and read from pod1" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] EmptyDir volumes volume on default medium should have the correct mode [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="10.328698483"></testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: emptyDir] should support restarting containers using directory as subpath [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gcePDPVC] should support existing single file" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gcePDPVC] should support readOnly directory specified in the volumeMount" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes:vsphere should test that deleting a PVC before the pod does not cause pod deletion to fail on vsphere volume detach" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] Should not scale GPU pool up if pod does not require GPUs [GpuType:nvidia-tesla-p100] [Feature:ClusterSizeAutoscalingGpu]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] NFSPersistentVolumes[Disruptive][Flaky] when kube-controller-manager restarts should delete a bound PVC from a clientPod, restart the kube-control-manager, and ensure the kube-controller-manager does not crash" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: emptyDir] should fail if subpath file is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Projected should set mode on item file [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="10.306515666"></testcase>
+      <testcase name="[sig-scheduling] SchedulerPredicates [Serial] validates local ephemeral storage resource limits of pods that are allowed to run [Feature:LocalStorageCapacityIsolation]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: gce-localssd-scsi-fs] [Serial] Set fsGroup for local volume should set fsGroup for one pod" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-instrumentation] MetricsGrabber should grab all metrics from a ControllerManager." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cluster-lifecycle] HA-master [Feature:HAMaster] survive addition/removal replicas different zones [Serial][Disruptive]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] StatefulSet [k8s.io] Basic StatefulSet functionality [StatefulSetBasic] should adopt matching orphans and release non-matching pods" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: nfs] should support creating multiple subpath from same volumes [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] NetworkPolicy NetworkPolicy between server and client should support allow-all policy [Feature:NetworkPolicy]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] [Serial] Volume metrics PVController should create unbound pvc count metrics for pvc controller after creating pvc only" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Storage Policy Based Volume Provisioning [Feature:vsphere] verify an if a SPBM policy and VSAN capabilities cannot be honored for dynamically provisioned pvc using storageclass" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Regional PD RegionalPD should provision storage [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Sysctls [NodeFeature:Sysctls] should reject invalid sysctls" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] InitContainer [NodeConformance] should invoke init containers on a RestartAlways pod" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: hostPathSymlink] should fail if subpath with backstepping is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scalability] Density [Feature:Performance] should allow starting 30 pods per node using { ReplicationController} with 0 secrets, 0 configmaps and 0 daemons" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scalability] Density [Feature:ManualPerformance] should allow starting 30 pods per node using {extensions Deployment} with 2 secrets, 0 configmaps and 0 daemons" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Probing container with readiness probe should not be ready before initial delay and never restart [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="48.391373888"></testcase>
+      <testcase name="[sig-cluster-lifecycle] Reboot [Disruptive] [Feature:Reboot] each node by switching off the network interface and ensure they function upon switch on" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] AdmissionWebhook Should not be able to prevent deleting validating-webhook-configurations or mutating-webhook-configurations" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] shouldn&#39;t scale down when non expendable pod is running [Feature:ClusterSizeAutoscalingScaleDown]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] StatefulSet [k8s.io] Basic StatefulSet functionality [StatefulSetBasic] should provide basic identity" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Loadbalancing: L7 GCE [Slow] [Feature:kubemci] should conform to Ingress spec" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Dynamic Provisioning DynamicProvisioner deletion should be idempotent" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Secrets should be consumable via the environment [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="10.302406453"></testcase>
+      <testcase name="[sig-storage] Dynamic Provisioning DynamicProvisioner should test that deleting a claim before the volume is provisioned deletes the volume." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Loadbalancing: L7 GCE [Slow] [Feature:Ingress] should create ingress with given static-ip" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Variable Expansion should fail substituting values in a volume subpath with absolute path [Feature:VolumeSubpathEnvExpansion][NodeAlphaFeature:VolumeSubpathEnvExpansion][Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  Pod with node different from PV&#39;s NodeAffinity should fail scheduling due to different NodeAffinity" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-instrumentation] [Feature:PrometheusMonitoring] Prometheus should scrape metrics from annotated pods." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: nfs] should support restarting containers using directory as subpath [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes NFS with Single PV - PVC pairs create a PVC and non-pre-bound PV: test write access" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cluster-lifecycle] Addon update should propagate add-on file changes [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: emptyDir] should fail for new directories when readOnly specified in the volumeSource" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] should scale down when expendable pod is running [Feature:ClusterSizeAutoscalingScaleDown]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: nfs] should support existing single file" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PV Protection Verify &#34;immediate&#34; deletion of a PV that is not bound to a PVC" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] ReplicaSet should serve a basic image on each replica with a private image" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scalability] Load capacity [Feature:ManualPerformance] should be able to handle 30 pods per node { Random} with 0 secrets, 0 configmaps and 0 daemons with quotas" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl Port forwarding [k8s.io] With a server listening on 0.0.0.0 [k8s.io] that expects NO client request should support a client that connects, sends DATA, and disconnects" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: blockfs] Set fsGroup for local volume should not set different fsGroups for two pods simultaneously" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: nfs] should support readOnly file specified in the volumeMount" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl alpha client [k8s.io] Kubectl run CronJob should create a CronJob" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-auth] [Feature:NodeAuthorizer] A node shouldn&#39;t be able to delete another node" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] AdmissionWebhook Should mutate configmap" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] GenericPersistentVolume[Disruptive] When kubelet restarts Should test that a file written to the mount before kubelet restart is readable after restart." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Servers with support for Table transformation should return chunks of table results for list calls" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Dynamic Provisioning DynamicProvisioner Default should be disabled by changing the default annotation [Serial] [Disruptive]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Initializers [Feature:Initializers] should be invisible to controllers by default" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Projected optional updates should be reflected in volume [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="28.694782189"></testcase>
+      <testcase name="[sig-storage] EmptyDir volumes should support (root,0777,tmpfs) [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="8.353035654"></testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gcePDPartitioned] should support existing single file" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cluster-lifecycle] Reboot [Disruptive] [Feature:Reboot] each node by ordering clean reboot and ensure they function upon restart" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-auth] PodSecurityPolicy should allow pods under the privileged extensions.PodSecurityPolicy" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Cluster size autoscaler scalability [Slow] should scale up twice [Feature:ClusterAutoscalerScalability2]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] StatefulSet [k8s.io] Basic StatefulSet functionality [StatefulSetBasic] should implement legacy replacement when the update strategy is OnDelete" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Guestbook application should create and stop a working application  [Conformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  Local volume provisioner [Serial] should discover dynamicly created local persistent volume mountpoint in discovery directory" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volume FStype [Feature:vsphere] verify fstype - ext3 formatted volume" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gcePDPartitioned] should fail if subpath file is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] EmptyDir volumes when FSGroup is specified [NodeFeature:FSGroup] new files should be created with FSGroup ownership when container is root" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Regional PD RegionalPD should failover to a different zone when all nodes in one zone become unreachable [Slow] [Disruptive]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: hostPath] should fail for new directories when readOnly specified in the volumeSource" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: hostPath] should support readOnly file specified in the volumeMount" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: hostPathSymlink] should support file as subpath" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gcePDPartitioned] should unmount if pod is force deleted while kubelet is down [Disruptive][Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] SchedulerPredicates [Serial] validates that taints-tolerations is respected if matching" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] NetworkPolicy NetworkPolicy between server and client should allow egress access on one named port [Feature:NetworkPolicy]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Projected should provide container&#39;s memory limit [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="8.296567738"></testcase>
+      <testcase name="[sig-storage] Volumes vsphere [Feature:Volumes] should be mountable" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Probing container should *not* be restarted with a /healthz http liveness probe [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="249.665324221"></testcase>
+      <testcase name="[sig-network] Networking Granular Checks: Services [Slow] should function for client IP based session affinity: http" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cluster-lifecycle] Upgrade [Feature:Upgrade] node upgrade should maintain a functioning cluster [Feature:NodeUpgrade]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scalability] Density [Feature:HighDensityPerformance] should allow starting 95 pods per node using { ReplicationController} with 0 secrets, 0 configmaps and 0 daemons" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Pod Disks detach in a disrupted environment [Slow] [Disruptive] when pod is evicted" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cluster-lifecycle] Reboot [Disruptive] [Feature:Reboot] each node by ordering unclean reboot and ensure they function upon restart" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volumes Azure Disk [Feature:Volumes] should be mountable [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: hostPath] should support restarting containers using file as subpath [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] ConfigMap optional updates should be reflected in volume [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="102.356287605"></testcase>
+      <testcase name="[k8s.io] [sig-node] Security Context [Feature:SecurityContext] should support seccomp alpha unconfined annotation on the container [Feature:Seccomp]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cluster-lifecycle] etcd Upgrade [Feature:EtcdUpgrade] etcd upgrade should maintain a functioning cluster" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: emptyDir] should fail if subpath with backstepping is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Generated clientset should create v1beta1 cronJobs, delete cronJobs, watch cronJobs" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-instrumentation] Cluster level logging implemented by Stackdriver should ingest logs" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gcePDPartitioned] should support restarting containers using file as subpath [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Projected should set DefaultMode on files [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="8.307781889"></testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gluster] should fail if non-existent subpath is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gluster] should support readOnly file specified in the volumeMount" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes:vsphere should test that a file written to the vspehre volume mount before kubelet restart can be read after restart [Disruptive]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Namespaces [Serial] should ensure that all pods are removed when a namespace is deleted." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: dir-link-bindmounted] Two pods mounting a local volume at the same time should be able to write from pod1 and read from pod2" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Services should be able to switch session affinity for LoadBalancer service with ESIPP off [Slow] [DisabledForLargeClusters]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] DisruptionController evictions: enough pods, replicaSet, percentage =&gt; should allow an eviction" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Dynamic Provisioning [k8s.io] GlusterDynamicProvisioner should create and delete persistent volumes [fast]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes GCEPD should test that deleting the Namespace of a PVC and Pod causes the successful detach of Persistent Disk" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] Should scale up GPU pool from 1 [GpuType:nvidia-tesla-v100] [Feature:ClusterSizeAutoscalingGpu]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] [HPA] Horizontal pod autoscaling (scale resource: Custom Metrics from Stackdriver) should scale down with Custom Metric of type Object from Stackdriver [Feature:CustomMetricsAutoscaling]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-auth] [Feature:NodeAuthorizer] Getting a non-existent secret should exit with the Forbidden error, not a NotFound error" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Projected should provide container&#39;s cpu limit [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="10.491624573"></testcase>
+      <testcase name="[sig-scheduling] Rescheduler [Serial] should ensure that critical pod is scheduled in case there is no resources available" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] GenericPersistentVolume[Disruptive] When kubelet restarts Should test that a volume mounted to a pod that is deleted while the kubelet is down unmounts when the kubelet returns." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gcePDPVC] should support existing directory" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volumes iSCSI [Feature:Volumes] should be mountable" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] AdmissionWebhook Should be able to deny custom resource creation" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [Feature:Example] [k8s.io] Redis should create and stop redis servers" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Etcd failure [Disruptive] should recover from SIGKILL" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-instrumentation] MetricsGrabber should grab all metrics from a Scheduler." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: hostPath] should unmount if pod is gracefully deleted while kubelet is down [Disruptive][Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Variable Expansion should allow substituting values in a container&#39;s command [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="10.399316687"></testcase>
+      <testcase name="[sig-instrumentation] MetricsGrabber should grab all metrics from a Kubelet." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes NFS with Single PV - PVC pairs should create a non-pre-bound PV and PVC: test write access " classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] EquivalenceCache [Serial] validates pod affinity works properly when new replica pod is scheduled" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Daemon set [Serial] should not update pod when spec was updated and update strategy is OnDelete" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Projected should be consumable in multiple volumes in the same pod [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="8.574796676"></testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: nfsPVC] should support existing single file" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Downward API volume should set DefaultMode on files [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="10.354054548"></testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: dir-link] Two pods mounting a local volume one after the other should be able to write from pod1 and read from pod2" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Dynamic Provisioning DynamicProvisioner should provision storage with different parameters [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gcePDPVC] should fail for new directories when readOnly specified in the volumeSource" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: hostPathSymlink] should support existing single file" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-auth] [Feature:NodeAuthorizer] Getting a secret for a workload the node has access to should succeed" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Loadbalancing: L7 Scalability GCE [Slow] [Serial] [Feature:IngressScale] Creating and updating ingresses should happen promptly with small/medium/large amount of ingresses" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] ConfigMap should be consumable from pods in volume as non-root with FSGroup [NodeFeature:FSGroup]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] ESIPP [Slow] [DisabledForLargeClusters] should work from pods" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Networking Granular Checks: Pods should function for intra-pod communication: http [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="45.404312229"></testcase>
+      <testcase name="[k8s.io] Pods should cap back-off at MaxContainerBackOff [Slow][NodeConformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Flexvolumes [Disruptive] should be mountable when attachable" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-instrumentation] Stackdriver Monitoring should run Custom Metrics - Stackdriver Adapter for new resource model [Feature:StackdriverCustomMetrics]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Daemon set [Serial] should run and stop complex daemon with node affinity" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [sig-node] Kubelet [Serial] [Slow] [k8s.io] [sig-node] regular resource usage tracking resource tracking for 0 pods per node" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Services should check NodePort out-of-range" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Ephemeralstorage When pod refers to non-existent ephemeral storage should allow deletion of pod with invalid volume : configmap" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Namespaces [Serial] should delete fast enough (90 percent of 100 namespaces in 150 seconds)" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] NetworkPolicy NetworkPolicy between server and client should support a &#39;default-deny&#39; policy [Feature:NetworkPolicy]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Storage Policy Based Volume Provisioning [Feature:vsphere] verify clean up of stale dummy VM for dynamically provisioned pvc using SPBM policy" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Projected should provide podname only [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="8.323492887"></testcase>
+      <testcase name="[sig-storage] EmptyDir volumes when FSGroup is specified [NodeFeature:FSGroup] nonexistent volume subPath should have the correct mode and owner using FSGroup" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gcePDPVC] should unmount if pod is force deleted while kubelet is down [Disruptive][Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes [Feature:ReclaimPolicy] [sig-storage] persistentvolumereclaim:vsphere should delete persistent volume when reclaimPolicy set to delete and associated claim is deleted" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: hostPathSymlink] should support readOnly file specified in the volumeMount" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Services should be able to create an internal type load balancer [Slow] [DisabledForLargeClusters]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gluster] should unmount if pod is force deleted while kubelet is down [Disruptive][Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] [Serial] Volume metrics PVController should create bound pv/pvc count metrics for pvc controller after creating both pv and pvc" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Projected should be consumable from pods in volume [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="10.439086958"></testcase>
+      <testcase name="[k8s.io] EquivalenceCache [Serial] validates pod anti-affinity works properly when new replica pod is scheduled" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: nfs] should support file as subpath" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Secrets should be able to mount in a volume regardless of a different secret existing with same name in different namespace [NodeConformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-instrumentation] Stackdriver Monitoring should have accelerator metrics [Feature:StackdriverAcceleratorMonitoring]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scalability] Density [Feature:ManualPerformance] should allow starting 30 pods per node using {extensions Deployment} with 0 secrets, 0 configmaps and 0 daemons" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Garbage collector should not be blocked by dependency circle [Conformance]" classname="Kubernetes e2e suite" time="11.470960113"></testcase>
+      <testcase name="[sig-cluster-lifecycle] gpu Upgrade [Feature:GPUUpgrade] cluster upgrade should be able to run gpu pod after upgrade [Feature:GPUClusterUpgrade]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Flexvolumes [Disruptive] should be mountable when non-attachable" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-auth] [Feature:NodeAuthorizer] Getting a non-existent configmap should exit with the Forbidden error, not a NotFound error" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-auth] Certificates API should support building a client with a CSR" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cluster-lifecycle] gpu Upgrade [Feature:GPUUpgrade] master upgrade should NOT disrupt gpu pod [Feature:GPUMasterUpgrade]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Networking Granular Checks: Services [Slow] should update nodePort: http [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Kubectl label should update the label on a resource  [Conformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volume plugin streaming [Slow] iSCSI [Feature:Volumes] should write files of various sizes, verify size, validate content" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes NFS with multiple PVs and PVCs all in same ns should create 2 PVs and 4 PVCs: test write access" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gluster] should fail if subpath with backstepping is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] ConfigMap updates should be reflected in volume [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="99.998133933"></testcase>
+      <testcase name="[sig-storage] Projected should be consumable from pods in volume with mappings [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="10.291120496"></testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: nfs] should support existing directory" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Secrets should be consumable in multiple volumes in a pod [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="10.544466427"></testcase>
+      <testcase name="[sig-network] ESIPP [Slow] [DisabledForLargeClusters] should work for type=NodePort" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: hostPath] should support existing single file" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-instrumentation] Cluster level logging implemented by Stackdriver [Feature:StackdriverLogging] [Soak] should ingest logs from applications running for a prolonged amount of time" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: blockfs] One pod requesting one prebound PVC should be able to mount volume and write from pod1" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] DNS horizontal autoscaling [Serial] [Slow] kube-dns-autoscaler should scale kube-dns pods when cluster size changed" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Projected should provide container&#39;s cpu request [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="8.333565617"></testcase>
+      <testcase name="[sig-apps] CronJob should not schedule new jobs when ForbidConcurrent [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Kubectl run pod should create a pod from an image when restart is Never  [Conformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: emptyDir] should support readOnly file specified in the volumeMount" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: hostPathSymlink] should support existing directories when readOnly specified in the volumeSource" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cluster-lifecycle] HA-master [Feature:HAMaster] survive addition/removal replicas multizone workers [Serial][Disruptive]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] DaemonRestart [Disruptive] Scheduler should continue assigning pods to nodes across restart" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Downward API volume should provide container&#39;s memory request [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="8.31034355"></testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: tmpfs] One pod requesting one prebound PVC should be able to mount volume and read from pod1" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] NetworkPolicy NetworkPolicy between server and client should enforce multiple, stacked policies with overlapping podSelectors [Feature:NetworkPolicy]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] StatefulSet [k8s.io] Basic StatefulSet functionality [StatefulSetBasic] should perform rolling updates and roll backs of template modifications [Conformance]" classname="Kubernetes e2e suite" time="169.127107307"></testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: dir] Two pods mounting a local volume at the same time should be able to write from pod1 and read from pod2" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: gce-localssd-scsi-fs] [Serial] One pod requesting one prebound PVC should be able to mount volume and read from pod1" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] Should be able to scale a node group up from 0[Feature:ClusterSizeAutoscalingScaleUp]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volume Provisioning On Clustered Datastore [Feature:vsphere] verify dynamic provision with spbm policy on clustered datastore" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Etcd failure [Disruptive] should recover from network partition with master" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cluster-lifecycle] Nodes [Disruptive] Resize [Slow] should be able to add nodes" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-auth] [Feature:NodeAuthorizer] Getting an existing secret should exit with the Forbidden error" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Servers with support for Table transformation should return a 406 for a backend which does not implement metadata" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [Feature:Example] [k8s.io] Cassandra should create and scale cassandra" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] should be able to scale down by draining multiple pods one by one as dictated by pdb[Feature:ClusterSizeAutoscalingScaleDown]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Networking should provide Internet connection for containers [Feature:Networking-IPv6][Experimental]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Dynamic Provisioning DynamicProvisioner Default should create and delete default persistent volumes [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] CronJob should remove from active list jobs that have been deleted" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Garbage collector should support orphan deletion of custom resources" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Downward API should provide container&#39;s limits.cpu/memory and requests.cpu/memory as env vars [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="12.570985162"></testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: hostPathSymlink] should support restarting containers using directory as subpath [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Initializers [Feature:Initializers] don&#39;t cause replicaset controller creating extra pods if the initializer is not handled [Serial]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Services should be able to change the type and ports of a service [Slow] [DisabledForLargeClusters]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [sig-node] AppArmor load AppArmor profiles can disable an AppArmor profile, using unconfined" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] [HPA] Horizontal pod autoscaling (scale resource: CPU) [sig-autoscaling] [Serial] [Slow] ReplicationController Should scale from 1 pod to 3 pods and from 3 to 5 and verify decision stability" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] ReplicaSet should serve a basic image on each replica with a public image  [Conformance]" classname="Kubernetes e2e suite" time="16.453582135"></testcase>
+      <testcase name="[sig-scheduling] ResourceQuota [Feature:Initializers] should create a ResourceQuota and capture the life of an uninitialized pod." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Networking Granular Checks: Services [Slow] should function for client IP based session affinity: udp" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Networking Granular Checks: Services [Slow] should update endpoints: udp" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] Should not scale GPU pool up if pod does not require GPUs [GpuType:nvidia-tesla-v100] [Feature:ClusterSizeAutoscalingGpu]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: nfsPVC] should fail for new directories when readOnly specified in the volumeSource" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-instrumentation] MetricsGrabber should grab all metrics from API server." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] StatefulSet [k8s.io] Basic StatefulSet functionality [StatefulSetBasic] should perform canary updates and phased rolling updates of template modifications [Conformance]" classname="Kubernetes e2e suite" time="86.779378155"></testcase>
+      <testcase name="[k8s.io] [Feature:Example] [k8s.io] Liveness liveness pods should be automatically restarted" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] ConfigMap binary data should be reflected in volume [NodeConformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Dynamic Provisioning DynamicProvisioner Default should be disabled by removing the default annotation [Serial] [Disruptive]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volumes PD should be mountable with xfs" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] [Serial] Volume metrics should create prometheus metrics for volume provisioning and attach/detach" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] DisruptionController should create a PodDisruptionBudget" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] StatefulSet [k8s.io] Basic StatefulSet functionality [StatefulSetBasic] Scaling should happen in predictable order and halt if any stateful pod is unhealthy [Conformance]" classname="Kubernetes e2e suite" time="373.89206836"></testcase>
+      <testcase name="[sig-network] Networking Granular Checks: Services [Slow] should function for pod-Service: http" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Update Demo should do a rolling update of a replication controller  [Conformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Dynamic Provisioning Block volume provisioning [Feature:BlockVolume] should create and delete block persistent volumes" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Networking should check kube-proxy urls" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl Port forwarding [k8s.io] With a server listening on localhost [k8s.io] that expects a client request should support a client that connects, sends DATA, and disconnects" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] DNS configMap nameserver Forward external name lookup should forward externalname lookup to upstream nameserver [Slow][Serial]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] SchedulerPredicates [Serial] validates that NodeSelector is respected if not matching  [Conformance]" classname="Kubernetes e2e suite" time="83.682789713"></testcase>
+      <testcase name="[sig-storage] Volumes ConfigMap should be mountable" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volume plugin streaming [Slow] GlusterFS should write files of various sizes, verify size, validate content" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes:vsphere should test that a vspehre volume mounted to a pod that is deleted while the kubelet is down unmounts when the kubelet returns [Disruptive]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Proxy server should support proxy with --port 0  [Conformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  Local volume provisioner [Serial] should create and recreate local persistent volume" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Watchers should observe add, update, and delete watch notifications on configmaps [Conformance]" classname="Kubernetes e2e suite" time="66.714393613"></testcase>
+      <testcase name="[sig-api-machinery] Servers with support for API chunking should return chunks of results for list calls" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-auth] PodSecurityPolicy should forbid pod creation when no PSP is available" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] DNS should provide DNS for the cluster  [Conformance]" classname="Kubernetes e2e suite" time="29.929517201"></testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Simple pod should support exec" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Services should be able to change the type from ClusterIP to ExternalName" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scalability] Density [Feature:ManualPerformance] should allow starting 50 pods per node using { ReplicationController} with 0 secrets, 0 configmaps and 0 daemons" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gcePDPVC] should fail if subpath with backstepping is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volume FStype [Feature:vsphere] verify fstype - default value should be ext4" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] ESIPP [Slow] [DisabledForLargeClusters] should handle updates to ExternalTrafficPolicy field" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [Feature:Example] [k8s.io] Hazelcast should create and scale hazelcast" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Pod Disks schedule a pod w/ RW PD(s) mounted to 1 or more containers, write to PD, verify content, delete pod, and repeat in rapid succession [Slow] using 1 containers and 2 PDs" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes [Feature:LabelSelector] [sig-storage] Selector-Label Volume Binding:vsphere should bind volume with claim for given label" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] [HPA] Horizontal pod autoscaling (scale resource: Custom Metrics from Stackdriver) should scale down with Custom Metric of type Pod from Stackdriver [Feature:CustomMetricsAutoscaling]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Proxy version v1 should proxy logs on node using proxy subresource  [Conformance]" classname="Kubernetes e2e suite" time="6.518463068"></testcase>
+      <testcase name="[sig-auth] Advanced Audit should audit API calls [DisabledForLargeClusters]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: dir] Two pods mounting a local volume one after the other should be able to write from pod1 and read from pod2" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Downward API volume should provide podname as non-root with fsgroup [NodeFeature:FSGroup]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Docker Containers should use the image defaults if command and args are blank [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="14.556381705"></testcase>
+      <testcase name="[sig-network] Networking Granular Checks: Pods should function for intra-pod communication: udp [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="43.310380115"></testcase>
+      <testcase name="[sig-storage] [Serial] Volume metrics PVController should create unbound pv count metrics for pvc controller after creating pv only" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Simple pod should support exec through an HTTP proxy" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-auth] ServiceAccounts should ensure a single API token exists" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes GCEPD should test that deleting the PV before the pod does not cause pod deletion to fail on PD detach" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Update Demo should create and stop a replication controller  [Conformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: nfs] should support readOnly directory specified in the volumeMount" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Projected should update labels on modification [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="29.051433573"></testcase>
+      <testcase name="[sig-api-machinery] Garbage collector should orphan RS created by deployment when deleteOptions.PropagationPolicy is Orphan [Conformance]" classname="Kubernetes e2e suite" time="36.796812231"></testcase>
+      <testcase name="[sig-network] DNS should support configurable pod resolv.conf" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] DisruptionController should update PodDisruptionBudget status" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] EmptyDir wrapper volumes should not conflict" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gluster] should support restarting containers using file as subpath [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes NFS with Single PV - PVC pairs create a PV and a pre-bound PVC: test write access" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: tmpfs] Two pods mounting a local volume one after the other should be able to write from pod1 and read from pod2" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [sig-node] Events should be sent by kubelets and the scheduler about pods scheduling and running  [Conformance]" classname="Kubernetes e2e suite" time="30.376825114"></testcase>
+      <testcase name="[sig-apps] ReplicationController should release no longer matching pods" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] shouldn&#39;t scale up when expendable pod is created [Feature:ClusterSizeAutoscalingScaleUp]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: hostPath] should fail if subpath with backstepping is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Downward API volume should update annotations on modification [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="29.110408871"></testcase>
+      <testcase name="[sig-storage] Dynamic Provisioning DynamicProvisioner should provision storage with mount options" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] EmptyDir volumes should support (root,0666,tmpfs) [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="8.280841912"></testcase>
+      <testcase name="[sig-scalability] Density [Feature:ManualPerformance] should allow starting 100 pods per node using { ReplicationController} with 0 secrets, 0 configmaps and 0 daemons" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Services should be able to switch session affinity for LoadBalancer service with ESIPP on [Slow] [DisabledForLargeClusters]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Storage Policy Based Volume Provisioning [Feature:vsphere] verify VSAN storage capability with invalid capability name objectSpaceReserve is not honored for dynamically provisioned pvc using storageclass" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: block] [Feature:BlockVolume] Two pods mounting a local volume one after the other should be able to write from pod1 and read from pod2" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] should add new node and new node pool on too big pod, scale down to 1 and scale down to 0 [Feature:ClusterSizeAutoscalingScaleWithNAP]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] AdmissionWebhook Should deny crd creation" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volumes PD should be mountable with ext4" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Projected should be consumable from pods in volume with defaultMode set [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="10.359767161"></testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gcePDPartitioned] should support readOnly directory specified in the volumeMount" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cluster-lifecycle] Reboot [Disruptive] [Feature:Reboot] each node by triggering kernel panic and ensure they function upon restart" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Secrets should be consumable from pods in volume with mappings [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="10.407672776"></testcase>
+      <testcase name="[sig-storage] Volume Disk Format [Feature:vsphere] verify disk format type - zeroedthick is honored for dynamically provisioned pv using storageclass" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] ReplicaSet should surface a failure condition on a common issue like exceeded quota" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Projected should be consumable from pods in volume with mappings as non-root [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="8.459516333"></testcase>
+      <testcase name="[sig-scalability] Density [Feature:ManualPerformance] should allow starting 30 pods per node using { ReplicationController} with 0 secrets, 0 configmaps and 0 daemons with quotas" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volume Placement test back to back pod creation and deletion with different volume sources on the same worker node" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Network Partition [Disruptive] [Slow] [k8s.io] [StatefulSet] should come back up if node goes down [Slow] [Disruptive]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volume Placement should create and delete pod with multiple volumes from different datastore" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-auth] [Feature:NodeAuthorizer] Getting an existing configmap should exit with the Forbidden error" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: dir] One pod requesting one prebound PVC should be able to mount volume and write from pod1" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scalability] Load capacity [Feature:ManualPerformance] should be able to handle 30 pods per node {extensions Deployment} with 2 secrets, 0 configmaps and 0 daemons" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cluster-lifecycle] kube-proxy migration [Feature:KubeProxyDaemonSetMigration] Downgrade kube-proxy from a DaemonSet to static pods should maintain a functioning cluster [Feature:KubeProxyDaemonSetDowngrade]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Loadbalancing: L7 GCE [Slow] [Feature:NEG] should be able to create a ClusterIP service [Unreleased]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Loadbalancing: L7 GCE [Slow] [Feature:kubemci] should support https-only annotation" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] EquivalenceCache [Serial] validates GeneralPredicates is properly invalidated when a pod is scheduled [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Kubectl run default should create an rc or deployment from an image  [Conformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Loadbalancing: L7 GCE [Slow] [Feature:kubemci] single and multi-cluster ingresses should be able to exist together" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Services should preserve source pod IP for traffic thru service cluster IP" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: dir-bindmounted] Two pods mounting a local volume at the same time should be able to write from pod1 and read from pod2" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Generated clientset should create pods, set the deletionTimestamp and deletionGracePeriodSeconds of the pod" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Storage Policy Based Volume Provisioning [Feature:vsphere] verify an existing and compatible SPBM policy is honored for dynamically provisioned pvc using storageclass" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Firewall rule [Slow] [Serial] should create valid firewall rules for LoadBalancer type service" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] Multi-AZ Clusters should spread the pods of a replication controller across zones" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] shouldn&#39;t add new node group if not needed [Feature:ClusterSizeAutoscalingScaleWithNAP]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Simple pod should handle in-cluster config" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volumes CephFS [Feature:Volumes] should be mountable" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] ConfigMap should be consumable from pods in volume with mappings and Item mode set [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="8.306455826"></testcase>
+      <testcase name="[sig-storage] Pod Disks detach in a disrupted environment [Slow] [Disruptive] when node is deleted" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] DNS horizontal autoscaling [DisabledForLargeClusters] kube-dns-autoscaler should scale kube-dns pods in both nonfaulty and faulty scenarios" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Storage Policy Based Volume Provisioning [Feature:vsphere] verify if a SPBM policy is not honored on a non-compatible datastore for dynamically provisioned pvc using storageclass" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: nfs] should unmount if pod is gracefully deleted while kubelet is down [Disruptive][Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] ResourceQuota should create a ResourceQuota and capture the life of a configMap." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Networking should provide Internet connection for containers [Feature:Networking-IPv4]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Projected should be consumable from pods in volume with mappings [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="8.280933125"></testcase>
+      <testcase name="[sig-cluster-lifecycle] ingress Downgrade [Feature:IngressDowngrade] ingress downgrade should maintain a functioning ingress" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: emptyDir] should support file as subpath" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Sysctls [NodeFeature:Sysctls] should not launch unsafe, but not explicitly enabled sysctls on the node" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Kubectl run --rm job should create a job from an image, then delete the job  [Conformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Initializers [Feature:Initializers] should dynamically register and apply initializers to pods [Serial]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-instrumentation] Stackdriver Monitoring should run Custom Metrics - Stackdriver Adapter for old resource model [Feature:StackdriverCustomMetrics]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Loadbalancing: L7 GCE [Slow] [Feature:kubemci] should create ingress with pre-shared certificate" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gcePDPVC] should support restarting containers using directory as subpath [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] StatefulSet [k8s.io] Deploy clustered applications [Feature:StatefulSet] [Slow] should creating a working CockroachDB cluster" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Service endpoints latency should not be very high  [Conformance]" classname="Kubernetes e2e suite" time="35.039737689"></testcase>
+      <testcase name="[k8s.io] [sig-node] AppArmor load AppArmor profiles should enforce an AppArmor profile" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Network Partition [Disruptive] [Slow] [k8s.io] Pods should be evicted from unready Node [Feature:TaintEviction] All pods on the unreachable node should be marked as NotReady upon the node turn NotReady AND all pods should be evicted after eviction timeout passes" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Storage Policy Based Volume Provisioning [Feature:vsphere] verify VSAN storage capability with valid objectSpaceReservation and iopsLimit values is honored for dynamically provisioned pvc using storageclass" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] ConfigMap should be consumable via the environment [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="10.373643652"></testcase>
+      <testcase name="[sig-scheduling] [Feature:GPUDevicePlugin] run Nvidia GPU Device Plugin tests on Container Optimized OS only" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] DNS should provide DNS for services  [Conformance]" classname="Kubernetes e2e suite" time="22.410479402"></testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: nfsPVC] should fail if subpath with backstepping is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Job should exceed active deadline" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] DaemonRestart [Disruptive] Kubelet should not restart containers across restart" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volume Provisioning On Clustered Datastore [Feature:vsphere] verify dynamic provision with default parameter on clustered datastore" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] CSI Volumes CSI plugin test using CSI driver: hostPath should provision storage" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-instrumentation] Cluster level logging using Elasticsearch [Feature:Elasticsearch] should check that logs from containers are ingested into Elasticsearch" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: tmpfs] Set fsGroup for local volume should set same fsGroup for two pods simultaneously" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volume Operations Storm [Feature:vsphere] should create pod with many volumes and verify no attach call fails" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Projected should be consumable from pods in volume with mappings and Item mode set [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="8.403898982"></testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] Should scale up GPU pool from 0 [GpuType:nvidia-tesla-v100] [Feature:ClusterSizeAutoscalingGpu]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  Local volume provisioner [Serial] should not create local persistent volume for filesystem volume that was not bind mounted" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] ResourceQuota should verify ResourceQuota with terminating scopes." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PVC Protection Verify that scheduling of a pod that uses PVC that is being deleted fails and the pod becomes Unschedulable" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: hostPath] should support restarting containers using directory as subpath [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] ResourceQuota should verify ResourceQuota with best effort scope." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] should increase cluster size if pending pods are small and there is another node pool that is not autoscaled [Feature:ClusterSizeAutoscalingScaleUp]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] [HPA] Horizontal pod autoscaling (scale resource: CPU) [sig-autoscaling] [Serial] [Slow] ReplicationController Should scale from 5 pods to 3 pods and from 3 to 1 and verify decision stability" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Services should create endpoints for unready pods" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Services should release NodePorts on delete" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-instrumentation] Kibana Logging Instances Is Alive [Feature:Elasticsearch] should check that the Kibana logging instance is alive" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] Should scale up GPU pool from 1 [GpuType:nvidia-tesla-k80] [Feature:ClusterSizeAutoscalingGpu]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] ConfigMap should be consumable from pods in volume [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="10.400715662"></testcase>
+      <testcase name="[k8s.io] Pods should support remote command execution over websockets [NodeConformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: dir] One pod requesting one prebound PVC should be able to mount volume and read from pod1" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Loadbalancing: L7 GCE [Slow] [Feature:NEG] should sync endpoints to NEG" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] EmptyDir volumes when FSGroup is specified [NodeFeature:FSGroup] volume on default medium should have the correct mode using FSGroup" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Kubectl rolling-update should support rolling-update to same image  [Conformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] SchedulerPredicates [Serial] validates that required NodeAffinity setting is respected if matching" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] SchedulerPredicates [Serial] validates that there is no conflict between pods with same hostPort but different hostIP and protocol" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Docker Containers should be able to override the image&#39;s default command and arguments [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="10.325495733"></testcase>
+      <testcase name="[k8s.io] [sig-node] SSH should SSH to all nodes and run commands" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Kubectl create quota should create a quota with scopes" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] DisruptionController evictions: too few pods, replicaSet, percentage =&gt; should not allow an eviction" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [sig-node] Security Context [Feature:SecurityContext] should support pod.Spec.SecurityContext.SupplementalGroups" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Kubectl taint [Serial] should update the taint on a node" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Pods should allow activeDeadlineSeconds to be updated [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="13.233655444"></testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gcePDPartitioned] should support file as subpath" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Sysctls [NodeFeature:Sysctls] should support unsafe sysctls which are actually whitelisted" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [sig-node] Security Context [Feature:SecurityContext] should support container.SecurityContext.RunAsUser" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Garbage collector should delete jobs and pods created by cronjob" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] DNS configMap nameserver Change stubDomain should be able to change stubDomain configuration [Slow][Serial]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] DisruptionController evictions: maxUnavailable deny evictions, integer =&gt; should not allow an eviction" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [sig-node] Security Context [Feature:SecurityContext] should support volume SELinux relabeling when using hostPID" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] HostPath should support existing single file subPath" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] EmptyDir volumes should support (non-root,0644,default) [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="10.409076767"></testcase>
+      <testcase name="[sig-storage] Subpath Atomic writer volumes should support subpaths with projected pod" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Dynamic Provisioning DynamicProvisioner should not provision a volume in an unmanaged GCE zone." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: dir-link] One pod requesting one prebound PVC should be able to mount volume and write from pod1" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Loadbalancing: L7 [Slow] Nginx should conform to Ingress spec" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Garbage collector should orphan pods created by rc if deleteOptions.OrphanDependents is nil" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gcePDPartitioned] should unmount if pod is gracefully deleted while kubelet is down [Disruptive][Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Kubectl create quota should create a quota without scopes" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: nfs] should support restarting containers using file as subpath [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Proxy version v1 should proxy through a service and a pod  [Conformance]" classname="Kubernetes e2e suite" time="16.65951454"></testcase>
+      <testcase name="[sig-network] Services should be able to change the type from ExternalName to ClusterIP" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] HostPath should support existing directory subPath" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Loadbalancing: L7 GCE [Slow] [Feature:Ingress] should update ingress while sync failures occur on other ingresses" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: hostPath] should unmount if pod is force deleted while kubelet is down [Disruptive][Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [sig-node] PreStop should call prestop when killing a pod  [Conformance]" classname="Kubernetes e2e suite" time="53.550889761"></testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gcePDPVC] should support readOnly file specified in the volumeMount" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Servers with support for Table transformation should return generic metadata details across all namespaces for nodes" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] Should scale up GPU pool from 0 [GpuType:nvidia-tesla-k80] [Feature:ClusterSizeAutoscalingGpu]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: nfs] should fail if subpath with backstepping is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Loadbalancing: L7 GCE [Slow] [Feature:NEG] rolling update backend pods should not cause service disruption" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [sig-node] kubelet [k8s.io] [sig-node] host cleanup with volume mounts [sig-storage][HostCleanup][Flaky] Host cleanup after disrupting NFS volume [NFS] after stopping the nfs-server and deleting the (sleeping) client pod, the NFS mount and the pod&#39;s UID directory should be removed." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] [HPA] Horizontal pod autoscaling (scale resource: CPU) [sig-autoscaling] [Serial] [Slow] ReplicaSet Should scale from 5 pods to 3 pods and from 3 to 1" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] DisruptionController evictions: too few pods, absolute =&gt; should not allow an eviction" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gluster] should support creating multiple subpath from same volumes [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Simple pod should support exec through kubectl proxy" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] SchedulerPriorities [Serial] Pod should perfer to scheduled to nodes pod can tolerate" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scalability] Density [Feature:ManualPerformance] should allow starting 30 pods per node using {batch Job} with 0 secrets, 0 configmaps and 0 daemons" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: nfsPVC] should support creating multiple subpath from same volumes [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] EmptyDir volumes when FSGroup is specified [NodeFeature:FSGroup] new files should be created with FSGroup ownership when container is non-root" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Projected should be consumable from pods in volume with mappings as non-root with FSGroup [NodeFeature:FSGroup]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Docker Containers should be able to override the image&#39;s default arguments (docker cmd) [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="10.30201265"></testcase>
+      <testcase name="[sig-storage] EmptyDir wrapper volumes should not cause race condition when used for git_repo [Serial] [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gcePDPartitioned] should fail if non-existent subpath is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gcePDPVC] should fail if subpath directory is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Loadbalancing: L7 GCE [Slow] [Feature:Ingress] should support multiple TLS certs" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Variable Expansion should allow substituting values in a volume subpath [Feature:VolumeSubpathEnvExpansion][NodeAlphaFeature:VolumeSubpathEnvExpansion]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] Should scale down GPU pool from 1 [GpuType:nvidia-tesla-p100] [Feature:ClusterSizeAutoscalingGpu]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] should increase cluster size if pods are pending due to pod anti-affinity [Feature:ClusterSizeAutoscalingScaleUp]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Projected should be consumable from pods in volume with mappings and Item Mode set [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="10.324057711"></testcase>
+      <testcase name="[sig-network] Services should be able to switch session affinity for NodePort service" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes NFS with multiple PVs and PVCs all in same ns should create 4 PVs and 2 PVCs: test write access [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] Should scale down GPU pool from 1 [GpuType:nvidia-tesla-k80] [Feature:ClusterSizeAutoscalingGpu]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-instrumentation] Logging soak [Performance] [Slow] [Disruptive] should survive logging 1KB every 1s seconds, for a duration of 2m0s, scaling up to 1 pods per node" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Loadbalancing: L7 GCE [Slow] [Feature:kubemci] should create ingress with backend HTTPS" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] InitContainer [NodeConformance] should not start app containers and fail the pod if init containers fail on a RestartNever pod" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] ResourceQuota should create a ResourceQuota and capture the life of a persistent volume claim. [sig-storage]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scalability] Load capacity [Feature:ManualPerformance] should be able to handle 30 pods per node {extensions Deployment} with 0 secrets, 0 configmaps and 0 daemons" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Kubectl run CronJob should create a CronJob" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: nfsPVC] should fail if subpath file is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-auth] [Feature:NodeAuthorizer] A node shouldn&#39;t be able to create another node" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: hostPathSymlink] should fail if subpath file is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] CronJob should replace jobs when ReplaceConcurrent" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gluster] should fail if subpath file is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl Port forwarding [k8s.io] With a server listening on 0.0.0.0 should support forwarding over websockets" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Services should use same NodePort with same port but different protocols" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Secrets should be consumable from pods in volume as non-root with defaultMode and fsGroup set [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="8.334778319"></testcase>
+      <testcase name="[sig-storage] ConfigMap should be consumable from pods in volume with defaultMode set [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="8.362996546"></testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: nfsPVC] should support existing directories when readOnly specified in the volumeSource" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Services should be able to create a functioning NodePort service" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] [HPA] Horizontal pod autoscaling (scale resource: Custom Metrics from Stackdriver) should scale up with two External metrics from Stackdriver [Feature:CustomMetricsAutoscaling]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-auth] PodSecurityPolicy should allow pods under the privileged policy.PodSecurityPolicy" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volumes Ceph RBD [Feature:Volumes] should be mountable" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] Should scale up GPU pool from 0 [GpuType:nvidia-tesla-p100] [Feature:ClusterSizeAutoscalingGpu]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] LimitRange should create a LimitRange with defaults and ensure pod has those defaults applied." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: gce-localssd-scsi-fs] [Serial] Two pods mounting a local volume at the same time should be able to write from pod1 and read from pod2" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scalability] Density [Feature:ManualPerformance] should allow starting 3 pods per node using { ReplicationController} with 0 secrets, 0 configmaps and 0 daemons" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gluster] should unmount if pod is gracefully deleted while kubelet is down [Disruptive][Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volumes GlusterFS should be mountable" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Services should be able to change the type from ExternalName to NodePort" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cluster-lifecycle] [Feature:BootstrapTokens] should resign the bootstrap tokens when the clusterInfo ConfigMap updated [Serial][Disruptive]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: hostPath] should fail if subpath file is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] shouldn&#39;t be able to scale down when rescheduling a pod is required, but pdb doesn&#39;t allow drain[Feature:ClusterSizeAutoscalingScaleDown]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: blockfs] One pod requesting one prebound PVC should be able to mount volume and read from pod1" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gcePDPartitioned] should support creating multiple subpath from same volumes [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Networking Granular Checks: Services [Slow] should function for pod-Service: udp" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scalability] Load capacity [Feature:ManualPerformance] should be able to handle 30 pods per node { ReplicationController} with 0 secrets, 0 configmaps and 0 daemons with quotas" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] SchedulerPredicates [Serial] validates that there exists conflict between pods with same hostPort and protocol but one using 0.0.0.0 hostIP" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scalability] Empty [Feature:Empty] starts a pod" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cluster-lifecycle] Upgrade [Feature:Upgrade] cluster upgrade should maintain a functioning cluster [Feature:ClusterUpgrade]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Garbage collector should delete pods created by rc when not orphaning [Conformance]" classname="Kubernetes e2e suite" time="16.387659241"></testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: hostPathSymlink] should support non-existent path" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] AdmissionWebhook Should unconditionally reject operations on fail closed webhook" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gcePDPVC] should unmount if pod is gracefully deleted while kubelet is down [Disruptive][Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: hostPathSymlink] should support existing directory" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [Feature:Example] [k8s.io] Secret should create a pod that reads a secret" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Docker Containers should be able to override the image&#39;s default command (docker entrypoint) [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="10.293301951"></testcase>
+      <testcase name="[sig-service-catalog] [Feature:PodPreset] PodPreset should create a pod preset" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: dir] Set fsGroup for local volume should not set different fsGroups for two pods simultaneously" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volume Provisioning On Clustered Datastore [Feature:vsphere] verify static provisioning on clustered datastore" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: dir-bindmounted] Set fsGroup for local volume should set fsGroup for one pod" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] should correctly scale down after a node is not needed and one node is broken [Feature:ClusterSizeAutoscalingScaleDown]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Secrets optional updates should be reflected in volume [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="97.902071591"></testcase>
+      <testcase name="[sig-network] Networking Granular Checks: Services [Slow] should function for endpoint-Service: udp" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volumes NFS should be mountable" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] Multi-AZ Cluster Volumes [sig-storage] should only be allowed to provision PDs in zones where nodes exist" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: dir-bindmounted] Set fsGroup for local volume should set same fsGroup for two pods simultaneously" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-instrumentation] [Feature:PrometheusMonitoring] Prometheus should contain correct container CPU metric." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Ephemeralstorage When pod refers to non-existent ephemeral storage should allow deletion of pod with invalid volume : secret" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] vsphere statefulset vsphere statefulset testing" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Projected should project all components that make up the projection API [Projection][NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="10.344553094"></testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: dir-link] Set fsGroup for local volume should set different fsGroup for second pod if first pod is deleted" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] ClusterDns [Feature:Example] should create pod that uses dns" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [Feature:Example] [k8s.io] Storm should create and stop Zookeeper, Nimbus and Storm worker servers" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] HostPath should support r/w [NodeConformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Services should have session affinity work for service with type clusterIP" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Pods should have their auto-restart back-off timer reset on image update [Slow][NodeConformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Watchers should be able to start watching from a specific resource version [Conformance]" classname="Kubernetes e2e suite" time="6.333463899"></testcase>
+      <testcase name="[sig-storage] Projected should provide node allocatable (cpu) as default cpu limit if the limit is not set [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="10.442673034"></testcase>
+      <testcase name="[sig-storage] Mounted volume expand[Slow] Should verify mounted devices can be resized" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Storage Policy Based Volume Provisioning [Feature:vsphere] verify VSAN storage capability with valid diskStripes and objectSpaceReservation values is honored for dynamically provisioned pvc using storageclass" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] shouldn&#39;t increase cluster size if pending pod is too large [Feature:ClusterSizeAutoscalingScaleUp]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: hostPath] should support creating multiple subpath from same volumes [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volume Placement should create and delete pod with multiple volumes from same datastore" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] SchedulerPriorities [Serial] Pod should be schedule to node that don&#39;t match the PodAntiAffinity terms" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] [HPA] Horizontal pod autoscaling (scale resource: CPU) [sig-autoscaling] [Serial] [Slow] ReplicaSet Should scale from 1 pod to 3 pods and from 3 to 5" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] DNS should provide DNS for ExternalName services" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] [HPA] Horizontal pod autoscaling (scale resource: Custom Metrics from Stackdriver) should scale down with Custom Metric of type Pod from Stackdriver with Prometheus [Feature:CustomMetricsAutoscaling]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: emptyDir] should support readOnly directory specified in the volumeMount" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] ConfigMap should be consumable from pods in volume as non-root [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="10.382949435"></testcase>
+      <testcase name="[sig-storage] PersistentVolumes GCEPD should test that deleting a PVC before the pod does not cause pod deletion to fail on PD detach" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: hostPath] should support readOnly directory specified in the volumeMount" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scalability] Load capacity [Feature:ManualPerformance] should be able to handle 30 pods per node {batch Job} with 0 secrets, 0 configmaps and 0 daemons" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Downward API volume should provide node allocatable (memory) as default memory limit if the limit is not set [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="8.334576832"></testcase>
+      <testcase name="[sig-storage] PersistentVolumes [Feature:ReclaimPolicy] [sig-storage] persistentvolumereclaim:vsphere should not detach and unmount PV when associated pvc with delete as reclaimPolicy is deleted when it is in use by the pod" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Projected should be able to mount in a volume regardless of a different secret existing with same name in different namespace [NodeConformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gcePDPartitioned] should fail if subpath with backstepping is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Networking Granular Checks: Services [Slow] should update endpoints: http" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] EmptyDir wrapper volumes should not cause race condition when used for configmaps [Serial] [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] NFSPersistentVolumes[Disruptive][Flaky] when kubelet restarts Should test that a file written to the mount before kubelet restart is readable after restart." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: hostPathSymlink] should support restarting containers using file as subpath [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scalability] Density [Feature:ManualPerformance] should allow starting 30 pods per node using { ReplicationController} with 0 secrets, 0 configmaps and 2 daemons" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] GKE node pools [Feature:GKENodePool] should create a cluster with multiple node pools [Feature:GKENodePool]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-instrumentation] [Feature:PrometheusMonitoring] Prometheus should scrape container metrics from all nodes." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Variable Expansion should fail substituting values in a volume subpath with backticks [Feature:VolumeSubpathEnvExpansion][NodeAlphaFeature:VolumeSubpathEnvExpansion][Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gluster] should support readOnly directory specified in the volumeMount" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Loadbalancing: L7 GCE [Slow] [Feature:Ingress] should not reconcile manually modified health check for ingress" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [sig-node] kubelet [k8s.io] [sig-node] Clean up pods on node kubelet should be able to delete 10 pods per node in 1m0s." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Daemon set [Serial] should run and stop simple daemon [Conformance]" classname="Kubernetes e2e suite" time="20.385944305"></testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: nfs] should fail if non-existent subpath is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: dir] Set fsGroup for local volume should set same fsGroup for two pods simultaneously" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Networking Granular Checks: Services [Slow] should update nodePort: udp [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Projected should be consumable in multiple volumes in a pod [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="8.311676802"></testcase>
+      <testcase name="[k8s.io] Variable Expansion should allow composing env vars into new env vars [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="12.303796242"></testcase>
+      <testcase name="[sig-cluster-lifecycle] [Feature:BootstrapTokens] should delete the signed bootstrap tokens from clusterInfo ConfigMap when bootstrap token is deleted" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  Local volume that cannot be mounted [Slow] should fail due to wrong node" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Sysctls [NodeFeature:Sysctls] should support sysctls" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Storage Policy Based Volume Provisioning [Feature:vsphere] verify if a non-existing SPBM policy is not honored for dynamically provisioned pvc using storageclass" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Kubectl version should check is all data is printed  [Conformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Pod Disks schedule pods each with a PD, delete pod and verify detach [Slow] for read-only PD with pod delete grace period of &#34;immediate (0s)&#34;" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] PodPriorityResolution [Serial] [Feature:PodPreemption] validates critical system priorities are created and resolved" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: blockfs] Set fsGroup for local volume should set fsGroup for one pod" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-auth] Metadata Concealment should run a check-metadata-concealment job to completion" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] DaemonRestart [Disruptive] Controller Manager should not create/delete replicas across restart" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: dir-link] Set fsGroup for local volume should set fsGroup for one pod" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Projected should be consumable from pods in volume as non-root with defaultMode and fsGroup set [NodeFeature:FSGroup]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Network Partition [Disruptive] [Slow] [k8s.io] [StatefulSet] should not reschedule stateful pods if there is a network partition [Slow] [Disruptive]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [sig-node] Pods Extended [k8s.io] Pods Set QOS Class should be submitted and removed  [Conformance]" classname="Kubernetes e2e suite" time="22.275499945"></testcase>
+      <testcase name="[sig-auth] PodSecurityPolicy should enforce the restricted policy.PodSecurityPolicy" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Aggregator Should be able to support the 1.7 Sample API Server using the current Aggregator" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Proxy version v1 should proxy logs on node with explicit kubelet port using proxy subresource  [Conformance]" classname="Kubernetes e2e suite" time="6.618706814"></testcase>
+      <testcase name="[sig-storage] Pod Disks schedule pods each with a PD, delete pod and verify detach [Slow] for RW PD with pod delete grace period of &#34;default (30s)&#34;" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: block] [Feature:BlockVolume] Set fsGroup for local volume should set fsGroup for one pod" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gcePDPartitioned] should fail if subpath directory is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Kubectl run deployment should create a deployment from an image  [Conformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gcePDPVC] should fail if subpath file is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] should increase cluster size if pending pods are small and one node is broken [Feature:ClusterSizeAutoscalingScaleUp]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] NetworkPolicy NetworkPolicy between server and client should allow ingress access on one named port [Feature:NetworkPolicy]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scalability] Density [Feature:ManualPerformance] should allow starting 30 pods per node using {extensions Deployment} with 0 secrets, 2 configmaps and 0 daemons" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Garbage collector should delete RS created by deployment when not orphaning [Conformance]" classname="Kubernetes e2e suite" time="7.479238726"></testcase>
+      <testcase name="[sig-instrumentation] Cadvisor should be healthy on every node." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] should increase cluster size if pod requesting volume is pending [Feature:ClusterSizeAutoscalingScaleUp]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: nfs] should support non-existent path" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Kubectl patch should add annotations for pods in rc  [Conformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] AdmissionWebhook Should mutate custom resource" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Pods should contain environment variables for services [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="32.591595666"></testcase>
+      <testcase name="[sig-network] Networking Granular Checks: Services [Slow] should function for node-Service: udp" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Simple pod should support inline execution and attach" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] DisruptionController evictions: no PDB =&gt; should allow an eviction" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Services should provide secure master service  [Conformance]" classname="Kubernetes e2e suite" time="6.236350742"></testcase>
+      <testcase name="[sig-storage] Projected should provide podname as non-root with fsgroup and defaultMode [NodeFeature:FSGroup]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] NFSPersistentVolumes[Disruptive][Flaky] when kubelet restarts Should test that a volume mounted to a pod that is force deleted while the kubelet is down unmounts when the kubelet returns." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Loadbalancing: L7 GCE [Slow] [Feature:Ingress] should conform to Ingress spec" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  StatefulSet with pod anti-affinity should use volumes spread across nodes" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-instrumentation] Cluster level logging implemented by Stackdriver should ingest system logs from all nodes [Feature:StackdriverLogging]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gluster] should support existing single file" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] SchedulerPredicates [Serial] validates that NodeSelector is respected if matching  [Conformance]" classname="Kubernetes e2e suite" time="90.513534529"></testcase>
+      <testcase name="[sig-network] Services should have session affinity work for NodePort service" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: gce-localssd-scsi-fs] [Serial] Set fsGroup for local volume should set different fsGroup for second pod if first pod is deleted" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] ReplicationController should serve a basic image on each replica with a private image" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Loadbalancing: L7 GCE [Slow] [Feature:Ingress] should create ingress with pre-shared certificate" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volume FStype [Feature:vsphere] verify invalid fstype" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] should correctly scale down after a node is not needed [Feature:ClusterSizeAutoscalingScaleDown]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: hostPath] should support non-existent path" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] vcp at scale [Feature:vsphere]  vsphere scale tests" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: hostPath] should fail if non-existent subpath is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] AdmissionWebhook Should be able to deny pod and configmap creation" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] GCP Volumes NFSv4 should be mountable for NFSv4" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-instrumentation] Monitoring should verify monitoring pods and all cluster nodes are available on influxdb using heapster [Feature:InfluxdbMonitoring]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Pod Disks schedule pods each with a PD, delete pod and verify detach [Slow] for RW PD with pod delete grace period of &#34;immediate (0s)&#34;" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Networking IPerf IPv4 [Experimental] [Feature:Networking-IPv4] [Slow] [Feature:Networking-Performance] should transfer ~ 1GB onto the service endpoint 1 servers (maximum of 1 clients)" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [sig-node] Security Context [Feature:SecurityContext] should support seccomp default which is unconfined [Feature:Seccomp]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [sig-node] Security Context [Feature:SecurityContext] should support pod.Spec.SecurityContext.RunAsUser" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Secrets should be consumable from pods in volume with mappings and Item Mode set [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="10.38922326"></testcase>
+      <testcase name="[k8s.io] Probing container should have monotonically increasing restart count [Slow][NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="151.342363115"></testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Simple pod should return command exit codes" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scalability] Load capacity [Feature:ManualPerformance] should be able to handle 3 pods per node { ReplicationController} with 0 secrets, 0 configmaps and 0 daemons" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: blockfs] Two pods mounting a local volume at the same time should be able to write from pod1 and read from pod2" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Deployment RollingUpdateDeployment should delete old pods and create new ones" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: block] [Feature:BlockVolume] Set fsGroup for local volume should not set different fsGroups for two pods simultaneously" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] StatefulSet [k8s.io] Deploy clustered applications [Feature:StatefulSet] [Slow] should creating a working mysql cluster" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gcePDPartitioned] should support readOnly file specified in the volumeMount" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volume Placement should create and delete pod with the same volume source on the same worker node" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: block] [Feature:BlockVolume] Two pods mounting a local volume at the same time should be able to write from pod1 and read from pod2" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [sig-node] Security Context [Feature:SecurityContext] should support pod.Spec.SecurityContext.RunAsUser And pod.Spec.SecurityContext.RunAsGroup [Feature:RunAsGroup]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] ReplicationController should serve a basic image on each replica with a public image  [Conformance]" classname="Kubernetes e2e suite" time="16.516758344"></testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: nfs] should fail if subpath directory is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Cluster size autoscaler scalability [Slow] shouldn&#39;t scale down with underutilized nodes due to host port conflicts [Feature:ClusterAutoscalerScalability5]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volumes PD should be mountable with ext3" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] HostPath should support subPath [NodeConformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] shouldn&#39;t scale up if cores limit too low, should scale up after limit is changed [Feature:ClusterSizeAutoscalingScaleWithNAP]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] CronJob should schedule multiple jobs concurrently" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Watchers should be able to restart watching from the last resource version observed by the previous watch [Conformance]" classname="Kubernetes e2e suite" time="6.350808474"></testcase>
+      <testcase name="[sig-storage] EmptyDir volumes should support (root,0644,default) [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="10.406854169"></testcase>
+      <testcase name="[sig-api-machinery] Downward API should provide pod name, namespace and IP address as env vars [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="12.421746268"></testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: hostPathSymlink] should unmount if pod is force deleted while kubelet is down [Disruptive][Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Probing container should be restarted with a /healthz http liveness probe [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="32.52485153"></testcase>
+      <testcase name="[sig-network] Loadbalancing: L7 GCE [Slow] [Feature:Ingress] multicluster ingress should get instance group annotation" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: hostPath] should support existing directory" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gcePDPVC] should support creating multiple subpath from same volumes [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cluster-lifecycle] [Feature:BootstrapTokens] should sign the new added bootstrap tokens" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] shouldn&#39;t scale up when expendable pod is preempted [Feature:ClusterSizeAutoscalingScaleUp]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [sig-node] kubelet [k8s.io] [sig-node] host cleanup with volume mounts [sig-storage][HostCleanup][Flaky] Host cleanup after disrupting NFS volume [NFS] after stopping the nfs-server and deleting the (active) client pod, the NFS mount and the pod&#39;s UID directory should be removed." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] EmptyDir volumes should support (root,0644,tmpfs) [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="8.311328129"></testcase>
+      <testcase name="[k8s.io] InitContainer [NodeConformance] should not start app containers if init containers fail on a RestartAlways pod" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Kubectl describe should check if kubectl describe prints relevant information for rc and pods  [Conformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Cluster size autoscaler scalability [Slow] should scale down empty nodes [Feature:ClusterAutoscalerScalability3]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] CronJob should not schedule jobs when suspended [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-auth] PodSecurityPolicy should enforce the restricted extensions.PodSecurityPolicy" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: emptyDir] should support existing directory" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] ConfigMap should be consumable from pods in volume with mappings as non-root with FSGroup [NodeFeature:FSGroup]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gluster] should fail for new directories when readOnly specified in the volumeSource" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Deployment iterative rollouts should eventually progress" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] DisruptionController evictions: maxUnavailable allow single eviction, percentage =&gt; should allow an eviction" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Loadbalancing: L7 GCE [Slow] [Feature:Ingress] should be able to switch between HTTPS and HTTP2 modes" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Job should delete a job" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gcePDPVC] should support restarting containers using file as subpath [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volume Placement should create and delete pod with the same volume source attach/detach to different worker nodes" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Pod Disks schedule pods each with a PD, delete pod and verify detach [Slow] for read-only PD with pod delete grace period of &#34;default (30s)&#34;" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] ConfigMap should be consumable from pods in volume as non-root with defaultMode and fsGroup set [NodeFeature:FSGroup]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cluster-lifecycle] ingress Upgrade [Feature:IngressUpgrade] ingress upgrade should maintain a functioning ingress" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: nfsPVC] should unmount if pod is force deleted while kubelet is down [Disruptive][Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] StatefulSet [k8s.io] Basic StatefulSet functionality [StatefulSetBasic] Burst scaling should run to completion even with unhealthy pods [Conformance]" classname="Kubernetes e2e suite" time="62.192033403"></testcase>
+      <testcase name="[sig-scheduling] SchedulerPreemption [Serial] [Feature:PodPreemption] validates basic preemption works" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Node Poweroff [Feature:vsphere] [Slow] [Disruptive] verify volume status after node power off" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [sig-node] Security Context [Feature:SecurityContext] should support volume SELinux relabeling when using hostIPC" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] SchedulerPreemption [Serial] [Feature:PodPreemption] validates lower priority pod preemption by critical pod" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath Atomic writer volumes should support subpaths with downward pod" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Kubectl replace should update a single-container pod&#39;s image  [Conformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Pod Disks should be able to delete a non-existent PD without error" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Downward API [Serial] [Disruptive] [NodeFeature:EphemeralStorage] Downward API tests for local ephemeral storage should provide container&#39;s limits.ephemeral-storage and requests.ephemeral-storage as env vars" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Kubectl run job should create a job from an image when restart is OnFailure  [Conformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: dir] Set fsGroup for local volume should set different fsGroup for second pod if first pod is deleted" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] should scale up when non expendable pod is created [Feature:ClusterSizeAutoscalingScaleUp]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: tmpfs] Two pods mounting a local volume at the same time should be able to write from pod1 and read from pod2" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Secrets should be consumable from pods in volume with defaultMode set [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="8.363893907"></testcase>
+      <testcase name="[sig-storage] Projected should update annotations on modification [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="28.874853949"></testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: nfsPVC] should support restarting containers using directory as subpath [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: emptyDir] should fail if non-existent subpath is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Projected should be consumable from pods in volume with defaultMode set [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="10.519917431"></testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: hostPath] should fail if subpath directory is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Namespaces [Serial] should ensure that all services are removed when a namespace is deleted." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volume Provisioning on Datastore [Feature:vsphere] verify dynamically provisioned pv using storageclass fails on an invalid datastore" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: hostPath] should support file as subpath" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cluster-lifecycle] Downgrade [Feature:Downgrade] cluster downgrade should maintain a functioning cluster [Feature:ClusterDowngrade]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] CustomResourceDefinition resources Simple CustomResourceDefinition creating/deleting custom resource definition objects works  [Conformance]" classname="Kubernetes e2e suite" time="7.352202446"></testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gcePDPVC] should support existing directories when readOnly specified in the volumeSource" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Services should be able to up and down services" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gcePDPartitioned] should support existing directory" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: dir-link-bindmounted] Set fsGroup for local volume should set same fsGroup for two pods simultaneously" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] DNS configMap federations should be able to change federation configuration [Slow][Serial]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: nfsPVC] should fail if non-existent subpath is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl Port forwarding [k8s.io] With a server listening on localhost [k8s.io] that expects NO client request should support a client that connects, sends DATA, and disconnects" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Kubectl cluster-info should check if Kubernetes master services is included in cluster-info  [Conformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cluster-lifecycle] Reboot [Disruptive] [Feature:Reboot] each node by dropping all inbound packets for a while and ensure they function afterwards" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: dir-link-bindmounted] Set fsGroup for local volume should not set different fsGroups for two pods simultaneously" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Secrets should be consumable from pods in volume [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="8.514620012"></testcase>
+      <testcase name="[sig-network] Loadbalancing: L7 GCE [Slow] [Feature:Ingress] should create ingress with backend HTTPS" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl Port forwarding [k8s.io] With a server listening on localhost should support forwarding over websockets" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] [Serial] Volume metrics should create volume metrics with the correct PVC ref" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] should increase cluster size if pod requesting EmptyDir volume is pending [Feature:ClusterSizeAutoscalingScaleUp]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] CSI Volumes CSI plugin test using CSI driver: [Feature: GCE PD CSI Plugin] gcePD should provision storage" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Kubectl create quota should reject quota with invalid scopes" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: nfsPVC] should support file as subpath" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cluster-lifecycle] Reboot [Disruptive] [Feature:Reboot] each node by dropping all outbound packets for a while and ensure they function afterwards" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gcePDPVC] should support file as subpath" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volume Attach Verify [Feature:vsphere][Serial][Disruptive] verify volume remains attached after master kubelet restart" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: dir] Set fsGroup for local volume should set fsGroup for one pod" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] [HPA] Horizontal pod autoscaling (scale resource: CPU) [sig-autoscaling] [Serial] [Slow] Deployment Should scale from 5 pods to 3 pods and from 3 to 1" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: blockfs] Set fsGroup for local volume should set different fsGroup for second pod if first pod is deleted" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Deployment deployment should support rollover" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] Should scale up GPU pool from 1 [GpuType:nvidia-tesla-p100] [Feature:ClusterSizeAutoscalingGpu]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] ReplicaSet should adopt matching pods on creation and release no longer matching pods" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Verify Volume Attach Through vpxd Restart [Feature:vsphere][Serial][Disruptive] verify volume remains attached through vpxd restart" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] EmptyDir volumes should support (root,0777,default) [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="10.379159534"></testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: block] [Feature:BlockVolume] One pod requesting one prebound PVC should be able to mount volume and read from pod1" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl Port forwarding [k8s.io] With a server listening on 0.0.0.0 [k8s.io] that expects a client request should support a client that connects, sends NO DATA, and disconnects" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] should disable node pool autoscaling [Feature:ClusterSizeAutoscalingScaleUp]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: emptyDir] should unmount if pod is force deleted while kubelet is down [Disruptive][Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes NFS with Single PV - PVC pairs create a PVC and a pre-bound PV: test write access" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] should increase cluster size if pending pods are small [Feature:ClusterSizeAutoscalingScaleUp]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: hostPathSymlink] should support creating multiple subpath from same volumes [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl Port forwarding [k8s.io] With a server listening on localhost [k8s.io] that expects a client request should support a client that connects, sends NO DATA, and disconnects" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Downward API volume should update labels on modification [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="28.889117318"></testcase>
+      <testcase name="[sig-scalability] Load capacity [Feature:ManualPerformance] should be able to handle 30 pods per node { Random} with 0 secrets, 0 configmaps and 0 daemons" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-instrumentation] Stackdriver Monitoring should have cluster metrics [Feature:StackdriverMonitoring]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] InitContainer [NodeConformance] should invoke init containers on a RestartNever pod" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: block] [Feature:BlockVolume] Set fsGroup for local volume should set different fsGroup for second pod if first pod is deleted" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Garbage collector should orphan pods created by rc if delete options say so [Conformance]" classname="Kubernetes e2e suite" time="48.272801173"></testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: emptyDir] should support existing directories when readOnly specified in the volumeSource" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Update Demo should scale a replication controller  [Conformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] ConfigMap should be consumable from pods in volume with mappings [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="10.502484856"></testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: dir-bindmounted] Set fsGroup for local volume should set different fsGroup for second pod if first pod is deleted" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cluster-lifecycle] Restart [Disruptive] should restart all nodes and ensure all nodes and pods recover" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: nfsPVC] should support non-existent path" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [sig-node] Security Context [Feature:SecurityContext] should support container.SecurityContext.RunAsUser And container.SecurityContext.RunAsGroup [Feature:RunAsGroup]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Simple pod should support port-forward" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: nfsPVC] should support readOnly directory specified in the volumeMount" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scalability] Load capacity [Feature:Performance] should be able to handle 30 pods per node { ReplicationController} with 0 secrets, 0 configmaps and 0 daemons" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cluster-lifecycle] [Feature:BootstrapTokens] should delete the token secret when the secret expired" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: dir-bindmounted] One pod requesting one prebound PVC should be able to mount volume and read from pod1" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Proxy server should support --unix-socket=/path  [Conformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Kubectl api-versions should check if v1 is in available api versions  [Conformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] ReplicationController should surface a failure condition on a common issue like exceeded quota" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: hostPathSymlink] should fail if subpath directory is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: nfsPVC] should unmount if pod is gracefully deleted while kubelet is down [Disruptive][Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] ResourceQuota should create a ResourceQuota and capture the life of a replica set." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Deployment deployment should delete old replica sets" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Pod Disks schedule a pod w/ RW PD(s) mounted to 1 or more containers, write to PD, verify content, delete pod, and repeat in rapid succession [Slow] using 4 containers and 1 PDs" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [sig-node] Kubelet [Serial] [Slow] [k8s.io] [sig-node] experimental resource usage tracking [Feature:ExperimentalResourceUsageTracking] resource tracking for 100 pods per node" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cluster-lifecycle] HA-master [Feature:HAMaster] survive addition/removal replicas same zone [Serial][Disruptive]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Projected should be consumable from pods in volume as non-root with defaultMode and fsGroup set [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="10.543152955"></testcase>
+      <testcase name="[sig-apps] Deployment deployment should support proportional scaling" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] DNS configMap nameserver Forward PTR lookup should forward PTR records lookup to upstream nameserver [Slow][Serial]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: hostPath] should support existing directories when readOnly specified in the volumeSource" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: tmpfs] One pod requesting one prebound PVC should be able to mount volume and write from pod1" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] EmptyDir volumes should support (non-root,0666,default) [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="10.336070236"></testcase>
+      <testcase name="[k8s.io] Cluster size autoscaler scalability [Slow] should scale up at all [Feature:ClusterAutoscalerScalability1]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Cluster size autoscaler scalability [Slow] CA ignores unschedulable pods while scheduling schedulable pods [Feature:ClusterAutoscalerScalability6]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes [Feature:ReclaimPolicy] [sig-storage] persistentvolumereclaim:vsphere should retain persistent volume when reclaimPolicy set to retain when associated claim is deleted" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] [HPA] Horizontal pod autoscaling (scale resource: Custom Metrics from Stackdriver) should scale up with two metrics of type Pod from Stackdriver [Feature:CustomMetricsAutoscaling]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] StatefulSet [k8s.io] Basic StatefulSet functionality [StatefulSetBasic] Should recreate evicted statefulset [Conformance]" classname="Kubernetes e2e suite" time="24.739151718"></testcase>
+      <testcase name="[sig-network] Loadbalancing: L7 GCE [Slow] [Feature:NEG] should be able to switch between IG and NEG modes" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Kubectl apply should reuse port when apply to an existing SVC" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] SchedulerPreemption [Serial] [Feature:PodPreemption] validates pod anti-affinity works in preemption" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] NetworkPolicy NetworkPolicy between server and client should enforce policy based on NamespaceSelector [Feature:NetworkPolicy]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] DisruptionController evictions: enough pods, absolute =&gt; should allow an eviction" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: dir-bindmounted] One pod requesting one prebound PVC should be able to mount volume and write from pod1" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volumes Cinder [Feature:Volumes] should be mountable" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Dynamic Provisioning DynamicProvisioner External should let an external dynamic provisioner create and delete persistent volumes [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] PrivilegedPod [NodeConformance] should enable privileged commands" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volume expand [Slow] Verify if editing PVC allows resize" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: nfsPVC] should fail if subpath directory is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] ESIPP [Slow] [DisabledForLargeClusters] should only target nodes with endpoints" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: dir-link-bindmounted] Set fsGroup for local volume should set fsGroup for one pod" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: hostPathSymlink] should fail if non-existent subpath is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Downward API volume should provide node allocatable (cpu) as default cpu limit if the limit is not set [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="8.303827808"></testcase>
+      <testcase name="[sig-network] Services should serve multiport endpoints from pods  [Conformance]" classname="Kubernetes e2e suite" time="12.585481709"></testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: dir-bindmounted] Two pods mounting a local volume one after the other should be able to write from pod1 and read from pod2" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: emptyDir] should support non-existent path" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PV Protection Verify that PV bound to a PVC is not removed immediately" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Job should run a job to completion when tasks sometimes fail and are not locally restarted" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  Pod with node different from PV&#39;s NodeAffinity should fail scheduling due to different NodeSelector" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Pods should support retrieving logs from the container over websockets [NodeConformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Kubectl taint [Serial] should remove all the taints with the same key off a node" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Job should adopt matching orphans and release non-matching pods" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] Should not scale GPU pool up if pod does not require GPUs [GpuType:nvidia-tesla-k80] [Feature:ClusterSizeAutoscalingGpu]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gcePDPartitioned] should support existing directories when readOnly specified in the volumeSource" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Kubectl run rc should create an rc from an image  [Conformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Downward API volume should provide container&#39;s cpu request [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="8.336664577"></testcase>
+      <testcase name="[sig-storage] vcp-performance [Feature:vsphere] vcp performance tests" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-instrumentation] Stackdriver Monitoring should run Stackdriver Metadata Agent [Feature:StackdriverMetadataAgent]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cluster-lifecycle] kube-proxy migration [Feature:KubeProxyDaemonSetMigration] Upgrade kube-proxy from static pods to a DaemonSet should maintain a functioning cluster [Feature:KubeProxyDaemonSetUpgrade]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Firewall rule should have correct firewall rules for e2e cluster" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volume Disk Format [Feature:vsphere] verify disk format type - thin is honored for dynamically provisioned pv using storageclass" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: dir-link] One pod requesting one prebound PVC should be able to mount volume and read from pod1" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: dir-link] Set fsGroup for local volume should set same fsGroup for two pods simultaneously" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath Atomic writer volumes should support subpaths with secret pod" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Pods should get a host IP [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="26.390419095"></testcase>
+      <testcase name="[sig-scheduling] ResourceQuota should create a ResourceQuota and capture the life of a service." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Downward API volume should provide container&#39;s cpu limit [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="10.402294858"></testcase>
+      <testcase name="[sig-storage] Storage Policy Based Volume Provisioning [Feature:vsphere] verify VSAN storage capability with non-vsan datastore is not honored for dynamically provisioned pvc using storageclass" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: nfs] should support existing directories when readOnly specified in the volumeSource" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] GenericPersistentVolume[Disruptive] When kubelet restarts Should test that a volume mounted to a pod that is force deleted while the kubelet is down unmounts when the kubelet returns." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] EmptyDir volumes when FSGroup is specified [NodeFeature:FSGroup] files with FSGroup ownership should support (root,0644,tmpfs)" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Projected should provide podname as non-root with fsgroup [NodeFeature:FSGroup]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] should scale up correct target pool [Feature:ClusterSizeAutoscalingScaleUp]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Projected updates should be reflected in volume [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="26.658735496"></testcase>
+      <testcase name="[sig-storage] EmptyDir volumes should support (root,0666,default) [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="10.416409129"></testcase>
+      <testcase name="[k8s.io] [sig-node] Pods Extended [k8s.io] Delete Grace Period should be submitted and removed  [Flaky] [Conformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes NFS when invoking the Recycle reclaim policy should test that a PV becomes Available and is clean after the PVC is deleted." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cluster-lifecycle] Upgrade [Feature:Upgrade] master upgrade should maintain a functioning cluster [Feature:MasterUpgrade]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gcePDPartitioned] should support restarting containers using directory as subpath [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Services should be able to update NodePorts with two same port numbers but different protocols" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: nfsPVC] should support existing directory" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] should be able to scale down when rescheduling a pod is required and pdb allows for it[Feature:ClusterSizeAutoscalingScaleDown]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Downward API volume should set mode on item file [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="10.387065875"></testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gcePDPartitioned] should fail for new directories when readOnly specified in the volumeSource" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Probing container with readiness probe that fails should never be ready and never restart [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="82.33289563"></testcase>
+      <testcase name="[sig-storage] PersistentVolumes NFS with multiple PVs and PVCs all in same ns should create 3 PVs and 3 PVCs: test write access" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Network Partition [Disruptive] [Slow] [k8s.io] [Job] should create new pods when node is partitioned" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] NetworkPolicy NetworkPolicy between server and client should enforce policy based on Ports [Feature:NetworkPolicy]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volume Disk Format [Feature:vsphere] verify disk format type - eagerzeroedthick is honored for dynamically provisioned pv using storageclass" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Secrets should be consumable from pods in env vars [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="12.323842628"></testcase>
+      <testcase name="[sig-autoscaling] [Feature:ClusterSizeAutoscalingScaleUp] [Slow] Autoscaling [sig-autoscaling] Autoscaling a service from 1 pod and 3 nodes to 8 pods and &gt;=4 nodes takes less than 15 minutes" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Network Partition [Disruptive] [Slow] [k8s.io] [ReplicationController] should eagerly create replacement pod during network partition when termination grace is non-zero" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Services should prevent NodePort collisions" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Downward API [Serial] [Disruptive] [NodeFeature:EphemeralStorage] Downward API tests for local ephemeral storage should provide default limits.ephemeral-storage from node allocatable" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Services should serve a basic endpoint from pods  [Conformance]" classname="Kubernetes e2e suite" time="14.526926085"></testcase>
+      <testcase name="[sig-network] NetworkPolicy NetworkPolicy between server and client should enforce policy based on PodSelector [Feature:NetworkPolicy]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: dir-link] Set fsGroup for local volume should not set different fsGroups for two pods simultaneously" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Downward API should provide host IP as an env var [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="10.287190078"></testcase>
+      <testcase name="[sig-storage] Volume plugin streaming [Slow] NFS should write files of various sizes, verify size, validate content" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Job should exceed backoffLimit" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Daemon set [Serial] should update pod when spec was updated and update strategy is RollingUpdate [Conformance]" classname="Kubernetes e2e suite" time="32.975399128"></testcase>
+      <testcase name="[sig-storage] GCP Volumes NFSv3 should be mountable for NFSv3" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] EmptyDir volumes should support (non-root,0777,tmpfs) [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="10.455697346000001"></testcase>
+      <testcase name="[sig-network] Services should have session affinity work for LoadBalancer service with ESIPP on [Slow] [DisabledForLargeClusters]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] CustomResourceDefinition Watch CustomResourceDefinition Watch watch on custom resource definition objects" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Projected optional updates should be reflected in volume [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="97.84568108"></testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gluster] should fail if subpath directory is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Services should work after restarting kube-proxy [Disruptive]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] AdmissionWebhook Should mutate pod and apply defaults after mutation" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: block] [Feature:BlockVolume] One pod requesting one prebound PVC should be able to mount volume and write from pod1" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gcePDPVC] should fail if non-existent subpath is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] ConfigMap should be consumable in multiple volumes in the same pod [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="8.376663837"></testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: dir-link] Two pods mounting a local volume at the same time should be able to write from pod1 and read from pod2" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Downward API should provide default limits.cpu/memory from node allocatable [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="10.248615308"></testcase>
+      <testcase name="[sig-apps] ReplicationController should adopt matching pods on creation" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] StatefulSet [k8s.io] Basic StatefulSet functionality [StatefulSetBasic] should not deadlock when a pod&#39;s predecessor fails" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: emptyDir] should support creating multiple subpath from same volumes [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Downward API volume should provide container&#39;s memory limit [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="10.494471527"></testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] Should be able to scale a node group down to 0[Feature:ClusterSizeAutoscalingScaleDown]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gluster] should support restarting containers using directory as subpath [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gluster] should support existing directories when readOnly specified in the volumeSource" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Pod Disks detach in a disrupted environment [Slow] [Disruptive] when node&#39;s API object is deleted" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] should correctly scale down after a node is not needed when there is non autoscaled pool[Feature:ClusterSizeAutoscalingScaleDown]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] ResourceQuota should create a ResourceQuota and capture the life of a persistent volume claim with a storage class. [sig-storage]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] SchedulerPriorities [Serial] Pod should avoid to schedule to node that have avoidPod annotation" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath Atomic writer volumes should support subpaths with configmap pod" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [sig-node] Pod garbage collector [Feature:PodGarbageCollector] [Slow] should handle the creation of 1000 pods" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: hostPathSymlink] should unmount if pod is gracefully deleted while kubelet is down [Disruptive][Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Services should be able to switch session affinity for service with type clusterIP" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Downward API should provide pod UID as env vars [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="12.35626432"></testcase>
+      <testcase name="[sig-network] ESIPP [Slow] [DisabledForLargeClusters] should work for type=LoadBalancer" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scalability] Load capacity [Feature:ManualPerformance] should be able to handle 30 pods per node {extensions Deployment} with 0 secrets, 2 configmaps and 0 daemons" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [Feature:Example] [k8s.io] Downward API should create a pod that prints his name and namespace" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  Local volume that cannot be mounted [Slow] should fail due to non-existent path" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] ResourceQuota should create a ResourceQuota and ensure its status is promptly calculated." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] [HPA] Horizontal pod autoscaling (scale resource: CPU) [sig-autoscaling] ReplicationController light Should scale from 2 pods to 1 pod" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Storage Policy Based Volume Provisioning [Feature:vsphere] verify VSAN storage capability with invalid hostFailuresToTolerate value is not honored for dynamically provisioned pvc using storageclass" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Watchers should observe an object deletion if it stops meeting the requirements of the selector [Conformance]" classname="Kubernetes e2e suite" time="16.37043982"></testcase>
+      <testcase name="[k8s.io] Probing container should be restarted with a exec &#34;cat /tmp/health&#34; liveness probe [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="60.565697699"></testcase>
+      <testcase name="[sig-network] NoSNAT [Feature:NoSNAT] [Slow] Should be able to send traffic between Pods without SNAT" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: hostPathSymlink] should support readOnly directory specified in the volumeMount" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [Feature:Example] [k8s.io] CassandraStatefulSet should create statefulset" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-instrumentation] Stackdriver Monitoring should run Custom Metrics - Stackdriver Adapter for external metrics [Feature:StackdriverExternalMetrics]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] EmptyDir volumes when FSGroup is specified [NodeFeature:FSGroup] volume on tmpfs should have the correct mode using FSGroup" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes:vsphere should test that deleting the PV before the pod does not cause pod deletion to fail on vspehre volume detach" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] [HPA] Horizontal pod autoscaling (scale resource: CPU) [sig-autoscaling] [Serial] [Slow] Deployment Should scale from 1 pod to 3 pods and from 3 to 5" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Storage Policy Based Volume Provisioning [Feature:vsphere] verify VSAN storage capability with valid diskStripes and objectSpaceReservation values and a VSAN datastore is honored for dynamically provisioned pvc using storageclass" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Job should run a job to completion when tasks sometimes fail and are locally restarted" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [sig-node] Security Context [Feature:SecurityContext] should support seccomp alpha unconfined annotation on the pod [Feature:Seccomp]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Projected should be consumable from pods in volume as non-root [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="8.532588858"></testcase>
+      <testcase name="[sig-scheduling] SchedulerPredicates [Serial] validates resource limits of pods that are allowed to run  [Conformance]" classname="Kubernetes e2e suite" time="87.619223691"></testcase>
+      <testcase name="[sig-scheduling] Multi-AZ Clusters should spread the pods of a service across zones" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  Stress with local volume provisioner [Serial] should use be able to process many pods and reuse local volumes" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Storage Policy Based Volume Provisioning [Feature:vsphere] verify VSAN storage capability with invalid diskStripes value is not honored for dynamically provisioned pvc using storageclass" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+  </testsuite>

--- a/v1.11/gardener-azure/version.txt
+++ b/v1.11/gardener-azure/version.txt
@@ -1,0 +1,2 @@
+Client Version: version.Info{Major:"1", Minor:"11", GitVersion:"v1.11.0", GitCommit:"91e7b4fd31fcd3d5f436da26c980becec37ceefe", GitTreeState:"clean", BuildDate:"2018-06-27T20:17:28Z", GoVersion:"go1.10.2", Compiler:"gc", Platform:"linux/amd64"}
+Server Version: version.Info{Major:"1", Minor:"11", GitVersion:"v1.11.0", GitCommit:"91e7b4fd31fcd3d5f436da26c980becec37ceefe", GitTreeState:"clean", BuildDate:"2018-06-27T20:08:34Z", GoVersion:"go1.10.2", Compiler:"gc", Platform:"linux/amd64"}

--- a/v1.11/gardener-gcp/PRODUCT.yaml
+++ b/v1.11/gardener-gcp/PRODUCT.yaml
@@ -1,0 +1,8 @@
+vendor: SAP
+name: Gardener (https://github.com/gardener/gardener) shoot cluster deployed on Google Cloud Platform
+version: 0.8.0
+website_url: https://gardener.cloud
+documentation_url: https://github.com/gardener/documentation/wiki
+product_logo_url: https://raw.githubusercontent.com/gardener/documentation/master/images/logo_w_saplogo.svg
+type: installer
+description: The Gardener implements automated management and operation of Kubernetes clusters as a service and aims to support that service on multiple Cloud providers.

--- a/v1.11/gardener-gcp/README.md
+++ b/v1.11/gardener-gcp/README.md
@@ -1,0 +1,43 @@
+# To reproduce:
+
+## Create Kubernetes Cluster
+
+Login to SAP Gardener Dashboard to create a Kubernetes Clusters on Amazon Web Services, Microsoft Azure, Google Cloud Platform, or OpenStack cloud provider.
+
+After the creation completed, copy the cluster's kubeconfig, which is provided by the Gardener Dashboard in the cluster's detail view, to ~/.kube/config and launch the Kubernetes E2E conformance tests.
+
+## Launch E2E Conformance Tests
+1. Launch e2e pod and sonobuoy master under namespace `sonobuoy`   
+    ```shell
+    curl -L https://raw.githubusercontent.com/cncf/k8s-conformance/master/sonobuoy-conformance.yaml | kubectl apply -f -
+    ```
+
+2. Check logs of `sonobuoy` pod to see when test can be finished   
+Run
+
+    ```shell
+    kubectl logs -f -n sonobuoy sonobuoy
+    ```
+    and wait for line `no-exit was specified, sonobuoy is now blocking`.
+
+3. Use `kubectl cp` to copy the results to the client   
+Get the name of the <result archive> from the log output in step 2.
+
+    ```shell
+    kubectl cp sonobuoy/sonobuoy:/tmp/sonobuoy/<result archive> /home/result
+    ```
+
+4. Delete the conformance test resources
+
+    ```shell
+    curl -L https://raw.githubusercontent.com/cncf/k8s-conformance/master/sonobuoy-conformance.yaml | kubectl delete -f -
+    ```
+
+5. Untar the tarball
+
+    ```shell
+    cd /home/result
+    tar -xzf *_sonobuoy_*.tar.gz
+    ```
+
+    The result files `e2e.log` and `junit_01.xml` are located in the in the directory `plugins/e2e/results/`.

--- a/v1.11/gardener-gcp/e2e.log
+++ b/v1.11/gardener-gcp/e2e.log
@@ -1,0 +1,7085 @@
+Jul  2 12:54:27.396: INFO: Overriding default scale value of zero to 1
+Jul  2 12:54:27.396: INFO: Overriding default milliseconds value of zero to 5000
+I0702 12:54:27.552673      18 test_context.go:382] Using a temporary kubeconfig file from in-cluster config : /tmp/kubeconfig-293271353
+I0702 12:54:27.552779      18 e2e.go:333] Starting e2e run "0d96e735-7df7-11e8-b0f5-565e625ec9a3" on Ginkgo node 1
+Running Suite: Kubernetes e2e suite
+===================================
+Random Seed: 1530536067 - Will randomize all specs
+Will run 144 of 998 specs
+
+Jul  2 12:54:27.652: INFO: >>> kubeConfig: /tmp/kubeconfig-293271353
+Jul  2 12:54:27.654: INFO: Waiting up to 30m0s for all (but 0) nodes to be schedulable
+Jul  2 12:54:27.667: INFO: Waiting up to 10m0s for all pods (need at least 0) in namespace 'kube-system' to be running and ready
+Jul  2 12:54:27.700: INFO: 14 / 14 pods in namespace 'kube-system' are running and ready (0 seconds elapsed)
+Jul  2 12:54:27.700: INFO: expected 8 pod replicas in namespace 'kube-system', 8 are Running and Ready.
+Jul  2 12:54:27.705: INFO: Waiting for pods to enter Success, but no pods in "kube-system" match label map[name:e2e-image-puller]
+Jul  2 12:54:27.705: INFO: Dumping network health container logs from all nodes to file /tmp/results/nethealth.txt
+Jul  2 12:54:27.709: INFO: e2e test version: v1.11.0
+Jul  2 12:54:27.711: INFO: kube-apiserver version: v1.11.0
+S
+------------------------------
+[sig-apps] StatefulSet [k8s.io] Basic StatefulSet functionality [StatefulSetBasic] 
+  Burst scaling should run to completion even with unhealthy pods [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-apps] StatefulSet
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 12:54:27.711: INFO: >>> kubeConfig: /tmp/kubeconfig-293271353
+STEP: Building a namespace api object
+Jul  2 12:54:27.798: INFO: No PodSecurityPolicies found; assuming PodSecurityPolicy is disabled.
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-apps] StatefulSet
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/statefulset.go:57
+[BeforeEach] [k8s.io] Basic StatefulSet functionality [StatefulSetBasic]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/statefulset.go:72
+STEP: Creating service test in namespace e2e-tests-statefulset-h9c8x
+[It] Burst scaling should run to completion even with unhealthy pods [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating stateful set ss in namespace e2e-tests-statefulset-h9c8x
+STEP: Waiting until all stateful set ss replicas will be running in namespace e2e-tests-statefulset-h9c8x
+Jul  2 12:54:27.811: INFO: Found 0 stateful pods, waiting for 1
+Jul  2 12:54:37.879: INFO: Waiting for pod ss-0 to enter Running - Ready=true, currently Running - Ready=true
+STEP: Confirming that stateful set scale up will not halt with unhealthy stateful pod
+Jul  2 12:54:37.976: INFO: Running '/usr/local/bin/kubectl --kubeconfig=/tmp/kubeconfig-293271353 exec --namespace=e2e-tests-statefulset-h9c8x ss-0 -- /bin/sh -c mv -v /usr/share/nginx/html/index.html /tmp/ || true'
+Jul  2 12:54:38.452: INFO: stderr: ""
+Jul  2 12:54:38.452: INFO: stdout: "'/usr/share/nginx/html/index.html' -> '/tmp/index.html'\n"
+Jul  2 12:54:38.452: INFO: stdout of mv -v /usr/share/nginx/html/index.html /tmp/ || true on ss-0: '/usr/share/nginx/html/index.html' -> '/tmp/index.html'
+
+Jul  2 12:54:38.456: INFO: Waiting for pod ss-0 to enter Running - Ready=false, currently Running - Ready=true
+Jul  2 12:54:48.461: INFO: Waiting for pod ss-0 to enter Running - Ready=false, currently Running - Ready=false
+Jul  2 12:54:48.461: INFO: Waiting for statefulset status.replicas updated to 0
+Jul  2 12:54:48.473: INFO: POD   NODE                                                  PHASE    GRACE  CONDITIONS
+Jul  2 12:54:48.473: INFO: ss-0  shoot--core--confgcp-worker-o1cev-z1-f757498dc-jzlxf  Running         [{Initialized True 0001-01-01 00:00:00 +0000 UTC 2018-07-02 12:54:27 +0000 UTC  } {Ready False 0001-01-01 00:00:00 +0000 UTC 2018-07-02 12:54:38 +0000 UTC ContainersNotReady containers with unready status: [nginx]} {ContainersReady False 0001-01-01 00:00:00 +0000 UTC 0001-01-01 00:00:00 +0000 UTC ContainersNotReady containers with unready status: [nginx]} {PodScheduled True 0001-01-01 00:00:00 +0000 UTC 2018-07-02 12:54:27 +0000 UTC  }]
+Jul  2 12:54:48.473: INFO: 
+Jul  2 12:54:48.473: INFO: StatefulSet ss has not reached scale 3, at 1
+Jul  2 12:54:49.478: INFO: Verifying statefulset ss doesn't scale past 3 for another 8.99677123s
+Jul  2 12:54:50.482: INFO: Verifying statefulset ss doesn't scale past 3 for another 7.992320918s
+Jul  2 12:54:51.490: INFO: Verifying statefulset ss doesn't scale past 3 for another 6.986734229s
+Jul  2 12:54:52.495: INFO: Verifying statefulset ss doesn't scale past 3 for another 5.979820729s
+Jul  2 12:54:53.499: INFO: Verifying statefulset ss doesn't scale past 3 for another 4.975283032s
+Jul  2 12:54:54.504: INFO: Verifying statefulset ss doesn't scale past 3 for another 3.970418209s
+Jul  2 12:54:55.509: INFO: Verifying statefulset ss doesn't scale past 3 for another 2.965933911s
+Jul  2 12:54:56.513: INFO: Verifying statefulset ss doesn't scale past 3 for another 1.961327521s
+Jul  2 12:54:57.518: INFO: Verifying statefulset ss doesn't scale past 3 for another 956.699407ms
+STEP: Scaling up stateful set ss to 3 replicas and waiting until all of them will be running in namespace e2e-tests-statefulset-h9c8x
+Jul  2 12:54:58.522: INFO: Running '/usr/local/bin/kubectl --kubeconfig=/tmp/kubeconfig-293271353 exec --namespace=e2e-tests-statefulset-h9c8x ss-0 -- /bin/sh -c mv -v /tmp/index.html /usr/share/nginx/html/ || true'
+Jul  2 12:54:59.034: INFO: stderr: ""
+Jul  2 12:54:59.034: INFO: stdout: "'/tmp/index.html' -> '/usr/share/nginx/html/index.html'\n"
+Jul  2 12:54:59.034: INFO: stdout of mv -v /tmp/index.html /usr/share/nginx/html/ || true on ss-0: '/tmp/index.html' -> '/usr/share/nginx/html/index.html'
+
+Jul  2 12:54:59.034: INFO: Running '/usr/local/bin/kubectl --kubeconfig=/tmp/kubeconfig-293271353 exec --namespace=e2e-tests-statefulset-h9c8x ss-1 -- /bin/sh -c mv -v /tmp/index.html /usr/share/nginx/html/ || true'
+Jul  2 12:54:59.507: INFO: stderr: "mv: cannot stat '/tmp/index.html': No such file or directory\n"
+Jul  2 12:54:59.507: INFO: stdout: ""
+Jul  2 12:54:59.507: INFO: stdout of mv -v /tmp/index.html /usr/share/nginx/html/ || true on ss-1: 
+Jul  2 12:54:59.507: INFO: Running '/usr/local/bin/kubectl --kubeconfig=/tmp/kubeconfig-293271353 exec --namespace=e2e-tests-statefulset-h9c8x ss-2 -- /bin/sh -c mv -v /tmp/index.html /usr/share/nginx/html/ || true'
+Jul  2 12:55:00.033: INFO: stderr: "mv: cannot stat '/tmp/index.html': No such file or directory\n"
+Jul  2 12:55:00.033: INFO: stdout: ""
+Jul  2 12:55:00.033: INFO: stdout of mv -v /tmp/index.html /usr/share/nginx/html/ || true on ss-2: 
+Jul  2 12:55:00.037: INFO: Waiting for pod ss-0 to enter Running - Ready=true, currently Running - Ready=true
+Jul  2 12:55:00.037: INFO: Waiting for pod ss-1 to enter Running - Ready=true, currently Running - Ready=true
+Jul  2 12:55:00.037: INFO: Waiting for pod ss-2 to enter Running - Ready=true, currently Running - Ready=true
+STEP: Scale down will not halt with unhealthy stateful pod
+Jul  2 12:55:00.041: INFO: Running '/usr/local/bin/kubectl --kubeconfig=/tmp/kubeconfig-293271353 exec --namespace=e2e-tests-statefulset-h9c8x ss-0 -- /bin/sh -c mv -v /usr/share/nginx/html/index.html /tmp/ || true'
+Jul  2 12:55:00.571: INFO: stderr: ""
+Jul  2 12:55:00.571: INFO: stdout: "'/usr/share/nginx/html/index.html' -> '/tmp/index.html'\n"
+Jul  2 12:55:00.571: INFO: stdout of mv -v /usr/share/nginx/html/index.html /tmp/ || true on ss-0: '/usr/share/nginx/html/index.html' -> '/tmp/index.html'
+
+Jul  2 12:55:00.571: INFO: Running '/usr/local/bin/kubectl --kubeconfig=/tmp/kubeconfig-293271353 exec --namespace=e2e-tests-statefulset-h9c8x ss-1 -- /bin/sh -c mv -v /usr/share/nginx/html/index.html /tmp/ || true'
+Jul  2 12:55:01.000: INFO: stderr: ""
+Jul  2 12:55:01.000: INFO: stdout: "'/usr/share/nginx/html/index.html' -> '/tmp/index.html'\n"
+Jul  2 12:55:01.000: INFO: stdout of mv -v /usr/share/nginx/html/index.html /tmp/ || true on ss-1: '/usr/share/nginx/html/index.html' -> '/tmp/index.html'
+
+Jul  2 12:55:01.000: INFO: Running '/usr/local/bin/kubectl --kubeconfig=/tmp/kubeconfig-293271353 exec --namespace=e2e-tests-statefulset-h9c8x ss-2 -- /bin/sh -c mv -v /usr/share/nginx/html/index.html /tmp/ || true'
+Jul  2 12:55:01.493: INFO: stderr: ""
+Jul  2 12:55:01.493: INFO: stdout: "'/usr/share/nginx/html/index.html' -> '/tmp/index.html'\n"
+Jul  2 12:55:01.493: INFO: stdout of mv -v /usr/share/nginx/html/index.html /tmp/ || true on ss-2: '/usr/share/nginx/html/index.html' -> '/tmp/index.html'
+
+Jul  2 12:55:01.493: INFO: Waiting for statefulset status.replicas updated to 0
+Jul  2 12:55:01.496: INFO: Waiting for stateful set status.readyReplicas to become 0, currently 1
+Jul  2 12:55:11.505: INFO: Waiting for pod ss-0 to enter Running - Ready=false, currently Running - Ready=false
+Jul  2 12:55:11.505: INFO: Waiting for pod ss-1 to enter Running - Ready=false, currently Running - Ready=false
+Jul  2 12:55:11.505: INFO: Waiting for pod ss-2 to enter Running - Ready=false, currently Running - Ready=false
+Jul  2 12:55:11.583: INFO: POD   NODE                                                  PHASE    GRACE  CONDITIONS
+Jul  2 12:55:11.583: INFO: ss-0  shoot--core--confgcp-worker-o1cev-z1-f757498dc-jzlxf  Running         [{Initialized True 0001-01-01 00:00:00 +0000 UTC 2018-07-02 12:54:27 +0000 UTC  } {Ready False 0001-01-01 00:00:00 +0000 UTC 2018-07-02 12:55:00 +0000 UTC ContainersNotReady containers with unready status: [nginx]} {ContainersReady False 0001-01-01 00:00:00 +0000 UTC 0001-01-01 00:00:00 +0000 UTC ContainersNotReady containers with unready status: [nginx]} {PodScheduled True 0001-01-01 00:00:00 +0000 UTC 2018-07-02 12:54:27 +0000 UTC  }]
+Jul  2 12:55:11.583: INFO: ss-1  shoot--core--confgcp-worker-o1cev-z1-f757498dc-qrtzr  Running         [{Initialized True 0001-01-01 00:00:00 +0000 UTC 2018-07-02 12:54:48 +0000 UTC  } {Ready False 0001-01-01 00:00:00 +0000 UTC 2018-07-02 12:55:01 +0000 UTC ContainersNotReady containers with unready status: [nginx]} {ContainersReady False 0001-01-01 00:00:00 +0000 UTC 0001-01-01 00:00:00 +0000 UTC ContainersNotReady containers with unready status: [nginx]} {PodScheduled True 0001-01-01 00:00:00 +0000 UTC 2018-07-02 12:54:48 +0000 UTC  }]
+Jul  2 12:55:11.583: INFO: ss-2  shoot--core--confgcp-worker-o1cev-z1-f757498dc-jzlxf  Running         [{Initialized True 0001-01-01 00:00:00 +0000 UTC 2018-07-02 12:54:48 +0000 UTC  } {Ready False 0001-01-01 00:00:00 +0000 UTC 2018-07-02 12:55:02 +0000 UTC ContainersNotReady containers with unready status: [nginx]} {ContainersReady False 0001-01-01 00:00:00 +0000 UTC 0001-01-01 00:00:00 +0000 UTC ContainersNotReady containers with unready status: [nginx]} {PodScheduled True 0001-01-01 00:00:00 +0000 UTC 2018-07-02 12:54:48 +0000 UTC  }]
+Jul  2 12:55:11.583: INFO: 
+Jul  2 12:55:11.583: INFO: StatefulSet ss has not reached scale 0, at 3
+Jul  2 12:55:12.588: INFO: POD   NODE                                                  PHASE    GRACE  CONDITIONS
+Jul  2 12:55:12.588: INFO: ss-0  shoot--core--confgcp-worker-o1cev-z1-f757498dc-jzlxf  Running  30s    [{Initialized True 0001-01-01 00:00:00 +0000 UTC 2018-07-02 12:54:27 +0000 UTC  } {Ready False 0001-01-01 00:00:00 +0000 UTC 2018-07-02 12:55:00 +0000 UTC ContainersNotReady containers with unready status: [nginx]} {ContainersReady False 0001-01-01 00:00:00 +0000 UTC 0001-01-01 00:00:00 +0000 UTC ContainersNotReady containers with unready status: [nginx]} {PodScheduled True 0001-01-01 00:00:00 +0000 UTC 2018-07-02 12:54:27 +0000 UTC  }]
+Jul  2 12:55:12.588: INFO: ss-1  shoot--core--confgcp-worker-o1cev-z1-f757498dc-qrtzr  Running  30s    [{Initialized True 0001-01-01 00:00:00 +0000 UTC 2018-07-02 12:54:48 +0000 UTC  } {Ready False 0001-01-01 00:00:00 +0000 UTC 2018-07-02 12:55:01 +0000 UTC ContainersNotReady containers with unready status: [nginx]} {ContainersReady False 0001-01-01 00:00:00 +0000 UTC 0001-01-01 00:00:00 +0000 UTC ContainersNotReady containers with unready status: [nginx]} {PodScheduled True 0001-01-01 00:00:00 +0000 UTC 2018-07-02 12:54:48 +0000 UTC  }]
+Jul  2 12:55:12.588: INFO: ss-2  shoot--core--confgcp-worker-o1cev-z1-f757498dc-jzlxf  Running  30s    [{Initialized True 0001-01-01 00:00:00 +0000 UTC 2018-07-02 12:54:48 +0000 UTC  } {Ready False 0001-01-01 00:00:00 +0000 UTC 2018-07-02 12:55:02 +0000 UTC ContainersNotReady containers with unready status: [nginx]} {ContainersReady False 0001-01-01 00:00:00 +0000 UTC 0001-01-01 00:00:00 +0000 UTC ContainersNotReady containers with unready status: [nginx]} {PodScheduled True 0001-01-01 00:00:00 +0000 UTC 2018-07-02 12:54:48 +0000 UTC  }]
+Jul  2 12:55:12.588: INFO: 
+Jul  2 12:55:12.588: INFO: StatefulSet ss has not reached scale 0, at 3
+Jul  2 12:55:13.593: INFO: POD   NODE                                                  PHASE    GRACE  CONDITIONS
+Jul  2 12:55:13.593: INFO: ss-0  shoot--core--confgcp-worker-o1cev-z1-f757498dc-jzlxf  Running  30s    [{Initialized True 0001-01-01 00:00:00 +0000 UTC 2018-07-02 12:54:27 +0000 UTC  } {Ready False 0001-01-01 00:00:00 +0000 UTC 2018-07-02 12:55:00 +0000 UTC ContainersNotReady containers with unready status: [nginx]} {ContainersReady False 0001-01-01 00:00:00 +0000 UTC 0001-01-01 00:00:00 +0000 UTC ContainersNotReady containers with unready status: [nginx]} {PodScheduled True 0001-01-01 00:00:00 +0000 UTC 2018-07-02 12:54:27 +0000 UTC  }]
+Jul  2 12:55:13.593: INFO: ss-2  shoot--core--confgcp-worker-o1cev-z1-f757498dc-jzlxf  Running  30s    [{Initialized True 0001-01-01 00:00:00 +0000 UTC 2018-07-02 12:54:48 +0000 UTC  } {Ready False 0001-01-01 00:00:00 +0000 UTC 2018-07-02 12:55:02 +0000 UTC ContainersNotReady containers with unready status: [nginx]} {ContainersReady False 0001-01-01 00:00:00 +0000 UTC 0001-01-01 00:00:00 +0000 UTC ContainersNotReady containers with unready status: [nginx]} {PodScheduled True 0001-01-01 00:00:00 +0000 UTC 2018-07-02 12:54:48 +0000 UTC  }]
+Jul  2 12:55:13.593: INFO: 
+Jul  2 12:55:13.593: INFO: StatefulSet ss has not reached scale 0, at 2
+Jul  2 12:55:14.597: INFO: POD   NODE                                                  PHASE    GRACE  CONDITIONS
+Jul  2 12:55:14.598: INFO: ss-2  shoot--core--confgcp-worker-o1cev-z1-f757498dc-jzlxf  Pending  30s    [{Initialized True 0001-01-01 00:00:00 +0000 UTC 2018-07-02 12:54:48 +0000 UTC  } {Ready False 0001-01-01 00:00:00 +0000 UTC 2018-07-02 12:55:02 +0000 UTC ContainersNotReady containers with unready status: [nginx]} {ContainersReady False 0001-01-01 00:00:00 +0000 UTC 0001-01-01 00:00:00 +0000 UTC ContainersNotReady containers with unready status: [nginx]} {PodScheduled True 0001-01-01 00:00:00 +0000 UTC 2018-07-02 12:54:48 +0000 UTC  }]
+Jul  2 12:55:14.598: INFO: 
+Jul  2 12:55:14.598: INFO: StatefulSet ss has not reached scale 0, at 1
+Jul  2 12:55:15.602: INFO: POD   NODE                                                  PHASE    GRACE  CONDITIONS
+Jul  2 12:55:15.603: INFO: ss-2  shoot--core--confgcp-worker-o1cev-z1-f757498dc-jzlxf  Pending  30s    [{Initialized True 0001-01-01 00:00:00 +0000 UTC 2018-07-02 12:54:48 +0000 UTC  } {Ready False 0001-01-01 00:00:00 +0000 UTC 2018-07-02 12:55:02 +0000 UTC ContainersNotReady containers with unready status: [nginx]} {ContainersReady False 0001-01-01 00:00:00 +0000 UTC 0001-01-01 00:00:00 +0000 UTC ContainersNotReady containers with unready status: [nginx]} {PodScheduled True 0001-01-01 00:00:00 +0000 UTC 2018-07-02 12:54:48 +0000 UTC  }]
+Jul  2 12:55:15.603: INFO: 
+Jul  2 12:55:15.603: INFO: StatefulSet ss has not reached scale 0, at 1
+Jul  2 12:55:16.608: INFO: POD   NODE                                                  PHASE    GRACE  CONDITIONS
+Jul  2 12:55:16.608: INFO: ss-2  shoot--core--confgcp-worker-o1cev-z1-f757498dc-jzlxf  Pending  30s    [{Initialized True 0001-01-01 00:00:00 +0000 UTC 2018-07-02 12:54:48 +0000 UTC  } {Ready False 0001-01-01 00:00:00 +0000 UTC 2018-07-02 12:55:02 +0000 UTC ContainersNotReady containers with unready status: [nginx]} {ContainersReady False 0001-01-01 00:00:00 +0000 UTC 0001-01-01 00:00:00 +0000 UTC ContainersNotReady containers with unready status: [nginx]} {PodScheduled True 0001-01-01 00:00:00 +0000 UTC 2018-07-02 12:54:48 +0000 UTC  }]
+Jul  2 12:55:16.608: INFO: 
+Jul  2 12:55:16.608: INFO: StatefulSet ss has not reached scale 0, at 1
+Jul  2 12:55:17.612: INFO: POD   NODE                                                  PHASE    GRACE  CONDITIONS
+Jul  2 12:55:17.612: INFO: ss-2  shoot--core--confgcp-worker-o1cev-z1-f757498dc-jzlxf  Pending  30s    [{Initialized True 0001-01-01 00:00:00 +0000 UTC 2018-07-02 12:54:48 +0000 UTC  } {Ready False 0001-01-01 00:00:00 +0000 UTC 2018-07-02 12:55:02 +0000 UTC ContainersNotReady containers with unready status: [nginx]} {ContainersReady False 0001-01-01 00:00:00 +0000 UTC 0001-01-01 00:00:00 +0000 UTC ContainersNotReady containers with unready status: [nginx]} {PodScheduled True 0001-01-01 00:00:00 +0000 UTC 2018-07-02 12:54:48 +0000 UTC  }]
+Jul  2 12:55:17.612: INFO: 
+Jul  2 12:55:17.612: INFO: StatefulSet ss has not reached scale 0, at 1
+Jul  2 12:55:18.617: INFO: POD   NODE                                                  PHASE    GRACE  CONDITIONS
+Jul  2 12:55:18.617: INFO: ss-2  shoot--core--confgcp-worker-o1cev-z1-f757498dc-jzlxf  Pending  30s    [{Initialized True 0001-01-01 00:00:00 +0000 UTC 2018-07-02 12:54:48 +0000 UTC  } {Ready False 0001-01-01 00:00:00 +0000 UTC 2018-07-02 12:55:02 +0000 UTC ContainersNotReady containers with unready status: [nginx]} {ContainersReady False 0001-01-01 00:00:00 +0000 UTC 0001-01-01 00:00:00 +0000 UTC ContainersNotReady containers with unready status: [nginx]} {PodScheduled True 0001-01-01 00:00:00 +0000 UTC 2018-07-02 12:54:48 +0000 UTC  }]
+Jul  2 12:55:18.617: INFO: 
+Jul  2 12:55:18.617: INFO: StatefulSet ss has not reached scale 0, at 1
+Jul  2 12:55:19.675: INFO: POD   NODE                                                  PHASE    GRACE  CONDITIONS
+Jul  2 12:55:19.675: INFO: ss-2  shoot--core--confgcp-worker-o1cev-z1-f757498dc-jzlxf  Pending  30s    [{Initialized True 0001-01-01 00:00:00 +0000 UTC 2018-07-02 12:54:48 +0000 UTC  } {Ready False 0001-01-01 00:00:00 +0000 UTC 2018-07-02 12:55:02 +0000 UTC ContainersNotReady containers with unready status: [nginx]} {ContainersReady False 0001-01-01 00:00:00 +0000 UTC 0001-01-01 00:00:00 +0000 UTC ContainersNotReady containers with unready status: [nginx]} {PodScheduled True 0001-01-01 00:00:00 +0000 UTC 2018-07-02 12:54:48 +0000 UTC  }]
+Jul  2 12:55:19.675: INFO: 
+Jul  2 12:55:19.675: INFO: StatefulSet ss has not reached scale 0, at 1
+Jul  2 12:55:20.680: INFO: Verifying statefulset ss doesn't scale past 0 for another 904.425915ms
+STEP: Scaling down stateful set ss to 0 replicas and waiting until none of pods will run in namespacee2e-tests-statefulset-h9c8x
+Jul  2 12:55:21.684: INFO: Scaling statefulset ss to 0
+Jul  2 12:55:21.779: INFO: Waiting for statefulset status.replicas updated to 0
+[AfterEach] [k8s.io] Basic StatefulSet functionality [StatefulSetBasic]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/statefulset.go:83
+Jul  2 12:55:21.782: INFO: Deleting all statefulset in ns e2e-tests-statefulset-h9c8x
+Jul  2 12:55:21.785: INFO: Scaling statefulset ss to 0
+Jul  2 12:55:21.795: INFO: Waiting for statefulset status.replicas updated to 0
+Jul  2 12:55:21.797: INFO: Deleting statefulset ss
+[AfterEach] [sig-apps] StatefulSet
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 12:55:21.810: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-statefulset-h9c8x" for this suite.
+Jul  2 12:55:27.824: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 12:55:27.856: INFO: namespace: e2e-tests-statefulset-h9c8x, resource: bindings, ignored listing per whitelist
+Jul  2 12:55:27.915: INFO: namespace e2e-tests-statefulset-h9c8x deletion completed in 6.100916437s
+
+• [SLOW TEST:60.204 seconds]
+[sig-apps] StatefulSet
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/framework.go:22
+  [k8s.io] Basic StatefulSet functionality [StatefulSetBasic]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:679
+    Burst scaling should run to completion even with unhealthy pods [Conformance]
+    /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSS
+------------------------------
+[sig-storage] Projected 
+  should be consumable from pods in volume with mappings and Item Mode set [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 12:55:27.915: INFO: >>> kubeConfig: /tmp/kubeconfig-293271353
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:858
+[It] should be consumable from pods in volume with mappings and Item Mode set [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating projection with secret that has name projected-secret-test-map-31c14aea-7df7-11e8-b0f5-565e625ec9a3
+STEP: Creating a pod to test consume secrets
+Jul  2 12:55:28.004: INFO: Waiting up to 5m0s for pod "pod-projected-secrets-31c1dc38-7df7-11e8-b0f5-565e625ec9a3" in namespace "e2e-tests-projected-sq6bv" to be "success or failure"
+Jul  2 12:55:28.006: INFO: Pod "pod-projected-secrets-31c1dc38-7df7-11e8-b0f5-565e625ec9a3": Phase="Pending", Reason="", readiness=false. Elapsed: 2.193224ms
+Jul  2 12:55:30.010: INFO: Pod "pod-projected-secrets-31c1dc38-7df7-11e8-b0f5-565e625ec9a3": Phase="Pending", Reason="", readiness=false. Elapsed: 2.006110314s
+Jul  2 12:55:32.075: INFO: Pod "pod-projected-secrets-31c1dc38-7df7-11e8-b0f5-565e625ec9a3": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.071346877s
+STEP: Saw pod success
+Jul  2 12:55:32.075: INFO: Pod "pod-projected-secrets-31c1dc38-7df7-11e8-b0f5-565e625ec9a3" satisfied condition "success or failure"
+Jul  2 12:55:32.078: INFO: Trying to get logs from node shoot--core--confgcp-worker-o1cev-z1-f757498dc-jzlxf pod pod-projected-secrets-31c1dc38-7df7-11e8-b0f5-565e625ec9a3 container projected-secret-volume-test: <nil>
+STEP: delete the pod
+Jul  2 12:55:32.231: INFO: Waiting for pod pod-projected-secrets-31c1dc38-7df7-11e8-b0f5-565e625ec9a3 to disappear
+Jul  2 12:55:32.234: INFO: Pod pod-projected-secrets-31c1dc38-7df7-11e8-b0f5-565e625ec9a3 no longer exists
+[AfterEach] [sig-storage] Projected
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 12:55:32.234: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-sq6bv" for this suite.
+Jul  2 12:55:38.250: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 12:55:38.293: INFO: namespace: e2e-tests-projected-sq6bv, resource: bindings, ignored listing per whitelist
+Jul  2 12:55:38.331: INFO: namespace e2e-tests-projected-sq6bv deletion completed in 6.094097188s
+
+• [SLOW TEST:10.416 seconds]
+[sig-storage] Projected
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:34
+  should be consumable from pods in volume with mappings and Item Mode set [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SS
+------------------------------
+[k8s.io] Pods 
+  should get a host IP [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [k8s.io] Pods
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 12:55:38.331: INFO: >>> kubeConfig: /tmp/kubeconfig-293271353
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [k8s.io] Pods
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/pods.go:127
+[It] should get a host IP [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: creating pod
+Jul  2 12:55:40.421: INFO: Pod pod-hostip-37f5ff34-7df7-11e8-b0f5-565e625ec9a3 has hostIP: 10.250.0.2
+[AfterEach] [k8s.io] Pods
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 12:55:40.421: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-pods-xkrjb" for this suite.
+Jul  2 12:56:02.435: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 12:56:02.519: INFO: namespace: e2e-tests-pods-xkrjb, resource: bindings, ignored listing per whitelist
+Jul  2 12:56:02.522: INFO: namespace e2e-tests-pods-xkrjb deletion completed in 22.097307475s
+
+• [SLOW TEST:24.191 seconds]
+[k8s.io] Pods
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:679
+  should get a host IP [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+S
+------------------------------
+[sig-api-machinery] CustomResourceDefinition resources Simple CustomResourceDefinition 
+  creating/deleting custom resource definition objects works  [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-api-machinery] CustomResourceDefinition resources
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 12:56:02.522: INFO: >>> kubeConfig: /tmp/kubeconfig-293271353
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] creating/deleting custom resource definition objects works  [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+Jul  2 12:56:02.601: INFO: >>> kubeConfig: /tmp/kubeconfig-293271353
+[AfterEach] [sig-api-machinery] CustomResourceDefinition resources
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 12:56:03.706: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-custom-resource-definition-2cw5q" for this suite.
+Jul  2 12:56:09.784: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 12:56:09.979: INFO: namespace: e2e-tests-custom-resource-definition-2cw5q, resource: bindings, ignored listing per whitelist
+Jul  2 12:56:09.986: INFO: namespace e2e-tests-custom-resource-definition-2cw5q deletion completed in 6.211552527s
+
+• [SLOW TEST:7.464 seconds]
+[sig-api-machinery] CustomResourceDefinition resources
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apimachinery/framework.go:22
+  Simple CustomResourceDefinition
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apimachinery/custom_resource_definition.go:35
+    creating/deleting custom resource definition objects works  [Conformance]
+    /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+S
+------------------------------
+[sig-scheduling] SchedulerPredicates [Serial] 
+  validates that NodeSelector is respected if matching  [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-scheduling] SchedulerPredicates [Serial]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 12:56:09.987: INFO: >>> kubeConfig: /tmp/kubeconfig-293271353
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-scheduling] SchedulerPredicates [Serial]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/scheduling/predicates.go:79
+Jul  2 12:56:10.060: INFO: Waiting up to 1m0s for all nodes to be ready
+Jul  2 12:57:10.085: INFO: Waiting for terminating namespaces to be deleted...
+Jul  2 12:57:10.096: INFO: Waiting up to 5m0s for all pods (need at least 0) in namespace 'kube-system' to be running and ready
+Jul  2 12:57:10.108: INFO: 14 / 14 pods in namespace 'kube-system' are running and ready (0 seconds elapsed)
+Jul  2 12:57:10.108: INFO: expected 8 pod replicas in namespace 'kube-system', 8 are Running and Ready.
+Jul  2 12:57:10.112: INFO: Waiting for pods to enter Success, but no pods in "kube-system" match label map[name:e2e-image-puller]
+Jul  2 12:57:10.112: INFO: 
+Logging pods the kubelet thinks is on node shoot--core--confgcp-worker-o1cev-z1-f757498dc-jzlxf before test
+Jul  2 12:57:10.176: INFO: kube-proxy-tplxb from kube-system started at 2018-07-02 12:47:10 +0000 UTC (1 container statuses recorded)
+Jul  2 12:57:10.176: INFO: 	Container kube-proxy ready: true, restart count 0
+Jul  2 12:57:10.176: INFO: calico-node-l9lrq from kube-system started at 2018-07-02 12:47:10 +0000 UTC (2 container statuses recorded)
+Jul  2 12:57:10.176: INFO: 	Container calico-node ready: true, restart count 0
+Jul  2 12:57:10.176: INFO: 	Container install-cni ready: true, restart count 0
+Jul  2 12:57:10.176: INFO: node-exporter-lj6t9 from kube-system started at 2018-07-02 12:47:10 +0000 UTC (1 container statuses recorded)
+Jul  2 12:57:10.176: INFO: 	Container node-exporter ready: true, restart count 0
+Jul  2 12:57:10.176: INFO: kube-dns-9c4dfc4fb-mppdx from kube-system started at 2018-07-02 12:48:11 +0000 UTC (3 container statuses recorded)
+Jul  2 12:57:10.176: INFO: 	Container dnsmasq ready: true, restart count 0
+Jul  2 12:57:10.176: INFO: 	Container kubedns ready: true, restart count 0
+Jul  2 12:57:10.176: INFO: 	Container sidecar ready: true, restart count 0
+Jul  2 12:57:10.176: INFO: sonobuoy from sonobuoy started at 2018-07-02 12:53:54 +0000 UTC (1 container statuses recorded)
+Jul  2 12:57:10.176: INFO: 	Container kube-sonobuoy ready: true, restart count 0
+Jul  2 12:57:10.176: INFO: sonobuoy-e2e-job-32b8333ad53140e4 from sonobuoy started at 2018-07-02 12:54:10 +0000 UTC (2 container statuses recorded)
+Jul  2 12:57:10.176: INFO: 	Container e2e ready: true, restart count 0
+Jul  2 12:57:10.176: INFO: 	Container sonobuoy-worker ready: true, restart count 0
+Jul  2 12:57:10.176: INFO: 
+Logging pods the kubelet thinks is on node shoot--core--confgcp-worker-o1cev-z1-f757498dc-qrtzr before test
+Jul  2 12:57:10.318: INFO: kube-dns-9c4dfc4fb-bcfks from kube-system started at 2018-07-02 12:47:38 +0000 UTC (3 container statuses recorded)
+Jul  2 12:57:10.318: INFO: 	Container dnsmasq ready: true, restart count 0
+Jul  2 12:57:10.318: INFO: 	Container kubedns ready: true, restart count 0
+Jul  2 12:57:10.318: INFO: 	Container sidecar ready: true, restart count 0
+Jul  2 12:57:10.318: INFO: kube-dns-autoscaler-6dd4765967-p2xtm from kube-system started at 2018-07-02 12:47:38 +0000 UTC (1 container statuses recorded)
+Jul  2 12:57:10.318: INFO: 	Container autoscaler ready: true, restart count 0
+Jul  2 12:57:10.318: INFO: addons-nginx-ingress-nginx-ingress-k8s-backend-7b5569797f-574s7 from kube-system started at 2018-07-02 12:47:38 +0000 UTC (1 container statuses recorded)
+Jul  2 12:57:10.318: INFO: 	Container nginx-ingress-nginx-ingress-k8s-backend ready: true, restart count 0
+Jul  2 12:57:10.318: INFO: addons-heapster-e3b0c-64455ddddb-zgn7v from kube-system started at 2018-07-02 12:47:38 +0000 UTC (2 container statuses recorded)
+Jul  2 12:57:10.318: INFO: 	Container heapster ready: true, restart count 0
+Jul  2 12:57:10.318: INFO: 	Container heapster-nanny ready: true, restart count 0
+Jul  2 12:57:10.318: INFO: addons-nginx-ingress-controller-79bfb57974-q2zxk from kube-system started at 2018-07-02 12:47:38 +0000 UTC (1 container statuses recorded)
+Jul  2 12:57:10.318: INFO: 	Container nginx-ingress-controller ready: true, restart count 0
+Jul  2 12:57:10.318: INFO: addons-kubernetes-dashboard-5486b968b7-wwpw5 from kube-system started at 2018-07-02 12:47:38 +0000 UTC (1 container statuses recorded)
+Jul  2 12:57:10.318: INFO: 	Container main ready: true, restart count 0
+Jul  2 12:57:10.318: INFO: vpn-shoot-c6458b4c-mtnxr from kube-system started at 2018-07-02 12:47:38 +0000 UTC (1 container statuses recorded)
+Jul  2 12:57:10.318: INFO: 	Container vpn-shoot ready: true, restart count 0
+Jul  2 12:57:10.318: INFO: calico-node-49xvm from kube-system started at 2018-07-02 12:47:08 +0000 UTC (2 container statuses recorded)
+Jul  2 12:57:10.318: INFO: 	Container calico-node ready: true, restart count 0
+Jul  2 12:57:10.318: INFO: 	Container install-cni ready: true, restart count 0
+Jul  2 12:57:10.318: INFO: kube-proxy-lddpf from kube-system started at 2018-07-02 12:47:08 +0000 UTC (1 container statuses recorded)
+Jul  2 12:57:10.318: INFO: 	Container kube-proxy ready: true, restart count 0
+Jul  2 12:57:10.318: INFO: node-exporter-fjp5f from kube-system started at 2018-07-02 12:47:08 +0000 UTC (1 container statuses recorded)
+Jul  2 12:57:10.318: INFO: 	Container node-exporter ready: true, restart count 0
+[It] validates that NodeSelector is respected if matching  [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Trying to launch a pod without a label to get a node which can launch it.
+STEP: Explicitly delete pod here to free the resource it takes.
+STEP: Trying to apply a random label on the found node.
+STEP: verifying the node has the label kubernetes.io/e2e-6ff378a9-7df7-11e8-b0f5-565e625ec9a3 42
+STEP: Trying to relaunch the pod, now with labels.
+STEP: removing the label kubernetes.io/e2e-6ff378a9-7df7-11e8-b0f5-565e625ec9a3 off the node shoot--core--confgcp-worker-o1cev-z1-f757498dc-jzlxf
+STEP: verifying the node doesn't have the label kubernetes.io/e2e-6ff378a9-7df7-11e8-b0f5-565e625ec9a3
+[AfterEach] [sig-scheduling] SchedulerPredicates [Serial]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 12:57:14.375: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-sched-pred-lxh6l" for this suite.
+Jul  2 12:57:36.389: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 12:57:36.449: INFO: namespace: e2e-tests-sched-pred-lxh6l, resource: bindings, ignored listing per whitelist
+Jul  2 12:57:36.501: INFO: namespace e2e-tests-sched-pred-lxh6l deletion completed in 22.123243825s
+[AfterEach] [sig-scheduling] SchedulerPredicates [Serial]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/scheduling/predicates.go:70
+
+• [SLOW TEST:86.515 seconds]
+[sig-scheduling] SchedulerPredicates [Serial]
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/scheduling/framework.go:22
+  validates that NodeSelector is respected if matching  [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSS
+------------------------------
+[sig-storage] EmptyDir volumes 
+  should support (root,0777,default) [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-storage] EmptyDir volumes
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 12:57:36.502: INFO: >>> kubeConfig: /tmp/kubeconfig-293271353
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should support (root,0777,default) [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating a pod to test emptydir 0777 on node default medium
+Jul  2 12:57:36.585: INFO: Waiting up to 5m0s for pod "pod-7e65f704-7df7-11e8-b0f5-565e625ec9a3" in namespace "e2e-tests-emptydir-c8h7v" to be "success or failure"
+Jul  2 12:57:36.587: INFO: Pod "pod-7e65f704-7df7-11e8-b0f5-565e625ec9a3": Phase="Pending", Reason="", readiness=false. Elapsed: 2.110192ms
+Jul  2 12:57:38.592: INFO: Pod "pod-7e65f704-7df7-11e8-b0f5-565e625ec9a3": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.006992898s
+STEP: Saw pod success
+Jul  2 12:57:38.592: INFO: Pod "pod-7e65f704-7df7-11e8-b0f5-565e625ec9a3" satisfied condition "success or failure"
+Jul  2 12:57:38.595: INFO: Trying to get logs from node shoot--core--confgcp-worker-o1cev-z1-f757498dc-jzlxf pod pod-7e65f704-7df7-11e8-b0f5-565e625ec9a3 container test-container: <nil>
+STEP: delete the pod
+Jul  2 12:57:38.618: INFO: Waiting for pod pod-7e65f704-7df7-11e8-b0f5-565e625ec9a3 to disappear
+Jul  2 12:57:38.621: INFO: Pod pod-7e65f704-7df7-11e8-b0f5-565e625ec9a3 no longer exists
+[AfterEach] [sig-storage] EmptyDir volumes
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 12:57:38.621: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-emptydir-c8h7v" for this suite.
+Jul  2 12:57:44.635: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 12:57:44.728: INFO: namespace: e2e-tests-emptydir-c8h7v, resource: bindings, ignored listing per whitelist
+Jul  2 12:57:44.751: INFO: namespace e2e-tests-emptydir-c8h7v deletion completed in 6.125164974s
+
+• [SLOW TEST:8.249 seconds]
+[sig-storage] EmptyDir volumes
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/empty_dir.go:40
+  should support (root,0777,default) [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+S
+------------------------------
+[sig-network] Services 
+  should provide secure master service  [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-network] Services
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 12:57:44.751: INFO: >>> kubeConfig: /tmp/kubeconfig-293271353
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-network] Services
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/network/service.go:83
+[It] should provide secure master service  [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[AfterEach] [sig-network] Services
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 12:57:44.831: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-services-lxqmm" for this suite.
+Jul  2 12:57:50.844: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 12:57:50.888: INFO: namespace: e2e-tests-services-lxqmm, resource: bindings, ignored listing per whitelist
+Jul  2 12:57:50.927: INFO: namespace e2e-tests-services-lxqmm deletion completed in 6.092536541s
+[AfterEach] [sig-network] Services
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/network/service.go:88
+
+• [SLOW TEST:6.176 seconds]
+[sig-network] Services
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/network/framework.go:22
+  should provide secure master service  [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSS
+------------------------------
+[k8s.io] Pods 
+  should be updated [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [k8s.io] Pods
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 12:57:50.927: INFO: >>> kubeConfig: /tmp/kubeconfig-293271353
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [k8s.io] Pods
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/pods.go:127
+[It] should be updated [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: creating the pod
+STEP: submitting the pod to kubernetes
+STEP: verifying the pod is in kubernetes
+STEP: updating the pod
+Jul  2 12:57:53.577: INFO: Successfully updated pod "pod-update-86ff2087-7df7-11e8-b0f5-565e625ec9a3"
+STEP: verifying the updated pod is in kubernetes
+Jul  2 12:57:53.582: INFO: Pod update OK
+[AfterEach] [k8s.io] Pods
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 12:57:53.582: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-pods-rmllv" for this suite.
+Jul  2 12:58:15.594: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 12:58:15.716: INFO: namespace: e2e-tests-pods-rmllv, resource: bindings, ignored listing per whitelist
+Jul  2 12:58:15.756: INFO: namespace e2e-tests-pods-rmllv deletion completed in 22.171336806s
+
+• [SLOW TEST:24.829 seconds]
+[k8s.io] Pods
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:679
+  should be updated [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+S
+------------------------------
+[sig-storage] Secrets 
+  should be consumable from pods in volume with defaultMode set [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-storage] Secrets
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 12:58:15.756: INFO: >>> kubeConfig: /tmp/kubeconfig-293271353
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should be consumable from pods in volume with defaultMode set [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating secret with name secret-test-95cbd31d-7df7-11e8-b0f5-565e625ec9a3
+STEP: Creating a pod to test consume secrets
+Jul  2 12:58:15.844: INFO: Waiting up to 5m0s for pod "pod-secrets-95cc51f6-7df7-11e8-b0f5-565e625ec9a3" in namespace "e2e-tests-secrets-szzz2" to be "success or failure"
+Jul  2 12:58:15.847: INFO: Pod "pod-secrets-95cc51f6-7df7-11e8-b0f5-565e625ec9a3": Phase="Pending", Reason="", readiness=false. Elapsed: 2.704224ms
+Jul  2 12:58:17.851: INFO: Pod "pod-secrets-95cc51f6-7df7-11e8-b0f5-565e625ec9a3": Phase="Pending", Reason="", readiness=false. Elapsed: 2.006847297s
+Jul  2 12:58:19.855: INFO: Pod "pod-secrets-95cc51f6-7df7-11e8-b0f5-565e625ec9a3": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.011011642s
+STEP: Saw pod success
+Jul  2 12:58:19.855: INFO: Pod "pod-secrets-95cc51f6-7df7-11e8-b0f5-565e625ec9a3" satisfied condition "success or failure"
+Jul  2 12:58:19.858: INFO: Trying to get logs from node shoot--core--confgcp-worker-o1cev-z1-f757498dc-jzlxf pod pod-secrets-95cc51f6-7df7-11e8-b0f5-565e625ec9a3 container secret-volume-test: <nil>
+STEP: delete the pod
+Jul  2 12:58:19.875: INFO: Waiting for pod pod-secrets-95cc51f6-7df7-11e8-b0f5-565e625ec9a3 to disappear
+Jul  2 12:58:19.894: INFO: Pod pod-secrets-95cc51f6-7df7-11e8-b0f5-565e625ec9a3 no longer exists
+[AfterEach] [sig-storage] Secrets
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 12:58:19.894: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-secrets-szzz2" for this suite.
+Jul  2 12:58:25.923: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 12:58:25.964: INFO: namespace: e2e-tests-secrets-szzz2, resource: bindings, ignored listing per whitelist
+Jul  2 12:58:26.018: INFO: namespace e2e-tests-secrets-szzz2 deletion completed in 6.108602209s
+
+• [SLOW TEST:10.262 seconds]
+[sig-storage] Secrets
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/secrets_volume.go:33
+  should be consumable from pods in volume with defaultMode set [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+[k8s.io] Docker Containers 
+  should be able to override the image's default command (docker entrypoint) [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [k8s.io] Docker Containers
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 12:58:26.018: INFO: >>> kubeConfig: /tmp/kubeconfig-293271353
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should be able to override the image's default command (docker entrypoint) [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating a pod to test override command
+Jul  2 12:58:26.123: INFO: Waiting up to 5m0s for pod "client-containers-9beca140-7df7-11e8-b0f5-565e625ec9a3" in namespace "e2e-tests-containers-2t7wh" to be "success or failure"
+Jul  2 12:58:26.127: INFO: Pod "client-containers-9beca140-7df7-11e8-b0f5-565e625ec9a3": Phase="Pending", Reason="", readiness=false. Elapsed: 4.345428ms
+Jul  2 12:58:28.133: INFO: Pod "client-containers-9beca140-7df7-11e8-b0f5-565e625ec9a3": Phase="Pending", Reason="", readiness=false. Elapsed: 2.010260657s
+Jul  2 12:58:30.137: INFO: Pod "client-containers-9beca140-7df7-11e8-b0f5-565e625ec9a3": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.014443972s
+STEP: Saw pod success
+Jul  2 12:58:30.137: INFO: Pod "client-containers-9beca140-7df7-11e8-b0f5-565e625ec9a3" satisfied condition "success or failure"
+Jul  2 12:58:30.140: INFO: Trying to get logs from node shoot--core--confgcp-worker-o1cev-z1-f757498dc-jzlxf pod client-containers-9beca140-7df7-11e8-b0f5-565e625ec9a3 container test-container: <nil>
+STEP: delete the pod
+Jul  2 12:58:30.157: INFO: Waiting for pod client-containers-9beca140-7df7-11e8-b0f5-565e625ec9a3 to disappear
+Jul  2 12:58:30.160: INFO: Pod client-containers-9beca140-7df7-11e8-b0f5-565e625ec9a3 no longer exists
+[AfterEach] [k8s.io] Docker Containers
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 12:58:30.160: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-containers-2t7wh" for this suite.
+Jul  2 12:58:36.173: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 12:58:36.245: INFO: namespace: e2e-tests-containers-2t7wh, resource: bindings, ignored listing per whitelist
+Jul  2 12:58:36.269: INFO: namespace e2e-tests-containers-2t7wh deletion completed in 6.10600196s
+
+• [SLOW TEST:10.251 seconds]
+[k8s.io] Docker Containers
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:679
+  should be able to override the image's default command (docker entrypoint) [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SS
+------------------------------
+[k8s.io] Probing container 
+  with readiness probe should not be ready before initial delay and never restart [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [k8s.io] Probing container
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 12:58:36.269: INFO: >>> kubeConfig: /tmp/kubeconfig-293271353
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [k8s.io] Probing container
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/container_probe.go:48
+[It] with readiness probe should not be ready before initial delay and never restart [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+Jul  2 12:59:00.472: INFO: Container started at 2018-07-02 12:58:38 +0000 UTC, pod became ready at 2018-07-02 12:58:58 +0000 UTC
+[AfterEach] [k8s.io] Probing container
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 12:59:00.473: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-container-probe-rk5tv" for this suite.
+Jul  2 12:59:22.487: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 12:59:22.503: INFO: namespace: e2e-tests-container-probe-rk5tv, resource: bindings, ignored listing per whitelist
+Jul  2 12:59:22.639: INFO: namespace e2e-tests-container-probe-rk5tv deletion completed in 22.162340387s
+
+• [SLOW TEST:46.370 seconds]
+[k8s.io] Probing container
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:679
+  with readiness probe should not be ready before initial delay and never restart [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SS
+------------------------------
+[sig-api-machinery] Garbage collector 
+  should orphan pods created by rc if delete options say so [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-api-machinery] Garbage collector
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 12:59:22.639: INFO: >>> kubeConfig: /tmp/kubeconfig-293271353
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should orphan pods created by rc if delete options say so [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: create the rc
+STEP: delete the rc
+STEP: wait for the rc to be deleted
+STEP: wait for 30 seconds to see if the garbage collector mistakenly deletes the pods
+STEP: Gathering metrics
+W0702 13:00:02.876688      18 metrics_grabber.go:81] Master node is not registered. Grabbing metrics from Scheduler, ControllerManager and ClusterAutoscaler is disabled.
+Jul  2 13:00:02.876: INFO: For apiserver_request_count:
+For apiserver_request_latencies_summary:
+For etcd_helper_cache_entry_count:
+For etcd_helper_cache_hit_count:
+For etcd_helper_cache_miss_count:
+For etcd_request_cache_add_latencies_summary:
+For etcd_request_cache_get_latencies_summary:
+For etcd_request_latencies_summary:
+For garbage_collector_attempt_to_delete_queue_latency:
+For garbage_collector_attempt_to_delete_work_duration:
+For garbage_collector_attempt_to_orphan_queue_latency:
+For garbage_collector_attempt_to_orphan_work_duration:
+For garbage_collector_dirty_processing_latency_microseconds:
+For garbage_collector_event_processing_latency_microseconds:
+For garbage_collector_graph_changes_queue_latency:
+For garbage_collector_graph_changes_work_duration:
+For garbage_collector_orphan_processing_latency_microseconds:
+For namespace_queue_latency:
+For namespace_queue_latency_sum:
+For namespace_queue_latency_count:
+For namespace_retries:
+For namespace_work_duration:
+For namespace_work_duration_sum:
+For namespace_work_duration_count:
+For function_duration_seconds:
+For errors_total:
+For evicted_pods_total:
+
+[AfterEach] [sig-api-machinery] Garbage collector
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:00:02.876: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-gc-dmscn" for this suite.
+Jul  2 13:00:08.892: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:00:08.987: INFO: namespace: e2e-tests-gc-dmscn, resource: bindings, ignored listing per whitelist
+Jul  2 13:00:08.999: INFO: namespace e2e-tests-gc-dmscn deletion completed in 6.119702484s
+
+• [SLOW TEST:46.361 seconds]
+[sig-api-machinery] Garbage collector
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apimachinery/framework.go:22
+  should orphan pods created by rc if delete options say so [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSSSSSSSSSSSSSSSSSSSS
+------------------------------
+[sig-storage] EmptyDir volumes 
+  should support (root,0777,tmpfs) [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-storage] EmptyDir volumes
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:00:09.000: INFO: >>> kubeConfig: /tmp/kubeconfig-293271353
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should support (root,0777,tmpfs) [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating a pod to test emptydir 0777 on tmpfs
+Jul  2 13:00:09.091: INFO: Waiting up to 5m0s for pod "pod-d94c5687-7df7-11e8-b0f5-565e625ec9a3" in namespace "e2e-tests-emptydir-rrsfb" to be "success or failure"
+Jul  2 13:00:09.093: INFO: Pod "pod-d94c5687-7df7-11e8-b0f5-565e625ec9a3": Phase="Pending", Reason="", readiness=false. Elapsed: 2.68546ms
+Jul  2 13:00:11.098: INFO: Pod "pod-d94c5687-7df7-11e8-b0f5-565e625ec9a3": Phase="Pending", Reason="", readiness=false. Elapsed: 2.007388902s
+Jul  2 13:00:13.102: INFO: Pod "pod-d94c5687-7df7-11e8-b0f5-565e625ec9a3": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.01141274s
+STEP: Saw pod success
+Jul  2 13:00:13.102: INFO: Pod "pod-d94c5687-7df7-11e8-b0f5-565e625ec9a3" satisfied condition "success or failure"
+Jul  2 13:00:13.105: INFO: Trying to get logs from node shoot--core--confgcp-worker-o1cev-z1-f757498dc-jzlxf pod pod-d94c5687-7df7-11e8-b0f5-565e625ec9a3 container test-container: <nil>
+STEP: delete the pod
+Jul  2 13:00:13.121: INFO: Waiting for pod pod-d94c5687-7df7-11e8-b0f5-565e625ec9a3 to disappear
+Jul  2 13:00:13.127: INFO: Pod pod-d94c5687-7df7-11e8-b0f5-565e625ec9a3 no longer exists
+[AfterEach] [sig-storage] EmptyDir volumes
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:00:13.127: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-emptydir-rrsfb" for this suite.
+Jul  2 13:00:19.142: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:00:19.176: INFO: namespace: e2e-tests-emptydir-rrsfb, resource: bindings, ignored listing per whitelist
+Jul  2 13:00:19.238: INFO: namespace e2e-tests-emptydir-rrsfb deletion completed in 6.107347459s
+
+• [SLOW TEST:10.238 seconds]
+[sig-storage] EmptyDir volumes
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/empty_dir.go:40
+  should support (root,0777,tmpfs) [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+S
+------------------------------
+[sig-storage] Downward API volume 
+  should update labels on modification [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:00:19.238: INFO: >>> kubeConfig: /tmp/kubeconfig-293271353
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downwardapi_volume.go:38
+[It] should update labels on modification [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating the pod
+Jul  2 13:00:21.863: INFO: Successfully updated pod "labelsupdatedf679102-7df7-11e8-b0f5-565e625ec9a3"
+[AfterEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:00:23.881: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-downward-api-56dq5" for this suite.
+Jul  2 13:00:43.985: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:00:43.991: INFO: namespace: e2e-tests-downward-api-56dq5, resource: bindings, ignored listing per whitelist
+Jul  2 13:00:44.081: INFO: namespace e2e-tests-downward-api-56dq5 deletion completed in 20.108236804s
+
+• [SLOW TEST:24.842 seconds]
+[sig-storage] Downward API volume
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downwardapi_volume.go:33
+  should update labels on modification [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SS
+------------------------------
+[sig-apps] Daemon set [Serial] 
+  should run and stop complex daemon [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-apps] Daemon set [Serial]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:00:44.081: INFO: >>> kubeConfig: /tmp/kubeconfig-293271353
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-apps] Daemon set [Serial]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/daemon_set.go:99
+[It] should run and stop complex daemon [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+Jul  2 13:00:44.178: INFO: Creating daemon "daemon-set" with a node selector
+STEP: Initially, daemon pods should not be running on any nodes.
+Jul  2 13:00:44.184: INFO: Number of nodes with available pods: 0
+Jul  2 13:00:44.185: INFO: Number of running nodes: 0, number of available pods: 0
+STEP: Change node label to blue, check that daemon pod is launched.
+Jul  2 13:00:44.198: INFO: Number of nodes with available pods: 0
+Jul  2 13:00:44.198: INFO: Node shoot--core--confgcp-worker-o1cev-z1-f757498dc-jzlxf is running more than one daemon pod
+Jul  2 13:00:45.202: INFO: Number of nodes with available pods: 0
+Jul  2 13:00:45.202: INFO: Node shoot--core--confgcp-worker-o1cev-z1-f757498dc-jzlxf is running more than one daemon pod
+Jul  2 13:00:46.204: INFO: Number of nodes with available pods: 0
+Jul  2 13:00:46.204: INFO: Node shoot--core--confgcp-worker-o1cev-z1-f757498dc-jzlxf is running more than one daemon pod
+Jul  2 13:00:47.202: INFO: Number of nodes with available pods: 1
+Jul  2 13:00:47.202: INFO: Number of running nodes: 1, number of available pods: 1
+STEP: Update the node label to green, and wait for daemons to be unscheduled
+Jul  2 13:00:47.216: INFO: Number of nodes with available pods: 1
+Jul  2 13:00:47.216: INFO: Number of running nodes: 0, number of available pods: 1
+Jul  2 13:00:48.220: INFO: Number of nodes with available pods: 0
+Jul  2 13:00:48.220: INFO: Number of running nodes: 0, number of available pods: 0
+STEP: Update DaemonSet node selector to green, and change its update strategy to RollingUpdate
+Jul  2 13:00:48.227: INFO: Number of nodes with available pods: 0
+Jul  2 13:00:48.227: INFO: Node shoot--core--confgcp-worker-o1cev-z1-f757498dc-jzlxf is running more than one daemon pod
+Jul  2 13:00:49.233: INFO: Number of nodes with available pods: 0
+Jul  2 13:00:49.233: INFO: Node shoot--core--confgcp-worker-o1cev-z1-f757498dc-jzlxf is running more than one daemon pod
+Jul  2 13:00:50.232: INFO: Number of nodes with available pods: 0
+Jul  2 13:00:50.232: INFO: Node shoot--core--confgcp-worker-o1cev-z1-f757498dc-jzlxf is running more than one daemon pod
+Jul  2 13:00:51.232: INFO: Number of nodes with available pods: 0
+Jul  2 13:00:51.232: INFO: Node shoot--core--confgcp-worker-o1cev-z1-f757498dc-jzlxf is running more than one daemon pod
+Jul  2 13:00:52.232: INFO: Number of nodes with available pods: 0
+Jul  2 13:00:52.232: INFO: Node shoot--core--confgcp-worker-o1cev-z1-f757498dc-jzlxf is running more than one daemon pod
+Jul  2 13:00:53.273: INFO: Number of nodes with available pods: 1
+Jul  2 13:00:53.273: INFO: Number of running nodes: 1, number of available pods: 1
+[AfterEach] [sig-apps] Daemon set [Serial]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/daemon_set.go:65
+STEP: Deleting DaemonSet "daemon-set"
+STEP: deleting {extensions DaemonSet} daemon-set in namespace e2e-tests-daemonsets-hkdvk, will wait for the garbage collector to delete the pods
+Jul  2 13:00:53.342: INFO: Deleting {extensions DaemonSet} daemon-set took: 6.146078ms
+Jul  2 13:00:53.443: INFO: Terminating {extensions DaemonSet} daemon-set pods took: 100.225401ms
+Jul  2 13:00:56.646: INFO: Number of nodes with available pods: 0
+Jul  2 13:00:56.647: INFO: Number of running nodes: 0, number of available pods: 0
+Jul  2 13:00:56.651: INFO: daemonset: {"kind":"DaemonSetList","apiVersion":"apps/v1","metadata":{"selfLink":"/apis/apps/v1/namespaces/e2e-tests-daemonsets-hkdvk/daemonsets","resourceVersion":"2767"},"items":null}
+
+Jul  2 13:00:56.655: INFO: pods: {"kind":"PodList","apiVersion":"v1","metadata":{"selfLink":"/api/v1/namespaces/e2e-tests-daemonsets-hkdvk/pods","resourceVersion":"2767"},"items":null}
+
+[AfterEach] [sig-apps] Daemon set [Serial]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:00:56.673: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-daemonsets-hkdvk" for this suite.
+Jul  2 13:01:02.734: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:01:03.001: INFO: namespace: e2e-tests-daemonsets-hkdvk, resource: bindings, ignored listing per whitelist
+Jul  2 13:01:03.050: INFO: namespace e2e-tests-daemonsets-hkdvk deletion completed in 6.364323081s
+
+• [SLOW TEST:18.969 seconds]
+[sig-apps] Daemon set [Serial]
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/framework.go:22
+  should run and stop complex daemon [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSSSSSS
+------------------------------
+[sig-storage] EmptyDir volumes 
+  volume on tmpfs should have the correct mode [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-storage] EmptyDir volumes
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:01:03.050: INFO: >>> kubeConfig: /tmp/kubeconfig-293271353
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] volume on tmpfs should have the correct mode [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating a pod to test emptydir volume type on tmpfs
+Jul  2 13:01:03.166: INFO: Waiting up to 5m0s for pod "pod-f9876193-7df7-11e8-b0f5-565e625ec9a3" in namespace "e2e-tests-emptydir-nrvlp" to be "success or failure"
+Jul  2 13:01:03.169: INFO: Pod "pod-f9876193-7df7-11e8-b0f5-565e625ec9a3": Phase="Pending", Reason="", readiness=false. Elapsed: 3.422246ms
+Jul  2 13:01:05.180: INFO: Pod "pod-f9876193-7df7-11e8-b0f5-565e625ec9a3": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.014228331s
+STEP: Saw pod success
+Jul  2 13:01:05.180: INFO: Pod "pod-f9876193-7df7-11e8-b0f5-565e625ec9a3" satisfied condition "success or failure"
+Jul  2 13:01:05.190: INFO: Trying to get logs from node shoot--core--confgcp-worker-o1cev-z1-f757498dc-jzlxf pod pod-f9876193-7df7-11e8-b0f5-565e625ec9a3 container test-container: <nil>
+STEP: delete the pod
+Jul  2 13:01:05.298: INFO: Waiting for pod pod-f9876193-7df7-11e8-b0f5-565e625ec9a3 to disappear
+Jul  2 13:01:05.306: INFO: Pod pod-f9876193-7df7-11e8-b0f5-565e625ec9a3 no longer exists
+[AfterEach] [sig-storage] EmptyDir volumes
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:01:05.306: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-emptydir-nrvlp" for this suite.
+Jul  2 13:01:11.339: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:01:11.429: INFO: namespace: e2e-tests-emptydir-nrvlp, resource: bindings, ignored listing per whitelist
+Jul  2 13:01:11.525: INFO: namespace e2e-tests-emptydir-nrvlp deletion completed in 6.209980017s
+
+• [SLOW TEST:8.475 seconds]
+[sig-storage] EmptyDir volumes
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/empty_dir.go:40
+  volume on tmpfs should have the correct mode [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSS
+------------------------------
+[sig-api-machinery] Garbage collector 
+  should not be blocked by dependency circle [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-api-machinery] Garbage collector
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:01:11.525: INFO: >>> kubeConfig: /tmp/kubeconfig-293271353
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should not be blocked by dependency circle [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+Jul  2 13:01:11.809: INFO: pod1.ObjectMeta.OwnerReferences=[]v1.OwnerReference{v1.OwnerReference{APIVersion:"v1", Kind:"Pod", Name:"pod3", UID:"feb27456-7df7-11e8-876c-5e517afbca85", Controller:(*bool)(0xc421e54aae), BlockOwnerDeletion:(*bool)(0xc421e54aaf)}}
+Jul  2 13:01:11.824: INFO: pod2.ObjectMeta.OwnerReferences=[]v1.OwnerReference{v1.OwnerReference{APIVersion:"v1", Kind:"Pod", Name:"pod1", UID:"feaf242c-7df7-11e8-876c-5e517afbca85", Controller:(*bool)(0xc421dc13ce), BlockOwnerDeletion:(*bool)(0xc421dc13cf)}}
+Jul  2 13:01:11.830: INFO: pod3.ObjectMeta.OwnerReferences=[]v1.OwnerReference{v1.OwnerReference{APIVersion:"v1", Kind:"Pod", Name:"pod2", UID:"feb0c10a-7df7-11e8-876c-5e517afbca85", Controller:(*bool)(0xc421d4d696), BlockOwnerDeletion:(*bool)(0xc421d4d697)}}
+[AfterEach] [sig-api-machinery] Garbage collector
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:01:16.843: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-gc-prn8j" for this suite.
+Jul  2 13:01:22.869: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:01:23.014: INFO: namespace: e2e-tests-gc-prn8j, resource: bindings, ignored listing per whitelist
+Jul  2 13:01:23.023: INFO: namespace e2e-tests-gc-prn8j deletion completed in 6.173311771s
+
+• [SLOW TEST:11.498 seconds]
+[sig-api-machinery] Garbage collector
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apimachinery/framework.go:22
+  should not be blocked by dependency circle [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS
+------------------------------
+[sig-apps] Daemon set [Serial] 
+  should rollback without unnecessary restarts [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-apps] Daemon set [Serial]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:01:23.024: INFO: >>> kubeConfig: /tmp/kubeconfig-293271353
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-apps] Daemon set [Serial]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/daemon_set.go:99
+[It] should rollback without unnecessary restarts [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+Jul  2 13:01:23.119: INFO: Requires at least 2 nodes (not -1)
+[AfterEach] [sig-apps] Daemon set [Serial]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/daemon_set.go:65
+Jul  2 13:01:23.125: INFO: daemonset: {"kind":"DaemonSetList","apiVersion":"apps/v1","metadata":{"selfLink":"/apis/apps/v1/namespaces/e2e-tests-daemonsets-kcf2x/daemonsets","resourceVersion":"2879"},"items":null}
+
+Jul  2 13:01:23.127: INFO: pods: {"kind":"PodList","apiVersion":"v1","metadata":{"selfLink":"/api/v1/namespaces/e2e-tests-daemonsets-kcf2x/pods","resourceVersion":"2879"},"items":null}
+
+[AfterEach] [sig-apps] Daemon set [Serial]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:01:23.136: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-daemonsets-kcf2x" for this suite.
+Jul  2 13:01:29.149: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:01:29.240: INFO: namespace: e2e-tests-daemonsets-kcf2x, resource: bindings, ignored listing per whitelist
+Jul  2 13:01:29.250: INFO: namespace e2e-tests-daemonsets-kcf2x deletion completed in 6.111117559s
+
+S [SKIPPING] [6.226 seconds]
+[sig-apps] Daemon set [Serial]
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/framework.go:22
+  should rollback without unnecessary restarts [Conformance] [It]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+
+  Jul  2 13:01:23.119: Requires at least 2 nodes (not -1)
+
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/util.go:305
+------------------------------
+SSS
+------------------------------
+[sig-storage] Projected 
+  should set DefaultMode on files [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:01:29.250: INFO: >>> kubeConfig: /tmp/kubeconfig-293271353
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:858
+[It] should set DefaultMode on files [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating a pod to test downward API volume plugin
+Jul  2 13:01:29.331: INFO: Waiting up to 5m0s for pod "downwardapi-volume-092007e4-7df8-11e8-b0f5-565e625ec9a3" in namespace "e2e-tests-projected-7xp6n" to be "success or failure"
+Jul  2 13:01:29.334: INFO: Pod "downwardapi-volume-092007e4-7df8-11e8-b0f5-565e625ec9a3": Phase="Pending", Reason="", readiness=false. Elapsed: 2.84011ms
+Jul  2 13:01:31.337: INFO: Pod "downwardapi-volume-092007e4-7df8-11e8-b0f5-565e625ec9a3": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.00666599s
+STEP: Saw pod success
+Jul  2 13:01:31.337: INFO: Pod "downwardapi-volume-092007e4-7df8-11e8-b0f5-565e625ec9a3" satisfied condition "success or failure"
+Jul  2 13:01:31.340: INFO: Trying to get logs from node shoot--core--confgcp-worker-o1cev-z1-f757498dc-jzlxf pod downwardapi-volume-092007e4-7df8-11e8-b0f5-565e625ec9a3 container client-container: <nil>
+STEP: delete the pod
+Jul  2 13:01:31.358: INFO: Waiting for pod downwardapi-volume-092007e4-7df8-11e8-b0f5-565e625ec9a3 to disappear
+Jul  2 13:01:31.360: INFO: Pod downwardapi-volume-092007e4-7df8-11e8-b0f5-565e625ec9a3 no longer exists
+[AfterEach] [sig-storage] Projected
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:01:31.360: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-7xp6n" for this suite.
+Jul  2 13:01:37.374: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:01:37.427: INFO: namespace: e2e-tests-projected-7xp6n, resource: bindings, ignored listing per whitelist
+Jul  2 13:01:37.460: INFO: namespace e2e-tests-projected-7xp6n deletion completed in 6.096510219s
+
+• [SLOW TEST:8.210 seconds]
+[sig-storage] Projected
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:34
+  should set DefaultMode on files [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSSSSSSSSSSSSS
+------------------------------
+[sig-storage] Projected 
+  should provide container's cpu request [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:01:37.460: INFO: >>> kubeConfig: /tmp/kubeconfig-293271353
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:858
+[It] should provide container's cpu request [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating a pod to test downward API volume plugin
+Jul  2 13:01:37.545: INFO: Waiting up to 5m0s for pod "downwardapi-volume-0e0571c3-7df8-11e8-b0f5-565e625ec9a3" in namespace "e2e-tests-projected-vlcjm" to be "success or failure"
+Jul  2 13:01:37.547: INFO: Pod "downwardapi-volume-0e0571c3-7df8-11e8-b0f5-565e625ec9a3": Phase="Pending", Reason="", readiness=false. Elapsed: 2.049421ms
+Jul  2 13:01:39.573: INFO: Pod "downwardapi-volume-0e0571c3-7df8-11e8-b0f5-565e625ec9a3": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.027517495s
+STEP: Saw pod success
+Jul  2 13:01:39.573: INFO: Pod "downwardapi-volume-0e0571c3-7df8-11e8-b0f5-565e625ec9a3" satisfied condition "success or failure"
+Jul  2 13:01:39.575: INFO: Trying to get logs from node shoot--core--confgcp-worker-o1cev-z1-f757498dc-jzlxf pod downwardapi-volume-0e0571c3-7df8-11e8-b0f5-565e625ec9a3 container client-container: <nil>
+STEP: delete the pod
+Jul  2 13:01:39.590: INFO: Waiting for pod downwardapi-volume-0e0571c3-7df8-11e8-b0f5-565e625ec9a3 to disappear
+Jul  2 13:01:39.592: INFO: Pod downwardapi-volume-0e0571c3-7df8-11e8-b0f5-565e625ec9a3 no longer exists
+[AfterEach] [sig-storage] Projected
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:01:39.592: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-vlcjm" for this suite.
+Jul  2 13:01:45.610: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:01:45.806: INFO: namespace: e2e-tests-projected-vlcjm, resource: bindings, ignored listing per whitelist
+Jul  2 13:01:45.817: INFO: namespace e2e-tests-projected-vlcjm deletion completed in 6.217330036s
+
+• [SLOW TEST:8.357 seconds]
+[sig-storage] Projected
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:34
+  should provide container's cpu request [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSSSSSSSSSSSSSSSS
+------------------------------
+[k8s.io] Probing container 
+  should be restarted with a /healthz http liveness probe [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [k8s.io] Probing container
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:01:45.817: INFO: >>> kubeConfig: /tmp/kubeconfig-293271353
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [k8s.io] Probing container
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/container_probe.go:48
+[It] should be restarted with a /healthz http liveness probe [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating pod liveness-http in namespace e2e-tests-container-probe-464d7
+Jul  2 13:01:49.902: INFO: Started pod liveness-http in namespace e2e-tests-container-probe-464d7
+STEP: checking the pod's current state and verifying that restartCount is present
+Jul  2 13:01:49.904: INFO: Initial restart count of pod liveness-http is 0
+Jul  2 13:02:05.941: INFO: Restart count of pod e2e-tests-container-probe-464d7/liveness-http is now 1 (16.036522253s elapsed)
+STEP: deleting the pod
+[AfterEach] [k8s.io] Probing container
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:02:05.949: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-container-probe-464d7" for this suite.
+Jul  2 13:02:11.966: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:02:11.989: INFO: namespace: e2e-tests-container-probe-464d7, resource: bindings, ignored listing per whitelist
+Jul  2 13:02:12.056: INFO: namespace e2e-tests-container-probe-464d7 deletion completed in 6.101304281s
+
+• [SLOW TEST:26.239 seconds]
+[k8s.io] Probing container
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:679
+  should be restarted with a /healthz http liveness probe [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SS
+------------------------------
+[sig-storage] EmptyDir volumes 
+  should support (non-root,0644,default) [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-storage] EmptyDir volumes
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:02:12.056: INFO: >>> kubeConfig: /tmp/kubeconfig-293271353
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should support (non-root,0644,default) [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating a pod to test emptydir 0644 on node default medium
+Jul  2 13:02:12.136: INFO: Waiting up to 5m0s for pod "pod-22a3a06b-7df8-11e8-b0f5-565e625ec9a3" in namespace "e2e-tests-emptydir-6r5qb" to be "success or failure"
+Jul  2 13:02:12.139: INFO: Pod "pod-22a3a06b-7df8-11e8-b0f5-565e625ec9a3": Phase="Pending", Reason="", readiness=false. Elapsed: 2.536691ms
+Jul  2 13:02:14.143: INFO: Pod "pod-22a3a06b-7df8-11e8-b0f5-565e625ec9a3": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.006800617s
+STEP: Saw pod success
+Jul  2 13:02:14.143: INFO: Pod "pod-22a3a06b-7df8-11e8-b0f5-565e625ec9a3" satisfied condition "success or failure"
+Jul  2 13:02:14.146: INFO: Trying to get logs from node shoot--core--confgcp-worker-o1cev-z1-f757498dc-jzlxf pod pod-22a3a06b-7df8-11e8-b0f5-565e625ec9a3 container test-container: <nil>
+STEP: delete the pod
+Jul  2 13:02:14.162: INFO: Waiting for pod pod-22a3a06b-7df8-11e8-b0f5-565e625ec9a3 to disappear
+Jul  2 13:02:14.166: INFO: Pod pod-22a3a06b-7df8-11e8-b0f5-565e625ec9a3 no longer exists
+[AfterEach] [sig-storage] EmptyDir volumes
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:02:14.166: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-emptydir-6r5qb" for this suite.
+Jul  2 13:02:20.183: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:02:20.213: INFO: namespace: e2e-tests-emptydir-6r5qb, resource: bindings, ignored listing per whitelist
+Jul  2 13:02:20.273: INFO: namespace e2e-tests-emptydir-6r5qb deletion completed in 6.103136799s
+
+• [SLOW TEST:8.217 seconds]
+[sig-storage] EmptyDir volumes
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/empty_dir.go:40
+  should support (non-root,0644,default) [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSSS
+------------------------------
+[sig-storage] EmptyDir volumes 
+  volume on default medium should have the correct mode [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-storage] EmptyDir volumes
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:02:20.273: INFO: >>> kubeConfig: /tmp/kubeconfig-293271353
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] volume on default medium should have the correct mode [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating a pod to test emptydir volume type on node default medium
+Jul  2 13:02:20.353: INFO: Waiting up to 5m0s for pod "pod-27895e69-7df8-11e8-b0f5-565e625ec9a3" in namespace "e2e-tests-emptydir-267dc" to be "success or failure"
+Jul  2 13:02:20.355: INFO: Pod "pod-27895e69-7df8-11e8-b0f5-565e625ec9a3": Phase="Pending", Reason="", readiness=false. Elapsed: 2.516743ms
+Jul  2 13:02:22.359: INFO: Pod "pod-27895e69-7df8-11e8-b0f5-565e625ec9a3": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.006358385s
+STEP: Saw pod success
+Jul  2 13:02:22.359: INFO: Pod "pod-27895e69-7df8-11e8-b0f5-565e625ec9a3" satisfied condition "success or failure"
+Jul  2 13:02:22.362: INFO: Trying to get logs from node shoot--core--confgcp-worker-o1cev-z1-f757498dc-jzlxf pod pod-27895e69-7df8-11e8-b0f5-565e625ec9a3 container test-container: <nil>
+STEP: delete the pod
+Jul  2 13:02:22.378: INFO: Waiting for pod pod-27895e69-7df8-11e8-b0f5-565e625ec9a3 to disappear
+Jul  2 13:02:22.380: INFO: Pod pod-27895e69-7df8-11e8-b0f5-565e625ec9a3 no longer exists
+[AfterEach] [sig-storage] EmptyDir volumes
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:02:22.380: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-emptydir-267dc" for this suite.
+Jul  2 13:02:28.393: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:02:28.469: INFO: namespace: e2e-tests-emptydir-267dc, resource: bindings, ignored listing per whitelist
+Jul  2 13:02:28.492: INFO: namespace e2e-tests-emptydir-267dc deletion completed in 6.1087648s
+
+• [SLOW TEST:8.218 seconds]
+[sig-storage] EmptyDir volumes
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/empty_dir.go:40
+  volume on default medium should have the correct mode [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSSSSSSS
+------------------------------
+[sig-network] Services 
+  should serve a basic endpoint from pods  [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-network] Services
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:02:28.492: INFO: >>> kubeConfig: /tmp/kubeconfig-293271353
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-network] Services
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/network/service.go:83
+[It] should serve a basic endpoint from pods  [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: creating service endpoint-test2 in namespace e2e-tests-services-lh6vb
+STEP: waiting up to 3m0s for service endpoint-test2 in namespace e2e-tests-services-lh6vb to expose endpoints map[]
+Jul  2 13:02:28.584: INFO: Get endpoints failed (2.469298ms elapsed, ignoring for 5s): endpoints "endpoint-test2" not found
+Jul  2 13:02:29.588: INFO: successfully validated that service endpoint-test2 in namespace e2e-tests-services-lh6vb exposes endpoints map[] (1.006547042s elapsed)
+STEP: Creating pod pod1 in namespace e2e-tests-services-lh6vb
+STEP: waiting up to 3m0s for service endpoint-test2 in namespace e2e-tests-services-lh6vb to expose endpoints map[pod1:[80]]
+Jul  2 13:02:31.611: INFO: successfully validated that service endpoint-test2 in namespace e2e-tests-services-lh6vb exposes endpoints map[pod1:[80]] (2.016955309s elapsed)
+STEP: Creating pod pod2 in namespace e2e-tests-services-lh6vb
+STEP: waiting up to 3m0s for service endpoint-test2 in namespace e2e-tests-services-lh6vb to expose endpoints map[pod2:[80] pod1:[80]]
+Jul  2 13:02:33.791: INFO: successfully validated that service endpoint-test2 in namespace e2e-tests-services-lh6vb exposes endpoints map[pod1:[80] pod2:[80]] (2.11908352s elapsed)
+STEP: Deleting pod pod1 in namespace e2e-tests-services-lh6vb
+STEP: waiting up to 3m0s for service endpoint-test2 in namespace e2e-tests-services-lh6vb to expose endpoints map[pod2:[80]]
+Jul  2 13:02:34.805: INFO: successfully validated that service endpoint-test2 in namespace e2e-tests-services-lh6vb exposes endpoints map[pod2:[80]] (1.010559521s elapsed)
+STEP: Deleting pod pod2 in namespace e2e-tests-services-lh6vb
+STEP: waiting up to 3m0s for service endpoint-test2 in namespace e2e-tests-services-lh6vb to expose endpoints map[]
+Jul  2 13:02:35.815: INFO: successfully validated that service endpoint-test2 in namespace e2e-tests-services-lh6vb exposes endpoints map[] (1.005863531s elapsed)
+[AfterEach] [sig-network] Services
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:02:35.878: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-services-lh6vb" for this suite.
+Jul  2 13:02:57.891: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:02:57.975: INFO: namespace: e2e-tests-services-lh6vb, resource: bindings, ignored listing per whitelist
+Jul  2 13:02:57.978: INFO: namespace e2e-tests-services-lh6vb deletion completed in 22.096662004s
+[AfterEach] [sig-network] Services
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/network/service.go:88
+
+• [SLOW TEST:29.486 seconds]
+[sig-network] Services
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/network/framework.go:22
+  should serve a basic endpoint from pods  [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSS
+------------------------------
+[sig-storage] EmptyDir volumes 
+  should support (non-root,0666,default) [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-storage] EmptyDir volumes
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:02:57.978: INFO: >>> kubeConfig: /tmp/kubeconfig-293271353
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should support (non-root,0666,default) [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating a pod to test emptydir 0666 on node default medium
+Jul  2 13:02:58.061: INFO: Waiting up to 5m0s for pod "pod-3e03257c-7df8-11e8-b0f5-565e625ec9a3" in namespace "e2e-tests-emptydir-4qh75" to be "success or failure"
+Jul  2 13:02:58.064: INFO: Pod "pod-3e03257c-7df8-11e8-b0f5-565e625ec9a3": Phase="Pending", Reason="", readiness=false. Elapsed: 3.049045ms
+Jul  2 13:03:00.068: INFO: Pod "pod-3e03257c-7df8-11e8-b0f5-565e625ec9a3": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.007253999s
+STEP: Saw pod success
+Jul  2 13:03:00.068: INFO: Pod "pod-3e03257c-7df8-11e8-b0f5-565e625ec9a3" satisfied condition "success or failure"
+Jul  2 13:03:00.071: INFO: Trying to get logs from node shoot--core--confgcp-worker-o1cev-z1-f757498dc-jzlxf pod pod-3e03257c-7df8-11e8-b0f5-565e625ec9a3 container test-container: <nil>
+STEP: delete the pod
+Jul  2 13:03:00.087: INFO: Waiting for pod pod-3e03257c-7df8-11e8-b0f5-565e625ec9a3 to disappear
+Jul  2 13:03:00.090: INFO: Pod pod-3e03257c-7df8-11e8-b0f5-565e625ec9a3 no longer exists
+[AfterEach] [sig-storage] EmptyDir volumes
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:03:00.090: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-emptydir-4qh75" for this suite.
+Jul  2 13:03:06.108: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:03:06.155: INFO: namespace: e2e-tests-emptydir-4qh75, resource: bindings, ignored listing per whitelist
+Jul  2 13:03:06.196: INFO: namespace e2e-tests-emptydir-4qh75 deletion completed in 6.102105865s
+
+• [SLOW TEST:8.218 seconds]
+[sig-storage] EmptyDir volumes
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/empty_dir.go:40
+  should support (non-root,0666,default) [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSSSSSSSSSSSSS
+------------------------------
+[sig-api-machinery] Downward API 
+  should provide host IP as an env var [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-api-machinery] Downward API
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:03:06.196: INFO: >>> kubeConfig: /tmp/kubeconfig-293271353
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should provide host IP as an env var [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating a pod to test downward api env vars
+Jul  2 13:03:06.276: INFO: Waiting up to 5m0s for pod "downward-api-42e8cab6-7df8-11e8-b0f5-565e625ec9a3" in namespace "e2e-tests-downward-api-r4wmm" to be "success or failure"
+Jul  2 13:03:06.283: INFO: Pod "downward-api-42e8cab6-7df8-11e8-b0f5-565e625ec9a3": Phase="Pending", Reason="", readiness=false. Elapsed: 6.998131ms
+Jul  2 13:03:08.287: INFO: Pod "downward-api-42e8cab6-7df8-11e8-b0f5-565e625ec9a3": Phase="Pending", Reason="", readiness=false. Elapsed: 2.010664867s
+Jul  2 13:03:10.291: INFO: Pod "downward-api-42e8cab6-7df8-11e8-b0f5-565e625ec9a3": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.014736389s
+STEP: Saw pod success
+Jul  2 13:03:10.291: INFO: Pod "downward-api-42e8cab6-7df8-11e8-b0f5-565e625ec9a3" satisfied condition "success or failure"
+Jul  2 13:03:10.372: INFO: Trying to get logs from node shoot--core--confgcp-worker-o1cev-z1-f757498dc-qrtzr pod downward-api-42e8cab6-7df8-11e8-b0f5-565e625ec9a3 container dapi-container: <nil>
+STEP: delete the pod
+Jul  2 13:03:10.393: INFO: Waiting for pod downward-api-42e8cab6-7df8-11e8-b0f5-565e625ec9a3 to disappear
+Jul  2 13:03:10.395: INFO: Pod downward-api-42e8cab6-7df8-11e8-b0f5-565e625ec9a3 no longer exists
+[AfterEach] [sig-api-machinery] Downward API
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:03:10.395: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-downward-api-r4wmm" for this suite.
+Jul  2 13:03:16.474: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:03:16.521: INFO: namespace: e2e-tests-downward-api-r4wmm, resource: bindings, ignored listing per whitelist
+Jul  2 13:03:16.558: INFO: namespace e2e-tests-downward-api-r4wmm deletion completed in 6.159862575s
+
+• [SLOW TEST:10.362 seconds]
+[sig-api-machinery] Downward API
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downward_api.go:37
+  should provide host IP as an env var [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+[sig-api-machinery] Garbage collector 
+  should keep the rc around until all its pods are deleted if the deleteOptions says so [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-api-machinery] Garbage collector
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:03:16.558: INFO: >>> kubeConfig: /tmp/kubeconfig-293271353
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should keep the rc around until all its pods are deleted if the deleteOptions says so [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: create the rc
+STEP: delete the rc
+STEP: wait for the rc to be deleted
+STEP: Gathering metrics
+W0702 13:03:22.661391      18 metrics_grabber.go:81] Master node is not registered. Grabbing metrics from Scheduler, ControllerManager and ClusterAutoscaler is disabled.
+Jul  2 13:03:22.661: INFO: For apiserver_request_count:
+For apiserver_request_latencies_summary:
+For etcd_helper_cache_entry_count:
+For etcd_helper_cache_hit_count:
+For etcd_helper_cache_miss_count:
+For etcd_request_cache_add_latencies_summary:
+For etcd_request_cache_get_latencies_summary:
+For etcd_request_latencies_summary:
+For garbage_collector_attempt_to_delete_queue_latency:
+For garbage_collector_attempt_to_delete_work_duration:
+For garbage_collector_attempt_to_orphan_queue_latency:
+For garbage_collector_attempt_to_orphan_work_duration:
+For garbage_collector_dirty_processing_latency_microseconds:
+For garbage_collector_event_processing_latency_microseconds:
+For garbage_collector_graph_changes_queue_latency:
+For garbage_collector_graph_changes_work_duration:
+For garbage_collector_orphan_processing_latency_microseconds:
+For namespace_queue_latency:
+For namespace_queue_latency_sum:
+For namespace_queue_latency_count:
+For namespace_retries:
+For namespace_work_duration:
+For namespace_work_duration_sum:
+For namespace_work_duration_count:
+For function_duration_seconds:
+For errors_total:
+For evicted_pods_total:
+
+[AfterEach] [sig-api-machinery] Garbage collector
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:03:22.661: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-gc-7p44z" for this suite.
+Jul  2 13:03:28.674: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:03:28.708: INFO: namespace: e2e-tests-gc-7p44z, resource: bindings, ignored listing per whitelist
+Jul  2 13:03:28.765: INFO: namespace e2e-tests-gc-7p44z deletion completed in 6.100274614s
+
+• [SLOW TEST:12.207 seconds]
+[sig-api-machinery] Garbage collector
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apimachinery/framework.go:22
+  should keep the rc around until all its pods are deleted if the deleteOptions says so [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSSS
+------------------------------
+[sig-storage] ConfigMap 
+  should be consumable from pods in volume as non-root [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-storage] ConfigMap
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:03:28.765: INFO: >>> kubeConfig: /tmp/kubeconfig-293271353
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should be consumable from pods in volume as non-root [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating configMap with name configmap-test-volume-505ce96d-7df8-11e8-b0f5-565e625ec9a3
+STEP: Creating a pod to test consume configMaps
+Jul  2 13:03:28.851: INFO: Waiting up to 5m0s for pod "pod-configmaps-505d766b-7df8-11e8-b0f5-565e625ec9a3" in namespace "e2e-tests-configmap-xzk59" to be "success or failure"
+Jul  2 13:03:28.854: INFO: Pod "pod-configmaps-505d766b-7df8-11e8-b0f5-565e625ec9a3": Phase="Pending", Reason="", readiness=false. Elapsed: 2.294334ms
+Jul  2 13:03:30.857: INFO: Pod "pod-configmaps-505d766b-7df8-11e8-b0f5-565e625ec9a3": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.005951637s
+STEP: Saw pod success
+Jul  2 13:03:30.857: INFO: Pod "pod-configmaps-505d766b-7df8-11e8-b0f5-565e625ec9a3" satisfied condition "success or failure"
+Jul  2 13:03:30.860: INFO: Trying to get logs from node shoot--core--confgcp-worker-o1cev-z1-f757498dc-jzlxf pod pod-configmaps-505d766b-7df8-11e8-b0f5-565e625ec9a3 container configmap-volume-test: <nil>
+STEP: delete the pod
+Jul  2 13:03:30.876: INFO: Waiting for pod pod-configmaps-505d766b-7df8-11e8-b0f5-565e625ec9a3 to disappear
+Jul  2 13:03:30.879: INFO: Pod pod-configmaps-505d766b-7df8-11e8-b0f5-565e625ec9a3 no longer exists
+[AfterEach] [sig-storage] ConfigMap
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:03:30.880: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-configmap-xzk59" for this suite.
+Jul  2 13:03:36.976: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:03:36.991: INFO: namespace: e2e-tests-configmap-xzk59, resource: bindings, ignored listing per whitelist
+Jul  2 13:03:37.080: INFO: namespace e2e-tests-configmap-xzk59 deletion completed in 6.194367212s
+
+• [SLOW TEST:8.315 seconds]
+[sig-storage] ConfigMap
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/configmap_volume.go:32
+  should be consumable from pods in volume as non-root [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+S
+------------------------------
+[sig-api-machinery] Garbage collector 
+  should not delete dependents that have both valid owner and owner that's waiting for dependents to be deleted [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-api-machinery] Garbage collector
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:03:37.080: INFO: >>> kubeConfig: /tmp/kubeconfig-293271353
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should not delete dependents that have both valid owner and owner that's waiting for dependents to be deleted [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: create the rc1
+STEP: create the rc2
+STEP: set half of pods created by rc simpletest-rc-to-be-deleted to have rc simpletest-rc-to-stay as owner as well
+STEP: delete the rc simpletest-rc-to-be-deleted
+STEP: wait for the rc to be deleted
+STEP: Gathering metrics
+W0702 13:03:47.212322      18 metrics_grabber.go:81] Master node is not registered. Grabbing metrics from Scheduler, ControllerManager and ClusterAutoscaler is disabled.
+Jul  2 13:03:47.212: INFO: For apiserver_request_count:
+For apiserver_request_latencies_summary:
+For etcd_helper_cache_entry_count:
+For etcd_helper_cache_hit_count:
+For etcd_helper_cache_miss_count:
+For etcd_request_cache_add_latencies_summary:
+For etcd_request_cache_get_latencies_summary:
+For etcd_request_latencies_summary:
+For garbage_collector_attempt_to_delete_queue_latency:
+For garbage_collector_attempt_to_delete_work_duration:
+For garbage_collector_attempt_to_orphan_queue_latency:
+For garbage_collector_attempt_to_orphan_work_duration:
+For garbage_collector_dirty_processing_latency_microseconds:
+For garbage_collector_event_processing_latency_microseconds:
+For garbage_collector_graph_changes_queue_latency:
+For garbage_collector_graph_changes_work_duration:
+For garbage_collector_orphan_processing_latency_microseconds:
+For namespace_queue_latency:
+For namespace_queue_latency_sum:
+For namespace_queue_latency_count:
+For namespace_retries:
+For namespace_work_duration:
+For namespace_work_duration_sum:
+For namespace_work_duration_count:
+For function_duration_seconds:
+For errors_total:
+For evicted_pods_total:
+
+[AfterEach] [sig-api-machinery] Garbage collector
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:03:47.212: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-gc-97c9z" for this suite.
+Jul  2 13:03:53.226: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:03:53.231: INFO: namespace: e2e-tests-gc-97c9z, resource: bindings, ignored listing per whitelist
+Jul  2 13:03:53.307: INFO: namespace e2e-tests-gc-97c9z deletion completed in 6.09221809s
+
+• [SLOW TEST:16.228 seconds]
+[sig-api-machinery] Garbage collector
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apimachinery/framework.go:22
+  should not delete dependents that have both valid owner and owner that's waiting for dependents to be deleted [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SS
+------------------------------
+[sig-auth] ServiceAccounts 
+  should mount an API token into pods  [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-auth] ServiceAccounts
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:03:53.308: INFO: >>> kubeConfig: /tmp/kubeconfig-293271353
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should mount an API token into pods  [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: getting the auto-created API token
+STEP: Creating a pod to test consume service account token
+Jul  2 13:03:53.978: INFO: Waiting up to 5m0s for pod "pod-service-account-5f579779-7df8-11e8-b0f5-565e625ec9a3-qxmvh" in namespace "e2e-tests-svcaccounts-4wj2h" to be "success or failure"
+Jul  2 13:03:53.981: INFO: Pod "pod-service-account-5f579779-7df8-11e8-b0f5-565e625ec9a3-qxmvh": Phase="Pending", Reason="", readiness=false. Elapsed: 2.789469ms
+Jul  2 13:03:55.985: INFO: Pod "pod-service-account-5f579779-7df8-11e8-b0f5-565e625ec9a3-qxmvh": Phase="Pending", Reason="", readiness=false. Elapsed: 2.006875627s
+Jul  2 13:03:57.994: INFO: Pod "pod-service-account-5f579779-7df8-11e8-b0f5-565e625ec9a3-qxmvh": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.015139899s
+STEP: Saw pod success
+Jul  2 13:03:57.994: INFO: Pod "pod-service-account-5f579779-7df8-11e8-b0f5-565e625ec9a3-qxmvh" satisfied condition "success or failure"
+Jul  2 13:03:57.996: INFO: Trying to get logs from node shoot--core--confgcp-worker-o1cev-z1-f757498dc-jzlxf pod pod-service-account-5f579779-7df8-11e8-b0f5-565e625ec9a3-qxmvh container token-test: <nil>
+STEP: delete the pod
+Jul  2 13:03:58.016: INFO: Waiting for pod pod-service-account-5f579779-7df8-11e8-b0f5-565e625ec9a3-qxmvh to disappear
+Jul  2 13:03:58.019: INFO: Pod pod-service-account-5f579779-7df8-11e8-b0f5-565e625ec9a3-qxmvh no longer exists
+STEP: Creating a pod to test consume service account root CA
+Jul  2 13:03:58.037: INFO: Waiting up to 5m0s for pod "pod-service-account-5f579779-7df8-11e8-b0f5-565e625ec9a3-74scq" in namespace "e2e-tests-svcaccounts-4wj2h" to be "success or failure"
+Jul  2 13:03:58.044: INFO: Pod "pod-service-account-5f579779-7df8-11e8-b0f5-565e625ec9a3-74scq": Phase="Pending", Reason="", readiness=false. Elapsed: 6.721021ms
+Jul  2 13:04:00.048: INFO: Pod "pod-service-account-5f579779-7df8-11e8-b0f5-565e625ec9a3-74scq": Phase="Pending", Reason="", readiness=false. Elapsed: 2.010858493s
+Jul  2 13:04:02.053: INFO: Pod "pod-service-account-5f579779-7df8-11e8-b0f5-565e625ec9a3-74scq": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.015093872s
+STEP: Saw pod success
+Jul  2 13:04:02.053: INFO: Pod "pod-service-account-5f579779-7df8-11e8-b0f5-565e625ec9a3-74scq" satisfied condition "success or failure"
+Jul  2 13:04:02.056: INFO: Trying to get logs from node shoot--core--confgcp-worker-o1cev-z1-f757498dc-jzlxf pod pod-service-account-5f579779-7df8-11e8-b0f5-565e625ec9a3-74scq container root-ca-test: <nil>
+STEP: delete the pod
+Jul  2 13:04:02.074: INFO: Waiting for pod pod-service-account-5f579779-7df8-11e8-b0f5-565e625ec9a3-74scq to disappear
+Jul  2 13:04:02.077: INFO: Pod pod-service-account-5f579779-7df8-11e8-b0f5-565e625ec9a3-74scq no longer exists
+STEP: Creating a pod to test consume service account namespace
+Jul  2 13:04:02.082: INFO: Waiting up to 5m0s for pod "pod-service-account-5f579779-7df8-11e8-b0f5-565e625ec9a3-8vsqp" in namespace "e2e-tests-svcaccounts-4wj2h" to be "success or failure"
+Jul  2 13:04:02.085: INFO: Pod "pod-service-account-5f579779-7df8-11e8-b0f5-565e625ec9a3-8vsqp": Phase="Pending", Reason="", readiness=false. Elapsed: 3.158755ms
+Jul  2 13:04:04.089: INFO: Pod "pod-service-account-5f579779-7df8-11e8-b0f5-565e625ec9a3-8vsqp": Phase="Pending", Reason="", readiness=false. Elapsed: 2.00708149s
+Jul  2 13:04:06.174: INFO: Pod "pod-service-account-5f579779-7df8-11e8-b0f5-565e625ec9a3-8vsqp": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.092055851s
+STEP: Saw pod success
+Jul  2 13:04:06.174: INFO: Pod "pod-service-account-5f579779-7df8-11e8-b0f5-565e625ec9a3-8vsqp" satisfied condition "success or failure"
+Jul  2 13:04:06.271: INFO: Trying to get logs from node shoot--core--confgcp-worker-o1cev-z1-f757498dc-jzlxf pod pod-service-account-5f579779-7df8-11e8-b0f5-565e625ec9a3-8vsqp container namespace-test: <nil>
+STEP: delete the pod
+Jul  2 13:04:06.289: INFO: Waiting for pod pod-service-account-5f579779-7df8-11e8-b0f5-565e625ec9a3-8vsqp to disappear
+Jul  2 13:04:06.292: INFO: Pod pod-service-account-5f579779-7df8-11e8-b0f5-565e625ec9a3-8vsqp no longer exists
+[AfterEach] [sig-auth] ServiceAccounts
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:04:06.292: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-svcaccounts-4wj2h" for this suite.
+Jul  2 13:04:12.306: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:04:12.394: INFO: namespace: e2e-tests-svcaccounts-4wj2h, resource: bindings, ignored listing per whitelist
+Jul  2 13:04:12.405: INFO: namespace e2e-tests-svcaccounts-4wj2h deletion completed in 6.108901664s
+
+• [SLOW TEST:19.097 seconds]
+[sig-auth] ServiceAccounts
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/auth/framework.go:22
+  should mount an API token into pods  [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SS
+------------------------------
+[sig-auth] ServiceAccounts 
+  should allow opting out of API token automount  [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-auth] ServiceAccounts
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:04:12.405: INFO: >>> kubeConfig: /tmp/kubeconfig-293271353
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should allow opting out of API token automount  [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: getting the auto-created API token
+Jul  2 13:04:13.000: INFO: created pod pod-service-account-defaultsa
+Jul  2 13:04:13.000: INFO: pod pod-service-account-defaultsa service account token volume mount: true
+Jul  2 13:04:13.003: INFO: created pod pod-service-account-mountsa
+Jul  2 13:04:13.003: INFO: pod pod-service-account-mountsa service account token volume mount: true
+Jul  2 13:04:13.007: INFO: created pod pod-service-account-nomountsa
+Jul  2 13:04:13.007: INFO: pod pod-service-account-nomountsa service account token volume mount: false
+Jul  2 13:04:13.011: INFO: created pod pod-service-account-defaultsa-mountspec
+Jul  2 13:04:13.011: INFO: pod pod-service-account-defaultsa-mountspec service account token volume mount: true
+Jul  2 13:04:13.016: INFO: created pod pod-service-account-mountsa-mountspec
+Jul  2 13:04:13.016: INFO: pod pod-service-account-mountsa-mountspec service account token volume mount: true
+Jul  2 13:04:13.019: INFO: created pod pod-service-account-nomountsa-mountspec
+Jul  2 13:04:13.019: INFO: pod pod-service-account-nomountsa-mountspec service account token volume mount: true
+Jul  2 13:04:13.022: INFO: created pod pod-service-account-defaultsa-nomountspec
+Jul  2 13:04:13.022: INFO: pod pod-service-account-defaultsa-nomountspec service account token volume mount: false
+Jul  2 13:04:13.025: INFO: created pod pod-service-account-mountsa-nomountspec
+Jul  2 13:04:13.025: INFO: pod pod-service-account-mountsa-nomountspec service account token volume mount: false
+Jul  2 13:04:13.029: INFO: created pod pod-service-account-nomountsa-nomountspec
+Jul  2 13:04:13.029: INFO: pod pod-service-account-nomountsa-nomountspec service account token volume mount: false
+[AfterEach] [sig-auth] ServiceAccounts
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:04:13.029: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-svcaccounts-d694p" for this suite.
+Jul  2 13:04:19.048: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:04:19.095: INFO: namespace: e2e-tests-svcaccounts-d694p, resource: bindings, ignored listing per whitelist
+Jul  2 13:04:19.204: INFO: namespace e2e-tests-svcaccounts-d694p deletion completed in 6.172161527s
+
+• [SLOW TEST:6.799 seconds]
+[sig-auth] ServiceAccounts
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/auth/framework.go:22
+  should allow opting out of API token automount  [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSS
+------------------------------
+[sig-storage] Projected 
+  should update labels on modification [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:04:19.204: INFO: >>> kubeConfig: /tmp/kubeconfig-293271353
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:858
+[It] should update labels on modification [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating the pod
+Jul  2 13:04:21.807: INFO: Successfully updated pod "labelsupdate6e6c84f4-7df8-11e8-b0f5-565e625ec9a3"
+[AfterEach] [sig-storage] Projected
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:04:25.836: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-n5dxz" for this suite.
+Jul  2 13:04:47.849: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:04:47.931: INFO: namespace: e2e-tests-projected-n5dxz, resource: bindings, ignored listing per whitelist
+Jul  2 13:04:47.931: INFO: namespace e2e-tests-projected-n5dxz deletion completed in 22.091327272s
+
+• [SLOW TEST:28.726 seconds]
+[sig-storage] Projected
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:34
+  should update labels on modification [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+[sig-api-machinery] Downward API 
+  should provide pod UID as env vars [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-api-machinery] Downward API
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:04:47.931: INFO: >>> kubeConfig: /tmp/kubeconfig-293271353
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should provide pod UID as env vars [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating a pod to test downward api env vars
+Jul  2 13:04:48.009: INFO: Waiting up to 5m0s for pod "downward-api-7f8c16ab-7df8-11e8-b0f5-565e625ec9a3" in namespace "e2e-tests-downward-api-zgkmz" to be "success or failure"
+Jul  2 13:04:48.011: INFO: Pod "downward-api-7f8c16ab-7df8-11e8-b0f5-565e625ec9a3": Phase="Pending", Reason="", readiness=false. Elapsed: 2.140374ms
+Jul  2 13:04:50.071: INFO: Pod "downward-api-7f8c16ab-7df8-11e8-b0f5-565e625ec9a3": Phase="Pending", Reason="", readiness=false. Elapsed: 2.061283688s
+Jul  2 13:04:52.179: INFO: Pod "downward-api-7f8c16ab-7df8-11e8-b0f5-565e625ec9a3": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.16936775s
+STEP: Saw pod success
+Jul  2 13:04:52.179: INFO: Pod "downward-api-7f8c16ab-7df8-11e8-b0f5-565e625ec9a3" satisfied condition "success or failure"
+Jul  2 13:04:52.182: INFO: Trying to get logs from node shoot--core--confgcp-worker-o1cev-z1-f757498dc-jzlxf pod downward-api-7f8c16ab-7df8-11e8-b0f5-565e625ec9a3 container dapi-container: <nil>
+STEP: delete the pod
+Jul  2 13:04:52.199: INFO: Waiting for pod downward-api-7f8c16ab-7df8-11e8-b0f5-565e625ec9a3 to disappear
+Jul  2 13:04:52.202: INFO: Pod downward-api-7f8c16ab-7df8-11e8-b0f5-565e625ec9a3 no longer exists
+[AfterEach] [sig-api-machinery] Downward API
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:04:52.202: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-downward-api-zgkmz" for this suite.
+Jul  2 13:04:58.215: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:04:58.290: INFO: namespace: e2e-tests-downward-api-zgkmz, resource: bindings, ignored listing per whitelist
+Jul  2 13:04:58.308: INFO: namespace e2e-tests-downward-api-zgkmz deletion completed in 6.102874784s
+
+• [SLOW TEST:10.377 seconds]
+[sig-api-machinery] Downward API
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downward_api.go:37
+  should provide pod UID as env vars [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSS
+------------------------------
+[k8s.io] Variable Expansion 
+  should allow substituting values in a container's args [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [k8s.io] Variable Expansion
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:04:58.308: INFO: >>> kubeConfig: /tmp/kubeconfig-293271353
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should allow substituting values in a container's args [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating a pod to test substitution in container's args
+Jul  2 13:04:58.398: INFO: Waiting up to 5m0s for pod "var-expansion-85bd31b5-7df8-11e8-b0f5-565e625ec9a3" in namespace "e2e-tests-var-expansion-2tdvt" to be "success or failure"
+Jul  2 13:04:58.400: INFO: Pod "var-expansion-85bd31b5-7df8-11e8-b0f5-565e625ec9a3": Phase="Pending", Reason="", readiness=false. Elapsed: 2.06887ms
+Jul  2 13:05:00.404: INFO: Pod "var-expansion-85bd31b5-7df8-11e8-b0f5-565e625ec9a3": Phase="Pending", Reason="", readiness=false. Elapsed: 2.005905127s
+Jul  2 13:05:02.412: INFO: Pod "var-expansion-85bd31b5-7df8-11e8-b0f5-565e625ec9a3": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.014255675s
+STEP: Saw pod success
+Jul  2 13:05:02.412: INFO: Pod "var-expansion-85bd31b5-7df8-11e8-b0f5-565e625ec9a3" satisfied condition "success or failure"
+Jul  2 13:05:02.415: INFO: Trying to get logs from node shoot--core--confgcp-worker-o1cev-z1-f757498dc-jzlxf pod var-expansion-85bd31b5-7df8-11e8-b0f5-565e625ec9a3 container dapi-container: <nil>
+STEP: delete the pod
+Jul  2 13:05:02.433: INFO: Waiting for pod var-expansion-85bd31b5-7df8-11e8-b0f5-565e625ec9a3 to disappear
+Jul  2 13:05:02.435: INFO: Pod var-expansion-85bd31b5-7df8-11e8-b0f5-565e625ec9a3 no longer exists
+[AfterEach] [k8s.io] Variable Expansion
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:05:02.435: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-var-expansion-2tdvt" for this suite.
+Jul  2 13:05:08.449: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:05:08.470: INFO: namespace: e2e-tests-var-expansion-2tdvt, resource: bindings, ignored listing per whitelist
+Jul  2 13:05:08.537: INFO: namespace e2e-tests-var-expansion-2tdvt deletion completed in 6.09767827s
+
+• [SLOW TEST:10.229 seconds]
+[k8s.io] Variable Expansion
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:679
+  should allow substituting values in a container's args [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSSSSSSS
+------------------------------
+[sig-storage] EmptyDir volumes 
+  should support (non-root,0666,tmpfs) [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-storage] EmptyDir volumes
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:05:08.537: INFO: >>> kubeConfig: /tmp/kubeconfig-293271353
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should support (non-root,0666,tmpfs) [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating a pod to test emptydir 0666 on tmpfs
+Jul  2 13:05:08.620: INFO: Waiting up to 5m0s for pod "pod-8bd4ebca-7df8-11e8-b0f5-565e625ec9a3" in namespace "e2e-tests-emptydir-spmcf" to be "success or failure"
+Jul  2 13:05:08.624: INFO: Pod "pod-8bd4ebca-7df8-11e8-b0f5-565e625ec9a3": Phase="Pending", Reason="", readiness=false. Elapsed: 4.440716ms
+Jul  2 13:05:10.628: INFO: Pod "pod-8bd4ebca-7df8-11e8-b0f5-565e625ec9a3": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.008480325s
+STEP: Saw pod success
+Jul  2 13:05:10.628: INFO: Pod "pod-8bd4ebca-7df8-11e8-b0f5-565e625ec9a3" satisfied condition "success or failure"
+Jul  2 13:05:10.631: INFO: Trying to get logs from node shoot--core--confgcp-worker-o1cev-z1-f757498dc-jzlxf pod pod-8bd4ebca-7df8-11e8-b0f5-565e625ec9a3 container test-container: <nil>
+STEP: delete the pod
+Jul  2 13:05:10.648: INFO: Waiting for pod pod-8bd4ebca-7df8-11e8-b0f5-565e625ec9a3 to disappear
+Jul  2 13:05:10.651: INFO: Pod pod-8bd4ebca-7df8-11e8-b0f5-565e625ec9a3 no longer exists
+[AfterEach] [sig-storage] EmptyDir volumes
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:05:10.651: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-emptydir-spmcf" for this suite.
+Jul  2 13:05:16.671: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:05:16.720: INFO: namespace: e2e-tests-emptydir-spmcf, resource: bindings, ignored listing per whitelist
+Jul  2 13:05:16.762: INFO: namespace e2e-tests-emptydir-spmcf deletion completed in 6.102418297s
+
+• [SLOW TEST:8.225 seconds]
+[sig-storage] EmptyDir volumes
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/empty_dir.go:40
+  should support (non-root,0666,tmpfs) [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSSSSSSSSS
+------------------------------
+[sig-storage] Projected 
+  should provide node allocatable (cpu) as default cpu limit if the limit is not set [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:05:16.762: INFO: >>> kubeConfig: /tmp/kubeconfig-293271353
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:858
+[It] should provide node allocatable (cpu) as default cpu limit if the limit is not set [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating a pod to test downward API volume plugin
+Jul  2 13:05:16.839: INFO: Waiting up to 5m0s for pod "downwardapi-volume-90bb272c-7df8-11e8-b0f5-565e625ec9a3" in namespace "e2e-tests-projected-2pnx6" to be "success or failure"
+Jul  2 13:05:16.842: INFO: Pod "downwardapi-volume-90bb272c-7df8-11e8-b0f5-565e625ec9a3": Phase="Pending", Reason="", readiness=false. Elapsed: 2.364263ms
+Jul  2 13:05:18.846: INFO: Pod "downwardapi-volume-90bb272c-7df8-11e8-b0f5-565e625ec9a3": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.006228262s
+STEP: Saw pod success
+Jul  2 13:05:18.846: INFO: Pod "downwardapi-volume-90bb272c-7df8-11e8-b0f5-565e625ec9a3" satisfied condition "success or failure"
+Jul  2 13:05:18.848: INFO: Trying to get logs from node shoot--core--confgcp-worker-o1cev-z1-f757498dc-jzlxf pod downwardapi-volume-90bb272c-7df8-11e8-b0f5-565e625ec9a3 container client-container: <nil>
+STEP: delete the pod
+Jul  2 13:05:18.869: INFO: Waiting for pod downwardapi-volume-90bb272c-7df8-11e8-b0f5-565e625ec9a3 to disappear
+Jul  2 13:05:18.875: INFO: Pod downwardapi-volume-90bb272c-7df8-11e8-b0f5-565e625ec9a3 no longer exists
+[AfterEach] [sig-storage] Projected
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:05:18.876: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-2pnx6" for this suite.
+Jul  2 13:05:24.890: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:05:24.960: INFO: namespace: e2e-tests-projected-2pnx6, resource: bindings, ignored listing per whitelist
+Jul  2 13:05:24.978: INFO: namespace e2e-tests-projected-2pnx6 deletion completed in 6.098459692s
+
+• [SLOW TEST:8.216 seconds]
+[sig-storage] Projected
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:34
+  should provide node allocatable (cpu) as default cpu limit if the limit is not set [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSSSSSSS
+------------------------------
+[sig-apps] Daemon set [Serial] 
+  should update pod when spec was updated and update strategy is RollingUpdate [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-apps] Daemon set [Serial]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:05:24.978: INFO: >>> kubeConfig: /tmp/kubeconfig-293271353
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-apps] Daemon set [Serial]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/daemon_set.go:99
+[It] should update pod when spec was updated and update strategy is RollingUpdate [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+Jul  2 13:05:25.064: INFO: Creating simple daemon set daemon-set
+STEP: Check that daemon pods launch on every node of the cluster.
+Jul  2 13:05:25.083: INFO: Number of nodes with available pods: 0
+Jul  2 13:05:25.083: INFO: Node shoot--core--confgcp-worker-o1cev-z1-f757498dc-jzlxf is running more than one daemon pod
+Jul  2 13:05:26.093: INFO: Number of nodes with available pods: 0
+Jul  2 13:05:26.093: INFO: Node shoot--core--confgcp-worker-o1cev-z1-f757498dc-jzlxf is running more than one daemon pod
+Jul  2 13:05:27.171: INFO: Number of nodes with available pods: 1
+Jul  2 13:05:27.171: INFO: Node shoot--core--confgcp-worker-o1cev-z1-f757498dc-qrtzr is running more than one daemon pod
+Jul  2 13:05:28.171: INFO: Number of nodes with available pods: 2
+Jul  2 13:05:28.171: INFO: Number of running nodes: 2, number of available pods: 2
+STEP: Update daemon pods image.
+STEP: Check that daemon pods images are updated.
+Jul  2 13:05:28.191: INFO: Wrong image for pod: daemon-set-9tf4x. Expected: gcr.io/kubernetes-e2e-test-images/redis-amd64:1.0, got: gcr.io/kubernetes-e2e-test-images/serve-hostname-amd64:1.0.
+Jul  2 13:05:28.191: INFO: Wrong image for pod: daemon-set-s6g26. Expected: gcr.io/kubernetes-e2e-test-images/redis-amd64:1.0, got: gcr.io/kubernetes-e2e-test-images/serve-hostname-amd64:1.0.
+Jul  2 13:05:29.198: INFO: Wrong image for pod: daemon-set-9tf4x. Expected: gcr.io/kubernetes-e2e-test-images/redis-amd64:1.0, got: gcr.io/kubernetes-e2e-test-images/serve-hostname-amd64:1.0.
+Jul  2 13:05:29.198: INFO: Wrong image for pod: daemon-set-s6g26. Expected: gcr.io/kubernetes-e2e-test-images/redis-amd64:1.0, got: gcr.io/kubernetes-e2e-test-images/serve-hostname-amd64:1.0.
+Jul  2 13:05:30.198: INFO: Wrong image for pod: daemon-set-9tf4x. Expected: gcr.io/kubernetes-e2e-test-images/redis-amd64:1.0, got: gcr.io/kubernetes-e2e-test-images/serve-hostname-amd64:1.0.
+Jul  2 13:05:30.198: INFO: Pod daemon-set-9tf4x is not available
+Jul  2 13:05:30.198: INFO: Wrong image for pod: daemon-set-s6g26. Expected: gcr.io/kubernetes-e2e-test-images/redis-amd64:1.0, got: gcr.io/kubernetes-e2e-test-images/serve-hostname-amd64:1.0.
+Jul  2 13:05:31.198: INFO: Pod daemon-set-dp2bb is not available
+Jul  2 13:05:31.198: INFO: Wrong image for pod: daemon-set-s6g26. Expected: gcr.io/kubernetes-e2e-test-images/redis-amd64:1.0, got: gcr.io/kubernetes-e2e-test-images/serve-hostname-amd64:1.0.
+Jul  2 13:05:32.198: INFO: Pod daemon-set-dp2bb is not available
+Jul  2 13:05:32.198: INFO: Wrong image for pod: daemon-set-s6g26. Expected: gcr.io/kubernetes-e2e-test-images/redis-amd64:1.0, got: gcr.io/kubernetes-e2e-test-images/serve-hostname-amd64:1.0.
+Jul  2 13:05:33.198: INFO: Pod daemon-set-dp2bb is not available
+Jul  2 13:05:33.198: INFO: Wrong image for pod: daemon-set-s6g26. Expected: gcr.io/kubernetes-e2e-test-images/redis-amd64:1.0, got: gcr.io/kubernetes-e2e-test-images/serve-hostname-amd64:1.0.
+Jul  2 13:05:34.317: INFO: Wrong image for pod: daemon-set-s6g26. Expected: gcr.io/kubernetes-e2e-test-images/redis-amd64:1.0, got: gcr.io/kubernetes-e2e-test-images/serve-hostname-amd64:1.0.
+Jul  2 13:05:35.271: INFO: Wrong image for pod: daemon-set-s6g26. Expected: gcr.io/kubernetes-e2e-test-images/redis-amd64:1.0, got: gcr.io/kubernetes-e2e-test-images/serve-hostname-amd64:1.0.
+Jul  2 13:05:35.271: INFO: Pod daemon-set-s6g26 is not available
+Jul  2 13:05:36.197: INFO: Pod daemon-set-cgqnp is not available
+STEP: Check that daemon pods are still running on every node of the cluster.
+Jul  2 13:05:36.207: INFO: Number of nodes with available pods: 1
+Jul  2 13:05:36.207: INFO: Node shoot--core--confgcp-worker-o1cev-z1-f757498dc-qrtzr is running more than one daemon pod
+Jul  2 13:05:37.214: INFO: Number of nodes with available pods: 1
+Jul  2 13:05:37.214: INFO: Node shoot--core--confgcp-worker-o1cev-z1-f757498dc-qrtzr is running more than one daemon pod
+Jul  2 13:05:38.214: INFO: Number of nodes with available pods: 2
+Jul  2 13:05:38.214: INFO: Number of running nodes: 2, number of available pods: 2
+[AfterEach] [sig-apps] Daemon set [Serial]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/daemon_set.go:65
+STEP: Deleting DaemonSet "daemon-set"
+STEP: deleting {extensions DaemonSet} daemon-set in namespace e2e-tests-daemonsets-5qc8q, will wait for the garbage collector to delete the pods
+Jul  2 13:05:38.287: INFO: Deleting {extensions DaemonSet} daemon-set took: 5.372604ms
+Jul  2 13:05:38.388: INFO: Terminating {extensions DaemonSet} daemon-set pods took: 100.206987ms
+Jul  2 13:05:41.591: INFO: Number of nodes with available pods: 0
+Jul  2 13:05:41.591: INFO: Number of running nodes: 0, number of available pods: 0
+Jul  2 13:05:41.594: INFO: daemonset: {"kind":"DaemonSetList","apiVersion":"apps/v1","metadata":{"selfLink":"/apis/apps/v1/namespaces/e2e-tests-daemonsets-5qc8q/daemonsets","resourceVersion":"4040"},"items":null}
+
+Jul  2 13:05:41.597: INFO: pods: {"kind":"PodList","apiVersion":"v1","metadata":{"selfLink":"/api/v1/namespaces/e2e-tests-daemonsets-5qc8q/pods","resourceVersion":"4040"},"items":null}
+
+[AfterEach] [sig-apps] Daemon set [Serial]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:05:41.607: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-daemonsets-5qc8q" for this suite.
+Jul  2 13:05:47.620: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:05:47.700: INFO: namespace: e2e-tests-daemonsets-5qc8q, resource: bindings, ignored listing per whitelist
+Jul  2 13:05:47.746: INFO: namespace e2e-tests-daemonsets-5qc8q deletion completed in 6.135354599s
+
+• [SLOW TEST:22.768 seconds]
+[sig-apps] Daemon set [Serial]
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/framework.go:22
+  should update pod when spec was updated and update strategy is RollingUpdate [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSSSSSSSSSSS
+------------------------------
+[sig-storage] Downward API volume 
+  should provide container's cpu request [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:05:47.746: INFO: >>> kubeConfig: /tmp/kubeconfig-293271353
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downwardapi_volume.go:38
+[It] should provide container's cpu request [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating a pod to test downward API volume plugin
+Jul  2 13:05:47.831: INFO: Waiting up to 5m0s for pod "downwardapi-volume-a334047b-7df8-11e8-b0f5-565e625ec9a3" in namespace "e2e-tests-downward-api-xn9sb" to be "success or failure"
+Jul  2 13:05:47.833: INFO: Pod "downwardapi-volume-a334047b-7df8-11e8-b0f5-565e625ec9a3": Phase="Pending", Reason="", readiness=false. Elapsed: 2.262941ms
+Jul  2 13:05:49.837: INFO: Pod "downwardapi-volume-a334047b-7df8-11e8-b0f5-565e625ec9a3": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.005862132s
+STEP: Saw pod success
+Jul  2 13:05:49.837: INFO: Pod "downwardapi-volume-a334047b-7df8-11e8-b0f5-565e625ec9a3" satisfied condition "success or failure"
+Jul  2 13:05:49.840: INFO: Trying to get logs from node shoot--core--confgcp-worker-o1cev-z1-f757498dc-jzlxf pod downwardapi-volume-a334047b-7df8-11e8-b0f5-565e625ec9a3 container client-container: <nil>
+STEP: delete the pod
+Jul  2 13:05:49.855: INFO: Waiting for pod downwardapi-volume-a334047b-7df8-11e8-b0f5-565e625ec9a3 to disappear
+Jul  2 13:05:49.860: INFO: Pod downwardapi-volume-a334047b-7df8-11e8-b0f5-565e625ec9a3 no longer exists
+[AfterEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:05:49.861: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-downward-api-xn9sb" for this suite.
+Jul  2 13:05:55.874: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:05:55.886: INFO: namespace: e2e-tests-downward-api-xn9sb, resource: bindings, ignored listing per whitelist
+Jul  2 13:05:56.015: INFO: namespace e2e-tests-downward-api-xn9sb deletion completed in 6.150799822s
+
+• [SLOW TEST:8.269 seconds]
+[sig-storage] Downward API volume
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downwardapi_volume.go:33
+  should provide container's cpu request [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSSSS
+------------------------------
+[sig-storage] Projected 
+  should provide container's memory limit [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:05:56.015: INFO: >>> kubeConfig: /tmp/kubeconfig-293271353
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:858
+[It] should provide container's memory limit [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating a pod to test downward API volume plugin
+Jul  2 13:05:56.103: INFO: Waiting up to 5m0s for pod "downwardapi-volume-a82219e6-7df8-11e8-b0f5-565e625ec9a3" in namespace "e2e-tests-projected-sbxd6" to be "success or failure"
+Jul  2 13:05:56.105: INFO: Pod "downwardapi-volume-a82219e6-7df8-11e8-b0f5-565e625ec9a3": Phase="Pending", Reason="", readiness=false. Elapsed: 2.69784ms
+Jul  2 13:05:58.109: INFO: Pod "downwardapi-volume-a82219e6-7df8-11e8-b0f5-565e625ec9a3": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.006357785s
+STEP: Saw pod success
+Jul  2 13:05:58.109: INFO: Pod "downwardapi-volume-a82219e6-7df8-11e8-b0f5-565e625ec9a3" satisfied condition "success or failure"
+Jul  2 13:05:58.112: INFO: Trying to get logs from node shoot--core--confgcp-worker-o1cev-z1-f757498dc-qrtzr pod downwardapi-volume-a82219e6-7df8-11e8-b0f5-565e625ec9a3 container client-container: <nil>
+STEP: delete the pod
+Jul  2 13:05:58.132: INFO: Waiting for pod downwardapi-volume-a82219e6-7df8-11e8-b0f5-565e625ec9a3 to disappear
+Jul  2 13:05:58.135: INFO: Pod downwardapi-volume-a82219e6-7df8-11e8-b0f5-565e625ec9a3 no longer exists
+[AfterEach] [sig-storage] Projected
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:05:58.135: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-sbxd6" for this suite.
+Jul  2 13:06:04.149: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:06:04.208: INFO: namespace: e2e-tests-projected-sbxd6, resource: bindings, ignored listing per whitelist
+Jul  2 13:06:04.279: INFO: namespace e2e-tests-projected-sbxd6 deletion completed in 6.140424875s
+
+• [SLOW TEST:8.264 seconds]
+[sig-storage] Projected
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:34
+  should provide container's memory limit [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+S
+------------------------------
+[sig-network] DNS 
+  should provide DNS for the cluster  [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-network] DNS
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:06:04.280: INFO: >>> kubeConfig: /tmp/kubeconfig-293271353
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should provide DNS for the cluster  [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Running these commands on wheezy: for i in `seq 1 600`; do test -n "$$(dig +notcp +noall +answer +search kubernetes.default A)" && echo OK > /results/wheezy_udp@kubernetes.default;test -n "$$(dig +tcp +noall +answer +search kubernetes.default A)" && echo OK > /results/wheezy_tcp@kubernetes.default;test -n "$$(dig +notcp +noall +answer +search kubernetes.default.svc A)" && echo OK > /results/wheezy_udp@kubernetes.default.svc;test -n "$$(dig +tcp +noall +answer +search kubernetes.default.svc A)" && echo OK > /results/wheezy_tcp@kubernetes.default.svc;test -n "$$(dig +notcp +noall +answer +search kubernetes.default.svc.cluster.local A)" && echo OK > /results/wheezy_udp@kubernetes.default.svc.cluster.local;test -n "$$(dig +tcp +noall +answer +search kubernetes.default.svc.cluster.local A)" && echo OK > /results/wheezy_tcp@kubernetes.default.svc.cluster.local;test -n "$$(getent hosts dns-querier-1.dns-test-service.e2e-tests-dns-l786l.svc.cluster.local)" && echo OK > /results/wheezy_hosts@dns-querier-1.dns-test-service.e2e-tests-dns-l786l.svc.cluster.local;test -n "$$(getent hosts dns-querier-1)" && echo OK > /results/wheezy_hosts@dns-querier-1;podARec=$$(hostname -i| awk -F. '{print $$1"-"$$2"-"$$3"-"$$4".e2e-tests-dns-l786l.pod.cluster.local"}');test -n "$$(dig +notcp +noall +answer +search $${podARec} A)" && echo OK > /results/wheezy_udp@PodARecord;test -n "$$(dig +tcp +noall +answer +search $${podARec} A)" && echo OK > /results/wheezy_tcp@PodARecord;sleep 1; done
+
+STEP: Running these commands on jessie: for i in `seq 1 600`; do test -n "$$(dig +notcp +noall +answer +search kubernetes.default A)" && echo OK > /results/jessie_udp@kubernetes.default;test -n "$$(dig +tcp +noall +answer +search kubernetes.default A)" && echo OK > /results/jessie_tcp@kubernetes.default;test -n "$$(dig +notcp +noall +answer +search kubernetes.default.svc A)" && echo OK > /results/jessie_udp@kubernetes.default.svc;test -n "$$(dig +tcp +noall +answer +search kubernetes.default.svc A)" && echo OK > /results/jessie_tcp@kubernetes.default.svc;test -n "$$(dig +notcp +noall +answer +search kubernetes.default.svc.cluster.local A)" && echo OK > /results/jessie_udp@kubernetes.default.svc.cluster.local;test -n "$$(dig +tcp +noall +answer +search kubernetes.default.svc.cluster.local A)" && echo OK > /results/jessie_tcp@kubernetes.default.svc.cluster.local;test -n "$$(getent hosts dns-querier-1.dns-test-service.e2e-tests-dns-l786l.svc.cluster.local)" && echo OK > /results/jessie_hosts@dns-querier-1.dns-test-service.e2e-tests-dns-l786l.svc.cluster.local;test -n "$$(getent hosts dns-querier-1)" && echo OK > /results/jessie_hosts@dns-querier-1;podARec=$$(hostname -i| awk -F. '{print $$1"-"$$2"-"$$3"-"$$4".e2e-tests-dns-l786l.pod.cluster.local"}');test -n "$$(dig +notcp +noall +answer +search $${podARec} A)" && echo OK > /results/jessie_udp@PodARecord;test -n "$$(dig +tcp +noall +answer +search $${podARec} A)" && echo OK > /results/jessie_tcp@PodARecord;sleep 1; done
+
+STEP: creating a pod to probe DNS
+STEP: submitting the pod to kubernetes
+STEP: retrieving the pod
+STEP: looking for the results for each expected name from probers
+Jul  2 13:06:25.793: INFO: DNS probes using dns-test-ad10da66-7df8-11e8-b0f5-565e625ec9a3 succeeded
+
+STEP: deleting the pod
+[AfterEach] [sig-network] DNS
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:06:25.811: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-dns-l786l" for this suite.
+Jul  2 13:06:31.826: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:06:31.832: INFO: namespace: e2e-tests-dns-l786l, resource: bindings, ignored listing per whitelist
+Jul  2 13:06:31.922: INFO: namespace e2e-tests-dns-l786l deletion completed in 6.10723357s
+
+• [SLOW TEST:27.642 seconds]
+[sig-network] DNS
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/network/framework.go:22
+  should provide DNS for the cluster  [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSSSSSSSSSSSSS
+------------------------------
+[sig-network] Networking Granular Checks: Pods 
+  should function for intra-pod communication: udp [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-network] Networking
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:06:31.922: INFO: >>> kubeConfig: /tmp/kubeconfig-293271353
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should function for intra-pod communication: udp [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Performing setup for networking test in namespace e2e-tests-pod-network-test-46bgb
+STEP: creating a selector
+STEP: Creating the service pods in kubernetes
+Jul  2 13:06:32.001: INFO: Waiting up to 10m0s for all (but 0) nodes to be schedulable
+STEP: Creating test pods
+Jul  2 13:06:54.182: INFO: ExecWithOptions {Command:[/bin/sh -c curl -g -q -s 'http://100.96.1.76:8080/dial?request=hostName&protocol=udp&host=100.96.0.30&port=8081&tries=1'] Namespace:e2e-tests-pod-network-test-46bgb PodName:host-test-container-pod ContainerName:hostexec Stdin:<nil> CaptureStdout:true CaptureStderr:true PreserveWhitespace:false}
+Jul  2 13:06:54.182: INFO: >>> kubeConfig: /tmp/kubeconfig-293271353
+Jul  2 13:06:54.531: INFO: Waiting for endpoints: map[]
+Jul  2 13:06:54.535: INFO: ExecWithOptions {Command:[/bin/sh -c curl -g -q -s 'http://100.96.1.76:8080/dial?request=hostName&protocol=udp&host=100.96.1.75&port=8081&tries=1'] Namespace:e2e-tests-pod-network-test-46bgb PodName:host-test-container-pod ContainerName:hostexec Stdin:<nil> CaptureStdout:true CaptureStderr:true PreserveWhitespace:false}
+Jul  2 13:06:54.535: INFO: >>> kubeConfig: /tmp/kubeconfig-293271353
+Jul  2 13:06:54.909: INFO: Waiting for endpoints: map[]
+[AfterEach] [sig-network] Networking
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:06:54.909: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-pod-network-test-46bgb" for this suite.
+Jul  2 13:07:16.978: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:07:17.011: INFO: namespace: e2e-tests-pod-network-test-46bgb, resource: bindings, ignored listing per whitelist
+Jul  2 13:07:17.119: INFO: namespace e2e-tests-pod-network-test-46bgb deletion completed in 22.206210282s
+
+• [SLOW TEST:45.197 seconds]
+[sig-network] Networking
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/networking.go:25
+  Granular Checks: Pods
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/networking.go:28
+    should function for intra-pod communication: udp [NodeConformance] [Conformance]
+    /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+[k8s.io] [sig-node] Events 
+  should be sent by kubelets and the scheduler about pods scheduling and running  [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [k8s.io] [sig-node] Events
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:07:17.119: INFO: >>> kubeConfig: /tmp/kubeconfig-293271353
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should be sent by kubelets and the scheduler about pods scheduling and running  [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: creating the pod
+STEP: submitting the pod to kubernetes
+STEP: verifying the pod is in kubernetes
+STEP: retrieving the pod
+&Pod{ObjectMeta:k8s_io_apimachinery_pkg_apis_meta_v1.ObjectMeta{Name:send-events-d879189d-7df8-11e8-b0f5-565e625ec9a3,GenerateName:,Namespace:e2e-tests-events-4bk82,SelfLink:/api/v1/namespaces/e2e-tests-events-4bk82/pods/send-events-d879189d-7df8-11e8-b0f5-565e625ec9a3,UID:d87ed756-7df8-11e8-876c-5e517afbca85,ResourceVersion:4338,Generation:0,CreationTimestamp:2018-07-02 13:07:17 +0000 UTC,DeletionTimestamp:<nil>,DeletionGracePeriodSeconds:nil,Labels:map[string]string{name: foo,time: 197640531,},Annotations:map[string]string{cni.projectcalico.org/podIP: 100.96.1.77/32,},OwnerReferences:[],Finalizers:[],ClusterName:,Initializers:nil,},Spec:PodSpec{Volumes:[{default-token-cxx8f {nil nil nil nil nil SecretVolumeSource{SecretName:default-token-cxx8f,Items:[],DefaultMode:*420,Optional:nil,} nil nil nil nil nil nil nil nil nil nil nil nil nil nil nil nil nil nil nil nil nil}}],Containers:[{p gcr.io/kubernetes-e2e-test-images/serve-hostname-amd64:1.0 [] []  [{ 0 80 TCP }] [] [] {map[] map[]} [{default-token-cxx8f true /var/run/secrets/kubernetes.io/serviceaccount  <nil>}] [] nil nil nil /dev/termination-log File IfNotPresent nil false false false}],RestartPolicy:Always,TerminationGracePeriodSeconds:*30,ActiveDeadlineSeconds:nil,DNSPolicy:ClusterFirst,NodeSelector:map[string]string{},ServiceAccountName:default,DeprecatedServiceAccount:default,NodeName:shoot--core--confgcp-worker-o1cev-z1-f757498dc-jzlxf,HostNetwork:false,HostPID:false,HostIPC:false,SecurityContext:&PodSecurityContext{SELinuxOptions:nil,RunAsUser:nil,RunAsNonRoot:nil,SupplementalGroups:[],FSGroup:nil,RunAsGroup:nil,Sysctls:[],},ImagePullSecrets:[],Hostname:,Subdomain:,Affinity:nil,SchedulerName:default-scheduler,InitContainers:[],AutomountServiceAccountToken:nil,Tolerations:[{node.kubernetes.io/not-ready Exists  NoExecute 0xc421b47c00} {node.kubernetes.io/unreachable Exists  NoExecute 0xc421b47c20}],HostAliases:[],PriorityClassName:,Priority:nil,DNSConfig:nil,ShareProcessNamespace:nil,ReadinessGates:[],},Status:PodStatus{Phase:Running,Conditions:[{Initialized True 0001-01-01 00:00:00 +0000 UTC 2018-07-02 13:07:17 +0000 UTC  } {Ready True 0001-01-01 00:00:00 +0000 UTC 2018-07-02 13:07:19 +0000 UTC  } {ContainersReady True 0001-01-01 00:00:00 +0000 UTC 0001-01-01 00:00:00 +0000 UTC  } {PodScheduled True 0001-01-01 00:00:00 +0000 UTC 2018-07-02 13:07:17 +0000 UTC  }],Message:,Reason:,HostIP:10.250.0.2,PodIP:100.96.1.77,StartTime:2018-07-02 13:07:17 +0000 UTC,ContainerStatuses:[{p {nil ContainerStateRunning{StartedAt:2018-07-02 13:07:18 +0000 UTC,} nil} {nil nil nil} true 0 gcr.io/kubernetes-e2e-test-images/serve-hostname-amd64:1.0 docker-pullable://gcr.io/kubernetes-e2e-test-images/serve-hostname-amd64@sha256:2dd4032e98a0450d95a0ac71a5e465f542a900812d8c41bc6ca635aed1a5fc91 docker://f5d9c2ca9d2fc58f4bfd57674205e0d2095387d1378533bc474b0da8c26c4def}],QOSClass:BestEffort,InitContainerStatuses:[],NominatedNodeName:,},}
+STEP: checking for scheduler event about the pod
+Saw scheduler event for our pod.
+STEP: checking for kubelet event about the pod
+Saw kubelet event for our pod.
+STEP: deleting the pod
+[AfterEach] [k8s.io] [sig-node] Events
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:07:23.275: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-events-4bk82" for this suite.
+Jul  2 13:07:45.297: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:07:45.417: INFO: namespace: e2e-tests-events-4bk82, resource: bindings, ignored listing per whitelist
+Jul  2 13:07:45.462: INFO: namespace e2e-tests-events-4bk82 deletion completed in 22.176326285s
+
+• [SLOW TEST:28.342 seconds]
+[k8s.io] [sig-node] Events
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:679
+  should be sent by kubelets and the scheduler about pods scheduling and running  [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSSSSSS
+------------------------------
+[sig-storage] EmptyDir volumes 
+  should support (root,0644,tmpfs) [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-storage] EmptyDir volumes
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:07:45.462: INFO: >>> kubeConfig: /tmp/kubeconfig-293271353
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should support (root,0644,tmpfs) [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating a pod to test emptydir 0644 on tmpfs
+Jul  2 13:07:45.554: INFO: Waiting up to 5m0s for pod "pod-e95f4922-7df8-11e8-b0f5-565e625ec9a3" in namespace "e2e-tests-emptydir-hxpbz" to be "success or failure"
+Jul  2 13:07:45.556: INFO: Pod "pod-e95f4922-7df8-11e8-b0f5-565e625ec9a3": Phase="Pending", Reason="", readiness=false. Elapsed: 1.939617ms
+Jul  2 13:07:47.560: INFO: Pod "pod-e95f4922-7df8-11e8-b0f5-565e625ec9a3": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.006013407s
+STEP: Saw pod success
+Jul  2 13:07:47.560: INFO: Pod "pod-e95f4922-7df8-11e8-b0f5-565e625ec9a3" satisfied condition "success or failure"
+Jul  2 13:07:47.563: INFO: Trying to get logs from node shoot--core--confgcp-worker-o1cev-z1-f757498dc-jzlxf pod pod-e95f4922-7df8-11e8-b0f5-565e625ec9a3 container test-container: <nil>
+STEP: delete the pod
+Jul  2 13:07:47.583: INFO: Waiting for pod pod-e95f4922-7df8-11e8-b0f5-565e625ec9a3 to disappear
+Jul  2 13:07:47.588: INFO: Pod pod-e95f4922-7df8-11e8-b0f5-565e625ec9a3 no longer exists
+[AfterEach] [sig-storage] EmptyDir volumes
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:07:47.588: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-emptydir-hxpbz" for this suite.
+Jul  2 13:07:53.601: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:07:53.622: INFO: namespace: e2e-tests-emptydir-hxpbz, resource: bindings, ignored listing per whitelist
+Jul  2 13:07:53.703: INFO: namespace e2e-tests-emptydir-hxpbz deletion completed in 6.112325749s
+
+• [SLOW TEST:8.242 seconds]
+[sig-storage] EmptyDir volumes
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/empty_dir.go:40
+  should support (root,0644,tmpfs) [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSS
+------------------------------
+[sig-storage] Projected 
+  should be consumable from pods in volume with mappings and Item mode set [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:07:53.703: INFO: >>> kubeConfig: /tmp/kubeconfig-293271353
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:858
+[It] should be consumable from pods in volume with mappings and Item mode set [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating configMap with name projected-configmap-test-volume-map-ee46494b-7df8-11e8-b0f5-565e625ec9a3
+STEP: Creating a pod to test consume configMaps
+Jul  2 13:07:53.782: INFO: Waiting up to 5m0s for pod "pod-projected-configmaps-ee46c74f-7df8-11e8-b0f5-565e625ec9a3" in namespace "e2e-tests-projected-k4dzk" to be "success or failure"
+Jul  2 13:07:53.785: INFO: Pod "pod-projected-configmaps-ee46c74f-7df8-11e8-b0f5-565e625ec9a3": Phase="Pending", Reason="", readiness=false. Elapsed: 2.298176ms
+Jul  2 13:07:55.789: INFO: Pod "pod-projected-configmaps-ee46c74f-7df8-11e8-b0f5-565e625ec9a3": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.006145808s
+STEP: Saw pod success
+Jul  2 13:07:55.789: INFO: Pod "pod-projected-configmaps-ee46c74f-7df8-11e8-b0f5-565e625ec9a3" satisfied condition "success or failure"
+Jul  2 13:07:55.791: INFO: Trying to get logs from node shoot--core--confgcp-worker-o1cev-z1-f757498dc-jzlxf pod pod-projected-configmaps-ee46c74f-7df8-11e8-b0f5-565e625ec9a3 container projected-configmap-volume-test: <nil>
+STEP: delete the pod
+Jul  2 13:07:55.807: INFO: Waiting for pod pod-projected-configmaps-ee46c74f-7df8-11e8-b0f5-565e625ec9a3 to disappear
+Jul  2 13:07:55.810: INFO: Pod pod-projected-configmaps-ee46c74f-7df8-11e8-b0f5-565e625ec9a3 no longer exists
+[AfterEach] [sig-storage] Projected
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:07:55.810: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-k4dzk" for this suite.
+Jul  2 13:08:01.823: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:08:01.885: INFO: namespace: e2e-tests-projected-k4dzk, resource: bindings, ignored listing per whitelist
+Jul  2 13:08:01.921: INFO: namespace e2e-tests-projected-k4dzk deletion completed in 6.108666461s
+
+• [SLOW TEST:8.218 seconds]
+[sig-storage] Projected
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:34
+  should be consumable from pods in volume with mappings and Item mode set [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSS
+------------------------------
+[k8s.io] Probing container 
+  with readiness probe that fails should never be ready and never restart [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [k8s.io] Probing container
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:08:01.921: INFO: >>> kubeConfig: /tmp/kubeconfig-293271353
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [k8s.io] Probing container
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/container_probe.go:48
+[It] with readiness probe that fails should never be ready and never restart [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[AfterEach] [k8s.io] Probing container
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:09:02.010: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-container-probe-kpp4r" for this suite.
+Jul  2 13:09:24.025: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:09:24.106: INFO: namespace: e2e-tests-container-probe-kpp4r, resource: bindings, ignored listing per whitelist
+Jul  2 13:09:24.146: INFO: namespace e2e-tests-container-probe-kpp4r deletion completed in 22.132697341s
+
+• [SLOW TEST:82.225 seconds]
+[k8s.io] Probing container
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:679
+  with readiness probe that fails should never be ready and never restart [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSSSSSSSSSSSSSSSSSSSSSSSSSS
+------------------------------
+[sig-storage] Projected 
+  optional updates should be reflected in volume [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:09:24.147: INFO: >>> kubeConfig: /tmp/kubeconfig-293271353
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:858
+[It] optional updates should be reflected in volume [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating configMap with name cm-test-opt-del-24308bbd-7df9-11e8-b0f5-565e625ec9a3
+STEP: Creating configMap with name cm-test-opt-upd-24308bf1-7df9-11e8-b0f5-565e625ec9a3
+STEP: Creating the pod
+STEP: Deleting configmap cm-test-opt-del-24308bbd-7df9-11e8-b0f5-565e625ec9a3
+STEP: Updating configmap cm-test-opt-upd-24308bf1-7df9-11e8-b0f5-565e625ec9a3
+STEP: Creating configMap with name cm-test-opt-create-24308c0b-7df9-11e8-b0f5-565e625ec9a3
+STEP: waiting to observe update in volume
+[AfterEach] [sig-storage] Projected
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:10:56.294: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-pt4v5" for this suite.
+Jul  2 13:11:18.310: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:11:18.330: INFO: namespace: e2e-tests-projected-pt4v5, resource: bindings, ignored listing per whitelist
+Jul  2 13:11:18.409: INFO: namespace e2e-tests-projected-pt4v5 deletion completed in 22.110989913s
+
+• [SLOW TEST:114.262 seconds]
+[sig-storage] Projected
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:34
+  optional updates should be reflected in volume [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSSSSSSSSSSSSS
+------------------------------
+[k8s.io] Probing container 
+  should be restarted with a exec "cat /tmp/health" liveness probe [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [k8s.io] Probing container
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:11:18.409: INFO: >>> kubeConfig: /tmp/kubeconfig-293271353
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [k8s.io] Probing container
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/container_probe.go:48
+[It] should be restarted with a exec "cat /tmp/health" liveness probe [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating pod liveness-exec in namespace e2e-tests-container-probe-2q7n7
+Jul  2 13:11:22.497: INFO: Started pod liveness-exec in namespace e2e-tests-container-probe-2q7n7
+STEP: checking the pod's current state and verifying that restartCount is present
+Jul  2 13:11:22.500: INFO: Initial restart count of pod liveness-exec is 0
+Jul  2 13:12:10.593: INFO: Restart count of pod e2e-tests-container-probe-2q7n7/liveness-exec is now 1 (48.093344597s elapsed)
+STEP: deleting the pod
+[AfterEach] [k8s.io] Probing container
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:12:10.676: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-container-probe-2q7n7" for this suite.
+Jul  2 13:12:16.700: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:12:16.730: INFO: namespace: e2e-tests-container-probe-2q7n7, resource: bindings, ignored listing per whitelist
+Jul  2 13:12:16.789: INFO: namespace e2e-tests-container-probe-2q7n7 deletion completed in 6.102390646s
+
+• [SLOW TEST:58.380 seconds]
+[k8s.io] Probing container
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:679
+  should be restarted with a exec "cat /tmp/health" liveness probe [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSS
+------------------------------
+[sig-api-machinery] Watchers 
+  should observe add, update, and delete watch notifications on configmaps [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-api-machinery] Watchers
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:12:16.789: INFO: >>> kubeConfig: /tmp/kubeconfig-293271353
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should observe add, update, and delete watch notifications on configmaps [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: creating a watch on configmaps with label A
+STEP: creating a watch on configmaps with label B
+STEP: creating a watch on configmaps with label A or B
+STEP: creating a configmap with label A and ensuring the correct watchers observe the notification
+Jul  2 13:12:16.877: INFO: Got : ADDED &ConfigMap{ObjectMeta:k8s_io_apimachinery_pkg_apis_meta_v1.ObjectMeta{Name:e2e-watch-test-configmap-a,GenerateName:,Namespace:e2e-tests-watch-qcsv5,SelfLink:/api/v1/namespaces/e2e-tests-watch-qcsv5/configmaps/e2e-watch-test-configmap-a,UID:8b1d9bea-7df9-11e8-876c-5e517afbca85,ResourceVersion:5045,Generation:0,CreationTimestamp:2018-07-02 13:12:16 +0000 UTC,DeletionTimestamp:<nil>,DeletionGracePeriodSeconds:nil,Labels:map[string]string{watch-this-configmap: multiple-watchers-A,},Annotations:map[string]string{},OwnerReferences:[],Finalizers:[],ClusterName:,Initializers:nil,},Data:map[string]string{},BinaryData:map[string][]byte{},}
+Jul  2 13:12:16.877: INFO: Got : ADDED &ConfigMap{ObjectMeta:k8s_io_apimachinery_pkg_apis_meta_v1.ObjectMeta{Name:e2e-watch-test-configmap-a,GenerateName:,Namespace:e2e-tests-watch-qcsv5,SelfLink:/api/v1/namespaces/e2e-tests-watch-qcsv5/configmaps/e2e-watch-test-configmap-a,UID:8b1d9bea-7df9-11e8-876c-5e517afbca85,ResourceVersion:5045,Generation:0,CreationTimestamp:2018-07-02 13:12:16 +0000 UTC,DeletionTimestamp:<nil>,DeletionGracePeriodSeconds:nil,Labels:map[string]string{watch-this-configmap: multiple-watchers-A,},Annotations:map[string]string{},OwnerReferences:[],Finalizers:[],ClusterName:,Initializers:nil,},Data:map[string]string{},BinaryData:map[string][]byte{},}
+STEP: modifying configmap A and ensuring the correct watchers observe the notification
+Jul  2 13:12:26.972: INFO: Got : MODIFIED &ConfigMap{ObjectMeta:k8s_io_apimachinery_pkg_apis_meta_v1.ObjectMeta{Name:e2e-watch-test-configmap-a,GenerateName:,Namespace:e2e-tests-watch-qcsv5,SelfLink:/api/v1/namespaces/e2e-tests-watch-qcsv5/configmaps/e2e-watch-test-configmap-a,UID:8b1d9bea-7df9-11e8-876c-5e517afbca85,ResourceVersion:5066,Generation:0,CreationTimestamp:2018-07-02 13:12:16 +0000 UTC,DeletionTimestamp:<nil>,DeletionGracePeriodSeconds:nil,Labels:map[string]string{watch-this-configmap: multiple-watchers-A,},Annotations:map[string]string{},OwnerReferences:[],Finalizers:[],ClusterName:,Initializers:nil,},Data:map[string]string{mutation: 1,},BinaryData:map[string][]byte{},}
+Jul  2 13:12:26.972: INFO: Got : MODIFIED &ConfigMap{ObjectMeta:k8s_io_apimachinery_pkg_apis_meta_v1.ObjectMeta{Name:e2e-watch-test-configmap-a,GenerateName:,Namespace:e2e-tests-watch-qcsv5,SelfLink:/api/v1/namespaces/e2e-tests-watch-qcsv5/configmaps/e2e-watch-test-configmap-a,UID:8b1d9bea-7df9-11e8-876c-5e517afbca85,ResourceVersion:5066,Generation:0,CreationTimestamp:2018-07-02 13:12:16 +0000 UTC,DeletionTimestamp:<nil>,DeletionGracePeriodSeconds:nil,Labels:map[string]string{watch-this-configmap: multiple-watchers-A,},Annotations:map[string]string{},OwnerReferences:[],Finalizers:[],ClusterName:,Initializers:nil,},Data:map[string]string{mutation: 1,},BinaryData:map[string][]byte{},}
+STEP: modifying configmap A again and ensuring the correct watchers observe the notification
+Jul  2 13:12:37.070: INFO: Got : MODIFIED &ConfigMap{ObjectMeta:k8s_io_apimachinery_pkg_apis_meta_v1.ObjectMeta{Name:e2e-watch-test-configmap-a,GenerateName:,Namespace:e2e-tests-watch-qcsv5,SelfLink:/api/v1/namespaces/e2e-tests-watch-qcsv5/configmaps/e2e-watch-test-configmap-a,UID:8b1d9bea-7df9-11e8-876c-5e517afbca85,ResourceVersion:5086,Generation:0,CreationTimestamp:2018-07-02 13:12:16 +0000 UTC,DeletionTimestamp:<nil>,DeletionGracePeriodSeconds:nil,Labels:map[string]string{watch-this-configmap: multiple-watchers-A,},Annotations:map[string]string{},OwnerReferences:[],Finalizers:[],ClusterName:,Initializers:nil,},Data:map[string]string{mutation: 2,},BinaryData:map[string][]byte{},}
+Jul  2 13:12:37.071: INFO: Got : MODIFIED &ConfigMap{ObjectMeta:k8s_io_apimachinery_pkg_apis_meta_v1.ObjectMeta{Name:e2e-watch-test-configmap-a,GenerateName:,Namespace:e2e-tests-watch-qcsv5,SelfLink:/api/v1/namespaces/e2e-tests-watch-qcsv5/configmaps/e2e-watch-test-configmap-a,UID:8b1d9bea-7df9-11e8-876c-5e517afbca85,ResourceVersion:5086,Generation:0,CreationTimestamp:2018-07-02 13:12:16 +0000 UTC,DeletionTimestamp:<nil>,DeletionGracePeriodSeconds:nil,Labels:map[string]string{watch-this-configmap: multiple-watchers-A,},Annotations:map[string]string{},OwnerReferences:[],Finalizers:[],ClusterName:,Initializers:nil,},Data:map[string]string{mutation: 2,},BinaryData:map[string][]byte{},}
+STEP: deleting configmap A and ensuring the correct watchers observe the notification
+Jul  2 13:12:47.080: INFO: Got : DELETED &ConfigMap{ObjectMeta:k8s_io_apimachinery_pkg_apis_meta_v1.ObjectMeta{Name:e2e-watch-test-configmap-a,GenerateName:,Namespace:e2e-tests-watch-qcsv5,SelfLink:/api/v1/namespaces/e2e-tests-watch-qcsv5/configmaps/e2e-watch-test-configmap-a,UID:8b1d9bea-7df9-11e8-876c-5e517afbca85,ResourceVersion:5108,Generation:0,CreationTimestamp:2018-07-02 13:12:16 +0000 UTC,DeletionTimestamp:<nil>,DeletionGracePeriodSeconds:nil,Labels:map[string]string{watch-this-configmap: multiple-watchers-A,},Annotations:map[string]string{},OwnerReferences:[],Finalizers:[],ClusterName:,Initializers:nil,},Data:map[string]string{mutation: 2,},BinaryData:map[string][]byte{},}
+Jul  2 13:12:47.080: INFO: Got : DELETED &ConfigMap{ObjectMeta:k8s_io_apimachinery_pkg_apis_meta_v1.ObjectMeta{Name:e2e-watch-test-configmap-a,GenerateName:,Namespace:e2e-tests-watch-qcsv5,SelfLink:/api/v1/namespaces/e2e-tests-watch-qcsv5/configmaps/e2e-watch-test-configmap-a,UID:8b1d9bea-7df9-11e8-876c-5e517afbca85,ResourceVersion:5108,Generation:0,CreationTimestamp:2018-07-02 13:12:16 +0000 UTC,DeletionTimestamp:<nil>,DeletionGracePeriodSeconds:nil,Labels:map[string]string{watch-this-configmap: multiple-watchers-A,},Annotations:map[string]string{},OwnerReferences:[],Finalizers:[],ClusterName:,Initializers:nil,},Data:map[string]string{mutation: 2,},BinaryData:map[string][]byte{},}
+STEP: creating a configmap with label B and ensuring the correct watchers observe the notification
+Jul  2 13:12:57.171: INFO: Got : ADDED &ConfigMap{ObjectMeta:k8s_io_apimachinery_pkg_apis_meta_v1.ObjectMeta{Name:e2e-watch-test-configmap-b,GenerateName:,Namespace:e2e-tests-watch-qcsv5,SelfLink:/api/v1/namespaces/e2e-tests-watch-qcsv5/configmaps/e2e-watch-test-configmap-b,UID:a314d186-7df9-11e8-876c-5e517afbca85,ResourceVersion:5130,Generation:0,CreationTimestamp:2018-07-02 13:12:57 +0000 UTC,DeletionTimestamp:<nil>,DeletionGracePeriodSeconds:nil,Labels:map[string]string{watch-this-configmap: multiple-watchers-B,},Annotations:map[string]string{},OwnerReferences:[],Finalizers:[],ClusterName:,Initializers:nil,},Data:map[string]string{},BinaryData:map[string][]byte{},}
+Jul  2 13:12:57.172: INFO: Got : ADDED &ConfigMap{ObjectMeta:k8s_io_apimachinery_pkg_apis_meta_v1.ObjectMeta{Name:e2e-watch-test-configmap-b,GenerateName:,Namespace:e2e-tests-watch-qcsv5,SelfLink:/api/v1/namespaces/e2e-tests-watch-qcsv5/configmaps/e2e-watch-test-configmap-b,UID:a314d186-7df9-11e8-876c-5e517afbca85,ResourceVersion:5130,Generation:0,CreationTimestamp:2018-07-02 13:12:57 +0000 UTC,DeletionTimestamp:<nil>,DeletionGracePeriodSeconds:nil,Labels:map[string]string{watch-this-configmap: multiple-watchers-B,},Annotations:map[string]string{},OwnerReferences:[],Finalizers:[],ClusterName:,Initializers:nil,},Data:map[string]string{},BinaryData:map[string][]byte{},}
+STEP: deleting configmap B and ensuring the correct watchers observe the notification
+Jul  2 13:13:07.272: INFO: Got : DELETED &ConfigMap{ObjectMeta:k8s_io_apimachinery_pkg_apis_meta_v1.ObjectMeta{Name:e2e-watch-test-configmap-b,GenerateName:,Namespace:e2e-tests-watch-qcsv5,SelfLink:/api/v1/namespaces/e2e-tests-watch-qcsv5/configmaps/e2e-watch-test-configmap-b,UID:a314d186-7df9-11e8-876c-5e517afbca85,ResourceVersion:5150,Generation:0,CreationTimestamp:2018-07-02 13:12:57 +0000 UTC,DeletionTimestamp:<nil>,DeletionGracePeriodSeconds:nil,Labels:map[string]string{watch-this-configmap: multiple-watchers-B,},Annotations:map[string]string{},OwnerReferences:[],Finalizers:[],ClusterName:,Initializers:nil,},Data:map[string]string{},BinaryData:map[string][]byte{},}
+Jul  2 13:13:07.272: INFO: Got : DELETED &ConfigMap{ObjectMeta:k8s_io_apimachinery_pkg_apis_meta_v1.ObjectMeta{Name:e2e-watch-test-configmap-b,GenerateName:,Namespace:e2e-tests-watch-qcsv5,SelfLink:/api/v1/namespaces/e2e-tests-watch-qcsv5/configmaps/e2e-watch-test-configmap-b,UID:a314d186-7df9-11e8-876c-5e517afbca85,ResourceVersion:5150,Generation:0,CreationTimestamp:2018-07-02 13:12:57 +0000 UTC,DeletionTimestamp:<nil>,DeletionGracePeriodSeconds:nil,Labels:map[string]string{watch-this-configmap: multiple-watchers-B,},Annotations:map[string]string{},OwnerReferences:[],Finalizers:[],ClusterName:,Initializers:nil,},Data:map[string]string{},BinaryData:map[string][]byte{},}
+[AfterEach] [sig-api-machinery] Watchers
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:13:17.272: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-watch-qcsv5" for this suite.
+Jul  2 13:13:23.472: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:13:23.596: INFO: namespace: e2e-tests-watch-qcsv5, resource: bindings, ignored listing per whitelist
+Jul  2 13:13:23.607: INFO: namespace e2e-tests-watch-qcsv5 deletion completed in 6.330552132s
+
+• [SLOW TEST:66.818 seconds]
+[sig-api-machinery] Watchers
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apimachinery/framework.go:22
+  should observe add, update, and delete watch notifications on configmaps [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSSSS
+------------------------------
+[sig-storage] ConfigMap 
+  should be consumable from pods in volume with mappings as non-root [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-storage] ConfigMap
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:13:23.607: INFO: >>> kubeConfig: /tmp/kubeconfig-293271353
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should be consumable from pods in volume with mappings as non-root [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating configMap with name configmap-test-volume-map-b2eabc8b-7df9-11e8-b0f5-565e625ec9a3
+STEP: Creating a pod to test consume configMaps
+Jul  2 13:13:23.693: INFO: Waiting up to 5m0s for pod "pod-configmaps-b2eb2cc4-7df9-11e8-b0f5-565e625ec9a3" in namespace "e2e-tests-configmap-vn4ls" to be "success or failure"
+Jul  2 13:13:23.695: INFO: Pod "pod-configmaps-b2eb2cc4-7df9-11e8-b0f5-565e625ec9a3": Phase="Pending", Reason="", readiness=false. Elapsed: 2.743927ms
+Jul  2 13:13:25.770: INFO: Pod "pod-configmaps-b2eb2cc4-7df9-11e8-b0f5-565e625ec9a3": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.077235397s
+STEP: Saw pod success
+Jul  2 13:13:25.770: INFO: Pod "pod-configmaps-b2eb2cc4-7df9-11e8-b0f5-565e625ec9a3" satisfied condition "success or failure"
+Jul  2 13:13:25.773: INFO: Trying to get logs from node shoot--core--confgcp-worker-o1cev-z1-f757498dc-jzlxf pod pod-configmaps-b2eb2cc4-7df9-11e8-b0f5-565e625ec9a3 container configmap-volume-test: <nil>
+STEP: delete the pod
+Jul  2 13:13:25.887: INFO: Waiting for pod pod-configmaps-b2eb2cc4-7df9-11e8-b0f5-565e625ec9a3 to disappear
+Jul  2 13:13:25.891: INFO: Pod pod-configmaps-b2eb2cc4-7df9-11e8-b0f5-565e625ec9a3 no longer exists
+[AfterEach] [sig-storage] ConfigMap
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:13:25.891: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-configmap-vn4ls" for this suite.
+Jul  2 13:13:31.903: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:13:31.911: INFO: namespace: e2e-tests-configmap-vn4ls, resource: bindings, ignored listing per whitelist
+Jul  2 13:13:32.034: INFO: namespace e2e-tests-configmap-vn4ls deletion completed in 6.140526202s
+
+• [SLOW TEST:8.427 seconds]
+[sig-storage] ConfigMap
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/configmap_volume.go:32
+  should be consumable from pods in volume with mappings as non-root [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSS
+------------------------------
+[k8s.io] Variable Expansion 
+  should allow composing env vars into new env vars [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [k8s.io] Variable Expansion
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:13:32.034: INFO: >>> kubeConfig: /tmp/kubeconfig-293271353
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should allow composing env vars into new env vars [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating a pod to test env composition
+Jul  2 13:13:32.118: INFO: Waiting up to 5m0s for pod "var-expansion-b7f09a4d-7df9-11e8-b0f5-565e625ec9a3" in namespace "e2e-tests-var-expansion-w787p" to be "success or failure"
+Jul  2 13:13:32.120: INFO: Pod "var-expansion-b7f09a4d-7df9-11e8-b0f5-565e625ec9a3": Phase="Pending", Reason="", readiness=false. Elapsed: 2.825384ms
+Jul  2 13:13:34.124: INFO: Pod "var-expansion-b7f09a4d-7df9-11e8-b0f5-565e625ec9a3": Phase="Pending", Reason="", readiness=false. Elapsed: 2.006448437s
+Jul  2 13:13:36.128: INFO: Pod "var-expansion-b7f09a4d-7df9-11e8-b0f5-565e625ec9a3": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.010649218s
+STEP: Saw pod success
+Jul  2 13:13:36.128: INFO: Pod "var-expansion-b7f09a4d-7df9-11e8-b0f5-565e625ec9a3" satisfied condition "success or failure"
+Jul  2 13:13:36.131: INFO: Trying to get logs from node shoot--core--confgcp-worker-o1cev-z1-f757498dc-jzlxf pod var-expansion-b7f09a4d-7df9-11e8-b0f5-565e625ec9a3 container dapi-container: <nil>
+STEP: delete the pod
+Jul  2 13:13:36.158: INFO: Waiting for pod var-expansion-b7f09a4d-7df9-11e8-b0f5-565e625ec9a3 to disappear
+Jul  2 13:13:36.164: INFO: Pod var-expansion-b7f09a4d-7df9-11e8-b0f5-565e625ec9a3 no longer exists
+[AfterEach] [k8s.io] Variable Expansion
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:13:36.164: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-var-expansion-w787p" for this suite.
+Jul  2 13:13:42.270: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:13:42.327: INFO: namespace: e2e-tests-var-expansion-w787p, resource: bindings, ignored listing per whitelist
+Jul  2 13:13:42.364: INFO: namespace e2e-tests-var-expansion-w787p deletion completed in 6.194147487s
+
+• [SLOW TEST:10.330 seconds]
+[k8s.io] Variable Expansion
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:679
+  should allow composing env vars into new env vars [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSSSSSS
+------------------------------
+[sig-storage] ConfigMap 
+  should be consumable from pods in volume with defaultMode set [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-storage] ConfigMap
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:13:42.365: INFO: >>> kubeConfig: /tmp/kubeconfig-293271353
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should be consumable from pods in volume with defaultMode set [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating configMap with name configmap-test-volume-be1858a6-7df9-11e8-b0f5-565e625ec9a3
+STEP: Creating a pod to test consume configMaps
+Jul  2 13:13:42.447: INFO: Waiting up to 5m0s for pod "pod-configmaps-be18c680-7df9-11e8-b0f5-565e625ec9a3" in namespace "e2e-tests-configmap-tdsfp" to be "success or failure"
+Jul  2 13:13:42.449: INFO: Pod "pod-configmaps-be18c680-7df9-11e8-b0f5-565e625ec9a3": Phase="Pending", Reason="", readiness=false. Elapsed: 2.115602ms
+Jul  2 13:13:44.453: INFO: Pod "pod-configmaps-be18c680-7df9-11e8-b0f5-565e625ec9a3": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.005798782s
+STEP: Saw pod success
+Jul  2 13:13:44.453: INFO: Pod "pod-configmaps-be18c680-7df9-11e8-b0f5-565e625ec9a3" satisfied condition "success or failure"
+Jul  2 13:13:44.455: INFO: Trying to get logs from node shoot--core--confgcp-worker-o1cev-z1-f757498dc-jzlxf pod pod-configmaps-be18c680-7df9-11e8-b0f5-565e625ec9a3 container configmap-volume-test: <nil>
+STEP: delete the pod
+Jul  2 13:13:44.473: INFO: Waiting for pod pod-configmaps-be18c680-7df9-11e8-b0f5-565e625ec9a3 to disappear
+Jul  2 13:13:44.477: INFO: Pod pod-configmaps-be18c680-7df9-11e8-b0f5-565e625ec9a3 no longer exists
+[AfterEach] [sig-storage] ConfigMap
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:13:44.477: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-configmap-tdsfp" for this suite.
+Jul  2 13:13:50.490: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:13:50.689: INFO: namespace: e2e-tests-configmap-tdsfp, resource: bindings, ignored listing per whitelist
+Jul  2 13:13:50.707: INFO: namespace e2e-tests-configmap-tdsfp deletion completed in 6.227461237s
+
+• [SLOW TEST:8.343 seconds]
+[sig-storage] ConfigMap
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/configmap_volume.go:32
+  should be consumable from pods in volume with defaultMode set [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+[sig-storage] Downward API volume 
+  should provide node allocatable (cpu) as default cpu limit if the limit is not set [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:13:50.707: INFO: >>> kubeConfig: /tmp/kubeconfig-293271353
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downwardapi_volume.go:38
+[It] should provide node allocatable (cpu) as default cpu limit if the limit is not set [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating a pod to test downward API volume plugin
+Jul  2 13:13:50.789: INFO: Waiting up to 5m0s for pod "downwardapi-volume-c311a56e-7df9-11e8-b0f5-565e625ec9a3" in namespace "e2e-tests-downward-api-4lwst" to be "success or failure"
+Jul  2 13:13:50.791: INFO: Pod "downwardapi-volume-c311a56e-7df9-11e8-b0f5-565e625ec9a3": Phase="Pending", Reason="", readiness=false. Elapsed: 2.222538ms
+Jul  2 13:13:52.795: INFO: Pod "downwardapi-volume-c311a56e-7df9-11e8-b0f5-565e625ec9a3": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.006160352s
+STEP: Saw pod success
+Jul  2 13:13:52.795: INFO: Pod "downwardapi-volume-c311a56e-7df9-11e8-b0f5-565e625ec9a3" satisfied condition "success or failure"
+Jul  2 13:13:52.798: INFO: Trying to get logs from node shoot--core--confgcp-worker-o1cev-z1-f757498dc-jzlxf pod downwardapi-volume-c311a56e-7df9-11e8-b0f5-565e625ec9a3 container client-container: <nil>
+STEP: delete the pod
+Jul  2 13:13:52.886: INFO: Waiting for pod downwardapi-volume-c311a56e-7df9-11e8-b0f5-565e625ec9a3 to disappear
+Jul  2 13:13:52.889: INFO: Pod downwardapi-volume-c311a56e-7df9-11e8-b0f5-565e625ec9a3 no longer exists
+[AfterEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:13:52.889: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-downward-api-4lwst" for this suite.
+Jul  2 13:13:58.902: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:13:58.962: INFO: namespace: e2e-tests-downward-api-4lwst, resource: bindings, ignored listing per whitelist
+Jul  2 13:13:58.991: INFO: namespace e2e-tests-downward-api-4lwst deletion completed in 6.099262382s
+
+• [SLOW TEST:8.284 seconds]
+[sig-storage] Downward API volume
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downwardapi_volume.go:33
+  should provide node allocatable (cpu) as default cpu limit if the limit is not set [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSSSSS
+------------------------------
+[sig-apps] ReplicationController 
+  should serve a basic image on each replica with a public image  [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-apps] ReplicationController
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:13:58.992: INFO: >>> kubeConfig: /tmp/kubeconfig-293271353
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should serve a basic image on each replica with a public image  [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating replication controller my-hostname-basic-c8018d77-7df9-11e8-b0f5-565e625ec9a3
+Jul  2 13:13:59.072: INFO: Pod name my-hostname-basic-c8018d77-7df9-11e8-b0f5-565e625ec9a3: Found 0 pods out of 1
+Jul  2 13:14:04.077: INFO: Pod name my-hostname-basic-c8018d77-7df9-11e8-b0f5-565e625ec9a3: Found 1 pods out of 1
+Jul  2 13:14:04.077: INFO: Ensuring all pods for ReplicationController "my-hostname-basic-c8018d77-7df9-11e8-b0f5-565e625ec9a3" are running
+Jul  2 13:14:04.080: INFO: Pod "my-hostname-basic-c8018d77-7df9-11e8-b0f5-565e625ec9a3-rnb28" is running (conditions: [{Type:Initialized Status:True LastProbeTime:0001-01-01 00:00:00 +0000 UTC LastTransitionTime:2018-07-02 13:13:59 +0000 UTC Reason: Message:} {Type:Ready Status:True LastProbeTime:0001-01-01 00:00:00 +0000 UTC LastTransitionTime:2018-07-02 13:14:00 +0000 UTC Reason: Message:} {Type:ContainersReady Status:True LastProbeTime:0001-01-01 00:00:00 +0000 UTC LastTransitionTime:0001-01-01 00:00:00 +0000 UTC Reason: Message:} {Type:PodScheduled Status:True LastProbeTime:0001-01-01 00:00:00 +0000 UTC LastTransitionTime:2018-07-02 13:13:59 +0000 UTC Reason: Message:}])
+Jul  2 13:14:04.080: INFO: Trying to dial the pod
+Jul  2 13:14:09.177: INFO: Controller my-hostname-basic-c8018d77-7df9-11e8-b0f5-565e625ec9a3: Got expected result from replica 1 [my-hostname-basic-c8018d77-7df9-11e8-b0f5-565e625ec9a3-rnb28]: "my-hostname-basic-c8018d77-7df9-11e8-b0f5-565e625ec9a3-rnb28", 1 of 1 required successes so far
+[AfterEach] [sig-apps] ReplicationController
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:14:09.177: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-replication-controller-k9jrr" for this suite.
+Jul  2 13:14:15.193: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:14:15.377: INFO: namespace: e2e-tests-replication-controller-k9jrr, resource: bindings, ignored listing per whitelist
+Jul  2 13:14:15.435: INFO: namespace e2e-tests-replication-controller-k9jrr deletion completed in 6.253865076s
+
+• [SLOW TEST:16.444 seconds]
+[sig-apps] ReplicationController
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/framework.go:22
+  should serve a basic image on each replica with a public image  [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSSSS
+------------------------------
+[sig-apps] StatefulSet [k8s.io] Basic StatefulSet functionality [StatefulSetBasic] 
+  should perform canary updates and phased rolling updates of template modifications [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-apps] StatefulSet
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:14:15.436: INFO: >>> kubeConfig: /tmp/kubeconfig-293271353
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-apps] StatefulSet
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/statefulset.go:57
+[BeforeEach] [k8s.io] Basic StatefulSet functionality [StatefulSetBasic]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/statefulset.go:72
+STEP: Creating service test in namespace e2e-tests-statefulset-5dfqv
+[It] should perform canary updates and phased rolling updates of template modifications [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating a new StaefulSet
+Jul  2 13:14:15.527: INFO: Found 0 stateful pods, waiting for 3
+Jul  2 13:14:25.532: INFO: Waiting for pod ss2-0 to enter Running - Ready=true, currently Running - Ready=true
+Jul  2 13:14:25.532: INFO: Waiting for pod ss2-1 to enter Running - Ready=true, currently Running - Ready=true
+Jul  2 13:14:25.532: INFO: Waiting for pod ss2-2 to enter Running - Ready=true, currently Running - Ready=true
+STEP: Updating stateful set template: update image from k8s.gcr.io/nginx-slim-amd64:0.20 to k8s.gcr.io/nginx-slim-amd64:0.21
+Jul  2 13:14:25.561: INFO: Updating stateful set ss2
+STEP: Creating a new revision
+STEP: Not applying an update when the partition is greater than the number of replicas
+STEP: Performing a canary update
+Jul  2 13:14:35.592: INFO: Updating stateful set ss2
+Jul  2 13:14:35.598: INFO: Waiting for Pod e2e-tests-statefulset-5dfqv/ss2-2 to have revision ss2-56dd5fb9c4 update revision ss2-76cb68b6ff
+STEP: Restoring Pods to the correct revision when they are deleted
+Jul  2 13:14:45.697: INFO: Found 2 stateful pods, waiting for 3
+Jul  2 13:14:55.702: INFO: Waiting for pod ss2-0 to enter Running - Ready=true, currently Running - Ready=true
+Jul  2 13:14:55.702: INFO: Waiting for pod ss2-1 to enter Running - Ready=true, currently Running - Ready=true
+Jul  2 13:14:55.702: INFO: Waiting for pod ss2-2 to enter Running - Ready=true, currently Running - Ready=true
+STEP: Performing a phased rolling update
+Jul  2 13:14:55.789: INFO: Updating stateful set ss2
+Jul  2 13:14:55.795: INFO: Waiting for Pod e2e-tests-statefulset-5dfqv/ss2-1 to have revision ss2-56dd5fb9c4 update revision ss2-76cb68b6ff
+Jul  2 13:15:05.803: INFO: Waiting for Pod e2e-tests-statefulset-5dfqv/ss2-1 to have revision ss2-56dd5fb9c4 update revision ss2-76cb68b6ff
+Jul  2 13:15:15.820: INFO: Updating stateful set ss2
+Jul  2 13:15:15.825: INFO: Waiting for StatefulSet e2e-tests-statefulset-5dfqv/ss2 to complete update
+Jul  2 13:15:15.825: INFO: Waiting for Pod e2e-tests-statefulset-5dfqv/ss2-0 to have revision ss2-56dd5fb9c4 update revision ss2-76cb68b6ff
+Jul  2 13:15:25.835: INFO: Waiting for StatefulSet e2e-tests-statefulset-5dfqv/ss2 to complete update
+Jul  2 13:15:25.836: INFO: Waiting for Pod e2e-tests-statefulset-5dfqv/ss2-0 to have revision ss2-56dd5fb9c4 update revision ss2-76cb68b6ff
+[AfterEach] [k8s.io] Basic StatefulSet functionality [StatefulSetBasic]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/statefulset.go:83
+Jul  2 13:15:35.833: INFO: Deleting all statefulset in ns e2e-tests-statefulset-5dfqv
+Jul  2 13:15:35.835: INFO: Scaling statefulset ss2 to 0
+Jul  2 13:16:05.849: INFO: Waiting for statefulset status.replicas updated to 0
+Jul  2 13:16:05.852: INFO: Deleting statefulset ss2
+[AfterEach] [sig-apps] StatefulSet
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:16:05.861: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-statefulset-5dfqv" for this suite.
+Jul  2 13:16:11.874: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:16:12.031: INFO: namespace: e2e-tests-statefulset-5dfqv, resource: bindings, ignored listing per whitelist
+Jul  2 13:16:12.043: INFO: namespace e2e-tests-statefulset-5dfqv deletion completed in 6.178731294s
+
+• [SLOW TEST:116.608 seconds]
+[sig-apps] StatefulSet
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/framework.go:22
+  [k8s.io] Basic StatefulSet functionality [StatefulSetBasic]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:679
+    should perform canary updates and phased rolling updates of template modifications [Conformance]
+    /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+[sig-storage] Secrets 
+  should be consumable from pods in volume with mappings and Item Mode set [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-storage] Secrets
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:16:12.043: INFO: >>> kubeConfig: /tmp/kubeconfig-293271353
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should be consumable from pods in volume with mappings and Item Mode set [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating secret with name secret-test-map-174f80fd-7dfa-11e8-b0f5-565e625ec9a3
+STEP: Creating a pod to test consume secrets
+Jul  2 13:16:12.125: INFO: Waiting up to 5m0s for pod "pod-secrets-174ff013-7dfa-11e8-b0f5-565e625ec9a3" in namespace "e2e-tests-secrets-7dslr" to be "success or failure"
+Jul  2 13:16:12.128: INFO: Pod "pod-secrets-174ff013-7dfa-11e8-b0f5-565e625ec9a3": Phase="Pending", Reason="", readiness=false. Elapsed: 2.316222ms
+Jul  2 13:16:14.131: INFO: Pod "pod-secrets-174ff013-7dfa-11e8-b0f5-565e625ec9a3": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.006006775s
+STEP: Saw pod success
+Jul  2 13:16:14.131: INFO: Pod "pod-secrets-174ff013-7dfa-11e8-b0f5-565e625ec9a3" satisfied condition "success or failure"
+Jul  2 13:16:14.134: INFO: Trying to get logs from node shoot--core--confgcp-worker-o1cev-z1-f757498dc-jzlxf pod pod-secrets-174ff013-7dfa-11e8-b0f5-565e625ec9a3 container secret-volume-test: <nil>
+STEP: delete the pod
+Jul  2 13:16:14.195: INFO: Waiting for pod pod-secrets-174ff013-7dfa-11e8-b0f5-565e625ec9a3 to disappear
+Jul  2 13:16:14.198: INFO: Pod pod-secrets-174ff013-7dfa-11e8-b0f5-565e625ec9a3 no longer exists
+[AfterEach] [sig-storage] Secrets
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:16:14.198: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-secrets-7dslr" for this suite.
+Jul  2 13:16:20.211: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:16:20.260: INFO: namespace: e2e-tests-secrets-7dslr, resource: bindings, ignored listing per whitelist
+Jul  2 13:16:20.374: INFO: namespace e2e-tests-secrets-7dslr deletion completed in 6.173276836s
+
+• [SLOW TEST:8.331 seconds]
+[sig-storage] Secrets
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/secrets_volume.go:33
+  should be consumable from pods in volume with mappings and Item Mode set [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSSSSSSSSSSSSS
+------------------------------
+[sig-storage] Downward API volume 
+  should provide node allocatable (memory) as default memory limit if the limit is not set [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:16:20.375: INFO: >>> kubeConfig: /tmp/kubeconfig-293271353
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downwardapi_volume.go:38
+[It] should provide node allocatable (memory) as default memory limit if the limit is not set [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating a pod to test downward API volume plugin
+Jul  2 13:16:20.451: INFO: Waiting up to 5m0s for pod "downwardapi-volume-1c4642ef-7dfa-11e8-b0f5-565e625ec9a3" in namespace "e2e-tests-downward-api-g896n" to be "success or failure"
+Jul  2 13:16:20.453: INFO: Pod "downwardapi-volume-1c4642ef-7dfa-11e8-b0f5-565e625ec9a3": Phase="Pending", Reason="", readiness=false. Elapsed: 2.00986ms
+Jul  2 13:16:22.456: INFO: Pod "downwardapi-volume-1c4642ef-7dfa-11e8-b0f5-565e625ec9a3": Phase="Pending", Reason="", readiness=false. Elapsed: 2.005710136s
+Jul  2 13:16:24.461: INFO: Pod "downwardapi-volume-1c4642ef-7dfa-11e8-b0f5-565e625ec9a3": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.010047598s
+STEP: Saw pod success
+Jul  2 13:16:24.461: INFO: Pod "downwardapi-volume-1c4642ef-7dfa-11e8-b0f5-565e625ec9a3" satisfied condition "success or failure"
+Jul  2 13:16:24.471: INFO: Trying to get logs from node shoot--core--confgcp-worker-o1cev-z1-f757498dc-jzlxf pod downwardapi-volume-1c4642ef-7dfa-11e8-b0f5-565e625ec9a3 container client-container: <nil>
+STEP: delete the pod
+Jul  2 13:16:24.494: INFO: Waiting for pod downwardapi-volume-1c4642ef-7dfa-11e8-b0f5-565e625ec9a3 to disappear
+Jul  2 13:16:24.496: INFO: Pod downwardapi-volume-1c4642ef-7dfa-11e8-b0f5-565e625ec9a3 no longer exists
+[AfterEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:16:24.496: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-downward-api-g896n" for this suite.
+Jul  2 13:16:30.518: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:16:30.558: INFO: namespace: e2e-tests-downward-api-g896n, resource: bindings, ignored listing per whitelist
+Jul  2 13:16:30.605: INFO: namespace e2e-tests-downward-api-g896n deletion completed in 6.104020607s
+
+• [SLOW TEST:10.230 seconds]
+[sig-storage] Downward API volume
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downwardapi_volume.go:33
+  should provide node allocatable (memory) as default memory limit if the limit is not set [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+[sig-storage] Projected 
+  should be consumable from pods in volume [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:16:30.605: INFO: >>> kubeConfig: /tmp/kubeconfig-293271353
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:858
+[It] should be consumable from pods in volume [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating projection with secret that has name projected-secret-test-22601183-7dfa-11e8-b0f5-565e625ec9a3
+STEP: Creating a pod to test consume secrets
+Jul  2 13:16:30.690: INFO: Waiting up to 5m0s for pod "pod-projected-secrets-2260a001-7dfa-11e8-b0f5-565e625ec9a3" in namespace "e2e-tests-projected-cdvkm" to be "success or failure"
+Jul  2 13:16:30.692: INFO: Pod "pod-projected-secrets-2260a001-7dfa-11e8-b0f5-565e625ec9a3": Phase="Pending", Reason="", readiness=false. Elapsed: 2.312044ms
+Jul  2 13:16:32.696: INFO: Pod "pod-projected-secrets-2260a001-7dfa-11e8-b0f5-565e625ec9a3": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.005880264s
+STEP: Saw pod success
+Jul  2 13:16:32.696: INFO: Pod "pod-projected-secrets-2260a001-7dfa-11e8-b0f5-565e625ec9a3" satisfied condition "success or failure"
+Jul  2 13:16:32.699: INFO: Trying to get logs from node shoot--core--confgcp-worker-o1cev-z1-f757498dc-jzlxf pod pod-projected-secrets-2260a001-7dfa-11e8-b0f5-565e625ec9a3 container projected-secret-volume-test: <nil>
+STEP: delete the pod
+Jul  2 13:16:32.716: INFO: Waiting for pod pod-projected-secrets-2260a001-7dfa-11e8-b0f5-565e625ec9a3 to disappear
+Jul  2 13:16:32.721: INFO: Pod pod-projected-secrets-2260a001-7dfa-11e8-b0f5-565e625ec9a3 no longer exists
+[AfterEach] [sig-storage] Projected
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:16:32.721: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-cdvkm" for this suite.
+Jul  2 13:16:38.735: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:16:38.741: INFO: namespace: e2e-tests-projected-cdvkm, resource: bindings, ignored listing per whitelist
+Jul  2 13:16:38.821: INFO: namespace e2e-tests-projected-cdvkm deletion completed in 6.096429118s
+
+• [SLOW TEST:8.216 seconds]
+[sig-storage] Projected
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:34
+  should be consumable from pods in volume [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSSSS
+------------------------------
+[sig-api-machinery] Garbage collector 
+  should orphan RS created by deployment when deleteOptions.PropagationPolicy is Orphan [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-api-machinery] Garbage collector
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:16:38.822: INFO: >>> kubeConfig: /tmp/kubeconfig-293271353
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should orphan RS created by deployment when deleteOptions.PropagationPolicy is Orphan [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: create the deployment
+STEP: Wait for the Deployment to create new ReplicaSet
+STEP: delete the deployment
+STEP: wait for 30 seconds to see if the garbage collector mistakenly deletes the rs
+STEP: Gathering metrics
+W0702 13:17:09.493060      18 metrics_grabber.go:81] Master node is not registered. Grabbing metrics from Scheduler, ControllerManager and ClusterAutoscaler is disabled.
+Jul  2 13:17:09.493: INFO: For apiserver_request_count:
+For apiserver_request_latencies_summary:
+For etcd_helper_cache_entry_count:
+For etcd_helper_cache_hit_count:
+For etcd_helper_cache_miss_count:
+For etcd_request_cache_add_latencies_summary:
+For etcd_request_cache_get_latencies_summary:
+For etcd_request_latencies_summary:
+For garbage_collector_attempt_to_delete_queue_latency:
+For garbage_collector_attempt_to_delete_work_duration:
+For garbage_collector_attempt_to_orphan_queue_latency:
+For garbage_collector_attempt_to_orphan_work_duration:
+For garbage_collector_dirty_processing_latency_microseconds:
+For garbage_collector_event_processing_latency_microseconds:
+For garbage_collector_graph_changes_queue_latency:
+For garbage_collector_graph_changes_work_duration:
+For garbage_collector_orphan_processing_latency_microseconds:
+For namespace_queue_latency:
+For namespace_queue_latency_sum:
+For namespace_queue_latency_count:
+For namespace_retries:
+For namespace_work_duration:
+For namespace_work_duration_sum:
+For namespace_work_duration_count:
+For function_duration_seconds:
+For errors_total:
+For evicted_pods_total:
+
+[AfterEach] [sig-api-machinery] Garbage collector
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:17:09.493: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-gc-xfxdl" for this suite.
+Jul  2 13:17:15.505: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:17:15.604: INFO: namespace: e2e-tests-gc-xfxdl, resource: bindings, ignored listing per whitelist
+Jul  2 13:17:15.648: INFO: namespace e2e-tests-gc-xfxdl deletion completed in 6.152134541s
+
+• [SLOW TEST:36.826 seconds]
+[sig-api-machinery] Garbage collector
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apimachinery/framework.go:22
+  should orphan RS created by deployment when deleteOptions.PropagationPolicy is Orphan [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+[sig-storage] Projected 
+  should be consumable from pods in volume with mappings as non-root [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:17:15.648: INFO: >>> kubeConfig: /tmp/kubeconfig-293271353
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:858
+[It] should be consumable from pods in volume with mappings as non-root [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating configMap with name projected-configmap-test-volume-map-3d3957a3-7dfa-11e8-b0f5-565e625ec9a3
+STEP: Creating a pod to test consume configMaps
+Jul  2 13:17:15.735: INFO: Waiting up to 5m0s for pod "pod-projected-configmaps-3d39dd71-7dfa-11e8-b0f5-565e625ec9a3" in namespace "e2e-tests-projected-f9rlw" to be "success or failure"
+Jul  2 13:17:15.737: INFO: Pod "pod-projected-configmaps-3d39dd71-7dfa-11e8-b0f5-565e625ec9a3": Phase="Pending", Reason="", readiness=false. Elapsed: 2.830787ms
+Jul  2 13:17:17.741: INFO: Pod "pod-projected-configmaps-3d39dd71-7dfa-11e8-b0f5-565e625ec9a3": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.006912076s
+STEP: Saw pod success
+Jul  2 13:17:17.742: INFO: Pod "pod-projected-configmaps-3d39dd71-7dfa-11e8-b0f5-565e625ec9a3" satisfied condition "success or failure"
+Jul  2 13:17:17.744: INFO: Trying to get logs from node shoot--core--confgcp-worker-o1cev-z1-f757498dc-jzlxf pod pod-projected-configmaps-3d39dd71-7dfa-11e8-b0f5-565e625ec9a3 container projected-configmap-volume-test: <nil>
+STEP: delete the pod
+Jul  2 13:17:17.761: INFO: Waiting for pod pod-projected-configmaps-3d39dd71-7dfa-11e8-b0f5-565e625ec9a3 to disappear
+Jul  2 13:17:17.763: INFO: Pod pod-projected-configmaps-3d39dd71-7dfa-11e8-b0f5-565e625ec9a3 no longer exists
+[AfterEach] [sig-storage] Projected
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:17:17.764: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-f9rlw" for this suite.
+Jul  2 13:17:23.777: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:17:23.932: INFO: namespace: e2e-tests-projected-f9rlw, resource: bindings, ignored listing per whitelist
+Jul  2 13:17:23.955: INFO: namespace e2e-tests-projected-f9rlw deletion completed in 6.187889559s
+
+• [SLOW TEST:8.307 seconds]
+[sig-storage] Projected
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:34
+  should be consumable from pods in volume with mappings as non-root [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSS
+------------------------------
+[sig-storage] Projected 
+  should provide podname only [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:17:23.955: INFO: >>> kubeConfig: /tmp/kubeconfig-293271353
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:858
+[It] should provide podname only [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating a pod to test downward API volume plugin
+Jul  2 13:17:24.041: INFO: Waiting up to 5m0s for pod "downwardapi-volume-422d58e3-7dfa-11e8-b0f5-565e625ec9a3" in namespace "e2e-tests-projected-t2kgh" to be "success or failure"
+Jul  2 13:17:24.044: INFO: Pod "downwardapi-volume-422d58e3-7dfa-11e8-b0f5-565e625ec9a3": Phase="Pending", Reason="", readiness=false. Elapsed: 2.619627ms
+Jul  2 13:17:26.048: INFO: Pod "downwardapi-volume-422d58e3-7dfa-11e8-b0f5-565e625ec9a3": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.006684885s
+STEP: Saw pod success
+Jul  2 13:17:26.048: INFO: Pod "downwardapi-volume-422d58e3-7dfa-11e8-b0f5-565e625ec9a3" satisfied condition "success or failure"
+Jul  2 13:17:26.072: INFO: Trying to get logs from node shoot--core--confgcp-worker-o1cev-z1-f757498dc-jzlxf pod downwardapi-volume-422d58e3-7dfa-11e8-b0f5-565e625ec9a3 container client-container: <nil>
+STEP: delete the pod
+Jul  2 13:17:26.088: INFO: Waiting for pod downwardapi-volume-422d58e3-7dfa-11e8-b0f5-565e625ec9a3 to disappear
+Jul  2 13:17:26.091: INFO: Pod downwardapi-volume-422d58e3-7dfa-11e8-b0f5-565e625ec9a3 no longer exists
+[AfterEach] [sig-storage] Projected
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:17:26.091: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-t2kgh" for this suite.
+Jul  2 13:17:32.104: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:17:32.118: INFO: namespace: e2e-tests-projected-t2kgh, resource: bindings, ignored listing per whitelist
+Jul  2 13:17:32.192: INFO: namespace e2e-tests-projected-t2kgh deletion completed in 6.098404051s
+
+• [SLOW TEST:8.237 seconds]
+[sig-storage] Projected
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:34
+  should provide podname only [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+[sig-storage] EmptyDir volumes 
+  should support (root,0666,tmpfs) [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-storage] EmptyDir volumes
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:17:32.192: INFO: >>> kubeConfig: /tmp/kubeconfig-293271353
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should support (root,0666,tmpfs) [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating a pod to test emptydir 0666 on tmpfs
+Jul  2 13:17:32.276: INFO: Waiting up to 5m0s for pod "pod-4715efeb-7dfa-11e8-b0f5-565e625ec9a3" in namespace "e2e-tests-emptydir-zr4z7" to be "success or failure"
+Jul  2 13:17:32.279: INFO: Pod "pod-4715efeb-7dfa-11e8-b0f5-565e625ec9a3": Phase="Pending", Reason="", readiness=false. Elapsed: 2.740255ms
+Jul  2 13:17:34.283: INFO: Pod "pod-4715efeb-7dfa-11e8-b0f5-565e625ec9a3": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.007020526s
+STEP: Saw pod success
+Jul  2 13:17:34.284: INFO: Pod "pod-4715efeb-7dfa-11e8-b0f5-565e625ec9a3" satisfied condition "success or failure"
+Jul  2 13:17:34.372: INFO: Trying to get logs from node shoot--core--confgcp-worker-o1cev-z1-f757498dc-jzlxf pod pod-4715efeb-7dfa-11e8-b0f5-565e625ec9a3 container test-container: <nil>
+STEP: delete the pod
+Jul  2 13:17:34.391: INFO: Waiting for pod pod-4715efeb-7dfa-11e8-b0f5-565e625ec9a3 to disappear
+Jul  2 13:17:34.393: INFO: Pod pod-4715efeb-7dfa-11e8-b0f5-565e625ec9a3 no longer exists
+[AfterEach] [sig-storage] EmptyDir volumes
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:17:34.393: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-emptydir-zr4z7" for this suite.
+Jul  2 13:17:40.408: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:17:40.461: INFO: namespace: e2e-tests-emptydir-zr4z7, resource: bindings, ignored listing per whitelist
+Jul  2 13:17:40.485: INFO: namespace e2e-tests-emptydir-zr4z7 deletion completed in 6.088941887s
+
+• [SLOW TEST:8.293 seconds]
+[sig-storage] EmptyDir volumes
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/empty_dir.go:40
+  should support (root,0666,tmpfs) [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SS
+------------------------------
+[sig-storage] Projected 
+  should provide container's cpu limit [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:17:40.485: INFO: >>> kubeConfig: /tmp/kubeconfig-293271353
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:858
+[It] should provide container's cpu limit [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating a pod to test downward API volume plugin
+Jul  2 13:17:40.561: INFO: Waiting up to 5m0s for pod "downwardapi-volume-4c05ffa8-7dfa-11e8-b0f5-565e625ec9a3" in namespace "e2e-tests-projected-77p7j" to be "success or failure"
+Jul  2 13:17:40.563: INFO: Pod "downwardapi-volume-4c05ffa8-7dfa-11e8-b0f5-565e625ec9a3": Phase="Pending", Reason="", readiness=false. Elapsed: 2.157553ms
+Jul  2 13:17:42.567: INFO: Pod "downwardapi-volume-4c05ffa8-7dfa-11e8-b0f5-565e625ec9a3": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.00589854s
+STEP: Saw pod success
+Jul  2 13:17:42.567: INFO: Pod "downwardapi-volume-4c05ffa8-7dfa-11e8-b0f5-565e625ec9a3" satisfied condition "success or failure"
+Jul  2 13:17:42.569: INFO: Trying to get logs from node shoot--core--confgcp-worker-o1cev-z1-f757498dc-jzlxf pod downwardapi-volume-4c05ffa8-7dfa-11e8-b0f5-565e625ec9a3 container client-container: <nil>
+STEP: delete the pod
+Jul  2 13:17:42.587: INFO: Waiting for pod downwardapi-volume-4c05ffa8-7dfa-11e8-b0f5-565e625ec9a3 to disappear
+Jul  2 13:17:42.590: INFO: Pod downwardapi-volume-4c05ffa8-7dfa-11e8-b0f5-565e625ec9a3 no longer exists
+[AfterEach] [sig-storage] Projected
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:17:42.590: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-77p7j" for this suite.
+Jul  2 13:17:48.604: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:17:48.709: INFO: namespace: e2e-tests-projected-77p7j, resource: bindings, ignored listing per whitelist
+Jul  2 13:17:48.741: INFO: namespace e2e-tests-projected-77p7j deletion completed in 6.146329231s
+
+• [SLOW TEST:8.255 seconds]
+[sig-storage] Projected
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:34
+  should provide container's cpu limit [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SS
+------------------------------
+[k8s.io] [sig-node] Pods Extended [k8s.io] Pods Set QOS Class 
+  should be submitted and removed  [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [k8s.io] [sig-node] Pods Extended
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:17:48.741: INFO: >>> kubeConfig: /tmp/kubeconfig-293271353
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [k8s.io] Pods Set QOS Class
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/node/pods.go:199
+[It] should be submitted and removed  [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: creating the pod
+STEP: submitting the pod to kubernetes
+STEP: verifying QOS class is set on the pod
+[AfterEach] [k8s.io] [sig-node] Pods Extended
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:17:48.822: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-pods-cqpjk" for this suite.
+Jul  2 13:18:10.834: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:18:10.892: INFO: namespace: e2e-tests-pods-cqpjk, resource: bindings, ignored listing per whitelist
+Jul  2 13:18:10.919: INFO: namespace e2e-tests-pods-cqpjk deletion completed in 22.094610356s
+
+• [SLOW TEST:22.178 seconds]
+[k8s.io] [sig-node] Pods Extended
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:679
+  [k8s.io] Pods Set QOS Class
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:679
+    should be submitted and removed  [Conformance]
+    /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSSSSSSSSSSSSSS
+------------------------------
+[sig-apps] Daemon set [Serial] 
+  should run and stop simple daemon [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-apps] Daemon set [Serial]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:18:10.919: INFO: >>> kubeConfig: /tmp/kubeconfig-293271353
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-apps] Daemon set [Serial]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/daemon_set.go:99
+[It] should run and stop simple daemon [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating simple DaemonSet "daemon-set"
+STEP: Check that daemon pods launch on every node of the cluster.
+Jul  2 13:18:11.019: INFO: Number of nodes with available pods: 0
+Jul  2 13:18:11.019: INFO: Node shoot--core--confgcp-worker-o1cev-z1-f757498dc-jzlxf is running more than one daemon pod
+Jul  2 13:18:12.026: INFO: Number of nodes with available pods: 0
+Jul  2 13:18:12.026: INFO: Node shoot--core--confgcp-worker-o1cev-z1-f757498dc-jzlxf is running more than one daemon pod
+Jul  2 13:18:13.027: INFO: Number of nodes with available pods: 2
+Jul  2 13:18:13.027: INFO: Number of running nodes: 2, number of available pods: 2
+STEP: Stop a daemon pod, check that the daemon pod is revived.
+Jul  2 13:18:13.042: INFO: Number of nodes with available pods: 1
+Jul  2 13:18:13.042: INFO: Node shoot--core--confgcp-worker-o1cev-z1-f757498dc-qrtzr is running more than one daemon pod
+Jul  2 13:18:14.052: INFO: Number of nodes with available pods: 1
+Jul  2 13:18:14.052: INFO: Node shoot--core--confgcp-worker-o1cev-z1-f757498dc-qrtzr is running more than one daemon pod
+Jul  2 13:18:15.081: INFO: Number of nodes with available pods: 1
+Jul  2 13:18:15.081: INFO: Node shoot--core--confgcp-worker-o1cev-z1-f757498dc-qrtzr is running more than one daemon pod
+Jul  2 13:18:16.050: INFO: Number of nodes with available pods: 1
+Jul  2 13:18:16.050: INFO: Node shoot--core--confgcp-worker-o1cev-z1-f757498dc-qrtzr is running more than one daemon pod
+Jul  2 13:18:17.050: INFO: Number of nodes with available pods: 1
+Jul  2 13:18:17.050: INFO: Node shoot--core--confgcp-worker-o1cev-z1-f757498dc-qrtzr is running more than one daemon pod
+Jul  2 13:18:18.049: INFO: Number of nodes with available pods: 1
+Jul  2 13:18:18.050: INFO: Node shoot--core--confgcp-worker-o1cev-z1-f757498dc-qrtzr is running more than one daemon pod
+Jul  2 13:18:19.050: INFO: Number of nodes with available pods: 1
+Jul  2 13:18:19.050: INFO: Node shoot--core--confgcp-worker-o1cev-z1-f757498dc-qrtzr is running more than one daemon pod
+Jul  2 13:18:20.051: INFO: Number of nodes with available pods: 1
+Jul  2 13:18:20.051: INFO: Node shoot--core--confgcp-worker-o1cev-z1-f757498dc-qrtzr is running more than one daemon pod
+Jul  2 13:18:21.072: INFO: Number of nodes with available pods: 2
+Jul  2 13:18:21.072: INFO: Number of running nodes: 2, number of available pods: 2
+[AfterEach] [sig-apps] Daemon set [Serial]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/daemon_set.go:65
+STEP: Deleting DaemonSet "daemon-set"
+STEP: deleting {extensions DaemonSet} daemon-set in namespace e2e-tests-daemonsets-zh2rv, will wait for the garbage collector to delete the pods
+Jul  2 13:18:21.134: INFO: Deleting {extensions DaemonSet} daemon-set took: 6.00504ms
+Jul  2 13:18:21.235: INFO: Terminating {extensions DaemonSet} daemon-set pods took: 100.195392ms
+Jul  2 13:18:29.939: INFO: Number of nodes with available pods: 0
+Jul  2 13:18:29.939: INFO: Number of running nodes: 0, number of available pods: 0
+Jul  2 13:18:29.942: INFO: daemonset: {"kind":"DaemonSetList","apiVersion":"apps/v1","metadata":{"selfLink":"/apis/apps/v1/namespaces/e2e-tests-daemonsets-zh2rv/daemonsets","resourceVersion":"6263"},"items":null}
+
+Jul  2 13:18:29.944: INFO: pods: {"kind":"PodList","apiVersion":"v1","metadata":{"selfLink":"/api/v1/namespaces/e2e-tests-daemonsets-zh2rv/pods","resourceVersion":"6263"},"items":null}
+
+[AfterEach] [sig-apps] Daemon set [Serial]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:18:29.953: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-daemonsets-zh2rv" for this suite.
+Jul  2 13:18:35.971: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:18:36.028: INFO: namespace: e2e-tests-daemonsets-zh2rv, resource: bindings, ignored listing per whitelist
+Jul  2 13:18:36.063: INFO: namespace e2e-tests-daemonsets-zh2rv deletion completed in 6.107388349s
+
+• [SLOW TEST:25.144 seconds]
+[sig-apps] Daemon set [Serial]
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/framework.go:22
+  should run and stop simple daemon [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSSSSSSSSSSSSSSSSSSSS
+------------------------------
+[sig-apps] StatefulSet [k8s.io] Basic StatefulSet functionality [StatefulSetBasic] 
+  Should recreate evicted statefulset [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-apps] StatefulSet
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:18:36.064: INFO: >>> kubeConfig: /tmp/kubeconfig-293271353
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-apps] StatefulSet
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/statefulset.go:57
+[BeforeEach] [k8s.io] Basic StatefulSet functionality [StatefulSetBasic]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/statefulset.go:72
+STEP: Creating service test in namespace e2e-tests-statefulset-7xj2j
+[It] Should recreate evicted statefulset [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Looking for a node to schedule stateful set and pod
+STEP: Creating pod with conflicting port in namespace e2e-tests-statefulset-7xj2j
+STEP: Creating statefulset with conflicting port in namespace e2e-tests-statefulset-7xj2j
+STEP: Waiting until pod test-pod will start running in namespace e2e-tests-statefulset-7xj2j
+STEP: Waiting until stateful pod ss-0 will be recreated and deleted at least once in namespace e2e-tests-statefulset-7xj2j
+Jul  2 13:18:40.177: INFO: Observed stateful pod in namespace: e2e-tests-statefulset-7xj2j, name: ss-0, uid: 6f39d15e-7dfa-11e8-876c-5e517afbca85, status phase: Failed. Waiting for statefulset controller to delete.
+Jul  2 13:18:40.180: INFO: Observed stateful pod in namespace: e2e-tests-statefulset-7xj2j, name: ss-0, uid: 6f39d15e-7dfa-11e8-876c-5e517afbca85, status phase: Failed. Waiting for statefulset controller to delete.
+Jul  2 13:18:40.183: INFO: Observed delete event for stateful pod ss-0 in namespace e2e-tests-statefulset-7xj2j
+STEP: Removing pod with conflicting port in namespace e2e-tests-statefulset-7xj2j
+STEP: Waiting when stateful pod ss-0 will be recreated in namespace e2e-tests-statefulset-7xj2j and will be in running state
+[AfterEach] [k8s.io] Basic StatefulSet functionality [StatefulSetBasic]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/statefulset.go:83
+Jul  2 13:18:44.205: INFO: Deleting all statefulset in ns e2e-tests-statefulset-7xj2j
+Jul  2 13:18:44.208: INFO: Scaling statefulset ss to 0
+Jul  2 13:18:54.223: INFO: Waiting for statefulset status.replicas updated to 0
+Jul  2 13:18:54.226: INFO: Deleting statefulset ss
+[AfterEach] [sig-apps] StatefulSet
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:18:54.235: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-statefulset-7xj2j" for this suite.
+Jul  2 13:19:00.248: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:19:00.354: INFO: namespace: e2e-tests-statefulset-7xj2j, resource: bindings, ignored listing per whitelist
+Jul  2 13:19:00.357: INFO: namespace e2e-tests-statefulset-7xj2j deletion completed in 6.118579908s
+
+• [SLOW TEST:24.293 seconds]
+[sig-apps] StatefulSet
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/framework.go:22
+  [k8s.io] Basic StatefulSet functionality [StatefulSetBasic]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:679
+    Should recreate evicted statefulset [Conformance]
+    /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSS
+------------------------------
+[sig-network] Networking Granular Checks: Pods 
+  should function for intra-pod communication: http [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-network] Networking
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:19:00.357: INFO: >>> kubeConfig: /tmp/kubeconfig-293271353
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should function for intra-pod communication: http [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Performing setup for networking test in namespace e2e-tests-pod-network-test-wvrdj
+STEP: creating a selector
+STEP: Creating the service pods in kubernetes
+Jul  2 13:19:00.433: INFO: Waiting up to 10m0s for all (but 0) nodes to be schedulable
+STEP: Creating test pods
+Jul  2 13:19:22.596: INFO: ExecWithOptions {Command:[/bin/sh -c curl -g -q -s 'http://100.96.1.108:8080/dial?request=hostName&protocol=http&host=100.96.0.36&port=8080&tries=1'] Namespace:e2e-tests-pod-network-test-wvrdj PodName:host-test-container-pod ContainerName:hostexec Stdin:<nil> CaptureStdout:true CaptureStderr:true PreserveWhitespace:false}
+Jul  2 13:19:22.596: INFO: >>> kubeConfig: /tmp/kubeconfig-293271353
+Jul  2 13:19:22.939: INFO: Waiting for endpoints: map[]
+Jul  2 13:19:22.943: INFO: ExecWithOptions {Command:[/bin/sh -c curl -g -q -s 'http://100.96.1.108:8080/dial?request=hostName&protocol=http&host=100.96.1.107&port=8080&tries=1'] Namespace:e2e-tests-pod-network-test-wvrdj PodName:host-test-container-pod ContainerName:hostexec Stdin:<nil> CaptureStdout:true CaptureStderr:true PreserveWhitespace:false}
+Jul  2 13:19:22.943: INFO: >>> kubeConfig: /tmp/kubeconfig-293271353
+Jul  2 13:19:23.347: INFO: Waiting for endpoints: map[]
+[AfterEach] [sig-network] Networking
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:19:23.347: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-pod-network-test-wvrdj" for this suite.
+Jul  2 13:19:45.362: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:19:45.368: INFO: namespace: e2e-tests-pod-network-test-wvrdj, resource: bindings, ignored listing per whitelist
+Jul  2 13:19:45.456: INFO: namespace e2e-tests-pod-network-test-wvrdj deletion completed in 22.10490435s
+
+• [SLOW TEST:45.099 seconds]
+[sig-network] Networking
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/networking.go:25
+  Granular Checks: Pods
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/networking.go:28
+    should function for intra-pod communication: http [NodeConformance] [Conformance]
+    /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSSS
+------------------------------
+[k8s.io] Probing container 
+  should *not* be restarted with a /healthz http liveness probe [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [k8s.io] Probing container
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:19:45.456: INFO: >>> kubeConfig: /tmp/kubeconfig-293271353
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [k8s.io] Probing container
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/container_probe.go:48
+[It] should *not* be restarted with a /healthz http liveness probe [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating pod liveness-http in namespace e2e-tests-container-probe-hbc4g
+Jul  2 13:19:47.549: INFO: Started pod liveness-http in namespace e2e-tests-container-probe-hbc4g
+STEP: checking the pod's current state and verifying that restartCount is present
+Jul  2 13:19:47.552: INFO: Initial restart count of pod liveness-http is 0
+STEP: deleting the pod
+[AfterEach] [k8s.io] Probing container
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:23:48.678: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-container-probe-hbc4g" for this suite.
+Jul  2 13:23:54.697: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:23:54.712: INFO: namespace: e2e-tests-container-probe-hbc4g, resource: bindings, ignored listing per whitelist
+Jul  2 13:23:54.792: INFO: namespace e2e-tests-container-probe-hbc4g deletion completed in 6.107486142s
+
+• [SLOW TEST:249.335 seconds]
+[k8s.io] Probing container
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:679
+  should *not* be restarted with a /healthz http liveness probe [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSSSSSSSS
+------------------------------
+[sig-storage] Downward API volume 
+  should update annotations on modification [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:23:54.792: INFO: >>> kubeConfig: /tmp/kubeconfig-293271353
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downwardapi_volume.go:38
+[It] should update annotations on modification [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating the pod
+Jul  2 13:23:59.573: INFO: Successfully updated pod "annotationupdate2b23a73b-7dfb-11e8-b0f5-565e625ec9a3"
+[AfterEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:24:01.676: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-downward-api-fm2dj" for this suite.
+Jul  2 13:24:23.691: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:24:23.735: INFO: namespace: e2e-tests-downward-api-fm2dj, resource: bindings, ignored listing per whitelist
+Jul  2 13:24:23.793: INFO: namespace e2e-tests-downward-api-fm2dj deletion completed in 22.112692364s
+
+• [SLOW TEST:29.001 seconds]
+[sig-storage] Downward API volume
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downwardapi_volume.go:33
+  should update annotations on modification [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSSSSSSSSSSS
+------------------------------
+[sig-storage] Projected 
+  should set mode on item file [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:24:23.793: INFO: >>> kubeConfig: /tmp/kubeconfig-293271353
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:858
+[It] should set mode on item file [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating a pod to test downward API volume plugin
+Jul  2 13:24:23.879: INFO: Waiting up to 5m0s for pod "downwardapi-volume-3c6b7b69-7dfb-11e8-b0f5-565e625ec9a3" in namespace "e2e-tests-projected-4jbv4" to be "success or failure"
+Jul  2 13:24:23.882: INFO: Pod "downwardapi-volume-3c6b7b69-7dfb-11e8-b0f5-565e625ec9a3": Phase="Pending", Reason="", readiness=false. Elapsed: 2.478352ms
+Jul  2 13:24:25.886: INFO: Pod "downwardapi-volume-3c6b7b69-7dfb-11e8-b0f5-565e625ec9a3": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.006400081s
+STEP: Saw pod success
+Jul  2 13:24:25.886: INFO: Pod "downwardapi-volume-3c6b7b69-7dfb-11e8-b0f5-565e625ec9a3" satisfied condition "success or failure"
+Jul  2 13:24:25.970: INFO: Trying to get logs from node shoot--core--confgcp-worker-o1cev-z1-f757498dc-jzlxf pod downwardapi-volume-3c6b7b69-7dfb-11e8-b0f5-565e625ec9a3 container client-container: <nil>
+STEP: delete the pod
+Jul  2 13:24:25.989: INFO: Waiting for pod downwardapi-volume-3c6b7b69-7dfb-11e8-b0f5-565e625ec9a3 to disappear
+Jul  2 13:24:25.991: INFO: Pod downwardapi-volume-3c6b7b69-7dfb-11e8-b0f5-565e625ec9a3 no longer exists
+[AfterEach] [sig-storage] Projected
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:24:25.991: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-4jbv4" for this suite.
+Jul  2 13:24:32.004: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:24:32.123: INFO: namespace: e2e-tests-projected-4jbv4, resource: bindings, ignored listing per whitelist
+Jul  2 13:24:32.157: INFO: namespace e2e-tests-projected-4jbv4 deletion completed in 6.162361226s
+
+• [SLOW TEST:8.364 seconds]
+[sig-storage] Projected
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:34
+  should set mode on item file [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+S
+------------------------------
+[sig-storage] Projected 
+  should be consumable from pods in volume [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:24:32.157: INFO: >>> kubeConfig: /tmp/kubeconfig-293271353
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:858
+[It] should be consumable from pods in volume [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating configMap with name projected-configmap-test-volume-4166b390-7dfb-11e8-b0f5-565e625ec9a3
+STEP: Creating a pod to test consume configMaps
+Jul  2 13:24:32.240: INFO: Waiting up to 5m0s for pod "pod-projected-configmaps-41672fa0-7dfb-11e8-b0f5-565e625ec9a3" in namespace "e2e-tests-projected-7sjzh" to be "success or failure"
+Jul  2 13:24:32.242: INFO: Pod "pod-projected-configmaps-41672fa0-7dfb-11e8-b0f5-565e625ec9a3": Phase="Pending", Reason="", readiness=false. Elapsed: 2.489682ms
+Jul  2 13:24:34.246: INFO: Pod "pod-projected-configmaps-41672fa0-7dfb-11e8-b0f5-565e625ec9a3": Phase="Pending", Reason="", readiness=false. Elapsed: 2.006563597s
+Jul  2 13:24:36.251: INFO: Pod "pod-projected-configmaps-41672fa0-7dfb-11e8-b0f5-565e625ec9a3": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.011163686s
+STEP: Saw pod success
+Jul  2 13:24:36.251: INFO: Pod "pod-projected-configmaps-41672fa0-7dfb-11e8-b0f5-565e625ec9a3" satisfied condition "success or failure"
+Jul  2 13:24:36.254: INFO: Trying to get logs from node shoot--core--confgcp-worker-o1cev-z1-f757498dc-jzlxf pod pod-projected-configmaps-41672fa0-7dfb-11e8-b0f5-565e625ec9a3 container projected-configmap-volume-test: <nil>
+STEP: delete the pod
+Jul  2 13:24:36.289: INFO: Waiting for pod pod-projected-configmaps-41672fa0-7dfb-11e8-b0f5-565e625ec9a3 to disappear
+Jul  2 13:24:36.295: INFO: Pod pod-projected-configmaps-41672fa0-7dfb-11e8-b0f5-565e625ec9a3 no longer exists
+[AfterEach] [sig-storage] Projected
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:24:36.295: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-7sjzh" for this suite.
+Jul  2 13:24:42.308: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:24:42.352: INFO: namespace: e2e-tests-projected-7sjzh, resource: bindings, ignored listing per whitelist
+Jul  2 13:24:42.400: INFO: namespace e2e-tests-projected-7sjzh deletion completed in 6.102076935s
+
+• [SLOW TEST:10.244 seconds]
+[sig-storage] Projected
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:34
+  should be consumable from pods in volume [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSSSSSSSSSSSS
+------------------------------
+[sig-api-machinery] Watchers 
+  should observe an object deletion if it stops meeting the requirements of the selector [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-api-machinery] Watchers
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:24:42.401: INFO: >>> kubeConfig: /tmp/kubeconfig-293271353
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should observe an object deletion if it stops meeting the requirements of the selector [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: creating a watch on configmaps with a certain label
+STEP: creating a new configmap
+STEP: modifying the configmap once
+STEP: changing the label value of the configmap
+STEP: Expecting to observe a delete notification for the watched object
+Jul  2 13:24:42.517: INFO: Got : ADDED &ConfigMap{ObjectMeta:k8s_io_apimachinery_pkg_apis_meta_v1.ObjectMeta{Name:e2e-watch-test-label-changed,GenerateName:,Namespace:e2e-tests-watch-5zmkg,SelfLink:/api/v1/namespaces/e2e-tests-watch-5zmkg/configmaps/e2e-watch-test-label-changed,UID:478b0b0a-7dfb-11e8-876c-5e517afbca85,ResourceVersion:7204,Generation:0,CreationTimestamp:2018-07-02 13:24:42 +0000 UTC,DeletionTimestamp:<nil>,DeletionGracePeriodSeconds:nil,Labels:map[string]string{watch-this-configmap: label-changed-and-restored,},Annotations:map[string]string{},OwnerReferences:[],Finalizers:[],ClusterName:,Initializers:nil,},Data:map[string]string{},BinaryData:map[string][]byte{},}
+Jul  2 13:24:42.517: INFO: Got : MODIFIED &ConfigMap{ObjectMeta:k8s_io_apimachinery_pkg_apis_meta_v1.ObjectMeta{Name:e2e-watch-test-label-changed,GenerateName:,Namespace:e2e-tests-watch-5zmkg,SelfLink:/api/v1/namespaces/e2e-tests-watch-5zmkg/configmaps/e2e-watch-test-label-changed,UID:478b0b0a-7dfb-11e8-876c-5e517afbca85,ResourceVersion:7205,Generation:0,CreationTimestamp:2018-07-02 13:24:42 +0000 UTC,DeletionTimestamp:<nil>,DeletionGracePeriodSeconds:nil,Labels:map[string]string{watch-this-configmap: label-changed-and-restored,},Annotations:map[string]string{},OwnerReferences:[],Finalizers:[],ClusterName:,Initializers:nil,},Data:map[string]string{mutation: 1,},BinaryData:map[string][]byte{},}
+Jul  2 13:24:42.517: INFO: Got : DELETED &ConfigMap{ObjectMeta:k8s_io_apimachinery_pkg_apis_meta_v1.ObjectMeta{Name:e2e-watch-test-label-changed,GenerateName:,Namespace:e2e-tests-watch-5zmkg,SelfLink:/api/v1/namespaces/e2e-tests-watch-5zmkg/configmaps/e2e-watch-test-label-changed,UID:478b0b0a-7dfb-11e8-876c-5e517afbca85,ResourceVersion:7206,Generation:0,CreationTimestamp:2018-07-02 13:24:42 +0000 UTC,DeletionTimestamp:<nil>,DeletionGracePeriodSeconds:nil,Labels:map[string]string{watch-this-configmap: label-changed-and-restored,},Annotations:map[string]string{},OwnerReferences:[],Finalizers:[],ClusterName:,Initializers:nil,},Data:map[string]string{mutation: 1,},BinaryData:map[string][]byte{},}
+STEP: modifying the configmap a second time
+STEP: Expecting not to observe a notification because the object no longer meets the selector's requirements
+STEP: changing the label value of the configmap back
+STEP: modifying the configmap a third time
+STEP: deleting the configmap
+STEP: Expecting to observe an add notification for the watched object when the label value was restored
+Jul  2 13:24:52.683: INFO: Got : ADDED &ConfigMap{ObjectMeta:k8s_io_apimachinery_pkg_apis_meta_v1.ObjectMeta{Name:e2e-watch-test-label-changed,GenerateName:,Namespace:e2e-tests-watch-5zmkg,SelfLink:/api/v1/namespaces/e2e-tests-watch-5zmkg/configmaps/e2e-watch-test-label-changed,UID:478b0b0a-7dfb-11e8-876c-5e517afbca85,ResourceVersion:7229,Generation:0,CreationTimestamp:2018-07-02 13:24:42 +0000 UTC,DeletionTimestamp:<nil>,DeletionGracePeriodSeconds:nil,Labels:map[string]string{watch-this-configmap: label-changed-and-restored,},Annotations:map[string]string{},OwnerReferences:[],Finalizers:[],ClusterName:,Initializers:nil,},Data:map[string]string{mutation: 2,},BinaryData:map[string][]byte{},}
+Jul  2 13:24:52.683: INFO: Got : MODIFIED &ConfigMap{ObjectMeta:k8s_io_apimachinery_pkg_apis_meta_v1.ObjectMeta{Name:e2e-watch-test-label-changed,GenerateName:,Namespace:e2e-tests-watch-5zmkg,SelfLink:/api/v1/namespaces/e2e-tests-watch-5zmkg/configmaps/e2e-watch-test-label-changed,UID:478b0b0a-7dfb-11e8-876c-5e517afbca85,ResourceVersion:7230,Generation:0,CreationTimestamp:2018-07-02 13:24:42 +0000 UTC,DeletionTimestamp:<nil>,DeletionGracePeriodSeconds:nil,Labels:map[string]string{watch-this-configmap: label-changed-and-restored,},Annotations:map[string]string{},OwnerReferences:[],Finalizers:[],ClusterName:,Initializers:nil,},Data:map[string]string{mutation: 3,},BinaryData:map[string][]byte{},}
+Jul  2 13:24:52.684: INFO: Got : DELETED &ConfigMap{ObjectMeta:k8s_io_apimachinery_pkg_apis_meta_v1.ObjectMeta{Name:e2e-watch-test-label-changed,GenerateName:,Namespace:e2e-tests-watch-5zmkg,SelfLink:/api/v1/namespaces/e2e-tests-watch-5zmkg/configmaps/e2e-watch-test-label-changed,UID:478b0b0a-7dfb-11e8-876c-5e517afbca85,ResourceVersion:7231,Generation:0,CreationTimestamp:2018-07-02 13:24:42 +0000 UTC,DeletionTimestamp:<nil>,DeletionGracePeriodSeconds:nil,Labels:map[string]string{watch-this-configmap: label-changed-and-restored,},Annotations:map[string]string{},OwnerReferences:[],Finalizers:[],ClusterName:,Initializers:nil,},Data:map[string]string{mutation: 3,},BinaryData:map[string][]byte{},}
+[AfterEach] [sig-api-machinery] Watchers
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:24:52.684: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-watch-5zmkg" for this suite.
+Jul  2 13:24:58.701: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:24:58.882: INFO: namespace: e2e-tests-watch-5zmkg, resource: bindings, ignored listing per whitelist
+Jul  2 13:24:58.934: INFO: namespace e2e-tests-watch-5zmkg deletion completed in 6.244891866s
+
+• [SLOW TEST:16.533 seconds]
+[sig-api-machinery] Watchers
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apimachinery/framework.go:22
+  should observe an object deletion if it stops meeting the requirements of the selector [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSSSSSSSSSSSSSSSSSSSSSSS
+------------------------------
+[sig-storage] ConfigMap 
+  should be consumable from pods in volume with mappings and Item mode set [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-storage] ConfigMap
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:24:58.934: INFO: >>> kubeConfig: /tmp/kubeconfig-293271353
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should be consumable from pods in volume with mappings and Item mode set [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating configMap with name configmap-test-volume-map-515d4778-7dfb-11e8-b0f5-565e625ec9a3
+STEP: Creating a pod to test consume configMaps
+Jul  2 13:24:59.021: INFO: Waiting up to 5m0s for pod "pod-configmaps-515dbb89-7dfb-11e8-b0f5-565e625ec9a3" in namespace "e2e-tests-configmap-5bmqb" to be "success or failure"
+Jul  2 13:24:59.023: INFO: Pod "pod-configmaps-515dbb89-7dfb-11e8-b0f5-565e625ec9a3": Phase="Pending", Reason="", readiness=false. Elapsed: 2.551861ms
+Jul  2 13:25:01.027: INFO: Pod "pod-configmaps-515dbb89-7dfb-11e8-b0f5-565e625ec9a3": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.006640764s
+STEP: Saw pod success
+Jul  2 13:25:01.028: INFO: Pod "pod-configmaps-515dbb89-7dfb-11e8-b0f5-565e625ec9a3" satisfied condition "success or failure"
+Jul  2 13:25:01.030: INFO: Trying to get logs from node shoot--core--confgcp-worker-o1cev-z1-f757498dc-jzlxf pod pod-configmaps-515dbb89-7dfb-11e8-b0f5-565e625ec9a3 container configmap-volume-test: <nil>
+STEP: delete the pod
+Jul  2 13:25:01.049: INFO: Waiting for pod pod-configmaps-515dbb89-7dfb-11e8-b0f5-565e625ec9a3 to disappear
+Jul  2 13:25:01.052: INFO: Pod pod-configmaps-515dbb89-7dfb-11e8-b0f5-565e625ec9a3 no longer exists
+[AfterEach] [sig-storage] ConfigMap
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:25:01.052: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-configmap-5bmqb" for this suite.
+Jul  2 13:25:07.065: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:25:07.076: INFO: namespace: e2e-tests-configmap-5bmqb, resource: bindings, ignored listing per whitelist
+Jul  2 13:25:07.157: INFO: namespace e2e-tests-configmap-5bmqb deletion completed in 6.101263384s
+
+• [SLOW TEST:8.223 seconds]
+[sig-storage] ConfigMap
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/configmap_volume.go:32
+  should be consumable from pods in volume with mappings and Item mode set [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SS
+------------------------------
+[sig-apps] Daemon set [Serial] 
+  should retry creating failed daemon pods [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-apps] Daemon set [Serial]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:25:07.157: INFO: >>> kubeConfig: /tmp/kubeconfig-293271353
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-apps] Daemon set [Serial]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/daemon_set.go:99
+[It] should retry creating failed daemon pods [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating a simple DaemonSet "daemon-set"
+STEP: Check that daemon pods launch on every node of the cluster.
+Jul  2 13:25:07.255: INFO: Number of nodes with available pods: 0
+Jul  2 13:25:07.255: INFO: Node shoot--core--confgcp-worker-o1cev-z1-f757498dc-jzlxf is running more than one daemon pod
+Jul  2 13:25:08.262: INFO: Number of nodes with available pods: 0
+Jul  2 13:25:08.262: INFO: Node shoot--core--confgcp-worker-o1cev-z1-f757498dc-jzlxf is running more than one daemon pod
+Jul  2 13:25:09.267: INFO: Number of nodes with available pods: 1
+Jul  2 13:25:09.267: INFO: Node shoot--core--confgcp-worker-o1cev-z1-f757498dc-qrtzr is running more than one daemon pod
+Jul  2 13:25:10.276: INFO: Number of nodes with available pods: 2
+Jul  2 13:25:10.276: INFO: Number of running nodes: 2, number of available pods: 2
+STEP: Set a daemon pod's phase to 'Failed', check that the daemon pod is revived.
+Jul  2 13:25:10.303: INFO: Number of nodes with available pods: 1
+Jul  2 13:25:10.303: INFO: Node shoot--core--confgcp-worker-o1cev-z1-f757498dc-jzlxf is running more than one daemon pod
+Jul  2 13:25:11.314: INFO: Number of nodes with available pods: 1
+Jul  2 13:25:11.314: INFO: Node shoot--core--confgcp-worker-o1cev-z1-f757498dc-jzlxf is running more than one daemon pod
+Jul  2 13:25:12.311: INFO: Number of nodes with available pods: 2
+Jul  2 13:25:12.311: INFO: Number of running nodes: 2, number of available pods: 2
+STEP: Wait for the failed daemon pod to be completely deleted.
+[AfterEach] [sig-apps] Daemon set [Serial]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/daemon_set.go:65
+STEP: Deleting DaemonSet "daemon-set"
+STEP: deleting {extensions DaemonSet} daemon-set in namespace e2e-tests-daemonsets-74skp, will wait for the garbage collector to delete the pods
+Jul  2 13:25:12.374: INFO: Deleting {extensions DaemonSet} daemon-set took: 6.177409ms
+Jul  2 13:25:12.475: INFO: Terminating {extensions DaemonSet} daemon-set pods took: 100.36385ms
+Jul  2 13:25:18.680: INFO: Number of nodes with available pods: 0
+Jul  2 13:25:18.680: INFO: Number of running nodes: 0, number of available pods: 0
+Jul  2 13:25:18.684: INFO: daemonset: {"kind":"DaemonSetList","apiVersion":"apps/v1","metadata":{"selfLink":"/apis/apps/v1/namespaces/e2e-tests-daemonsets-74skp/daemonsets","resourceVersion":"7345"},"items":null}
+
+Jul  2 13:25:18.686: INFO: pods: {"kind":"PodList","apiVersion":"v1","metadata":{"selfLink":"/api/v1/namespaces/e2e-tests-daemonsets-74skp/pods","resourceVersion":"7345"},"items":null}
+
+[AfterEach] [sig-apps] Daemon set [Serial]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:25:18.695: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-daemonsets-74skp" for this suite.
+Jul  2 13:25:24.709: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:25:24.742: INFO: namespace: e2e-tests-daemonsets-74skp, resource: bindings, ignored listing per whitelist
+Jul  2 13:25:24.802: INFO: namespace e2e-tests-daemonsets-74skp deletion completed in 6.103287729s
+
+• [SLOW TEST:17.645 seconds]
+[sig-apps] Daemon set [Serial]
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/framework.go:22
+  should retry creating failed daemon pods [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSS
+------------------------------
+[sig-network] DNS 
+  should provide DNS for services  [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-network] DNS
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:25:24.802: INFO: >>> kubeConfig: /tmp/kubeconfig-293271353
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should provide DNS for services  [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating a test headless service
+STEP: Running these commands on wheezy: for i in `seq 1 600`; do test -n "$$(dig +notcp +noall +answer +search dns-test-service A)" && echo OK > /results/wheezy_udp@dns-test-service;test -n "$$(dig +tcp +noall +answer +search dns-test-service A)" && echo OK > /results/wheezy_tcp@dns-test-service;test -n "$$(dig +notcp +noall +answer +search dns-test-service.e2e-tests-dns-vhftn A)" && echo OK > /results/wheezy_udp@dns-test-service.e2e-tests-dns-vhftn;test -n "$$(dig +tcp +noall +answer +search dns-test-service.e2e-tests-dns-vhftn A)" && echo OK > /results/wheezy_tcp@dns-test-service.e2e-tests-dns-vhftn;test -n "$$(dig +notcp +noall +answer +search dns-test-service.e2e-tests-dns-vhftn.svc A)" && echo OK > /results/wheezy_udp@dns-test-service.e2e-tests-dns-vhftn.svc;test -n "$$(dig +tcp +noall +answer +search dns-test-service.e2e-tests-dns-vhftn.svc A)" && echo OK > /results/wheezy_tcp@dns-test-service.e2e-tests-dns-vhftn.svc;test -n "$$(dig +notcp +noall +answer +search _http._tcp.dns-test-service.e2e-tests-dns-vhftn.svc SRV)" && echo OK > /results/wheezy_udp@_http._tcp.dns-test-service.e2e-tests-dns-vhftn.svc;test -n "$$(dig +tcp +noall +answer +search _http._tcp.dns-test-service.e2e-tests-dns-vhftn.svc SRV)" && echo OK > /results/wheezy_tcp@_http._tcp.dns-test-service.e2e-tests-dns-vhftn.svc;test -n "$$(dig +notcp +noall +answer +search _http._tcp.test-service-2.e2e-tests-dns-vhftn.svc SRV)" && echo OK > /results/wheezy_udp@_http._tcp.test-service-2.e2e-tests-dns-vhftn.svc;test -n "$$(dig +tcp +noall +answer +search _http._tcp.test-service-2.e2e-tests-dns-vhftn.svc SRV)" && echo OK > /results/wheezy_tcp@_http._tcp.test-service-2.e2e-tests-dns-vhftn.svc;podARec=$$(hostname -i| awk -F. '{print $$1"-"$$2"-"$$3"-"$$4".e2e-tests-dns-vhftn.pod.cluster.local"}');test -n "$$(dig +notcp +noall +answer +search $${podARec} A)" && echo OK > /results/wheezy_udp@PodARecord;test -n "$$(dig +tcp +noall +answer +search $${podARec} A)" && echo OK > /results/wheezy_tcp@PodARecord;test -n "$$(dig +notcp +noall +answer +search 189.147.65.100.in-addr.arpa. PTR)" && echo OK > /results/100.65.147.189_udp@PTR;test -n "$$(dig +tcp +noall +answer +search 189.147.65.100.in-addr.arpa. PTR)" && echo OK > /results/100.65.147.189_tcp@PTR;sleep 1; done
+
+STEP: Running these commands on jessie: for i in `seq 1 600`; do test -n "$$(dig +notcp +noall +answer +search dns-test-service A)" && echo OK > /results/jessie_udp@dns-test-service;test -n "$$(dig +tcp +noall +answer +search dns-test-service A)" && echo OK > /results/jessie_tcp@dns-test-service;test -n "$$(dig +notcp +noall +answer +search dns-test-service.e2e-tests-dns-vhftn A)" && echo OK > /results/jessie_udp@dns-test-service.e2e-tests-dns-vhftn;test -n "$$(dig +tcp +noall +answer +search dns-test-service.e2e-tests-dns-vhftn A)" && echo OK > /results/jessie_tcp@dns-test-service.e2e-tests-dns-vhftn;test -n "$$(dig +notcp +noall +answer +search dns-test-service.e2e-tests-dns-vhftn.svc A)" && echo OK > /results/jessie_udp@dns-test-service.e2e-tests-dns-vhftn.svc;test -n "$$(dig +tcp +noall +answer +search dns-test-service.e2e-tests-dns-vhftn.svc A)" && echo OK > /results/jessie_tcp@dns-test-service.e2e-tests-dns-vhftn.svc;test -n "$$(dig +notcp +noall +answer +search _http._tcp.dns-test-service.e2e-tests-dns-vhftn.svc SRV)" && echo OK > /results/jessie_udp@_http._tcp.dns-test-service.e2e-tests-dns-vhftn.svc;test -n "$$(dig +tcp +noall +answer +search _http._tcp.dns-test-service.e2e-tests-dns-vhftn.svc SRV)" && echo OK > /results/jessie_tcp@_http._tcp.dns-test-service.e2e-tests-dns-vhftn.svc;test -n "$$(dig +notcp +noall +answer +search _http._tcp.test-service-2.e2e-tests-dns-vhftn.svc SRV)" && echo OK > /results/jessie_udp@_http._tcp.test-service-2.e2e-tests-dns-vhftn.svc;test -n "$$(dig +tcp +noall +answer +search _http._tcp.test-service-2.e2e-tests-dns-vhftn.svc SRV)" && echo OK > /results/jessie_tcp@_http._tcp.test-service-2.e2e-tests-dns-vhftn.svc;podARec=$$(hostname -i| awk -F. '{print $$1"-"$$2"-"$$3"-"$$4".e2e-tests-dns-vhftn.pod.cluster.local"}');test -n "$$(dig +notcp +noall +answer +search $${podARec} A)" && echo OK > /results/jessie_udp@PodARecord;test -n "$$(dig +tcp +noall +answer +search $${podARec} A)" && echo OK > /results/jessie_tcp@PodARecord;test -n "$$(dig +notcp +noall +answer +search 189.147.65.100.in-addr.arpa. PTR)" && echo OK > /results/100.65.147.189_udp@PTR;test -n "$$(dig +tcp +noall +answer +search 189.147.65.100.in-addr.arpa. PTR)" && echo OK > /results/100.65.147.189_tcp@PTR;sleep 1; done
+
+STEP: creating a pod to probe DNS
+STEP: submitting the pod to kubernetes
+STEP: retrieving the pod
+STEP: looking for the results for each expected name from probers
+Jul  2 13:25:40.802: INFO: DNS probes using dns-test-60ca646b-7dfb-11e8-b0f5-565e625ec9a3 succeeded
+
+STEP: deleting the pod
+STEP: deleting the test service
+STEP: deleting the test headless service
+[AfterEach] [sig-network] DNS
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:25:40.830: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-dns-vhftn" for this suite.
+Jul  2 13:25:46.844: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:25:46.884: INFO: namespace: e2e-tests-dns-vhftn, resource: bindings, ignored listing per whitelist
+Jul  2 13:25:46.936: INFO: namespace e2e-tests-dns-vhftn deletion completed in 6.102494026s
+
+• [SLOW TEST:22.134 seconds]
+[sig-network] DNS
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/network/framework.go:22
+  should provide DNS for services  [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSS
+------------------------------
+[sig-network] Proxy version v1 
+  should proxy through a service and a pod  [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] version v1
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:25:46.936: INFO: >>> kubeConfig: /tmp/kubeconfig-293271353
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should proxy through a service and a pod  [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: starting an echo server on multiple ports
+STEP: creating replication controller proxy-service-fm49q in namespace e2e-tests-proxy-fgqrw
+I0702 13:25:47.026565      18 runners.go:177] Created replication controller with name: proxy-service-fm49q, namespace: e2e-tests-proxy-fgqrw, replica count: 1
+I0702 13:25:48.077040      18 runners.go:177] proxy-service-fm49q Pods: 1 out of 1 created, 0 running, 1 pending, 0 waiting, 0 inactive, 0 terminating, 0 unknown, 0 runningButNotReady 
+I0702 13:25:49.077268      18 runners.go:177] proxy-service-fm49q Pods: 1 out of 1 created, 0 running, 1 pending, 0 waiting, 0 inactive, 0 terminating, 0 unknown, 0 runningButNotReady 
+I0702 13:25:50.077524      18 runners.go:177] proxy-service-fm49q Pods: 1 out of 1 created, 0 running, 0 pending, 0 waiting, 0 inactive, 0 terminating, 0 unknown, 1 runningButNotReady 
+I0702 13:25:51.077786      18 runners.go:177] proxy-service-fm49q Pods: 1 out of 1 created, 0 running, 0 pending, 0 waiting, 0 inactive, 0 terminating, 0 unknown, 1 runningButNotReady 
+I0702 13:25:52.078002      18 runners.go:177] proxy-service-fm49q Pods: 1 out of 1 created, 0 running, 0 pending, 0 waiting, 0 inactive, 0 terminating, 0 unknown, 1 runningButNotReady 
+I0702 13:25:53.078248      18 runners.go:177] proxy-service-fm49q Pods: 1 out of 1 created, 0 running, 0 pending, 0 waiting, 0 inactive, 0 terminating, 0 unknown, 1 runningButNotReady 
+I0702 13:25:54.078470      18 runners.go:177] proxy-service-fm49q Pods: 1 out of 1 created, 0 running, 0 pending, 0 waiting, 0 inactive, 0 terminating, 0 unknown, 1 runningButNotReady 
+I0702 13:25:55.078671      18 runners.go:177] proxy-service-fm49q Pods: 1 out of 1 created, 0 running, 0 pending, 0 waiting, 0 inactive, 0 terminating, 0 unknown, 1 runningButNotReady 
+I0702 13:25:56.078875      18 runners.go:177] proxy-service-fm49q Pods: 1 out of 1 created, 1 running, 0 pending, 0 waiting, 0 inactive, 0 terminating, 0 unknown, 0 runningButNotReady 
+Jul  2 13:25:56.082: INFO: setup took 9.06615729s, starting test cases
+STEP: running 16 cases, 20 attempts per case, 320 total attempts
+Jul  2 13:25:56.182: INFO: (0) /api/v1/namespaces/e2e-tests-proxy-fgqrw/pods/proxy-service-fm49q-rtrbz:160/proxy/: foo (200; 99.788724ms)
+Jul  2 13:25:56.182: INFO: (0) /api/v1/namespaces/e2e-tests-proxy-fgqrw/pods/http:proxy-service-fm49q-rtrbz:160/proxy/: foo (200; 100.011392ms)
+Jul  2 13:25:56.182: INFO: (0) /api/v1/namespaces/e2e-tests-proxy-fgqrw/pods/proxy-service-fm49q-rtrbz:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-fgqrw/pods/proxy-service-fm49q-rtrbz:1080/proxy/rewri... (200; 100.01294ms)
+Jul  2 13:25:56.182: INFO: (0) /api/v1/namespaces/e2e-tests-proxy-fgqrw/pods/proxy-service-fm49q-rtrbz:162/proxy/: bar (200; 100.039733ms)
+Jul  2 13:25:56.182: INFO: (0) /api/v1/namespaces/e2e-tests-proxy-fgqrw/pods/http:proxy-service-fm49q-rtrbz:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-fgqrw/pods/http:proxy-service-fm49q-rtrbz:1080/proxy/... (200; 99.946415ms)
+Jul  2 13:25:56.182: INFO: (0) /api/v1/namespaces/e2e-tests-proxy-fgqrw/services/http:proxy-service-fm49q:portname1/proxy/: foo (200; 100.01389ms)
+Jul  2 13:25:56.185: INFO: (0) /api/v1/namespaces/e2e-tests-proxy-fgqrw/services/proxy-service-fm49q:portname1/proxy/: foo (200; 103.289681ms)
+Jul  2 13:25:56.186: INFO: (0) /api/v1/namespaces/e2e-tests-proxy-fgqrw/services/proxy-service-fm49q:portname2/proxy/: bar (200; 103.729422ms)
+Jul  2 13:25:56.186: INFO: (0) /api/v1/namespaces/e2e-tests-proxy-fgqrw/services/http:proxy-service-fm49q:portname2/proxy/: bar (200; 103.707758ms)
+Jul  2 13:25:56.191: INFO: (0) /api/v1/namespaces/e2e-tests-proxy-fgqrw/pods/http:proxy-service-fm49q-rtrbz:162/proxy/: bar (200; 109.608815ms)
+Jul  2 13:25:56.192: INFO: (0) /api/v1/namespaces/e2e-tests-proxy-fgqrw/pods/proxy-service-fm49q-rtrbz/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-fgqrw/pods/proxy-service-fm49q-rtrbz/proxy/rewriteme"... (200; 109.880143ms)
+Jul  2 13:25:56.275: INFO: (0) /api/v1/namespaces/e2e-tests-proxy-fgqrw/services/https:proxy-service-fm49q:tlsportname2/proxy/: tls qux (200; 192.896218ms)
+Jul  2 13:25:56.275: INFO: (0) /api/v1/namespaces/e2e-tests-proxy-fgqrw/pods/https:proxy-service-fm49q-rtrbz:443/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-fgqrw/pods/https:proxy-service-fm49q-rtrbz:443/proxy/... (200; 192.772259ms)
+Jul  2 13:25:56.275: INFO: (0) /api/v1/namespaces/e2e-tests-proxy-fgqrw/services/https:proxy-service-fm49q:tlsportname1/proxy/: tls baz (200; 193.212935ms)
+Jul  2 13:25:56.275: INFO: (0) /api/v1/namespaces/e2e-tests-proxy-fgqrw/pods/https:proxy-service-fm49q-rtrbz:460/proxy/: tls baz (200; 193.218357ms)
+Jul  2 13:25:56.275: INFO: (0) /api/v1/namespaces/e2e-tests-proxy-fgqrw/pods/https:proxy-service-fm49q-rtrbz:462/proxy/: tls qux (200; 193.204374ms)
+Jul  2 13:25:56.281: INFO: (1) /api/v1/namespaces/e2e-tests-proxy-fgqrw/pods/proxy-service-fm49q-rtrbz/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-fgqrw/pods/proxy-service-fm49q-rtrbz/proxy/rewriteme"... (200; 5.766224ms)
+Jul  2 13:25:56.281: INFO: (1) /api/v1/namespaces/e2e-tests-proxy-fgqrw/pods/http:proxy-service-fm49q-rtrbz:162/proxy/: bar (200; 5.901245ms)
+Jul  2 13:25:56.281: INFO: (1) /api/v1/namespaces/e2e-tests-proxy-fgqrw/pods/proxy-service-fm49q-rtrbz:162/proxy/: bar (200; 5.958842ms)
+Jul  2 13:25:56.281: INFO: (1) /api/v1/namespaces/e2e-tests-proxy-fgqrw/pods/https:proxy-service-fm49q-rtrbz:443/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-fgqrw/pods/https:proxy-service-fm49q-rtrbz:443/proxy/... (200; 6.013921ms)
+Jul  2 13:25:56.281: INFO: (1) /api/v1/namespaces/e2e-tests-proxy-fgqrw/pods/http:proxy-service-fm49q-rtrbz:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-fgqrw/pods/http:proxy-service-fm49q-rtrbz:1080/proxy/... (200; 5.883824ms)
+Jul  2 13:25:56.281: INFO: (1) /api/v1/namespaces/e2e-tests-proxy-fgqrw/pods/https:proxy-service-fm49q-rtrbz:462/proxy/: tls qux (200; 5.987613ms)
+Jul  2 13:25:56.281: INFO: (1) /api/v1/namespaces/e2e-tests-proxy-fgqrw/pods/proxy-service-fm49q-rtrbz:160/proxy/: foo (200; 6.13125ms)
+Jul  2 13:25:56.282: INFO: (1) /api/v1/namespaces/e2e-tests-proxy-fgqrw/pods/https:proxy-service-fm49q-rtrbz:460/proxy/: tls baz (200; 6.510316ms)
+Jul  2 13:25:56.282: INFO: (1) /api/v1/namespaces/e2e-tests-proxy-fgqrw/pods/http:proxy-service-fm49q-rtrbz:160/proxy/: foo (200; 6.306441ms)
+Jul  2 13:25:56.282: INFO: (1) /api/v1/namespaces/e2e-tests-proxy-fgqrw/pods/proxy-service-fm49q-rtrbz:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-fgqrw/pods/proxy-service-fm49q-rtrbz:1080/proxy/rewri... (200; 6.520062ms)
+Jul  2 13:25:56.282: INFO: (1) /api/v1/namespaces/e2e-tests-proxy-fgqrw/services/https:proxy-service-fm49q:tlsportname2/proxy/: tls qux (200; 6.525092ms)
+Jul  2 13:25:56.282: INFO: (1) /api/v1/namespaces/e2e-tests-proxy-fgqrw/services/https:proxy-service-fm49q:tlsportname1/proxy/: tls baz (200; 6.553099ms)
+Jul  2 13:25:56.283: INFO: (1) /api/v1/namespaces/e2e-tests-proxy-fgqrw/services/proxy-service-fm49q:portname2/proxy/: bar (200; 7.318023ms)
+Jul  2 13:25:56.325: INFO: (1) /api/v1/namespaces/e2e-tests-proxy-fgqrw/services/http:proxy-service-fm49q:portname1/proxy/: foo (200; 49.643605ms)
+Jul  2 13:25:56.325: INFO: (1) /api/v1/namespaces/e2e-tests-proxy-fgqrw/services/http:proxy-service-fm49q:portname2/proxy/: bar (200; 49.918404ms)
+Jul  2 13:25:56.325: INFO: (1) /api/v1/namespaces/e2e-tests-proxy-fgqrw/services/proxy-service-fm49q:portname1/proxy/: foo (200; 49.766792ms)
+Jul  2 13:25:56.331: INFO: (2) /api/v1/namespaces/e2e-tests-proxy-fgqrw/pods/http:proxy-service-fm49q-rtrbz:160/proxy/: foo (200; 5.795769ms)
+Jul  2 13:25:56.331: INFO: (2) /api/v1/namespaces/e2e-tests-proxy-fgqrw/pods/http:proxy-service-fm49q-rtrbz:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-fgqrw/pods/http:proxy-service-fm49q-rtrbz:1080/proxy/... (200; 5.617042ms)
+Jul  2 13:25:56.331: INFO: (2) /api/v1/namespaces/e2e-tests-proxy-fgqrw/pods/proxy-service-fm49q-rtrbz:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-fgqrw/pods/proxy-service-fm49q-rtrbz:1080/proxy/rewri... (200; 5.577813ms)
+Jul  2 13:25:56.331: INFO: (2) /api/v1/namespaces/e2e-tests-proxy-fgqrw/pods/http:proxy-service-fm49q-rtrbz:162/proxy/: bar (200; 6.050376ms)
+Jul  2 13:25:56.331: INFO: (2) /api/v1/namespaces/e2e-tests-proxy-fgqrw/pods/https:proxy-service-fm49q-rtrbz:460/proxy/: tls baz (200; 5.973619ms)
+Jul  2 13:25:56.331: INFO: (2) /api/v1/namespaces/e2e-tests-proxy-fgqrw/pods/https:proxy-service-fm49q-rtrbz:443/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-fgqrw/pods/https:proxy-service-fm49q-rtrbz:443/proxy/... (200; 6.046252ms)
+Jul  2 13:25:56.331: INFO: (2) /api/v1/namespaces/e2e-tests-proxy-fgqrw/pods/proxy-service-fm49q-rtrbz:162/proxy/: bar (200; 5.325862ms)
+Jul  2 13:25:56.331: INFO: (2) /api/v1/namespaces/e2e-tests-proxy-fgqrw/pods/https:proxy-service-fm49q-rtrbz:462/proxy/: tls qux (200; 6.027895ms)
+Jul  2 13:25:56.331: INFO: (2) /api/v1/namespaces/e2e-tests-proxy-fgqrw/pods/proxy-service-fm49q-rtrbz:160/proxy/: foo (200; 6.142822ms)
+Jul  2 13:25:56.331: INFO: (2) /api/v1/namespaces/e2e-tests-proxy-fgqrw/pods/proxy-service-fm49q-rtrbz/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-fgqrw/pods/proxy-service-fm49q-rtrbz/proxy/rewriteme"... (200; 6.362037ms)
+Jul  2 13:25:56.332: INFO: (2) /api/v1/namespaces/e2e-tests-proxy-fgqrw/services/https:proxy-service-fm49q:tlsportname2/proxy/: tls qux (200; 6.872289ms)
+Jul  2 13:25:56.332: INFO: (2) /api/v1/namespaces/e2e-tests-proxy-fgqrw/services/https:proxy-service-fm49q:tlsportname1/proxy/: tls baz (200; 6.858344ms)
+Jul  2 13:25:56.333: INFO: (2) /api/v1/namespaces/e2e-tests-proxy-fgqrw/services/proxy-service-fm49q:portname1/proxy/: foo (200; 7.578871ms)
+Jul  2 13:25:56.334: INFO: (2) /api/v1/namespaces/e2e-tests-proxy-fgqrw/services/http:proxy-service-fm49q:portname2/proxy/: bar (200; 8.475649ms)
+Jul  2 13:25:56.334: INFO: (2) /api/v1/namespaces/e2e-tests-proxy-fgqrw/services/proxy-service-fm49q:portname2/proxy/: bar (200; 8.336305ms)
+Jul  2 13:25:56.334: INFO: (2) /api/v1/namespaces/e2e-tests-proxy-fgqrw/services/http:proxy-service-fm49q:portname1/proxy/: foo (200; 8.537011ms)
+Jul  2 13:25:56.338: INFO: (3) /api/v1/namespaces/e2e-tests-proxy-fgqrw/pods/proxy-service-fm49q-rtrbz:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-fgqrw/pods/proxy-service-fm49q-rtrbz:1080/proxy/rewri... (200; 4.24577ms)
+Jul  2 13:25:56.339: INFO: (3) /api/v1/namespaces/e2e-tests-proxy-fgqrw/pods/proxy-service-fm49q-rtrbz/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-fgqrw/pods/proxy-service-fm49q-rtrbz/proxy/rewriteme"... (200; 5.070315ms)
+Jul  2 13:25:56.339: INFO: (3) /api/v1/namespaces/e2e-tests-proxy-fgqrw/pods/https:proxy-service-fm49q-rtrbz:462/proxy/: tls qux (200; 4.913247ms)
+Jul  2 13:25:56.339: INFO: (3) /api/v1/namespaces/e2e-tests-proxy-fgqrw/pods/proxy-service-fm49q-rtrbz:160/proxy/: foo (200; 4.941884ms)
+Jul  2 13:25:56.340: INFO: (3) /api/v1/namespaces/e2e-tests-proxy-fgqrw/pods/http:proxy-service-fm49q-rtrbz:160/proxy/: foo (200; 5.746111ms)
+Jul  2 13:25:56.340: INFO: (3) /api/v1/namespaces/e2e-tests-proxy-fgqrw/pods/http:proxy-service-fm49q-rtrbz:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-fgqrw/pods/http:proxy-service-fm49q-rtrbz:1080/proxy/... (200; 5.81793ms)
+Jul  2 13:25:56.340: INFO: (3) /api/v1/namespaces/e2e-tests-proxy-fgqrw/services/https:proxy-service-fm49q:tlsportname2/proxy/: tls qux (200; 5.916546ms)
+Jul  2 13:25:56.340: INFO: (3) /api/v1/namespaces/e2e-tests-proxy-fgqrw/pods/https:proxy-service-fm49q-rtrbz:443/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-fgqrw/pods/https:proxy-service-fm49q-rtrbz:443/proxy/... (200; 5.926167ms)
+Jul  2 13:25:56.340: INFO: (3) /api/v1/namespaces/e2e-tests-proxy-fgqrw/pods/https:proxy-service-fm49q-rtrbz:460/proxy/: tls baz (200; 5.893078ms)
+Jul  2 13:25:56.340: INFO: (3) /api/v1/namespaces/e2e-tests-proxy-fgqrw/services/https:proxy-service-fm49q:tlsportname1/proxy/: tls baz (200; 6.079675ms)
+Jul  2 13:25:56.340: INFO: (3) /api/v1/namespaces/e2e-tests-proxy-fgqrw/pods/http:proxy-service-fm49q-rtrbz:162/proxy/: bar (200; 6.124786ms)
+Jul  2 13:25:56.340: INFO: (3) /api/v1/namespaces/e2e-tests-proxy-fgqrw/pods/proxy-service-fm49q-rtrbz:162/proxy/: bar (200; 6.12336ms)
+Jul  2 13:25:56.341: INFO: (3) /api/v1/namespaces/e2e-tests-proxy-fgqrw/services/proxy-service-fm49q:portname1/proxy/: foo (200; 7.12292ms)
+Jul  2 13:25:56.342: INFO: (3) /api/v1/namespaces/e2e-tests-proxy-fgqrw/services/proxy-service-fm49q:portname2/proxy/: bar (200; 7.844682ms)
+Jul  2 13:25:56.342: INFO: (3) /api/v1/namespaces/e2e-tests-proxy-fgqrw/services/http:proxy-service-fm49q:portname2/proxy/: bar (200; 7.748377ms)
+Jul  2 13:25:56.342: INFO: (3) /api/v1/namespaces/e2e-tests-proxy-fgqrw/services/http:proxy-service-fm49q:portname1/proxy/: foo (200; 7.653762ms)
+Jul  2 13:25:56.347: INFO: (4) /api/v1/namespaces/e2e-tests-proxy-fgqrw/pods/http:proxy-service-fm49q-rtrbz:162/proxy/: bar (200; 5.453449ms)
+Jul  2 13:25:56.347: INFO: (4) /api/v1/namespaces/e2e-tests-proxy-fgqrw/services/proxy-service-fm49q:portname2/proxy/: bar (200; 5.528267ms)
+Jul  2 13:25:56.348: INFO: (4) /api/v1/namespaces/e2e-tests-proxy-fgqrw/pods/http:proxy-service-fm49q-rtrbz:160/proxy/: foo (200; 5.70097ms)
+Jul  2 13:25:56.348: INFO: (4) /api/v1/namespaces/e2e-tests-proxy-fgqrw/pods/proxy-service-fm49q-rtrbz/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-fgqrw/pods/proxy-service-fm49q-rtrbz/proxy/rewriteme"... (200; 5.546066ms)
+Jul  2 13:25:56.348: INFO: (4) /api/v1/namespaces/e2e-tests-proxy-fgqrw/pods/proxy-service-fm49q-rtrbz:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-fgqrw/pods/proxy-service-fm49q-rtrbz:1080/proxy/rewri... (200; 5.412185ms)
+Jul  2 13:25:56.348: INFO: (4) /api/v1/namespaces/e2e-tests-proxy-fgqrw/pods/https:proxy-service-fm49q-rtrbz:460/proxy/: tls baz (200; 5.673045ms)
+Jul  2 13:25:56.348: INFO: (4) /api/v1/namespaces/e2e-tests-proxy-fgqrw/pods/https:proxy-service-fm49q-rtrbz:443/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-fgqrw/pods/https:proxy-service-fm49q-rtrbz:443/proxy/... (200; 6.003972ms)
+Jul  2 13:25:56.348: INFO: (4) /api/v1/namespaces/e2e-tests-proxy-fgqrw/services/http:proxy-service-fm49q:portname1/proxy/: foo (200; 6.165957ms)
+Jul  2 13:25:56.348: INFO: (4) /api/v1/namespaces/e2e-tests-proxy-fgqrw/pods/https:proxy-service-fm49q-rtrbz:462/proxy/: tls qux (200; 6.076804ms)
+Jul  2 13:25:56.348: INFO: (4) /api/v1/namespaces/e2e-tests-proxy-fgqrw/services/https:proxy-service-fm49q:tlsportname2/proxy/: tls qux (200; 6.013551ms)
+Jul  2 13:25:56.348: INFO: (4) /api/v1/namespaces/e2e-tests-proxy-fgqrw/pods/http:proxy-service-fm49q-rtrbz:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-fgqrw/pods/http:proxy-service-fm49q-rtrbz:1080/proxy/... (200; 6.005056ms)
+Jul  2 13:25:56.349: INFO: (4) /api/v1/namespaces/e2e-tests-proxy-fgqrw/services/https:proxy-service-fm49q:tlsportname1/proxy/: tls baz (200; 6.630426ms)
+Jul  2 13:25:56.349: INFO: (4) /api/v1/namespaces/e2e-tests-proxy-fgqrw/pods/proxy-service-fm49q-rtrbz:162/proxy/: bar (200; 7.049612ms)
+Jul  2 13:25:56.349: INFO: (4) /api/v1/namespaces/e2e-tests-proxy-fgqrw/services/http:proxy-service-fm49q:portname2/proxy/: bar (200; 7.304698ms)
+Jul  2 13:25:56.349: INFO: (4) /api/v1/namespaces/e2e-tests-proxy-fgqrw/services/proxy-service-fm49q:portname1/proxy/: foo (200; 7.054727ms)
+Jul  2 13:25:56.350: INFO: (4) /api/v1/namespaces/e2e-tests-proxy-fgqrw/pods/proxy-service-fm49q-rtrbz:160/proxy/: foo (200; 7.444194ms)
+Jul  2 13:25:56.355: INFO: (5) /api/v1/namespaces/e2e-tests-proxy-fgqrw/pods/http:proxy-service-fm49q-rtrbz:162/proxy/: bar (200; 4.991196ms)
+Jul  2 13:25:56.355: INFO: (5) /api/v1/namespaces/e2e-tests-proxy-fgqrw/pods/http:proxy-service-fm49q-rtrbz:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-fgqrw/pods/http:proxy-service-fm49q-rtrbz:1080/proxy/... (200; 5.211062ms)
+Jul  2 13:25:56.355: INFO: (5) /api/v1/namespaces/e2e-tests-proxy-fgqrw/pods/proxy-service-fm49q-rtrbz:160/proxy/: foo (200; 5.236183ms)
+Jul  2 13:25:56.355: INFO: (5) /api/v1/namespaces/e2e-tests-proxy-fgqrw/pods/http:proxy-service-fm49q-rtrbz:160/proxy/: foo (200; 5.210059ms)
+Jul  2 13:25:56.355: INFO: (5) /api/v1/namespaces/e2e-tests-proxy-fgqrw/pods/https:proxy-service-fm49q-rtrbz:443/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-fgqrw/pods/https:proxy-service-fm49q-rtrbz:443/proxy/... (200; 5.272447ms)
+Jul  2 13:25:56.356: INFO: (5) /api/v1/namespaces/e2e-tests-proxy-fgqrw/pods/https:proxy-service-fm49q-rtrbz:462/proxy/: tls qux (200; 5.608829ms)
+Jul  2 13:25:56.356: INFO: (5) /api/v1/namespaces/e2e-tests-proxy-fgqrw/pods/proxy-service-fm49q-rtrbz:162/proxy/: bar (200; 5.894801ms)
+Jul  2 13:25:56.356: INFO: (5) /api/v1/namespaces/e2e-tests-proxy-fgqrw/pods/proxy-service-fm49q-rtrbz/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-fgqrw/pods/proxy-service-fm49q-rtrbz/proxy/rewriteme"... (200; 5.722799ms)
+Jul  2 13:25:56.356: INFO: (5) /api/v1/namespaces/e2e-tests-proxy-fgqrw/pods/proxy-service-fm49q-rtrbz:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-fgqrw/pods/proxy-service-fm49q-rtrbz:1080/proxy/rewri... (200; 5.511647ms)
+Jul  2 13:25:56.356: INFO: (5) /api/v1/namespaces/e2e-tests-proxy-fgqrw/pods/https:proxy-service-fm49q-rtrbz:460/proxy/: tls baz (200; 5.821425ms)
+Jul  2 13:25:56.375: INFO: (5) /api/v1/namespaces/e2e-tests-proxy-fgqrw/services/proxy-service-fm49q:portname1/proxy/: foo (200; 24.83673ms)
+Jul  2 13:25:56.375: INFO: (5) /api/v1/namespaces/e2e-tests-proxy-fgqrw/services/https:proxy-service-fm49q:tlsportname2/proxy/: tls qux (200; 24.800841ms)
+Jul  2 13:25:56.375: INFO: (5) /api/v1/namespaces/e2e-tests-proxy-fgqrw/services/proxy-service-fm49q:portname2/proxy/: bar (200; 25.019305ms)
+Jul  2 13:25:56.375: INFO: (5) /api/v1/namespaces/e2e-tests-proxy-fgqrw/services/https:proxy-service-fm49q:tlsportname1/proxy/: tls baz (200; 24.889886ms)
+Jul  2 13:25:56.375: INFO: (5) /api/v1/namespaces/e2e-tests-proxy-fgqrw/services/http:proxy-service-fm49q:portname2/proxy/: bar (200; 24.938238ms)
+Jul  2 13:25:56.375: INFO: (5) /api/v1/namespaces/e2e-tests-proxy-fgqrw/services/http:proxy-service-fm49q:portname1/proxy/: foo (200; 25.198258ms)
+Jul  2 13:25:56.381: INFO: (6) /api/v1/namespaces/e2e-tests-proxy-fgqrw/pods/http:proxy-service-fm49q-rtrbz:162/proxy/: bar (200; 5.898839ms)
+Jul  2 13:25:56.382: INFO: (6) /api/v1/namespaces/e2e-tests-proxy-fgqrw/pods/https:proxy-service-fm49q-rtrbz:443/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-fgqrw/pods/https:proxy-service-fm49q-rtrbz:443/proxy/... (200; 6.044785ms)
+Jul  2 13:25:56.382: INFO: (6) /api/v1/namespaces/e2e-tests-proxy-fgqrw/pods/proxy-service-fm49q-rtrbz:162/proxy/: bar (200; 6.210247ms)
+Jul  2 13:25:56.382: INFO: (6) /api/v1/namespaces/e2e-tests-proxy-fgqrw/pods/http:proxy-service-fm49q-rtrbz:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-fgqrw/pods/http:proxy-service-fm49q-rtrbz:1080/proxy/... (200; 6.184435ms)
+Jul  2 13:25:56.382: INFO: (6) /api/v1/namespaces/e2e-tests-proxy-fgqrw/pods/proxy-service-fm49q-rtrbz/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-fgqrw/pods/proxy-service-fm49q-rtrbz/proxy/rewriteme"... (200; 6.0462ms)
+Jul  2 13:25:56.382: INFO: (6) /api/v1/namespaces/e2e-tests-proxy-fgqrw/pods/https:proxy-service-fm49q-rtrbz:462/proxy/: tls qux (200; 5.977585ms)
+Jul  2 13:25:56.382: INFO: (6) /api/v1/namespaces/e2e-tests-proxy-fgqrw/pods/https:proxy-service-fm49q-rtrbz:460/proxy/: tls baz (200; 6.129267ms)
+Jul  2 13:25:56.382: INFO: (6) /api/v1/namespaces/e2e-tests-proxy-fgqrw/pods/proxy-service-fm49q-rtrbz:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-fgqrw/pods/proxy-service-fm49q-rtrbz:1080/proxy/rewri... (200; 6.32428ms)
+Jul  2 13:25:56.382: INFO: (6) /api/v1/namespaces/e2e-tests-proxy-fgqrw/services/https:proxy-service-fm49q:tlsportname1/proxy/: tls baz (200; 6.935833ms)
+Jul  2 13:25:56.382: INFO: (6) /api/v1/namespaces/e2e-tests-proxy-fgqrw/services/https:proxy-service-fm49q:tlsportname2/proxy/: tls qux (200; 6.927118ms)
+Jul  2 13:25:56.382: INFO: (6) /api/v1/namespaces/e2e-tests-proxy-fgqrw/pods/http:proxy-service-fm49q-rtrbz:160/proxy/: foo (200; 7.275801ms)
+Jul  2 13:25:56.382: INFO: (6) /api/v1/namespaces/e2e-tests-proxy-fgqrw/pods/proxy-service-fm49q-rtrbz:160/proxy/: foo (200; 7.058902ms)
+Jul  2 13:25:56.383: INFO: (6) /api/v1/namespaces/e2e-tests-proxy-fgqrw/services/http:proxy-service-fm49q:portname2/proxy/: bar (200; 7.572581ms)
+Jul  2 13:25:56.383: INFO: (6) /api/v1/namespaces/e2e-tests-proxy-fgqrw/services/proxy-service-fm49q:portname2/proxy/: bar (200; 7.247404ms)
+Jul  2 13:25:56.426: INFO: (6) /api/v1/namespaces/e2e-tests-proxy-fgqrw/services/http:proxy-service-fm49q:portname1/proxy/: foo (200; 50.702289ms)
+Jul  2 13:25:56.426: INFO: (6) /api/v1/namespaces/e2e-tests-proxy-fgqrw/services/proxy-service-fm49q:portname1/proxy/: foo (200; 50.829818ms)
+Jul  2 13:25:56.433: INFO: (7) /api/v1/namespaces/e2e-tests-proxy-fgqrw/pods/proxy-service-fm49q-rtrbz:160/proxy/: foo (200; 6.246487ms)
+Jul  2 13:25:56.433: INFO: (7) /api/v1/namespaces/e2e-tests-proxy-fgqrw/pods/http:proxy-service-fm49q-rtrbz:160/proxy/: foo (200; 6.733132ms)
+Jul  2 13:25:56.433: INFO: (7) /api/v1/namespaces/e2e-tests-proxy-fgqrw/pods/proxy-service-fm49q-rtrbz:162/proxy/: bar (200; 6.603417ms)
+Jul  2 13:25:56.433: INFO: (7) /api/v1/namespaces/e2e-tests-proxy-fgqrw/pods/https:proxy-service-fm49q-rtrbz:443/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-fgqrw/pods/https:proxy-service-fm49q-rtrbz:443/proxy/... (200; 6.559778ms)
+Jul  2 13:25:56.434: INFO: (7) /api/v1/namespaces/e2e-tests-proxy-fgqrw/pods/https:proxy-service-fm49q-rtrbz:460/proxy/: tls baz (200; 6.719093ms)
+Jul  2 13:25:56.434: INFO: (7) /api/v1/namespaces/e2e-tests-proxy-fgqrw/pods/http:proxy-service-fm49q-rtrbz:162/proxy/: bar (200; 6.646111ms)
+Jul  2 13:25:56.434: INFO: (7) /api/v1/namespaces/e2e-tests-proxy-fgqrw/pods/https:proxy-service-fm49q-rtrbz:462/proxy/: tls qux (200; 6.607631ms)
+Jul  2 13:25:56.434: INFO: (7) /api/v1/namespaces/e2e-tests-proxy-fgqrw/pods/proxy-service-fm49q-rtrbz:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-fgqrw/pods/proxy-service-fm49q-rtrbz:1080/proxy/rewri... (200; 7.194872ms)
+Jul  2 13:25:56.434: INFO: (7) /api/v1/namespaces/e2e-tests-proxy-fgqrw/services/https:proxy-service-fm49q:tlsportname2/proxy/: tls qux (200; 7.40004ms)
+Jul  2 13:25:56.434: INFO: (7) /api/v1/namespaces/e2e-tests-proxy-fgqrw/pods/proxy-service-fm49q-rtrbz/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-fgqrw/pods/proxy-service-fm49q-rtrbz/proxy/rewriteme"... (200; 7.623258ms)
+Jul  2 13:25:56.434: INFO: (7) /api/v1/namespaces/e2e-tests-proxy-fgqrw/services/https:proxy-service-fm49q:tlsportname1/proxy/: tls baz (200; 7.610648ms)
+Jul  2 13:25:56.434: INFO: (7) /api/v1/namespaces/e2e-tests-proxy-fgqrw/pods/http:proxy-service-fm49q-rtrbz:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-fgqrw/pods/http:proxy-service-fm49q-rtrbz:1080/proxy/... (200; 7.515556ms)
+Jul  2 13:25:56.435: INFO: (7) /api/v1/namespaces/e2e-tests-proxy-fgqrw/services/http:proxy-service-fm49q:portname2/proxy/: bar (200; 7.667511ms)
+Jul  2 13:25:56.435: INFO: (7) /api/v1/namespaces/e2e-tests-proxy-fgqrw/services/http:proxy-service-fm49q:portname1/proxy/: foo (200; 7.974702ms)
+Jul  2 13:25:56.435: INFO: (7) /api/v1/namespaces/e2e-tests-proxy-fgqrw/services/proxy-service-fm49q:portname1/proxy/: foo (200; 8.282516ms)
+Jul  2 13:25:56.435: INFO: (7) /api/v1/namespaces/e2e-tests-proxy-fgqrw/services/proxy-service-fm49q:portname2/proxy/: bar (200; 8.347111ms)
+Jul  2 13:25:56.441: INFO: (8) /api/v1/namespaces/e2e-tests-proxy-fgqrw/pods/proxy-service-fm49q-rtrbz:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-fgqrw/pods/proxy-service-fm49q-rtrbz:1080/proxy/rewri... (200; 5.229494ms)
+Jul  2 13:25:56.441: INFO: (8) /api/v1/namespaces/e2e-tests-proxy-fgqrw/pods/http:proxy-service-fm49q-rtrbz:160/proxy/: foo (200; 5.456854ms)
+Jul  2 13:25:56.441: INFO: (8) /api/v1/namespaces/e2e-tests-proxy-fgqrw/pods/proxy-service-fm49q-rtrbz:162/proxy/: bar (200; 5.394497ms)
+Jul  2 13:25:56.441: INFO: (8) /api/v1/namespaces/e2e-tests-proxy-fgqrw/pods/http:proxy-service-fm49q-rtrbz:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-fgqrw/pods/http:proxy-service-fm49q-rtrbz:1080/proxy/... (200; 5.364353ms)
+Jul  2 13:25:56.441: INFO: (8) /api/v1/namespaces/e2e-tests-proxy-fgqrw/pods/http:proxy-service-fm49q-rtrbz:162/proxy/: bar (200; 5.400846ms)
+Jul  2 13:25:56.441: INFO: (8) /api/v1/namespaces/e2e-tests-proxy-fgqrw/pods/proxy-service-fm49q-rtrbz:160/proxy/: foo (200; 5.96591ms)
+Jul  2 13:25:56.441: INFO: (8) /api/v1/namespaces/e2e-tests-proxy-fgqrw/pods/https:proxy-service-fm49q-rtrbz:460/proxy/: tls baz (200; 5.943246ms)
+Jul  2 13:25:56.442: INFO: (8) /api/v1/namespaces/e2e-tests-proxy-fgqrw/pods/https:proxy-service-fm49q-rtrbz:443/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-fgqrw/pods/https:proxy-service-fm49q-rtrbz:443/proxy/... (200; 6.071264ms)
+Jul  2 13:25:56.442: INFO: (8) /api/v1/namespaces/e2e-tests-proxy-fgqrw/pods/proxy-service-fm49q-rtrbz/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-fgqrw/pods/proxy-service-fm49q-rtrbz/proxy/rewriteme"... (200; 6.111616ms)
+Jul  2 13:25:56.442: INFO: (8) /api/v1/namespaces/e2e-tests-proxy-fgqrw/pods/https:proxy-service-fm49q-rtrbz:462/proxy/: tls qux (200; 6.045574ms)
+Jul  2 13:25:56.442: INFO: (8) /api/v1/namespaces/e2e-tests-proxy-fgqrw/services/https:proxy-service-fm49q:tlsportname2/proxy/: tls qux (200; 6.403452ms)
+Jul  2 13:25:56.442: INFO: (8) /api/v1/namespaces/e2e-tests-proxy-fgqrw/services/https:proxy-service-fm49q:tlsportname1/proxy/: tls baz (200; 6.497036ms)
+Jul  2 13:25:56.442: INFO: (8) /api/v1/namespaces/e2e-tests-proxy-fgqrw/services/http:proxy-service-fm49q:portname2/proxy/: bar (200; 7.187023ms)
+Jul  2 13:25:56.442: INFO: (8) /api/v1/namespaces/e2e-tests-proxy-fgqrw/services/proxy-service-fm49q:portname2/proxy/: bar (200; 6.95388ms)
+Jul  2 13:25:56.442: INFO: (8) /api/v1/namespaces/e2e-tests-proxy-fgqrw/services/http:proxy-service-fm49q:portname1/proxy/: foo (200; 7.00013ms)
+Jul  2 13:25:56.443: INFO: (8) /api/v1/namespaces/e2e-tests-proxy-fgqrw/services/proxy-service-fm49q:portname1/proxy/: foo (200; 7.840329ms)
+Jul  2 13:25:56.448: INFO: (9) /api/v1/namespaces/e2e-tests-proxy-fgqrw/pods/proxy-service-fm49q-rtrbz/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-fgqrw/pods/proxy-service-fm49q-rtrbz/proxy/rewriteme"... (200; 4.377595ms)
+Jul  2 13:25:56.449: INFO: (9) /api/v1/namespaces/e2e-tests-proxy-fgqrw/pods/proxy-service-fm49q-rtrbz:162/proxy/: bar (200; 5.455337ms)
+Jul  2 13:25:56.449: INFO: (9) /api/v1/namespaces/e2e-tests-proxy-fgqrw/pods/https:proxy-service-fm49q-rtrbz:460/proxy/: tls baz (200; 5.290902ms)
+Jul  2 13:25:56.449: INFO: (9) /api/v1/namespaces/e2e-tests-proxy-fgqrw/pods/https:proxy-service-fm49q-rtrbz:462/proxy/: tls qux (200; 5.216292ms)
+Jul  2 13:25:56.449: INFO: (9) /api/v1/namespaces/e2e-tests-proxy-fgqrw/pods/http:proxy-service-fm49q-rtrbz:160/proxy/: foo (200; 5.493444ms)
+Jul  2 13:25:56.449: INFO: (9) /api/v1/namespaces/e2e-tests-proxy-fgqrw/pods/proxy-service-fm49q-rtrbz:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-fgqrw/pods/proxy-service-fm49q-rtrbz:1080/proxy/rewri... (200; 5.36756ms)
+Jul  2 13:25:56.449: INFO: (9) /api/v1/namespaces/e2e-tests-proxy-fgqrw/pods/http:proxy-service-fm49q-rtrbz:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-fgqrw/pods/http:proxy-service-fm49q-rtrbz:1080/proxy/... (200; 5.672534ms)
+Jul  2 13:25:56.449: INFO: (9) /api/v1/namespaces/e2e-tests-proxy-fgqrw/pods/https:proxy-service-fm49q-rtrbz:443/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-fgqrw/pods/https:proxy-service-fm49q-rtrbz:443/proxy/... (200; 5.818367ms)
+Jul  2 13:25:56.449: INFO: (9) /api/v1/namespaces/e2e-tests-proxy-fgqrw/services/https:proxy-service-fm49q:tlsportname1/proxy/: tls baz (200; 6.061392ms)
+Jul  2 13:25:56.449: INFO: (9) /api/v1/namespaces/e2e-tests-proxy-fgqrw/pods/proxy-service-fm49q-rtrbz:160/proxy/: foo (200; 5.909307ms)
+Jul  2 13:25:56.450: INFO: (9) /api/v1/namespaces/e2e-tests-proxy-fgqrw/pods/http:proxy-service-fm49q-rtrbz:162/proxy/: bar (200; 6.050493ms)
+Jul  2 13:25:56.451: INFO: (9) /api/v1/namespaces/e2e-tests-proxy-fgqrw/services/https:proxy-service-fm49q:tlsportname2/proxy/: tls qux (200; 7.413988ms)
+Jul  2 13:25:56.451: INFO: (9) /api/v1/namespaces/e2e-tests-proxy-fgqrw/services/proxy-service-fm49q:portname1/proxy/: foo (200; 7.476832ms)
+Jul  2 13:25:56.451: INFO: (9) /api/v1/namespaces/e2e-tests-proxy-fgqrw/services/proxy-service-fm49q:portname2/proxy/: bar (200; 7.641399ms)
+Jul  2 13:25:56.451: INFO: (9) /api/v1/namespaces/e2e-tests-proxy-fgqrw/services/http:proxy-service-fm49q:portname1/proxy/: foo (200; 8.062964ms)
+Jul  2 13:25:56.452: INFO: (9) /api/v1/namespaces/e2e-tests-proxy-fgqrw/services/http:proxy-service-fm49q:portname2/proxy/: bar (200; 8.107193ms)
+Jul  2 13:25:56.457: INFO: (10) /api/v1/namespaces/e2e-tests-proxy-fgqrw/pods/http:proxy-service-fm49q-rtrbz:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-fgqrw/pods/http:proxy-service-fm49q-rtrbz:1080/proxy/... (200; 5.723461ms)
+Jul  2 13:25:56.457: INFO: (10) /api/v1/namespaces/e2e-tests-proxy-fgqrw/pods/http:proxy-service-fm49q-rtrbz:160/proxy/: foo (200; 5.428327ms)
+Jul  2 13:25:56.457: INFO: (10) /api/v1/namespaces/e2e-tests-proxy-fgqrw/pods/proxy-service-fm49q-rtrbz:162/proxy/: bar (200; 5.54362ms)
+Jul  2 13:25:56.457: INFO: (10) /api/v1/namespaces/e2e-tests-proxy-fgqrw/pods/proxy-service-fm49q-rtrbz:160/proxy/: foo (200; 5.771879ms)
+Jul  2 13:25:56.457: INFO: (10) /api/v1/namespaces/e2e-tests-proxy-fgqrw/pods/http:proxy-service-fm49q-rtrbz:162/proxy/: bar (200; 5.8545ms)
+Jul  2 13:25:56.458: INFO: (10) /api/v1/namespaces/e2e-tests-proxy-fgqrw/pods/proxy-service-fm49q-rtrbz:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-fgqrw/pods/proxy-service-fm49q-rtrbz:1080/proxy/rewri... (200; 5.723776ms)
+Jul  2 13:25:56.458: INFO: (10) /api/v1/namespaces/e2e-tests-proxy-fgqrw/pods/https:proxy-service-fm49q-rtrbz:443/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-fgqrw/pods/https:proxy-service-fm49q-rtrbz:443/proxy/... (200; 5.839261ms)
+Jul  2 13:25:56.458: INFO: (10) /api/v1/namespaces/e2e-tests-proxy-fgqrw/pods/proxy-service-fm49q-rtrbz/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-fgqrw/pods/proxy-service-fm49q-rtrbz/proxy/rewriteme"... (200; 5.802446ms)
+Jul  2 13:25:56.458: INFO: (10) /api/v1/namespaces/e2e-tests-proxy-fgqrw/pods/https:proxy-service-fm49q-rtrbz:462/proxy/: tls qux (200; 5.853511ms)
+Jul  2 13:25:56.458: INFO: (10) /api/v1/namespaces/e2e-tests-proxy-fgqrw/pods/https:proxy-service-fm49q-rtrbz:460/proxy/: tls baz (200; 5.976562ms)
+Jul  2 13:25:56.474: INFO: (10) /api/v1/namespaces/e2e-tests-proxy-fgqrw/services/proxy-service-fm49q:portname2/proxy/: bar (200; 21.961719ms)
+Jul  2 13:25:56.474: INFO: (10) /api/v1/namespaces/e2e-tests-proxy-fgqrw/services/http:proxy-service-fm49q:portname2/proxy/: bar (200; 21.882943ms)
+Jul  2 13:25:56.474: INFO: (10) /api/v1/namespaces/e2e-tests-proxy-fgqrw/services/proxy-service-fm49q:portname1/proxy/: foo (200; 21.835419ms)
+Jul  2 13:25:56.474: INFO: (10) /api/v1/namespaces/e2e-tests-proxy-fgqrw/services/https:proxy-service-fm49q:tlsportname1/proxy/: tls baz (200; 21.899139ms)
+Jul  2 13:25:56.474: INFO: (10) /api/v1/namespaces/e2e-tests-proxy-fgqrw/services/http:proxy-service-fm49q:portname1/proxy/: foo (200; 22.138732ms)
+Jul  2 13:25:56.474: INFO: (10) /api/v1/namespaces/e2e-tests-proxy-fgqrw/services/https:proxy-service-fm49q:tlsportname2/proxy/: tls qux (200; 22.016671ms)
+Jul  2 13:25:56.484: INFO: (11) /api/v1/namespaces/e2e-tests-proxy-fgqrw/pods/http:proxy-service-fm49q-rtrbz:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-fgqrw/pods/http:proxy-service-fm49q-rtrbz:1080/proxy/... (200; 9.350609ms)
+Jul  2 13:25:56.484: INFO: (11) /api/v1/namespaces/e2e-tests-proxy-fgqrw/pods/https:proxy-service-fm49q-rtrbz:462/proxy/: tls qux (200; 9.774424ms)
+Jul  2 13:25:56.484: INFO: (11) /api/v1/namespaces/e2e-tests-proxy-fgqrw/pods/http:proxy-service-fm49q-rtrbz:162/proxy/: bar (200; 9.991915ms)
+Jul  2 13:25:56.484: INFO: (11) /api/v1/namespaces/e2e-tests-proxy-fgqrw/pods/http:proxy-service-fm49q-rtrbz:160/proxy/: foo (200; 9.337329ms)
+Jul  2 13:25:56.484: INFO: (11) /api/v1/namespaces/e2e-tests-proxy-fgqrw/pods/proxy-service-fm49q-rtrbz:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-fgqrw/pods/proxy-service-fm49q-rtrbz:1080/proxy/rewri... (200; 9.583577ms)
+Jul  2 13:25:56.484: INFO: (11) /api/v1/namespaces/e2e-tests-proxy-fgqrw/services/proxy-service-fm49q:portname2/proxy/: bar (200; 10.199435ms)
+Jul  2 13:25:56.484: INFO: (11) /api/v1/namespaces/e2e-tests-proxy-fgqrw/pods/proxy-service-fm49q-rtrbz/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-fgqrw/pods/proxy-service-fm49q-rtrbz/proxy/rewriteme"... (200; 10.181133ms)
+Jul  2 13:25:56.484: INFO: (11) /api/v1/namespaces/e2e-tests-proxy-fgqrw/pods/proxy-service-fm49q-rtrbz:160/proxy/: foo (200; 9.572483ms)
+Jul  2 13:25:56.484: INFO: (11) /api/v1/namespaces/e2e-tests-proxy-fgqrw/pods/https:proxy-service-fm49q-rtrbz:460/proxy/: tls baz (200; 10.547022ms)
+Jul  2 13:25:56.484: INFO: (11) /api/v1/namespaces/e2e-tests-proxy-fgqrw/pods/https:proxy-service-fm49q-rtrbz:443/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-fgqrw/pods/https:proxy-service-fm49q-rtrbz:443/proxy/... (200; 10.181689ms)
+Jul  2 13:25:56.485: INFO: (11) /api/v1/namespaces/e2e-tests-proxy-fgqrw/services/https:proxy-service-fm49q:tlsportname1/proxy/: tls baz (200; 10.51428ms)
+Jul  2 13:25:56.485: INFO: (11) /api/v1/namespaces/e2e-tests-proxy-fgqrw/services/https:proxy-service-fm49q:tlsportname2/proxy/: tls qux (200; 10.586702ms)
+Jul  2 13:25:56.485: INFO: (11) /api/v1/namespaces/e2e-tests-proxy-fgqrw/services/proxy-service-fm49q:portname1/proxy/: foo (200; 10.898862ms)
+Jul  2 13:25:56.486: INFO: (11) /api/v1/namespaces/e2e-tests-proxy-fgqrw/pods/proxy-service-fm49q-rtrbz:162/proxy/: bar (200; 10.950015ms)
+Jul  2 13:25:56.486: INFO: (11) /api/v1/namespaces/e2e-tests-proxy-fgqrw/services/http:proxy-service-fm49q:portname2/proxy/: bar (200; 11.206499ms)
+Jul  2 13:25:56.486: INFO: (11) /api/v1/namespaces/e2e-tests-proxy-fgqrw/services/http:proxy-service-fm49q:portname1/proxy/: foo (200; 11.570347ms)
+Jul  2 13:25:56.498: INFO: (12) /api/v1/namespaces/e2e-tests-proxy-fgqrw/services/proxy-service-fm49q:portname2/proxy/: bar (200; 11.898199ms)
+Jul  2 13:25:56.498: INFO: (12) /api/v1/namespaces/e2e-tests-proxy-fgqrw/pods/proxy-service-fm49q-rtrbz:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-fgqrw/pods/proxy-service-fm49q-rtrbz:1080/proxy/rewri... (200; 11.969509ms)
+Jul  2 13:25:56.498: INFO: (12) /api/v1/namespaces/e2e-tests-proxy-fgqrw/services/http:proxy-service-fm49q:portname1/proxy/: foo (200; 12.021293ms)
+Jul  2 13:25:56.499: INFO: (12) /api/v1/namespaces/e2e-tests-proxy-fgqrw/pods/http:proxy-service-fm49q-rtrbz:162/proxy/: bar (200; 12.106363ms)
+Jul  2 13:25:56.499: INFO: (12) /api/v1/namespaces/e2e-tests-proxy-fgqrw/pods/proxy-service-fm49q-rtrbz/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-fgqrw/pods/proxy-service-fm49q-rtrbz/proxy/rewriteme"... (200; 12.288413ms)
+Jul  2 13:25:56.499: INFO: (12) /api/v1/namespaces/e2e-tests-proxy-fgqrw/pods/https:proxy-service-fm49q-rtrbz:462/proxy/: tls qux (200; 12.237798ms)
+Jul  2 13:25:56.499: INFO: (12) /api/v1/namespaces/e2e-tests-proxy-fgqrw/pods/http:proxy-service-fm49q-rtrbz:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-fgqrw/pods/http:proxy-service-fm49q-rtrbz:1080/proxy/... (200; 12.283155ms)
+Jul  2 13:25:56.499: INFO: (12) /api/v1/namespaces/e2e-tests-proxy-fgqrw/pods/http:proxy-service-fm49q-rtrbz:160/proxy/: foo (200; 12.219982ms)
+Jul  2 13:25:56.499: INFO: (12) /api/v1/namespaces/e2e-tests-proxy-fgqrw/pods/https:proxy-service-fm49q-rtrbz:443/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-fgqrw/pods/https:proxy-service-fm49q-rtrbz:443/proxy/... (200; 12.196429ms)
+Jul  2 13:25:56.499: INFO: (12) /api/v1/namespaces/e2e-tests-proxy-fgqrw/services/https:proxy-service-fm49q:tlsportname2/proxy/: tls qux (200; 12.427103ms)
+Jul  2 13:25:56.499: INFO: (12) /api/v1/namespaces/e2e-tests-proxy-fgqrw/services/https:proxy-service-fm49q:tlsportname1/proxy/: tls baz (200; 12.510146ms)
+Jul  2 13:25:56.499: INFO: (12) /api/v1/namespaces/e2e-tests-proxy-fgqrw/pods/https:proxy-service-fm49q-rtrbz:460/proxy/: tls baz (200; 12.355971ms)
+Jul  2 13:25:56.542: INFO: (12) /api/v1/namespaces/e2e-tests-proxy-fgqrw/services/http:proxy-service-fm49q:portname2/proxy/: bar (200; 55.076361ms)
+Jul  2 13:25:56.542: INFO: (12) /api/v1/namespaces/e2e-tests-proxy-fgqrw/pods/proxy-service-fm49q-rtrbz:160/proxy/: foo (200; 55.012969ms)
+Jul  2 13:25:56.542: INFO: (12) /api/v1/namespaces/e2e-tests-proxy-fgqrw/services/proxy-service-fm49q:portname1/proxy/: foo (200; 54.971269ms)
+Jul  2 13:25:56.542: INFO: (12) /api/v1/namespaces/e2e-tests-proxy-fgqrw/pods/proxy-service-fm49q-rtrbz:162/proxy/: bar (200; 55.276047ms)
+Jul  2 13:25:56.548: INFO: (13) /api/v1/namespaces/e2e-tests-proxy-fgqrw/pods/http:proxy-service-fm49q-rtrbz:160/proxy/: foo (200; 5.667566ms)
+Jul  2 13:25:56.548: INFO: (13) /api/v1/namespaces/e2e-tests-proxy-fgqrw/pods/proxy-service-fm49q-rtrbz:160/proxy/: foo (200; 5.768626ms)
+Jul  2 13:25:56.548: INFO: (13) /api/v1/namespaces/e2e-tests-proxy-fgqrw/pods/http:proxy-service-fm49q-rtrbz:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-fgqrw/pods/http:proxy-service-fm49q-rtrbz:1080/proxy/... (200; 5.5538ms)
+Jul  2 13:25:56.548: INFO: (13) /api/v1/namespaces/e2e-tests-proxy-fgqrw/pods/http:proxy-service-fm49q-rtrbz:162/proxy/: bar (200; 5.676709ms)
+Jul  2 13:25:56.548: INFO: (13) /api/v1/namespaces/e2e-tests-proxy-fgqrw/pods/proxy-service-fm49q-rtrbz:162/proxy/: bar (200; 5.760635ms)
+Jul  2 13:25:56.548: INFO: (13) /api/v1/namespaces/e2e-tests-proxy-fgqrw/pods/proxy-service-fm49q-rtrbz:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-fgqrw/pods/proxy-service-fm49q-rtrbz:1080/proxy/rewri... (200; 5.802462ms)
+Jul  2 13:25:56.548: INFO: (13) /api/v1/namespaces/e2e-tests-proxy-fgqrw/pods/https:proxy-service-fm49q-rtrbz:460/proxy/: tls baz (200; 6.064159ms)
+Jul  2 13:25:56.548: INFO: (13) /api/v1/namespaces/e2e-tests-proxy-fgqrw/pods/proxy-service-fm49q-rtrbz/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-fgqrw/pods/proxy-service-fm49q-rtrbz/proxy/rewriteme"... (200; 5.798512ms)
+Jul  2 13:25:56.548: INFO: (13) /api/v1/namespaces/e2e-tests-proxy-fgqrw/pods/https:proxy-service-fm49q-rtrbz:462/proxy/: tls qux (200; 5.744723ms)
+Jul  2 13:25:56.548: INFO: (13) /api/v1/namespaces/e2e-tests-proxy-fgqrw/pods/https:proxy-service-fm49q-rtrbz:443/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-fgqrw/pods/https:proxy-service-fm49q-rtrbz:443/proxy/... (200; 5.794035ms)
+Jul  2 13:25:56.549: INFO: (13) /api/v1/namespaces/e2e-tests-proxy-fgqrw/services/https:proxy-service-fm49q:tlsportname1/proxy/: tls baz (200; 6.831647ms)
+Jul  2 13:25:56.549: INFO: (13) /api/v1/namespaces/e2e-tests-proxy-fgqrw/services/https:proxy-service-fm49q:tlsportname2/proxy/: tls qux (200; 6.812567ms)
+Jul  2 13:25:56.550: INFO: (13) /api/v1/namespaces/e2e-tests-proxy-fgqrw/services/http:proxy-service-fm49q:portname1/proxy/: foo (200; 7.346452ms)
+Jul  2 13:25:56.550: INFO: (13) /api/v1/namespaces/e2e-tests-proxy-fgqrw/services/proxy-service-fm49q:portname2/proxy/: bar (200; 7.327338ms)
+Jul  2 13:25:56.550: INFO: (13) /api/v1/namespaces/e2e-tests-proxy-fgqrw/services/http:proxy-service-fm49q:portname2/proxy/: bar (200; 7.642845ms)
+Jul  2 13:25:56.550: INFO: (13) /api/v1/namespaces/e2e-tests-proxy-fgqrw/services/proxy-service-fm49q:portname1/proxy/: foo (200; 7.611809ms)
+Jul  2 13:25:56.555: INFO: (14) /api/v1/namespaces/e2e-tests-proxy-fgqrw/pods/http:proxy-service-fm49q-rtrbz:162/proxy/: bar (200; 4.851808ms)
+Jul  2 13:25:56.555: INFO: (14) /api/v1/namespaces/e2e-tests-proxy-fgqrw/pods/proxy-service-fm49q-rtrbz/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-fgqrw/pods/proxy-service-fm49q-rtrbz/proxy/rewriteme"... (200; 4.985624ms)
+Jul  2 13:25:56.555: INFO: (14) /api/v1/namespaces/e2e-tests-proxy-fgqrw/pods/http:proxy-service-fm49q-rtrbz:160/proxy/: foo (200; 5.227955ms)
+Jul  2 13:25:56.555: INFO: (14) /api/v1/namespaces/e2e-tests-proxy-fgqrw/pods/http:proxy-service-fm49q-rtrbz:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-fgqrw/pods/http:proxy-service-fm49q-rtrbz:1080/proxy/... (200; 5.387101ms)
+Jul  2 13:25:56.555: INFO: (14) /api/v1/namespaces/e2e-tests-proxy-fgqrw/pods/proxy-service-fm49q-rtrbz:160/proxy/: foo (200; 5.380217ms)
+Jul  2 13:25:56.555: INFO: (14) /api/v1/namespaces/e2e-tests-proxy-fgqrw/pods/https:proxy-service-fm49q-rtrbz:443/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-fgqrw/pods/https:proxy-service-fm49q-rtrbz:443/proxy/... (200; 5.111833ms)
+Jul  2 13:25:56.555: INFO: (14) /api/v1/namespaces/e2e-tests-proxy-fgqrw/pods/https:proxy-service-fm49q-rtrbz:460/proxy/: tls baz (200; 5.362179ms)
+Jul  2 13:25:56.555: INFO: (14) /api/v1/namespaces/e2e-tests-proxy-fgqrw/pods/proxy-service-fm49q-rtrbz:162/proxy/: bar (200; 4.965264ms)
+Jul  2 13:25:56.556: INFO: (14) /api/v1/namespaces/e2e-tests-proxy-fgqrw/pods/proxy-service-fm49q-rtrbz:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-fgqrw/pods/proxy-service-fm49q-rtrbz:1080/proxy/rewri... (200; 5.225361ms)
+Jul  2 13:25:56.556: INFO: (14) /api/v1/namespaces/e2e-tests-proxy-fgqrw/pods/https:proxy-service-fm49q-rtrbz:462/proxy/: tls qux (200; 5.423337ms)
+Jul  2 13:25:56.556: INFO: (14) /api/v1/namespaces/e2e-tests-proxy-fgqrw/services/https:proxy-service-fm49q:tlsportname2/proxy/: tls qux (200; 5.992218ms)
+Jul  2 13:25:56.557: INFO: (14) /api/v1/namespaces/e2e-tests-proxy-fgqrw/services/http:proxy-service-fm49q:portname1/proxy/: foo (200; 6.834772ms)
+Jul  2 13:25:56.557: INFO: (14) /api/v1/namespaces/e2e-tests-proxy-fgqrw/services/https:proxy-service-fm49q:tlsportname1/proxy/: tls baz (200; 6.572402ms)
+Jul  2 13:25:56.557: INFO: (14) /api/v1/namespaces/e2e-tests-proxy-fgqrw/services/proxy-service-fm49q:portname1/proxy/: foo (200; 6.95102ms)
+Jul  2 13:25:56.557: INFO: (14) /api/v1/namespaces/e2e-tests-proxy-fgqrw/services/http:proxy-service-fm49q:portname2/proxy/: bar (200; 7.487003ms)
+Jul  2 13:25:56.557: INFO: (14) /api/v1/namespaces/e2e-tests-proxy-fgqrw/services/proxy-service-fm49q:portname2/proxy/: bar (200; 7.12104ms)
+Jul  2 13:25:56.563: INFO: (15) /api/v1/namespaces/e2e-tests-proxy-fgqrw/pods/http:proxy-service-fm49q-rtrbz:162/proxy/: bar (200; 5.296367ms)
+Jul  2 13:25:56.563: INFO: (15) /api/v1/namespaces/e2e-tests-proxy-fgqrw/pods/http:proxy-service-fm49q-rtrbz:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-fgqrw/pods/http:proxy-service-fm49q-rtrbz:1080/proxy/... (200; 5.22367ms)
+Jul  2 13:25:56.563: INFO: (15) /api/v1/namespaces/e2e-tests-proxy-fgqrw/pods/proxy-service-fm49q-rtrbz:162/proxy/: bar (200; 5.145491ms)
+Jul  2 13:25:56.563: INFO: (15) /api/v1/namespaces/e2e-tests-proxy-fgqrw/pods/proxy-service-fm49q-rtrbz:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-fgqrw/pods/proxy-service-fm49q-rtrbz:1080/proxy/rewri... (200; 5.253512ms)
+Jul  2 13:25:56.564: INFO: (15) /api/v1/namespaces/e2e-tests-proxy-fgqrw/services/http:proxy-service-fm49q:portname1/proxy/: foo (200; 6.001826ms)
+Jul  2 13:25:56.564: INFO: (15) /api/v1/namespaces/e2e-tests-proxy-fgqrw/pods/https:proxy-service-fm49q-rtrbz:443/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-fgqrw/pods/https:proxy-service-fm49q-rtrbz:443/proxy/... (200; 6.239986ms)
+Jul  2 13:25:56.564: INFO: (15) /api/v1/namespaces/e2e-tests-proxy-fgqrw/pods/proxy-service-fm49q-rtrbz:160/proxy/: foo (200; 6.404061ms)
+Jul  2 13:25:56.564: INFO: (15) /api/v1/namespaces/e2e-tests-proxy-fgqrw/pods/https:proxy-service-fm49q-rtrbz:460/proxy/: tls baz (200; 6.47427ms)
+Jul  2 13:25:56.564: INFO: (15) /api/v1/namespaces/e2e-tests-proxy-fgqrw/services/https:proxy-service-fm49q:tlsportname1/proxy/: tls baz (200; 6.470523ms)
+Jul  2 13:25:56.564: INFO: (15) /api/v1/namespaces/e2e-tests-proxy-fgqrw/pods/proxy-service-fm49q-rtrbz/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-fgqrw/pods/proxy-service-fm49q-rtrbz/proxy/rewriteme"... (200; 6.628732ms)
+Jul  2 13:25:56.564: INFO: (15) /api/v1/namespaces/e2e-tests-proxy-fgqrw/services/https:proxy-service-fm49q:tlsportname2/proxy/: tls qux (200; 6.837946ms)
+Jul  2 13:25:56.564: INFO: (15) /api/v1/namespaces/e2e-tests-proxy-fgqrw/pods/https:proxy-service-fm49q-rtrbz:462/proxy/: tls qux (200; 6.677904ms)
+Jul  2 13:25:56.565: INFO: (15) /api/v1/namespaces/e2e-tests-proxy-fgqrw/services/http:proxy-service-fm49q:portname2/proxy/: bar (200; 7.142865ms)
+Jul  2 13:25:56.565: INFO: (15) /api/v1/namespaces/e2e-tests-proxy-fgqrw/services/proxy-service-fm49q:portname2/proxy/: bar (200; 7.040276ms)
+Jul  2 13:25:56.565: INFO: (15) /api/v1/namespaces/e2e-tests-proxy-fgqrw/services/proxy-service-fm49q:portname1/proxy/: foo (200; 7.639963ms)
+Jul  2 13:25:56.566: INFO: (15) /api/v1/namespaces/e2e-tests-proxy-fgqrw/pods/http:proxy-service-fm49q-rtrbz:160/proxy/: foo (200; 7.87058ms)
+Jul  2 13:25:56.571: INFO: (16) /api/v1/namespaces/e2e-tests-proxy-fgqrw/pods/proxy-service-fm49q-rtrbz:162/proxy/: bar (200; 5.606645ms)
+Jul  2 13:25:56.571: INFO: (16) /api/v1/namespaces/e2e-tests-proxy-fgqrw/pods/proxy-service-fm49q-rtrbz:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-fgqrw/pods/proxy-service-fm49q-rtrbz:1080/proxy/rewri... (200; 5.42692ms)
+Jul  2 13:25:56.571: INFO: (16) /api/v1/namespaces/e2e-tests-proxy-fgqrw/pods/http:proxy-service-fm49q-rtrbz:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-fgqrw/pods/http:proxy-service-fm49q-rtrbz:1080/proxy/... (200; 5.463701ms)
+Jul  2 13:25:56.571: INFO: (16) /api/v1/namespaces/e2e-tests-proxy-fgqrw/pods/http:proxy-service-fm49q-rtrbz:162/proxy/: bar (200; 5.444149ms)
+Jul  2 13:25:56.571: INFO: (16) /api/v1/namespaces/e2e-tests-proxy-fgqrw/pods/proxy-service-fm49q-rtrbz/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-fgqrw/pods/proxy-service-fm49q-rtrbz/proxy/rewriteme"... (200; 5.595474ms)
+Jul  2 13:25:56.572: INFO: (16) /api/v1/namespaces/e2e-tests-proxy-fgqrw/pods/http:proxy-service-fm49q-rtrbz:160/proxy/: foo (200; 5.840344ms)
+Jul  2 13:25:56.572: INFO: (16) /api/v1/namespaces/e2e-tests-proxy-fgqrw/pods/https:proxy-service-fm49q-rtrbz:443/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-fgqrw/pods/https:proxy-service-fm49q-rtrbz:443/proxy/... (200; 5.837346ms)
+Jul  2 13:25:56.572: INFO: (16) /api/v1/namespaces/e2e-tests-proxy-fgqrw/services/https:proxy-service-fm49q:tlsportname2/proxy/: tls qux (200; 6.258063ms)
+Jul  2 13:25:56.572: INFO: (16) /api/v1/namespaces/e2e-tests-proxy-fgqrw/pods/proxy-service-fm49q-rtrbz:160/proxy/: foo (200; 6.322905ms)
+Jul  2 13:25:56.572: INFO: (16) /api/v1/namespaces/e2e-tests-proxy-fgqrw/services/https:proxy-service-fm49q:tlsportname1/proxy/: tls baz (200; 6.523297ms)
+Jul  2 13:25:56.572: INFO: (16) /api/v1/namespaces/e2e-tests-proxy-fgqrw/pods/https:proxy-service-fm49q-rtrbz:462/proxy/: tls qux (200; 6.725151ms)
+Jul  2 13:25:56.572: INFO: (16) /api/v1/namespaces/e2e-tests-proxy-fgqrw/pods/https:proxy-service-fm49q-rtrbz:460/proxy/: tls baz (200; 6.475219ms)
+Jul  2 13:25:56.573: INFO: (16) /api/v1/namespaces/e2e-tests-proxy-fgqrw/services/proxy-service-fm49q:portname2/proxy/: bar (200; 7.20408ms)
+Jul  2 13:25:56.573: INFO: (16) /api/v1/namespaces/e2e-tests-proxy-fgqrw/services/http:proxy-service-fm49q:portname2/proxy/: bar (200; 7.11788ms)
+Jul  2 13:25:56.573: INFO: (16) /api/v1/namespaces/e2e-tests-proxy-fgqrw/services/http:proxy-service-fm49q:portname1/proxy/: foo (200; 7.690894ms)
+Jul  2 13:25:56.574: INFO: (16) /api/v1/namespaces/e2e-tests-proxy-fgqrw/services/proxy-service-fm49q:portname1/proxy/: foo (200; 7.901599ms)
+Jul  2 13:25:56.580: INFO: (17) /api/v1/namespaces/e2e-tests-proxy-fgqrw/pods/http:proxy-service-fm49q-rtrbz:162/proxy/: bar (200; 5.621043ms)
+Jul  2 13:25:56.580: INFO: (17) /api/v1/namespaces/e2e-tests-proxy-fgqrw/pods/https:proxy-service-fm49q-rtrbz:443/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-fgqrw/pods/https:proxy-service-fm49q-rtrbz:443/proxy/... (200; 5.583891ms)
+Jul  2 13:25:56.580: INFO: (17) /api/v1/namespaces/e2e-tests-proxy-fgqrw/pods/proxy-service-fm49q-rtrbz/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-fgqrw/pods/proxy-service-fm49q-rtrbz/proxy/rewriteme"... (200; 5.776089ms)
+Jul  2 13:25:56.580: INFO: (17) /api/v1/namespaces/e2e-tests-proxy-fgqrw/pods/https:proxy-service-fm49q-rtrbz:460/proxy/: tls baz (200; 5.929493ms)
+Jul  2 13:25:56.580: INFO: (17) /api/v1/namespaces/e2e-tests-proxy-fgqrw/pods/proxy-service-fm49q-rtrbz:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-fgqrw/pods/proxy-service-fm49q-rtrbz:1080/proxy/rewri... (200; 5.826499ms)
+Jul  2 13:25:56.580: INFO: (17) /api/v1/namespaces/e2e-tests-proxy-fgqrw/pods/proxy-service-fm49q-rtrbz:160/proxy/: foo (200; 5.995611ms)
+Jul  2 13:25:56.580: INFO: (17) /api/v1/namespaces/e2e-tests-proxy-fgqrw/pods/proxy-service-fm49q-rtrbz:162/proxy/: bar (200; 6.108823ms)
+Jul  2 13:25:56.580: INFO: (17) /api/v1/namespaces/e2e-tests-proxy-fgqrw/pods/https:proxy-service-fm49q-rtrbz:462/proxy/: tls qux (200; 5.968072ms)
+Jul  2 13:25:56.580: INFO: (17) /api/v1/namespaces/e2e-tests-proxy-fgqrw/pods/http:proxy-service-fm49q-rtrbz:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-fgqrw/pods/http:proxy-service-fm49q-rtrbz:1080/proxy/... (200; 6.178567ms)
+Jul  2 13:25:56.580: INFO: (17) /api/v1/namespaces/e2e-tests-proxy-fgqrw/services/http:proxy-service-fm49q:portname1/proxy/: foo (200; 6.346468ms)
+Jul  2 13:25:56.580: INFO: (17) /api/v1/namespaces/e2e-tests-proxy-fgqrw/services/https:proxy-service-fm49q:tlsportname1/proxy/: tls baz (200; 6.38049ms)
+Jul  2 13:25:56.581: INFO: (17) /api/v1/namespaces/e2e-tests-proxy-fgqrw/services/https:proxy-service-fm49q:tlsportname2/proxy/: tls qux (200; 6.827186ms)
+Jul  2 13:25:56.581: INFO: (17) /api/v1/namespaces/e2e-tests-proxy-fgqrw/services/http:proxy-service-fm49q:portname2/proxy/: bar (200; 7.191505ms)
+Jul  2 13:25:56.623: INFO: (17) /api/v1/namespaces/e2e-tests-proxy-fgqrw/services/proxy-service-fm49q:portname2/proxy/: bar (200; 48.968376ms)
+Jul  2 13:25:56.623: INFO: (17) /api/v1/namespaces/e2e-tests-proxy-fgqrw/services/proxy-service-fm49q:portname1/proxy/: foo (200; 48.885078ms)
+Jul  2 13:25:56.623: INFO: (17) /api/v1/namespaces/e2e-tests-proxy-fgqrw/pods/http:proxy-service-fm49q-rtrbz:160/proxy/: foo (200; 48.640768ms)
+Jul  2 13:25:56.628: INFO: (18) /api/v1/namespaces/e2e-tests-proxy-fgqrw/pods/https:proxy-service-fm49q-rtrbz:462/proxy/: tls qux (200; 5.007624ms)
+Jul  2 13:25:56.629: INFO: (18) /api/v1/namespaces/e2e-tests-proxy-fgqrw/pods/http:proxy-service-fm49q-rtrbz:160/proxy/: foo (200; 6.22255ms)
+Jul  2 13:25:56.630: INFO: (18) /api/v1/namespaces/e2e-tests-proxy-fgqrw/services/https:proxy-service-fm49q:tlsportname1/proxy/: tls baz (200; 6.501464ms)
+Jul  2 13:25:56.630: INFO: (18) /api/v1/namespaces/e2e-tests-proxy-fgqrw/pods/proxy-service-fm49q-rtrbz:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-fgqrw/pods/proxy-service-fm49q-rtrbz:1080/proxy/rewri... (200; 6.150153ms)
+Jul  2 13:25:56.630: INFO: (18) /api/v1/namespaces/e2e-tests-proxy-fgqrw/pods/http:proxy-service-fm49q-rtrbz:162/proxy/: bar (200; 6.489728ms)
+Jul  2 13:25:56.630: INFO: (18) /api/v1/namespaces/e2e-tests-proxy-fgqrw/pods/https:proxy-service-fm49q-rtrbz:460/proxy/: tls baz (200; 6.542692ms)
+Jul  2 13:25:56.630: INFO: (18) /api/v1/namespaces/e2e-tests-proxy-fgqrw/pods/proxy-service-fm49q-rtrbz:160/proxy/: foo (200; 6.784131ms)
+Jul  2 13:25:56.630: INFO: (18) /api/v1/namespaces/e2e-tests-proxy-fgqrw/pods/http:proxy-service-fm49q-rtrbz:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-fgqrw/pods/http:proxy-service-fm49q-rtrbz:1080/proxy/... (200; 6.857101ms)
+Jul  2 13:25:56.630: INFO: (18) /api/v1/namespaces/e2e-tests-proxy-fgqrw/pods/https:proxy-service-fm49q-rtrbz:443/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-fgqrw/pods/https:proxy-service-fm49q-rtrbz:443/proxy/... (200; 6.678607ms)
+Jul  2 13:25:56.630: INFO: (18) /api/v1/namespaces/e2e-tests-proxy-fgqrw/pods/proxy-service-fm49q-rtrbz:162/proxy/: bar (200; 6.859991ms)
+Jul  2 13:25:56.630: INFO: (18) /api/v1/namespaces/e2e-tests-proxy-fgqrw/services/https:proxy-service-fm49q:tlsportname2/proxy/: tls qux (200; 6.802041ms)
+Jul  2 13:25:56.630: INFO: (18) /api/v1/namespaces/e2e-tests-proxy-fgqrw/pods/proxy-service-fm49q-rtrbz/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-fgqrw/pods/proxy-service-fm49q-rtrbz/proxy/rewriteme"... (200; 7.122392ms)
+Jul  2 13:25:56.631: INFO: (18) /api/v1/namespaces/e2e-tests-proxy-fgqrw/services/http:proxy-service-fm49q:portname1/proxy/: foo (200; 8.05947ms)
+Jul  2 13:25:56.631: INFO: (18) /api/v1/namespaces/e2e-tests-proxy-fgqrw/services/proxy-service-fm49q:portname1/proxy/: foo (200; 8.280438ms)
+Jul  2 13:25:56.632: INFO: (18) /api/v1/namespaces/e2e-tests-proxy-fgqrw/services/proxy-service-fm49q:portname2/proxy/: bar (200; 8.744731ms)
+Jul  2 13:25:56.632: INFO: (18) /api/v1/namespaces/e2e-tests-proxy-fgqrw/services/http:proxy-service-fm49q:portname2/proxy/: bar (200; 8.890139ms)
+Jul  2 13:25:56.637: INFO: (19) /api/v1/namespaces/e2e-tests-proxy-fgqrw/pods/http:proxy-service-fm49q-rtrbz:162/proxy/: bar (200; 5.128358ms)
+Jul  2 13:25:56.638: INFO: (19) /api/v1/namespaces/e2e-tests-proxy-fgqrw/pods/proxy-service-fm49q-rtrbz:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-fgqrw/pods/proxy-service-fm49q-rtrbz:1080/proxy/rewri... (200; 5.032094ms)
+Jul  2 13:25:56.638: INFO: (19) /api/v1/namespaces/e2e-tests-proxy-fgqrw/pods/https:proxy-service-fm49q-rtrbz:460/proxy/: tls baz (200; 5.645087ms)
+Jul  2 13:25:56.638: INFO: (19) /api/v1/namespaces/e2e-tests-proxy-fgqrw/services/http:proxy-service-fm49q:portname1/proxy/: foo (200; 5.708197ms)
+Jul  2 13:25:56.638: INFO: (19) /api/v1/namespaces/e2e-tests-proxy-fgqrw/pods/http:proxy-service-fm49q-rtrbz:160/proxy/: foo (200; 5.801488ms)
+Jul  2 13:25:56.638: INFO: (19) /api/v1/namespaces/e2e-tests-proxy-fgqrw/services/https:proxy-service-fm49q:tlsportname2/proxy/: tls qux (200; 5.431557ms)
+Jul  2 13:25:56.638: INFO: (19) /api/v1/namespaces/e2e-tests-proxy-fgqrw/pods/https:proxy-service-fm49q-rtrbz:443/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-fgqrw/pods/https:proxy-service-fm49q-rtrbz:443/proxy/... (200; 5.749899ms)
+Jul  2 13:25:56.638: INFO: (19) /api/v1/namespaces/e2e-tests-proxy-fgqrw/pods/https:proxy-service-fm49q-rtrbz:462/proxy/: tls qux (200; 5.697565ms)
+Jul  2 13:25:56.638: INFO: (19) /api/v1/namespaces/e2e-tests-proxy-fgqrw/pods/proxy-service-fm49q-rtrbz:162/proxy/: bar (200; 5.397682ms)
+Jul  2 13:25:56.638: INFO: (19) /api/v1/namespaces/e2e-tests-proxy-fgqrw/pods/proxy-service-fm49q-rtrbz/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-fgqrw/pods/proxy-service-fm49q-rtrbz/proxy/rewriteme"... (200; 6.03269ms)
+Jul  2 13:25:56.639: INFO: (19) /api/v1/namespaces/e2e-tests-proxy-fgqrw/services/https:proxy-service-fm49q:tlsportname1/proxy/: tls baz (200; 6.098841ms)
+Jul  2 13:25:56.639: INFO: (19) /api/v1/namespaces/e2e-tests-proxy-fgqrw/pods/http:proxy-service-fm49q-rtrbz:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-fgqrw/pods/http:proxy-service-fm49q-rtrbz:1080/proxy/... (200; 5.841776ms)
+Jul  2 13:25:56.639: INFO: (19) /api/v1/namespaces/e2e-tests-proxy-fgqrw/services/http:proxy-service-fm49q:portname2/proxy/: bar (200; 6.516804ms)
+Jul  2 13:25:56.640: INFO: (19) /api/v1/namespaces/e2e-tests-proxy-fgqrw/services/proxy-service-fm49q:portname1/proxy/: foo (200; 6.894222ms)
+Jul  2 13:25:56.640: INFO: (19) /api/v1/namespaces/e2e-tests-proxy-fgqrw/services/proxy-service-fm49q:portname2/proxy/: bar (200; 7.515157ms)
+Jul  2 13:25:56.640: INFO: (19) /api/v1/namespaces/e2e-tests-proxy-fgqrw/pods/proxy-service-fm49q-rtrbz:160/proxy/: foo (200; 6.818675ms)
+STEP: deleting { ReplicationController} proxy-service-fm49q in namespace e2e-tests-proxy-fgqrw, will wait for the garbage collector to delete the pods
+Jul  2 13:25:56.698: INFO: Deleting { ReplicationController} proxy-service-fm49q took: 5.541441ms
+Jul  2 13:25:56.798: INFO: Terminating { ReplicationController} proxy-service-fm49q pods took: 100.225612ms
+[AfterEach] version v1
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:25:58.598: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-proxy-fgqrw" for this suite.
+Jul  2 13:26:04.671: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:26:04.706: INFO: namespace: e2e-tests-proxy-fgqrw, resource: bindings, ignored listing per whitelist
+Jul  2 13:26:04.760: INFO: namespace e2e-tests-proxy-fgqrw deletion completed in 6.1577383s
+
+• [SLOW TEST:17.824 seconds]
+[sig-network] Proxy
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/network/framework.go:22
+  version v1
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/network/proxy.go:56
+    should proxy through a service and a pod  [Conformance]
+    /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSS
+------------------------------
+[sig-api-machinery] ConfigMap 
+  should be consumable via the environment [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-api-machinery] ConfigMap
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:26:04.760: INFO: >>> kubeConfig: /tmp/kubeconfig-293271353
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should be consumable via the environment [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating configMap e2e-tests-configmap-r2pfq/configmap-test-789b28e7-7dfb-11e8-b0f5-565e625ec9a3
+STEP: Creating a pod to test consume configMaps
+Jul  2 13:26:04.859: INFO: Waiting up to 5m0s for pod "pod-configmaps-789bafb7-7dfb-11e8-b0f5-565e625ec9a3" in namespace "e2e-tests-configmap-r2pfq" to be "success or failure"
+Jul  2 13:26:04.861: INFO: Pod "pod-configmaps-789bafb7-7dfb-11e8-b0f5-565e625ec9a3": Phase="Pending", Reason="", readiness=false. Elapsed: 2.459992ms
+Jul  2 13:26:06.865: INFO: Pod "pod-configmaps-789bafb7-7dfb-11e8-b0f5-565e625ec9a3": Phase="Pending", Reason="", readiness=false. Elapsed: 2.006370633s
+Jul  2 13:26:08.869: INFO: Pod "pod-configmaps-789bafb7-7dfb-11e8-b0f5-565e625ec9a3": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.010311118s
+STEP: Saw pod success
+Jul  2 13:26:08.869: INFO: Pod "pod-configmaps-789bafb7-7dfb-11e8-b0f5-565e625ec9a3" satisfied condition "success or failure"
+Jul  2 13:26:08.872: INFO: Trying to get logs from node shoot--core--confgcp-worker-o1cev-z1-f757498dc-jzlxf pod pod-configmaps-789bafb7-7dfb-11e8-b0f5-565e625ec9a3 container env-test: <nil>
+STEP: delete the pod
+Jul  2 13:26:08.890: INFO: Waiting for pod pod-configmaps-789bafb7-7dfb-11e8-b0f5-565e625ec9a3 to disappear
+Jul  2 13:26:08.893: INFO: Pod pod-configmaps-789bafb7-7dfb-11e8-b0f5-565e625ec9a3 no longer exists
+[AfterEach] [sig-api-machinery] ConfigMap
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:26:08.893: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-configmap-r2pfq" for this suite.
+Jul  2 13:26:14.909: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:26:15.025: INFO: namespace: e2e-tests-configmap-r2pfq, resource: bindings, ignored listing per whitelist
+Jul  2 13:26:15.030: INFO: namespace e2e-tests-configmap-r2pfq deletion completed in 6.132999177s
+
+• [SLOW TEST:10.270 seconds]
+[sig-api-machinery] ConfigMap
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/configmap.go:29
+  should be consumable via the environment [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSSSSSS
+------------------------------
+[sig-network] Proxy version v1 
+  should proxy logs on node with explicit kubelet port using proxy subresource  [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] version v1
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:26:15.031: INFO: >>> kubeConfig: /tmp/kubeconfig-293271353
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should proxy logs on node with explicit kubelet port using proxy subresource  [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+Jul  2 13:26:15.134: INFO: (0) /api/v1/nodes/shoot--core--confgcp-worker-o1cev-z1-f757498dc-jzlxf:10250/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 7.916291ms)
+Jul  2 13:26:15.177: INFO: (1) /api/v1/nodes/shoot--core--confgcp-worker-o1cev-z1-f757498dc-jzlxf:10250/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 43.450138ms)
+Jul  2 13:26:15.182: INFO: (2) /api/v1/nodes/shoot--core--confgcp-worker-o1cev-z1-f757498dc-jzlxf:10250/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 5.006665ms)
+Jul  2 13:26:15.187: INFO: (3) /api/v1/nodes/shoot--core--confgcp-worker-o1cev-z1-f757498dc-jzlxf:10250/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 4.575779ms)
+Jul  2 13:26:15.191: INFO: (4) /api/v1/nodes/shoot--core--confgcp-worker-o1cev-z1-f757498dc-jzlxf:10250/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 4.039124ms)
+Jul  2 13:26:15.196: INFO: (5) /api/v1/nodes/shoot--core--confgcp-worker-o1cev-z1-f757498dc-jzlxf:10250/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 4.45282ms)
+Jul  2 13:26:15.201: INFO: (6) /api/v1/nodes/shoot--core--confgcp-worker-o1cev-z1-f757498dc-jzlxf:10250/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 5.08713ms)
+Jul  2 13:26:15.205: INFO: (7) /api/v1/nodes/shoot--core--confgcp-worker-o1cev-z1-f757498dc-jzlxf:10250/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 4.296288ms)
+Jul  2 13:26:15.210: INFO: (8) /api/v1/nodes/shoot--core--confgcp-worker-o1cev-z1-f757498dc-jzlxf:10250/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 4.753876ms)
+Jul  2 13:26:15.214: INFO: (9) /api/v1/nodes/shoot--core--confgcp-worker-o1cev-z1-f757498dc-jzlxf:10250/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 4.248533ms)
+Jul  2 13:26:15.219: INFO: (10) /api/v1/nodes/shoot--core--confgcp-worker-o1cev-z1-f757498dc-jzlxf:10250/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 4.483352ms)
+Jul  2 13:26:15.223: INFO: (11) /api/v1/nodes/shoot--core--confgcp-worker-o1cev-z1-f757498dc-jzlxf:10250/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 4.749816ms)
+Jul  2 13:26:15.228: INFO: (12) /api/v1/nodes/shoot--core--confgcp-worker-o1cev-z1-f757498dc-jzlxf:10250/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 4.769461ms)
+Jul  2 13:26:15.233: INFO: (13) /api/v1/nodes/shoot--core--confgcp-worker-o1cev-z1-f757498dc-jzlxf:10250/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 4.55197ms)
+Jul  2 13:26:15.237: INFO: (14) /api/v1/nodes/shoot--core--confgcp-worker-o1cev-z1-f757498dc-jzlxf:10250/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 4.153329ms)
+Jul  2 13:26:15.241: INFO: (15) /api/v1/nodes/shoot--core--confgcp-worker-o1cev-z1-f757498dc-jzlxf:10250/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 4.206394ms)
+Jul  2 13:26:15.245: INFO: (16) /api/v1/nodes/shoot--core--confgcp-worker-o1cev-z1-f757498dc-jzlxf:10250/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 4.210885ms)
+Jul  2 13:26:15.250: INFO: (17) /api/v1/nodes/shoot--core--confgcp-worker-o1cev-z1-f757498dc-jzlxf:10250/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 4.91434ms)
+Jul  2 13:26:15.274: INFO: (18) /api/v1/nodes/shoot--core--confgcp-worker-o1cev-z1-f757498dc-jzlxf:10250/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 23.395053ms)
+Jul  2 13:26:15.279: INFO: (19) /api/v1/nodes/shoot--core--confgcp-worker-o1cev-z1-f757498dc-jzlxf:10250/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 4.956759ms)
+[AfterEach] version v1
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:26:15.279: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-proxy-w685q" for this suite.
+Jul  2 13:26:21.293: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:26:21.444: INFO: namespace: e2e-tests-proxy-w685q, resource: bindings, ignored listing per whitelist
+Jul  2 13:26:21.462: INFO: namespace e2e-tests-proxy-w685q deletion completed in 6.180227059s
+
+• [SLOW TEST:6.432 seconds]
+[sig-network] Proxy
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/network/framework.go:22
+  version v1
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/network/proxy.go:56
+    should proxy logs on node with explicit kubelet port using proxy subresource  [Conformance]
+    /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSSSS
+------------------------------
+[sig-api-machinery] Downward API 
+  should provide container's limits.cpu/memory and requests.cpu/memory as env vars [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-api-machinery] Downward API
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:26:21.463: INFO: >>> kubeConfig: /tmp/kubeconfig-293271353
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should provide container's limits.cpu/memory and requests.cpu/memory as env vars [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating a pod to test downward api env vars
+Jul  2 13:26:21.543: INFO: Waiting up to 5m0s for pod "downward-api-828da03b-7dfb-11e8-b0f5-565e625ec9a3" in namespace "e2e-tests-downward-api-99kfk" to be "success or failure"
+Jul  2 13:26:21.546: INFO: Pod "downward-api-828da03b-7dfb-11e8-b0f5-565e625ec9a3": Phase="Pending", Reason="", readiness=false. Elapsed: 2.346818ms
+Jul  2 13:26:23.550: INFO: Pod "downward-api-828da03b-7dfb-11e8-b0f5-565e625ec9a3": Phase="Pending", Reason="", readiness=false. Elapsed: 2.006459739s
+Jul  2 13:26:25.554: INFO: Pod "downward-api-828da03b-7dfb-11e8-b0f5-565e625ec9a3": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.010472772s
+STEP: Saw pod success
+Jul  2 13:26:25.554: INFO: Pod "downward-api-828da03b-7dfb-11e8-b0f5-565e625ec9a3" satisfied condition "success or failure"
+Jul  2 13:26:25.557: INFO: Trying to get logs from node shoot--core--confgcp-worker-o1cev-z1-f757498dc-jzlxf pod downward-api-828da03b-7dfb-11e8-b0f5-565e625ec9a3 container dapi-container: <nil>
+STEP: delete the pod
+Jul  2 13:26:25.575: INFO: Waiting for pod downward-api-828da03b-7dfb-11e8-b0f5-565e625ec9a3 to disappear
+Jul  2 13:26:25.578: INFO: Pod downward-api-828da03b-7dfb-11e8-b0f5-565e625ec9a3 no longer exists
+[AfterEach] [sig-api-machinery] Downward API
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:26:25.578: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-downward-api-99kfk" for this suite.
+Jul  2 13:26:31.592: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:26:31.614: INFO: namespace: e2e-tests-downward-api-99kfk, resource: bindings, ignored listing per whitelist
+Jul  2 13:26:31.681: INFO: namespace e2e-tests-downward-api-99kfk deletion completed in 6.099615555s
+
+• [SLOW TEST:10.218 seconds]
+[sig-api-machinery] Downward API
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downward_api.go:37
+  should provide container's limits.cpu/memory and requests.cpu/memory as env vars [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+S
+------------------------------
+[sig-api-machinery] Secrets 
+  should be consumable via the environment [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-api-machinery] Secrets
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:26:31.681: INFO: >>> kubeConfig: /tmp/kubeconfig-293271353
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should be consumable via the environment [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: creating secret e2e-tests-secrets-jgnxw/secret-test-88a5d60b-7dfb-11e8-b0f5-565e625ec9a3
+STEP: Creating a pod to test consume secrets
+Jul  2 13:26:31.771: INFO: Waiting up to 5m0s for pod "pod-configmaps-88a64b85-7dfb-11e8-b0f5-565e625ec9a3" in namespace "e2e-tests-secrets-jgnxw" to be "success or failure"
+Jul  2 13:26:31.773: INFO: Pod "pod-configmaps-88a64b85-7dfb-11e8-b0f5-565e625ec9a3": Phase="Pending", Reason="", readiness=false. Elapsed: 2.293591ms
+Jul  2 13:26:33.778: INFO: Pod "pod-configmaps-88a64b85-7dfb-11e8-b0f5-565e625ec9a3": Phase="Pending", Reason="", readiness=false. Elapsed: 2.006669669s
+Jul  2 13:26:35.781: INFO: Pod "pod-configmaps-88a64b85-7dfb-11e8-b0f5-565e625ec9a3": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.010514616s
+STEP: Saw pod success
+Jul  2 13:26:35.781: INFO: Pod "pod-configmaps-88a64b85-7dfb-11e8-b0f5-565e625ec9a3" satisfied condition "success or failure"
+Jul  2 13:26:35.872: INFO: Trying to get logs from node shoot--core--confgcp-worker-o1cev-z1-f757498dc-jzlxf pod pod-configmaps-88a64b85-7dfb-11e8-b0f5-565e625ec9a3 container env-test: <nil>
+STEP: delete the pod
+Jul  2 13:26:35.888: INFO: Waiting for pod pod-configmaps-88a64b85-7dfb-11e8-b0f5-565e625ec9a3 to disappear
+Jul  2 13:26:35.891: INFO: Pod pod-configmaps-88a64b85-7dfb-11e8-b0f5-565e625ec9a3 no longer exists
+[AfterEach] [sig-api-machinery] Secrets
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:26:35.891: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-secrets-jgnxw" for this suite.
+Jul  2 13:26:41.905: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:26:41.943: INFO: namespace: e2e-tests-secrets-jgnxw, resource: bindings, ignored listing per whitelist
+Jul  2 13:26:41.990: INFO: namespace e2e-tests-secrets-jgnxw deletion completed in 6.095965982s
+
+• [SLOW TEST:10.309 seconds]
+[sig-api-machinery] Secrets
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/secrets.go:30
+  should be consumable via the environment [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSSS
+------------------------------
+[sig-storage] Secrets 
+  should be consumable from pods in volume [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-storage] Secrets
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:26:41.990: INFO: >>> kubeConfig: /tmp/kubeconfig-293271353
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should be consumable from pods in volume [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating secret with name secret-test-8eca401e-7dfb-11e8-b0f5-565e625ec9a3
+STEP: Creating a pod to test consume secrets
+Jul  2 13:26:42.077: INFO: Waiting up to 5m0s for pod "pod-secrets-8ecac6d0-7dfb-11e8-b0f5-565e625ec9a3" in namespace "e2e-tests-secrets-rcrk2" to be "success or failure"
+Jul  2 13:26:42.079: INFO: Pod "pod-secrets-8ecac6d0-7dfb-11e8-b0f5-565e625ec9a3": Phase="Pending", Reason="", readiness=false. Elapsed: 2.178743ms
+Jul  2 13:26:44.082: INFO: Pod "pod-secrets-8ecac6d0-7dfb-11e8-b0f5-565e625ec9a3": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.005413136s
+STEP: Saw pod success
+Jul  2 13:26:44.082: INFO: Pod "pod-secrets-8ecac6d0-7dfb-11e8-b0f5-565e625ec9a3" satisfied condition "success or failure"
+Jul  2 13:26:44.084: INFO: Trying to get logs from node shoot--core--confgcp-worker-o1cev-z1-f757498dc-jzlxf pod pod-secrets-8ecac6d0-7dfb-11e8-b0f5-565e625ec9a3 container secret-volume-test: <nil>
+STEP: delete the pod
+Jul  2 13:26:44.104: INFO: Waiting for pod pod-secrets-8ecac6d0-7dfb-11e8-b0f5-565e625ec9a3 to disappear
+Jul  2 13:26:44.106: INFO: Pod pod-secrets-8ecac6d0-7dfb-11e8-b0f5-565e625ec9a3 no longer exists
+[AfterEach] [sig-storage] Secrets
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:26:44.106: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-secrets-rcrk2" for this suite.
+Jul  2 13:26:50.119: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:26:50.202: INFO: namespace: e2e-tests-secrets-rcrk2, resource: bindings, ignored listing per whitelist
+Jul  2 13:26:50.204: INFO: namespace e2e-tests-secrets-rcrk2 deletion completed in 6.094687657s
+
+• [SLOW TEST:8.214 seconds]
+[sig-storage] Secrets
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/secrets_volume.go:33
+  should be consumable from pods in volume [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSSSSSSSS
+------------------------------
+[sig-storage] Projected 
+  should be consumable from pods in volume with mappings [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:26:50.204: INFO: >>> kubeConfig: /tmp/kubeconfig-293271353
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:858
+[It] should be consumable from pods in volume with mappings [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating projection with secret that has name projected-secret-test-map-93aeb0c5-7dfb-11e8-b0f5-565e625ec9a3
+STEP: Creating a pod to test consume secrets
+Jul  2 13:26:50.285: INFO: Waiting up to 5m0s for pod "pod-projected-secrets-93af35de-7dfb-11e8-b0f5-565e625ec9a3" in namespace "e2e-tests-projected-8hwp2" to be "success or failure"
+Jul  2 13:26:50.287: INFO: Pod "pod-projected-secrets-93af35de-7dfb-11e8-b0f5-565e625ec9a3": Phase="Pending", Reason="", readiness=false. Elapsed: 2.248694ms
+Jul  2 13:26:52.291: INFO: Pod "pod-projected-secrets-93af35de-7dfb-11e8-b0f5-565e625ec9a3": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.005969944s
+STEP: Saw pod success
+Jul  2 13:26:52.291: INFO: Pod "pod-projected-secrets-93af35de-7dfb-11e8-b0f5-565e625ec9a3" satisfied condition "success or failure"
+Jul  2 13:26:52.293: INFO: Trying to get logs from node shoot--core--confgcp-worker-o1cev-z1-f757498dc-jzlxf pod pod-projected-secrets-93af35de-7dfb-11e8-b0f5-565e625ec9a3 container projected-secret-volume-test: <nil>
+STEP: delete the pod
+Jul  2 13:26:52.311: INFO: Waiting for pod pod-projected-secrets-93af35de-7dfb-11e8-b0f5-565e625ec9a3 to disappear
+Jul  2 13:26:52.313: INFO: Pod pod-projected-secrets-93af35de-7dfb-11e8-b0f5-565e625ec9a3 no longer exists
+[AfterEach] [sig-storage] Projected
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:26:52.313: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-8hwp2" for this suite.
+Jul  2 13:26:58.327: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:26:58.439: INFO: namespace: e2e-tests-projected-8hwp2, resource: bindings, ignored listing per whitelist
+Jul  2 13:26:58.439: INFO: namespace e2e-tests-projected-8hwp2 deletion completed in 6.122259465s
+
+• [SLOW TEST:8.235 seconds]
+[sig-storage] Projected
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:34
+  should be consumable from pods in volume with mappings [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+S
+------------------------------
+[sig-storage] Projected 
+  should be consumable from pods in volume as non-root with defaultMode and fsGroup set [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:26:58.440: INFO: >>> kubeConfig: /tmp/kubeconfig-293271353
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:858
+[It] should be consumable from pods in volume as non-root with defaultMode and fsGroup set [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating projection with secret that has name projected-secret-test-98982fee-7dfb-11e8-b0f5-565e625ec9a3
+STEP: Creating a pod to test consume secrets
+Jul  2 13:26:58.526: INFO: Waiting up to 5m0s for pod "pod-projected-secrets-9898add0-7dfb-11e8-b0f5-565e625ec9a3" in namespace "e2e-tests-projected-ccbfq" to be "success or failure"
+Jul  2 13:26:58.528: INFO: Pod "pod-projected-secrets-9898add0-7dfb-11e8-b0f5-565e625ec9a3": Phase="Pending", Reason="", readiness=false. Elapsed: 2.264605ms
+Jul  2 13:27:00.532: INFO: Pod "pod-projected-secrets-9898add0-7dfb-11e8-b0f5-565e625ec9a3": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.006222203s
+STEP: Saw pod success
+Jul  2 13:27:00.532: INFO: Pod "pod-projected-secrets-9898add0-7dfb-11e8-b0f5-565e625ec9a3" satisfied condition "success or failure"
+Jul  2 13:27:00.572: INFO: Trying to get logs from node shoot--core--confgcp-worker-o1cev-z1-f757498dc-jzlxf pod pod-projected-secrets-9898add0-7dfb-11e8-b0f5-565e625ec9a3 container projected-secret-volume-test: <nil>
+STEP: delete the pod
+Jul  2 13:27:00.589: INFO: Waiting for pod pod-projected-secrets-9898add0-7dfb-11e8-b0f5-565e625ec9a3 to disappear
+Jul  2 13:27:00.594: INFO: Pod pod-projected-secrets-9898add0-7dfb-11e8-b0f5-565e625ec9a3 no longer exists
+[AfterEach] [sig-storage] Projected
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:27:00.594: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-ccbfq" for this suite.
+Jul  2 13:27:06.607: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:27:06.647: INFO: namespace: e2e-tests-projected-ccbfq, resource: bindings, ignored listing per whitelist
+Jul  2 13:27:06.689: INFO: namespace e2e-tests-projected-ccbfq deletion completed in 6.091485424s
+
+• [SLOW TEST:8.250 seconds]
+[sig-storage] Projected
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:34
+  should be consumable from pods in volume as non-root with defaultMode and fsGroup set [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSSS
+------------------------------
+[sig-storage] Projected 
+  should be consumable from pods in volume with defaultMode set [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:27:06.689: INFO: >>> kubeConfig: /tmp/kubeconfig-293271353
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:858
+[It] should be consumable from pods in volume with defaultMode set [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating projection with secret that has name projected-secret-test-9d8262f1-7dfb-11e8-b0f5-565e625ec9a3
+STEP: Creating a pod to test consume secrets
+Jul  2 13:27:06.772: INFO: Waiting up to 5m0s for pod "pod-projected-secrets-9d82e55d-7dfb-11e8-b0f5-565e625ec9a3" in namespace "e2e-tests-projected-thzgc" to be "success or failure"
+Jul  2 13:27:06.775: INFO: Pod "pod-projected-secrets-9d82e55d-7dfb-11e8-b0f5-565e625ec9a3": Phase="Pending", Reason="", readiness=false. Elapsed: 2.757537ms
+Jul  2 13:27:08.778: INFO: Pod "pod-projected-secrets-9d82e55d-7dfb-11e8-b0f5-565e625ec9a3": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.006644782s
+STEP: Saw pod success
+Jul  2 13:27:08.778: INFO: Pod "pod-projected-secrets-9d82e55d-7dfb-11e8-b0f5-565e625ec9a3" satisfied condition "success or failure"
+Jul  2 13:27:08.781: INFO: Trying to get logs from node shoot--core--confgcp-worker-o1cev-z1-f757498dc-jzlxf pod pod-projected-secrets-9d82e55d-7dfb-11e8-b0f5-565e625ec9a3 container projected-secret-volume-test: <nil>
+STEP: delete the pod
+Jul  2 13:27:08.885: INFO: Waiting for pod pod-projected-secrets-9d82e55d-7dfb-11e8-b0f5-565e625ec9a3 to disappear
+Jul  2 13:27:08.888: INFO: Pod pod-projected-secrets-9d82e55d-7dfb-11e8-b0f5-565e625ec9a3 no longer exists
+[AfterEach] [sig-storage] Projected
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:27:08.888: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-thzgc" for this suite.
+Jul  2 13:27:14.901: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:27:15.007: INFO: namespace: e2e-tests-projected-thzgc, resource: bindings, ignored listing per whitelist
+Jul  2 13:27:15.030: INFO: namespace e2e-tests-projected-thzgc deletion completed in 6.138718308s
+
+• [SLOW TEST:8.341 seconds]
+[sig-storage] Projected
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:34
+  should be consumable from pods in volume with defaultMode set [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+[k8s.io] KubeletManagedEtcHosts 
+  should test kubelet managed /etc/hosts file [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [k8s.io] KubeletManagedEtcHosts
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:27:15.031: INFO: >>> kubeConfig: /tmp/kubeconfig-293271353
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should test kubelet managed /etc/hosts file [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Setting up the test
+STEP: Creating hostNetwork=false pod
+STEP: Creating hostNetwork=true pod
+STEP: Running the test
+STEP: Verifying /etc/hosts of container is kubelet-managed for pod with hostNetwork=false
+Jul  2 13:27:21.139: INFO: ExecWithOptions {Command:[cat /etc/hosts] Namespace:e2e-tests-e2e-kubelet-etc-hosts-lggsx PodName:test-pod ContainerName:busybox-1 Stdin:<nil> CaptureStdout:true CaptureStderr:true PreserveWhitespace:false}
+Jul  2 13:27:21.139: INFO: >>> kubeConfig: /tmp/kubeconfig-293271353
+Jul  2 13:27:21.531: INFO: Exec stderr: ""
+Jul  2 13:27:21.531: INFO: ExecWithOptions {Command:[cat /etc/hosts-original] Namespace:e2e-tests-e2e-kubelet-etc-hosts-lggsx PodName:test-pod ContainerName:busybox-1 Stdin:<nil> CaptureStdout:true CaptureStderr:true PreserveWhitespace:false}
+Jul  2 13:27:21.531: INFO: >>> kubeConfig: /tmp/kubeconfig-293271353
+Jul  2 13:27:21.890: INFO: Exec stderr: ""
+Jul  2 13:27:21.890: INFO: ExecWithOptions {Command:[cat /etc/hosts] Namespace:e2e-tests-e2e-kubelet-etc-hosts-lggsx PodName:test-pod ContainerName:busybox-2 Stdin:<nil> CaptureStdout:true CaptureStderr:true PreserveWhitespace:false}
+Jul  2 13:27:21.890: INFO: >>> kubeConfig: /tmp/kubeconfig-293271353
+Jul  2 13:27:22.290: INFO: Exec stderr: ""
+Jul  2 13:27:22.290: INFO: ExecWithOptions {Command:[cat /etc/hosts-original] Namespace:e2e-tests-e2e-kubelet-etc-hosts-lggsx PodName:test-pod ContainerName:busybox-2 Stdin:<nil> CaptureStdout:true CaptureStderr:true PreserveWhitespace:false}
+Jul  2 13:27:22.290: INFO: >>> kubeConfig: /tmp/kubeconfig-293271353
+Jul  2 13:27:22.688: INFO: Exec stderr: ""
+STEP: Verifying /etc/hosts of container is not kubelet-managed since container specifies /etc/hosts mount
+Jul  2 13:27:22.688: INFO: ExecWithOptions {Command:[cat /etc/hosts] Namespace:e2e-tests-e2e-kubelet-etc-hosts-lggsx PodName:test-pod ContainerName:busybox-3 Stdin:<nil> CaptureStdout:true CaptureStderr:true PreserveWhitespace:false}
+Jul  2 13:27:22.688: INFO: >>> kubeConfig: /tmp/kubeconfig-293271353
+Jul  2 13:27:23.091: INFO: Exec stderr: ""
+Jul  2 13:27:23.091: INFO: ExecWithOptions {Command:[cat /etc/hosts-original] Namespace:e2e-tests-e2e-kubelet-etc-hosts-lggsx PodName:test-pod ContainerName:busybox-3 Stdin:<nil> CaptureStdout:true CaptureStderr:true PreserveWhitespace:false}
+Jul  2 13:27:23.091: INFO: >>> kubeConfig: /tmp/kubeconfig-293271353
+Jul  2 13:27:23.449: INFO: Exec stderr: ""
+STEP: Verifying /etc/hosts content of container is not kubelet-managed for pod with hostNetwork=true
+Jul  2 13:27:23.450: INFO: ExecWithOptions {Command:[cat /etc/hosts] Namespace:e2e-tests-e2e-kubelet-etc-hosts-lggsx PodName:test-host-network-pod ContainerName:busybox-1 Stdin:<nil> CaptureStdout:true CaptureStderr:true PreserveWhitespace:false}
+Jul  2 13:27:23.450: INFO: >>> kubeConfig: /tmp/kubeconfig-293271353
+Jul  2 13:27:23.880: INFO: Exec stderr: ""
+Jul  2 13:27:23.880: INFO: ExecWithOptions {Command:[cat /etc/hosts-original] Namespace:e2e-tests-e2e-kubelet-etc-hosts-lggsx PodName:test-host-network-pod ContainerName:busybox-1 Stdin:<nil> CaptureStdout:true CaptureStderr:true PreserveWhitespace:false}
+Jul  2 13:27:23.880: INFO: >>> kubeConfig: /tmp/kubeconfig-293271353
+Jul  2 13:27:24.334: INFO: Exec stderr: ""
+Jul  2 13:27:24.334: INFO: ExecWithOptions {Command:[cat /etc/hosts] Namespace:e2e-tests-e2e-kubelet-etc-hosts-lggsx PodName:test-host-network-pod ContainerName:busybox-2 Stdin:<nil> CaptureStdout:true CaptureStderr:true PreserveWhitespace:false}
+Jul  2 13:27:24.334: INFO: >>> kubeConfig: /tmp/kubeconfig-293271353
+Jul  2 13:27:24.723: INFO: Exec stderr: ""
+Jul  2 13:27:24.723: INFO: ExecWithOptions {Command:[cat /etc/hosts-original] Namespace:e2e-tests-e2e-kubelet-etc-hosts-lggsx PodName:test-host-network-pod ContainerName:busybox-2 Stdin:<nil> CaptureStdout:true CaptureStderr:true PreserveWhitespace:false}
+Jul  2 13:27:24.723: INFO: >>> kubeConfig: /tmp/kubeconfig-293271353
+Jul  2 13:27:25.081: INFO: Exec stderr: ""
+[AfterEach] [k8s.io] KubeletManagedEtcHosts
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:27:25.081: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-e2e-kubelet-etc-hosts-lggsx" for this suite.
+Jul  2 13:28:11.183: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:28:11.192: INFO: namespace: e2e-tests-e2e-kubelet-etc-hosts-lggsx, resource: bindings, ignored listing per whitelist
+Jul  2 13:28:11.327: INFO: namespace e2e-tests-e2e-kubelet-etc-hosts-lggsx deletion completed in 46.155429615s
+
+• [SLOW TEST:56.297 seconds]
+[k8s.io] KubeletManagedEtcHosts
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:679
+  should test kubelet managed /etc/hosts file [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSSSS
+------------------------------
+[sig-storage] HostPath 
+  should give a volume the correct mode [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-storage] HostPath
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:28:11.327: INFO: >>> kubeConfig: /tmp/kubeconfig-293271353
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] HostPath
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/host_path.go:36
+[It] should give a volume the correct mode [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating a pod to test hostPath mode
+Jul  2 13:28:11.411: INFO: Waiting up to 5m0s for pod "pod-host-path-test" in namespace "e2e-tests-hostpath-c6bm2" to be "success or failure"
+Jul  2 13:28:11.413: INFO: Pod "pod-host-path-test": Phase="Pending", Reason="", readiness=false. Elapsed: 2.180429ms
+Jul  2 13:28:13.417: INFO: Pod "pod-host-path-test": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.005871293s
+STEP: Saw pod success
+Jul  2 13:28:13.417: INFO: Pod "pod-host-path-test" satisfied condition "success or failure"
+Jul  2 13:28:13.419: INFO: Trying to get logs from node shoot--core--confgcp-worker-o1cev-z1-f757498dc-jzlxf pod pod-host-path-test container test-container-1: <nil>
+STEP: delete the pod
+Jul  2 13:28:13.436: INFO: Waiting for pod pod-host-path-test to disappear
+Jul  2 13:28:13.438: INFO: Pod pod-host-path-test no longer exists
+[AfterEach] [sig-storage] HostPath
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:28:13.438: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-hostpath-c6bm2" for this suite.
+Jul  2 13:28:19.472: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:28:19.533: INFO: namespace: e2e-tests-hostpath-c6bm2, resource: bindings, ignored listing per whitelist
+Jul  2 13:28:19.557: INFO: namespace e2e-tests-hostpath-c6bm2 deletion completed in 6.116234637s
+
+• [SLOW TEST:8.230 seconds]
+[sig-storage] HostPath
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/host_path.go:33
+  should give a volume the correct mode [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSS
+------------------------------
+[sig-api-machinery] Downward API 
+  should provide default limits.cpu/memory from node allocatable [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-api-machinery] Downward API
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:28:19.557: INFO: >>> kubeConfig: /tmp/kubeconfig-293271353
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should provide default limits.cpu/memory from node allocatable [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating a pod to test downward api env vars
+Jul  2 13:28:19.635: INFO: Waiting up to 5m0s for pod "downward-api-c8f1027e-7dfb-11e8-b0f5-565e625ec9a3" in namespace "e2e-tests-downward-api-qhgqk" to be "success or failure"
+Jul  2 13:28:19.638: INFO: Pod "downward-api-c8f1027e-7dfb-11e8-b0f5-565e625ec9a3": Phase="Pending", Reason="", readiness=false. Elapsed: 2.789333ms
+Jul  2 13:28:21.642: INFO: Pod "downward-api-c8f1027e-7dfb-11e8-b0f5-565e625ec9a3": Phase="Pending", Reason="", readiness=false. Elapsed: 2.00696833s
+Jul  2 13:28:23.646: INFO: Pod "downward-api-c8f1027e-7dfb-11e8-b0f5-565e625ec9a3": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.010644932s
+STEP: Saw pod success
+Jul  2 13:28:23.646: INFO: Pod "downward-api-c8f1027e-7dfb-11e8-b0f5-565e625ec9a3" satisfied condition "success or failure"
+Jul  2 13:28:23.649: INFO: Trying to get logs from node shoot--core--confgcp-worker-o1cev-z1-f757498dc-jzlxf pod downward-api-c8f1027e-7dfb-11e8-b0f5-565e625ec9a3 container dapi-container: <nil>
+STEP: delete the pod
+Jul  2 13:28:23.665: INFO: Waiting for pod downward-api-c8f1027e-7dfb-11e8-b0f5-565e625ec9a3 to disappear
+Jul  2 13:28:23.668: INFO: Pod downward-api-c8f1027e-7dfb-11e8-b0f5-565e625ec9a3 no longer exists
+[AfterEach] [sig-api-machinery] Downward API
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:28:23.668: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-downward-api-qhgqk" for this suite.
+Jul  2 13:28:29.681: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:28:29.803: INFO: namespace: e2e-tests-downward-api-qhgqk, resource: bindings, ignored listing per whitelist
+Jul  2 13:28:29.847: INFO: namespace e2e-tests-downward-api-qhgqk deletion completed in 6.175847962s
+
+• [SLOW TEST:10.290 seconds]
+[sig-api-machinery] Downward API
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downward_api.go:37
+  should provide default limits.cpu/memory from node allocatable [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSSSSSSSSSSSSSSSS
+------------------------------
+[sig-storage] Downward API volume 
+  should set mode on item file [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:28:29.847: INFO: >>> kubeConfig: /tmp/kubeconfig-293271353
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downwardapi_volume.go:38
+[It] should set mode on item file [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating a pod to test downward API volume plugin
+Jul  2 13:28:29.930: INFO: Waiting up to 5m0s for pod "downwardapi-volume-cf13e52e-7dfb-11e8-b0f5-565e625ec9a3" in namespace "e2e-tests-downward-api-qq8sh" to be "success or failure"
+Jul  2 13:28:29.932: INFO: Pod "downwardapi-volume-cf13e52e-7dfb-11e8-b0f5-565e625ec9a3": Phase="Pending", Reason="", readiness=false. Elapsed: 2.528023ms
+Jul  2 13:28:31.936: INFO: Pod "downwardapi-volume-cf13e52e-7dfb-11e8-b0f5-565e625ec9a3": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.006413551s
+STEP: Saw pod success
+Jul  2 13:28:31.936: INFO: Pod "downwardapi-volume-cf13e52e-7dfb-11e8-b0f5-565e625ec9a3" satisfied condition "success or failure"
+Jul  2 13:28:31.939: INFO: Trying to get logs from node shoot--core--confgcp-worker-o1cev-z1-f757498dc-jzlxf pod downwardapi-volume-cf13e52e-7dfb-11e8-b0f5-565e625ec9a3 container client-container: <nil>
+STEP: delete the pod
+Jul  2 13:28:31.955: INFO: Waiting for pod downwardapi-volume-cf13e52e-7dfb-11e8-b0f5-565e625ec9a3 to disappear
+Jul  2 13:28:31.958: INFO: Pod downwardapi-volume-cf13e52e-7dfb-11e8-b0f5-565e625ec9a3 no longer exists
+[AfterEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:28:31.958: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-downward-api-qq8sh" for this suite.
+Jul  2 13:28:37.972: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:28:38.183: INFO: namespace: e2e-tests-downward-api-qq8sh, resource: bindings, ignored listing per whitelist
+Jul  2 13:28:38.214: INFO: namespace e2e-tests-downward-api-qq8sh deletion completed in 6.252132307s
+
+• [SLOW TEST:8.367 seconds]
+[sig-storage] Downward API volume
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downwardapi_volume.go:33
+  should set mode on item file [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSSSSSSSSSS
+------------------------------
+[sig-storage] Projected 
+  should be consumable in multiple volumes in a pod [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:28:38.214: INFO: >>> kubeConfig: /tmp/kubeconfig-293271353
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:858
+[It] should be consumable in multiple volumes in a pod [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating secret with name projected-secret-test-d40f9386-7dfb-11e8-b0f5-565e625ec9a3
+STEP: Creating a pod to test consume secrets
+Jul  2 13:28:38.294: INFO: Waiting up to 5m0s for pod "pod-projected-secrets-d410144d-7dfb-11e8-b0f5-565e625ec9a3" in namespace "e2e-tests-projected-6jwzj" to be "success or failure"
+Jul  2 13:28:38.296: INFO: Pod "pod-projected-secrets-d410144d-7dfb-11e8-b0f5-565e625ec9a3": Phase="Pending", Reason="", readiness=false. Elapsed: 2.353972ms
+Jul  2 13:28:40.300: INFO: Pod "pod-projected-secrets-d410144d-7dfb-11e8-b0f5-565e625ec9a3": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.006299184s
+STEP: Saw pod success
+Jul  2 13:28:40.300: INFO: Pod "pod-projected-secrets-d410144d-7dfb-11e8-b0f5-565e625ec9a3" satisfied condition "success or failure"
+Jul  2 13:28:40.303: INFO: Trying to get logs from node shoot--core--confgcp-worker-o1cev-z1-f757498dc-jzlxf pod pod-projected-secrets-d410144d-7dfb-11e8-b0f5-565e625ec9a3 container secret-volume-test: <nil>
+STEP: delete the pod
+Jul  2 13:28:40.321: INFO: Waiting for pod pod-projected-secrets-d410144d-7dfb-11e8-b0f5-565e625ec9a3 to disappear
+Jul  2 13:28:40.323: INFO: Pod pod-projected-secrets-d410144d-7dfb-11e8-b0f5-565e625ec9a3 no longer exists
+[AfterEach] [sig-storage] Projected
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:28:40.323: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-6jwzj" for this suite.
+Jul  2 13:28:46.335: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:28:46.389: INFO: namespace: e2e-tests-projected-6jwzj, resource: bindings, ignored listing per whitelist
+Jul  2 13:28:46.420: INFO: namespace e2e-tests-projected-6jwzj deletion completed in 6.093496644s
+
+• [SLOW TEST:8.205 seconds]
+[sig-storage] Projected
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:34
+  should be consumable in multiple volumes in a pod [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SS
+------------------------------
+[sig-scheduling] SchedulerPredicates [Serial] 
+  validates resource limits of pods that are allowed to run  [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-scheduling] SchedulerPredicates [Serial]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:28:46.420: INFO: >>> kubeConfig: /tmp/kubeconfig-293271353
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-scheduling] SchedulerPredicates [Serial]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/scheduling/predicates.go:79
+Jul  2 13:28:46.494: INFO: Waiting up to 1m0s for all nodes to be ready
+Jul  2 13:29:46.516: INFO: Waiting for terminating namespaces to be deleted...
+Jul  2 13:29:46.521: INFO: Waiting up to 5m0s for all pods (need at least 0) in namespace 'kube-system' to be running and ready
+Jul  2 13:29:46.533: INFO: 14 / 14 pods in namespace 'kube-system' are running and ready (0 seconds elapsed)
+Jul  2 13:29:46.533: INFO: expected 8 pod replicas in namespace 'kube-system', 8 are Running and Ready.
+Jul  2 13:29:46.536: INFO: Waiting for pods to enter Success, but no pods in "kube-system" match label map[name:e2e-image-puller]
+Jul  2 13:29:46.536: INFO: 
+Logging pods the kubelet thinks is on node shoot--core--confgcp-worker-o1cev-z1-f757498dc-jzlxf before test
+Jul  2 13:29:46.546: INFO: sonobuoy from sonobuoy started at 2018-07-02 12:53:54 +0000 UTC (1 container statuses recorded)
+Jul  2 13:29:46.546: INFO: 	Container kube-sonobuoy ready: true, restart count 0
+Jul  2 13:29:46.546: INFO: sonobuoy-e2e-job-32b8333ad53140e4 from sonobuoy started at 2018-07-02 12:54:10 +0000 UTC (2 container statuses recorded)
+Jul  2 13:29:46.546: INFO: 	Container e2e ready: true, restart count 0
+Jul  2 13:29:46.546: INFO: 	Container sonobuoy-worker ready: true, restart count 0
+Jul  2 13:29:46.546: INFO: kube-proxy-tplxb from kube-system started at 2018-07-02 12:47:10 +0000 UTC (1 container statuses recorded)
+Jul  2 13:29:46.546: INFO: 	Container kube-proxy ready: true, restart count 0
+Jul  2 13:29:46.546: INFO: calico-node-l9lrq from kube-system started at 2018-07-02 12:47:10 +0000 UTC (2 container statuses recorded)
+Jul  2 13:29:46.546: INFO: 	Container calico-node ready: true, restart count 0
+Jul  2 13:29:46.546: INFO: 	Container install-cni ready: true, restart count 0
+Jul  2 13:29:46.546: INFO: node-exporter-lj6t9 from kube-system started at 2018-07-02 12:47:10 +0000 UTC (1 container statuses recorded)
+Jul  2 13:29:46.546: INFO: 	Container node-exporter ready: true, restart count 0
+Jul  2 13:29:46.546: INFO: kube-dns-9c4dfc4fb-mppdx from kube-system started at 2018-07-02 12:48:11 +0000 UTC (3 container statuses recorded)
+Jul  2 13:29:46.546: INFO: 	Container dnsmasq ready: true, restart count 0
+Jul  2 13:29:46.546: INFO: 	Container kubedns ready: true, restart count 0
+Jul  2 13:29:46.546: INFO: 	Container sidecar ready: true, restart count 0
+Jul  2 13:29:46.546: INFO: 
+Logging pods the kubelet thinks is on node shoot--core--confgcp-worker-o1cev-z1-f757498dc-qrtzr before test
+Jul  2 13:29:46.596: INFO: addons-heapster-e3b0c-64455ddddb-zgn7v from kube-system started at 2018-07-02 12:47:38 +0000 UTC (2 container statuses recorded)
+Jul  2 13:29:46.596: INFO: 	Container heapster ready: true, restart count 0
+Jul  2 13:29:46.596: INFO: 	Container heapster-nanny ready: true, restart count 0
+Jul  2 13:29:46.596: INFO: addons-nginx-ingress-controller-79bfb57974-q2zxk from kube-system started at 2018-07-02 12:47:38 +0000 UTC (1 container statuses recorded)
+Jul  2 13:29:46.596: INFO: 	Container nginx-ingress-controller ready: true, restart count 0
+Jul  2 13:29:46.596: INFO: addons-kubernetes-dashboard-5486b968b7-wwpw5 from kube-system started at 2018-07-02 12:47:38 +0000 UTC (1 container statuses recorded)
+Jul  2 13:29:46.596: INFO: 	Container main ready: true, restart count 0
+Jul  2 13:29:46.596: INFO: vpn-shoot-c6458b4c-mtnxr from kube-system started at 2018-07-02 12:47:38 +0000 UTC (1 container statuses recorded)
+Jul  2 13:29:46.596: INFO: 	Container vpn-shoot ready: true, restart count 0
+Jul  2 13:29:46.596: INFO: calico-node-49xvm from kube-system started at 2018-07-02 12:47:08 +0000 UTC (2 container statuses recorded)
+Jul  2 13:29:46.596: INFO: 	Container calico-node ready: true, restart count 0
+Jul  2 13:29:46.596: INFO: 	Container install-cni ready: true, restart count 0
+Jul  2 13:29:46.596: INFO: addons-nginx-ingress-nginx-ingress-k8s-backend-7b5569797f-574s7 from kube-system started at 2018-07-02 12:47:38 +0000 UTC (1 container statuses recorded)
+Jul  2 13:29:46.596: INFO: 	Container nginx-ingress-nginx-ingress-k8s-backend ready: true, restart count 0
+Jul  2 13:29:46.596: INFO: kube-proxy-lddpf from kube-system started at 2018-07-02 12:47:08 +0000 UTC (1 container statuses recorded)
+Jul  2 13:29:46.596: INFO: 	Container kube-proxy ready: true, restart count 0
+Jul  2 13:29:46.596: INFO: node-exporter-fjp5f from kube-system started at 2018-07-02 12:47:08 +0000 UTC (1 container statuses recorded)
+Jul  2 13:29:46.596: INFO: 	Container node-exporter ready: true, restart count 0
+Jul  2 13:29:46.596: INFO: kube-dns-9c4dfc4fb-bcfks from kube-system started at 2018-07-02 12:47:38 +0000 UTC (3 container statuses recorded)
+Jul  2 13:29:46.596: INFO: 	Container dnsmasq ready: true, restart count 0
+Jul  2 13:29:46.596: INFO: 	Container kubedns ready: true, restart count 0
+Jul  2 13:29:46.596: INFO: 	Container sidecar ready: true, restart count 0
+Jul  2 13:29:46.596: INFO: kube-dns-autoscaler-6dd4765967-p2xtm from kube-system started at 2018-07-02 12:47:38 +0000 UTC (1 container statuses recorded)
+Jul  2 13:29:46.596: INFO: 	Container autoscaler ready: true, restart count 0
+[It] validates resource limits of pods that are allowed to run  [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: verifying the node has the label node shoot--core--confgcp-worker-o1cev-z1-f757498dc-jzlxf
+STEP: verifying the node has the label node shoot--core--confgcp-worker-o1cev-z1-f757498dc-qrtzr
+Jul  2 13:29:46.622: INFO: Pod addons-heapster-e3b0c-64455ddddb-zgn7v requesting resource cpu=50m on Node shoot--core--confgcp-worker-o1cev-z1-f757498dc-qrtzr
+Jul  2 13:29:46.622: INFO: Pod addons-kubernetes-dashboard-5486b968b7-wwpw5 requesting resource cpu=50m on Node shoot--core--confgcp-worker-o1cev-z1-f757498dc-qrtzr
+Jul  2 13:29:46.622: INFO: Pod addons-nginx-ingress-controller-79bfb57974-q2zxk requesting resource cpu=100m on Node shoot--core--confgcp-worker-o1cev-z1-f757498dc-qrtzr
+Jul  2 13:29:46.622: INFO: Pod addons-nginx-ingress-nginx-ingress-k8s-backend-7b5569797f-574s7 requesting resource cpu=0m on Node shoot--core--confgcp-worker-o1cev-z1-f757498dc-qrtzr
+Jul  2 13:29:46.622: INFO: Pod calico-node-49xvm requesting resource cpu=250m on Node shoot--core--confgcp-worker-o1cev-z1-f757498dc-qrtzr
+Jul  2 13:29:46.622: INFO: Pod calico-node-l9lrq requesting resource cpu=250m on Node shoot--core--confgcp-worker-o1cev-z1-f757498dc-jzlxf
+Jul  2 13:29:46.622: INFO: Pod kube-dns-9c4dfc4fb-bcfks requesting resource cpu=260m on Node shoot--core--confgcp-worker-o1cev-z1-f757498dc-qrtzr
+Jul  2 13:29:46.622: INFO: Pod kube-dns-9c4dfc4fb-mppdx requesting resource cpu=260m on Node shoot--core--confgcp-worker-o1cev-z1-f757498dc-jzlxf
+Jul  2 13:29:46.622: INFO: Pod kube-dns-autoscaler-6dd4765967-p2xtm requesting resource cpu=20m on Node shoot--core--confgcp-worker-o1cev-z1-f757498dc-qrtzr
+Jul  2 13:29:46.622: INFO: Pod kube-proxy-lddpf requesting resource cpu=50m on Node shoot--core--confgcp-worker-o1cev-z1-f757498dc-qrtzr
+Jul  2 13:29:46.622: INFO: Pod kube-proxy-tplxb requesting resource cpu=50m on Node shoot--core--confgcp-worker-o1cev-z1-f757498dc-jzlxf
+Jul  2 13:29:46.622: INFO: Pod node-exporter-fjp5f requesting resource cpu=10m on Node shoot--core--confgcp-worker-o1cev-z1-f757498dc-qrtzr
+Jul  2 13:29:46.622: INFO: Pod node-exporter-lj6t9 requesting resource cpu=10m on Node shoot--core--confgcp-worker-o1cev-z1-f757498dc-jzlxf
+Jul  2 13:29:46.622: INFO: Pod vpn-shoot-c6458b4c-mtnxr requesting resource cpu=100m on Node shoot--core--confgcp-worker-o1cev-z1-f757498dc-qrtzr
+Jul  2 13:29:46.622: INFO: Pod sonobuoy requesting resource cpu=0m on Node shoot--core--confgcp-worker-o1cev-z1-f757498dc-jzlxf
+Jul  2 13:29:46.622: INFO: Pod sonobuoy-e2e-job-32b8333ad53140e4 requesting resource cpu=0m on Node shoot--core--confgcp-worker-o1cev-z1-f757498dc-jzlxf
+STEP: Starting Pods to consume most of the cluster CPU.
+STEP: Creating another pod that requires unavailable amount of CPU.
+STEP: Considering event: 
+Type = [Normal], Name = [filler-pod-fccb038c-7dfb-11e8-b0f5-565e625ec9a3.153d905f2371ccbf], Reason = [Scheduled], Message = [Successfully assigned e2e-tests-sched-pred-q9p87/filler-pod-fccb038c-7dfb-11e8-b0f5-565e625ec9a3 to shoot--core--confgcp-worker-o1cev-z1-f757498dc-jzlxf]
+STEP: Considering event: 
+Type = [Normal], Name = [filler-pod-fccb038c-7dfb-11e8-b0f5-565e625ec9a3.153d905f53a19f0f], Reason = [Pulled], Message = [Container image "k8s.gcr.io/pause:3.1" already present on machine]
+STEP: Considering event: 
+Type = [Normal], Name = [filler-pod-fccb038c-7dfb-11e8-b0f5-565e625ec9a3.153d905f56b6af11], Reason = [Created], Message = [Created container]
+STEP: Considering event: 
+Type = [Normal], Name = [filler-pod-fccb038c-7dfb-11e8-b0f5-565e625ec9a3.153d905f629d27cc], Reason = [Started], Message = [Started container]
+STEP: Considering event: 
+Type = [Normal], Name = [filler-pod-fccc1639-7dfb-11e8-b0f5-565e625ec9a3.153d905f238b5e4a], Reason = [Scheduled], Message = [Successfully assigned e2e-tests-sched-pred-q9p87/filler-pod-fccc1639-7dfb-11e8-b0f5-565e625ec9a3 to shoot--core--confgcp-worker-o1cev-z1-f757498dc-qrtzr]
+STEP: Considering event: 
+Type = [Normal], Name = [filler-pod-fccc1639-7dfb-11e8-b0f5-565e625ec9a3.153d905f500f7b66], Reason = [Pulled], Message = [Container image "k8s.gcr.io/pause:3.1" already present on machine]
+STEP: Considering event: 
+Type = [Normal], Name = [filler-pod-fccc1639-7dfb-11e8-b0f5-565e625ec9a3.153d905f533bff97], Reason = [Created], Message = [Created container]
+STEP: Considering event: 
+Type = [Normal], Name = [filler-pod-fccc1639-7dfb-11e8-b0f5-565e625ec9a3.153d905f5ef5c3a4], Reason = [Started], Message = [Started container]
+STEP: Considering event: 
+Type = [Warning], Name = [additional-pod.153d905f9cfe3a7d], Reason = [FailedScheduling], Message = [0/2 nodes are available: 2 Insufficient cpu.]
+STEP: removing the label node off the node shoot--core--confgcp-worker-o1cev-z1-f757498dc-jzlxf
+STEP: verifying the node doesn't have the label node
+STEP: removing the label node off the node shoot--core--confgcp-worker-o1cev-z1-f757498dc-qrtzr
+STEP: verifying the node doesn't have the label node
+[AfterEach] [sig-scheduling] SchedulerPredicates [Serial]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:29:49.699: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-sched-pred-q9p87" for this suite.
+Jul  2 13:30:11.712: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:30:11.834: INFO: namespace: e2e-tests-sched-pred-q9p87, resource: bindings, ignored listing per whitelist
+Jul  2 13:30:11.884: INFO: namespace e2e-tests-sched-pred-q9p87 deletion completed in 22.181821406s
+[AfterEach] [sig-scheduling] SchedulerPredicates [Serial]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/scheduling/predicates.go:70
+
+• [SLOW TEST:85.464 seconds]
+[sig-scheduling] SchedulerPredicates [Serial]
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/scheduling/framework.go:22
+  validates resource limits of pods that are allowed to run  [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+S
+------------------------------
+[k8s.io] Pods 
+  should contain environment variables for services [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [k8s.io] Pods
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:30:11.884: INFO: >>> kubeConfig: /tmp/kubeconfig-293271353
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [k8s.io] Pods
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/pods.go:127
+[It] should contain environment variables for services [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+Jul  2 13:30:14.088: INFO: Waiting up to 5m0s for pod "client-envvars-0d294db6-7dfc-11e8-b0f5-565e625ec9a3" in namespace "e2e-tests-pods-94qjd" to be "success or failure"
+Jul  2 13:30:14.090: INFO: Pod "client-envvars-0d294db6-7dfc-11e8-b0f5-565e625ec9a3": Phase="Pending", Reason="", readiness=false. Elapsed: 2.043358ms
+Jul  2 13:30:16.094: INFO: Pod "client-envvars-0d294db6-7dfc-11e8-b0f5-565e625ec9a3": Phase="Pending", Reason="", readiness=false. Elapsed: 2.006267348s
+Jul  2 13:30:18.097: INFO: Pod "client-envvars-0d294db6-7dfc-11e8-b0f5-565e625ec9a3": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.009874389s
+STEP: Saw pod success
+Jul  2 13:30:18.098: INFO: Pod "client-envvars-0d294db6-7dfc-11e8-b0f5-565e625ec9a3" satisfied condition "success or failure"
+Jul  2 13:30:18.100: INFO: Trying to get logs from node shoot--core--confgcp-worker-o1cev-z1-f757498dc-jzlxf pod client-envvars-0d294db6-7dfc-11e8-b0f5-565e625ec9a3 container env3cont: <nil>
+STEP: delete the pod
+Jul  2 13:30:18.200: INFO: Waiting for pod client-envvars-0d294db6-7dfc-11e8-b0f5-565e625ec9a3 to disappear
+Jul  2 13:30:18.204: INFO: Pod client-envvars-0d294db6-7dfc-11e8-b0f5-565e625ec9a3 no longer exists
+[AfterEach] [k8s.io] Pods
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:30:18.204: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-pods-94qjd" for this suite.
+Jul  2 13:30:40.219: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:30:40.241: INFO: namespace: e2e-tests-pods-94qjd, resource: bindings, ignored listing per whitelist
+Jul  2 13:30:40.307: INFO: namespace e2e-tests-pods-94qjd deletion completed in 22.09867259s
+
+• [SLOW TEST:28.423 seconds]
+[k8s.io] Pods
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:679
+  should contain environment variables for services [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSS
+------------------------------
+[sig-scheduling] SchedulerPredicates [Serial] 
+  validates that NodeSelector is respected if not matching  [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-scheduling] SchedulerPredicates [Serial]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:30:40.307: INFO: >>> kubeConfig: /tmp/kubeconfig-293271353
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-scheduling] SchedulerPredicates [Serial]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/scheduling/predicates.go:79
+Jul  2 13:30:40.383: INFO: Waiting up to 1m0s for all nodes to be ready
+Jul  2 13:31:40.403: INFO: Waiting for terminating namespaces to be deleted...
+Jul  2 13:31:40.409: INFO: Waiting up to 5m0s for all pods (need at least 0) in namespace 'kube-system' to be running and ready
+Jul  2 13:31:40.421: INFO: 14 / 14 pods in namespace 'kube-system' are running and ready (0 seconds elapsed)
+Jul  2 13:31:40.421: INFO: expected 8 pod replicas in namespace 'kube-system', 8 are Running and Ready.
+Jul  2 13:31:40.425: INFO: Waiting for pods to enter Success, but no pods in "kube-system" match label map[name:e2e-image-puller]
+Jul  2 13:31:40.425: INFO: 
+Logging pods the kubelet thinks is on node shoot--core--confgcp-worker-o1cev-z1-f757498dc-jzlxf before test
+Jul  2 13:31:40.434: INFO: kube-dns-9c4dfc4fb-mppdx from kube-system started at 2018-07-02 12:48:11 +0000 UTC (3 container statuses recorded)
+Jul  2 13:31:40.434: INFO: 	Container dnsmasq ready: true, restart count 0
+Jul  2 13:31:40.434: INFO: 	Container kubedns ready: true, restart count 0
+Jul  2 13:31:40.434: INFO: 	Container sidecar ready: true, restart count 0
+Jul  2 13:31:40.434: INFO: kube-proxy-tplxb from kube-system started at 2018-07-02 12:47:10 +0000 UTC (1 container statuses recorded)
+Jul  2 13:31:40.434: INFO: 	Container kube-proxy ready: true, restart count 0
+Jul  2 13:31:40.434: INFO: calico-node-l9lrq from kube-system started at 2018-07-02 12:47:10 +0000 UTC (2 container statuses recorded)
+Jul  2 13:31:40.434: INFO: 	Container calico-node ready: true, restart count 0
+Jul  2 13:31:40.434: INFO: 	Container install-cni ready: true, restart count 0
+Jul  2 13:31:40.434: INFO: node-exporter-lj6t9 from kube-system started at 2018-07-02 12:47:10 +0000 UTC (1 container statuses recorded)
+Jul  2 13:31:40.434: INFO: 	Container node-exporter ready: true, restart count 0
+Jul  2 13:31:40.434: INFO: sonobuoy from sonobuoy started at 2018-07-02 12:53:54 +0000 UTC (1 container statuses recorded)
+Jul  2 13:31:40.434: INFO: 	Container kube-sonobuoy ready: true, restart count 0
+Jul  2 13:31:40.434: INFO: sonobuoy-e2e-job-32b8333ad53140e4 from sonobuoy started at 2018-07-02 12:54:10 +0000 UTC (2 container statuses recorded)
+Jul  2 13:31:40.434: INFO: 	Container e2e ready: true, restart count 0
+Jul  2 13:31:40.434: INFO: 	Container sonobuoy-worker ready: true, restart count 0
+Jul  2 13:31:40.434: INFO: 
+Logging pods the kubelet thinks is on node shoot--core--confgcp-worker-o1cev-z1-f757498dc-qrtzr before test
+Jul  2 13:31:40.482: INFO: kube-proxy-lddpf from kube-system started at 2018-07-02 12:47:08 +0000 UTC (1 container statuses recorded)
+Jul  2 13:31:40.482: INFO: 	Container kube-proxy ready: true, restart count 0
+Jul  2 13:31:40.482: INFO: node-exporter-fjp5f from kube-system started at 2018-07-02 12:47:08 +0000 UTC (1 container statuses recorded)
+Jul  2 13:31:40.482: INFO: 	Container node-exporter ready: true, restart count 0
+Jul  2 13:31:40.482: INFO: kube-dns-9c4dfc4fb-bcfks from kube-system started at 2018-07-02 12:47:38 +0000 UTC (3 container statuses recorded)
+Jul  2 13:31:40.482: INFO: 	Container dnsmasq ready: true, restart count 0
+Jul  2 13:31:40.482: INFO: 	Container kubedns ready: true, restart count 0
+Jul  2 13:31:40.482: INFO: 	Container sidecar ready: true, restart count 0
+Jul  2 13:31:40.482: INFO: kube-dns-autoscaler-6dd4765967-p2xtm from kube-system started at 2018-07-02 12:47:38 +0000 UTC (1 container statuses recorded)
+Jul  2 13:31:40.482: INFO: 	Container autoscaler ready: true, restart count 0
+Jul  2 13:31:40.482: INFO: vpn-shoot-c6458b4c-mtnxr from kube-system started at 2018-07-02 12:47:38 +0000 UTC (1 container statuses recorded)
+Jul  2 13:31:40.482: INFO: 	Container vpn-shoot ready: true, restart count 0
+Jul  2 13:31:40.482: INFO: calico-node-49xvm from kube-system started at 2018-07-02 12:47:08 +0000 UTC (2 container statuses recorded)
+Jul  2 13:31:40.482: INFO: 	Container calico-node ready: true, restart count 0
+Jul  2 13:31:40.482: INFO: 	Container install-cni ready: true, restart count 0
+Jul  2 13:31:40.482: INFO: addons-nginx-ingress-nginx-ingress-k8s-backend-7b5569797f-574s7 from kube-system started at 2018-07-02 12:47:38 +0000 UTC (1 container statuses recorded)
+Jul  2 13:31:40.482: INFO: 	Container nginx-ingress-nginx-ingress-k8s-backend ready: true, restart count 0
+Jul  2 13:31:40.482: INFO: addons-heapster-e3b0c-64455ddddb-zgn7v from kube-system started at 2018-07-02 12:47:38 +0000 UTC (2 container statuses recorded)
+Jul  2 13:31:40.482: INFO: 	Container heapster ready: true, restart count 0
+Jul  2 13:31:40.482: INFO: 	Container heapster-nanny ready: true, restart count 0
+Jul  2 13:31:40.482: INFO: addons-nginx-ingress-controller-79bfb57974-q2zxk from kube-system started at 2018-07-02 12:47:38 +0000 UTC (1 container statuses recorded)
+Jul  2 13:31:40.482: INFO: 	Container nginx-ingress-controller ready: true, restart count 0
+Jul  2 13:31:40.482: INFO: addons-kubernetes-dashboard-5486b968b7-wwpw5 from kube-system started at 2018-07-02 12:47:38 +0000 UTC (1 container statuses recorded)
+Jul  2 13:31:40.482: INFO: 	Container main ready: true, restart count 0
+[It] validates that NodeSelector is respected if not matching  [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Trying to schedule Pod with nonempty NodeSelector.
+STEP: Considering event: 
+Type = [Warning], Name = [restricted-pod.153d9079a7224c92], Reason = [FailedScheduling], Message = [0/2 nodes are available: 2 node(s) didn't match node selector.]
+[AfterEach] [sig-scheduling] SchedulerPredicates [Serial]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:31:41.504: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-sched-pred-znjs7" for this suite.
+Jul  2 13:32:03.573: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:32:03.609: INFO: namespace: e2e-tests-sched-pred-znjs7, resource: bindings, ignored listing per whitelist
+Jul  2 13:32:03.658: INFO: namespace e2e-tests-sched-pred-znjs7 deletion completed in 22.1507688s
+[AfterEach] [sig-scheduling] SchedulerPredicates [Serial]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/scheduling/predicates.go:70
+
+• [SLOW TEST:83.351 seconds]
+[sig-scheduling] SchedulerPredicates [Serial]
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/scheduling/framework.go:22
+  validates that NodeSelector is respected if not matching  [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SS
+------------------------------
+[sig-storage] Downward API volume 
+  should provide podname only [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:32:03.658: INFO: >>> kubeConfig: /tmp/kubeconfig-293271353
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downwardapi_volume.go:38
+[It] should provide podname only [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating a pod to test downward API volume plugin
+Jul  2 13:32:03.747: INFO: Waiting up to 5m0s for pod "downwardapi-volume-4e85a0a4-7dfc-11e8-b0f5-565e625ec9a3" in namespace "e2e-tests-downward-api-84vkx" to be "success or failure"
+Jul  2 13:32:03.749: INFO: Pod "downwardapi-volume-4e85a0a4-7dfc-11e8-b0f5-565e625ec9a3": Phase="Pending", Reason="", readiness=false. Elapsed: 2.596836ms
+Jul  2 13:32:05.754: INFO: Pod "downwardapi-volume-4e85a0a4-7dfc-11e8-b0f5-565e625ec9a3": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.007368097s
+STEP: Saw pod success
+Jul  2 13:32:05.754: INFO: Pod "downwardapi-volume-4e85a0a4-7dfc-11e8-b0f5-565e625ec9a3" satisfied condition "success or failure"
+Jul  2 13:32:05.756: INFO: Trying to get logs from node shoot--core--confgcp-worker-o1cev-z1-f757498dc-jzlxf pod downwardapi-volume-4e85a0a4-7dfc-11e8-b0f5-565e625ec9a3 container client-container: <nil>
+STEP: delete the pod
+Jul  2 13:32:05.774: INFO: Waiting for pod downwardapi-volume-4e85a0a4-7dfc-11e8-b0f5-565e625ec9a3 to disappear
+Jul  2 13:32:05.777: INFO: Pod downwardapi-volume-4e85a0a4-7dfc-11e8-b0f5-565e625ec9a3 no longer exists
+[AfterEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:32:05.777: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-downward-api-84vkx" for this suite.
+Jul  2 13:32:11.794: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:32:11.944: INFO: namespace: e2e-tests-downward-api-84vkx, resource: bindings, ignored listing per whitelist
+Jul  2 13:32:11.967: INFO: namespace e2e-tests-downward-api-84vkx deletion completed in 6.185232366s
+
+• [SLOW TEST:8.309 seconds]
+[sig-storage] Downward API volume
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downwardapi_volume.go:33
+  should provide podname only [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSS
+------------------------------
+[sig-network] Networking Granular Checks: Pods 
+  should function for node-pod communication: http [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-network] Networking
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:32:11.967: INFO: >>> kubeConfig: /tmp/kubeconfig-293271353
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should function for node-pod communication: http [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Performing setup for networking test in namespace e2e-tests-pod-network-test-md585
+STEP: creating a selector
+STEP: Creating the service pods in kubernetes
+Jul  2 13:32:12.043: INFO: Waiting up to 10m0s for all (but 0) nodes to be schedulable
+STEP: Creating test pods
+Jul  2 13:32:36.183: INFO: ExecWithOptions {Command:[/bin/sh -c timeout -t 15 curl -g -q -s --connect-timeout 1 http://100.96.0.39:8080/hostName | grep -v '^\s*$'] Namespace:e2e-tests-pod-network-test-md585 PodName:host-test-container-pod ContainerName:hostexec Stdin:<nil> CaptureStdout:true CaptureStderr:true PreserveWhitespace:false}
+Jul  2 13:32:36.183: INFO: >>> kubeConfig: /tmp/kubeconfig-293271353
+Jul  2 13:32:36.562: INFO: Found all expected endpoints: [netserver-0]
+Jul  2 13:32:36.565: INFO: ExecWithOptions {Command:[/bin/sh -c timeout -t 15 curl -g -q -s --connect-timeout 1 http://100.96.1.135:8080/hostName | grep -v '^\s*$'] Namespace:e2e-tests-pod-network-test-md585 PodName:host-test-container-pod ContainerName:hostexec Stdin:<nil> CaptureStdout:true CaptureStderr:true PreserveWhitespace:false}
+Jul  2 13:32:36.565: INFO: >>> kubeConfig: /tmp/kubeconfig-293271353
+Jul  2 13:32:36.917: INFO: Found all expected endpoints: [netserver-1]
+[AfterEach] [sig-network] Networking
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:32:36.917: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-pod-network-test-md585" for this suite.
+Jul  2 13:32:58.984: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:32:59.223: INFO: namespace: e2e-tests-pod-network-test-md585, resource: bindings, ignored listing per whitelist
+Jul  2 13:32:59.227: INFO: namespace e2e-tests-pod-network-test-md585 deletion completed in 22.252628742s
+
+• [SLOW TEST:47.260 seconds]
+[sig-network] Networking
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/networking.go:25
+  Granular Checks: Pods
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/networking.go:28
+    should function for node-pod communication: http [NodeConformance] [Conformance]
+    /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSS
+------------------------------
+[sig-apps] StatefulSet [k8s.io] Basic StatefulSet functionality [StatefulSetBasic] 
+  should perform rolling updates and roll backs of template modifications [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-apps] StatefulSet
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:32:59.227: INFO: >>> kubeConfig: /tmp/kubeconfig-293271353
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-apps] StatefulSet
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/statefulset.go:57
+[BeforeEach] [k8s.io] Basic StatefulSet functionality [StatefulSetBasic]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/statefulset.go:72
+STEP: Creating service test in namespace e2e-tests-statefulset-8wpp9
+[It] should perform rolling updates and roll backs of template modifications [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating a new StatefulSet
+Jul  2 13:32:59.315: INFO: Found 0 stateful pods, waiting for 3
+Jul  2 13:33:09.320: INFO: Waiting for pod ss2-0 to enter Running - Ready=true, currently Running - Ready=true
+Jul  2 13:33:09.320: INFO: Waiting for pod ss2-1 to enter Running - Ready=true, currently Running - Ready=true
+Jul  2 13:33:09.320: INFO: Waiting for pod ss2-2 to enter Running - Ready=true, currently Running - Ready=true
+Jul  2 13:33:09.386: INFO: Running '/usr/local/bin/kubectl --kubeconfig=/tmp/kubeconfig-293271353 exec --namespace=e2e-tests-statefulset-8wpp9 ss2-1 -- /bin/sh -c mv -v /usr/share/nginx/html/index.html /tmp/ || true'
+Jul  2 13:33:09.808: INFO: stderr: ""
+Jul  2 13:33:09.808: INFO: stdout: "'/usr/share/nginx/html/index.html' -> '/tmp/index.html'\n"
+Jul  2 13:33:09.808: INFO: stdout of mv -v /usr/share/nginx/html/index.html /tmp/ || true on ss2-1: '/usr/share/nginx/html/index.html' -> '/tmp/index.html'
+
+STEP: Updating StatefulSet template: update image from k8s.gcr.io/nginx-slim-amd64:0.20 to k8s.gcr.io/nginx-slim-amd64:0.21
+Jul  2 13:33:19.878: INFO: Updating stateful set ss2
+STEP: Creating a new revision
+STEP: Updating Pods in reverse ordinal order
+Jul  2 13:33:29.895: INFO: Running '/usr/local/bin/kubectl --kubeconfig=/tmp/kubeconfig-293271353 exec --namespace=e2e-tests-statefulset-8wpp9 ss2-1 -- /bin/sh -c mv -v /tmp/index.html /usr/share/nginx/html/ || true'
+Jul  2 13:33:30.396: INFO: stderr: ""
+Jul  2 13:33:30.396: INFO: stdout: "'/tmp/index.html' -> '/usr/share/nginx/html/index.html'\n"
+Jul  2 13:33:30.396: INFO: stdout of mv -v /tmp/index.html /usr/share/nginx/html/ || true on ss2-1: '/tmp/index.html' -> '/usr/share/nginx/html/index.html'
+
+Jul  2 13:33:40.415: INFO: Waiting for StatefulSet e2e-tests-statefulset-8wpp9/ss2 to complete update
+Jul  2 13:33:40.415: INFO: Waiting for Pod e2e-tests-statefulset-8wpp9/ss2-0 to have revision ss2-56dd5fb9c4 update revision ss2-76cb68b6ff
+Jul  2 13:33:40.415: INFO: Waiting for Pod e2e-tests-statefulset-8wpp9/ss2-1 to have revision ss2-56dd5fb9c4 update revision ss2-76cb68b6ff
+Jul  2 13:33:50.422: INFO: Waiting for StatefulSet e2e-tests-statefulset-8wpp9/ss2 to complete update
+Jul  2 13:33:50.422: INFO: Waiting for Pod e2e-tests-statefulset-8wpp9/ss2-0 to have revision ss2-56dd5fb9c4 update revision ss2-76cb68b6ff
+STEP: Rolling back to a previous revision
+Jul  2 13:34:00.425: INFO: Running '/usr/local/bin/kubectl --kubeconfig=/tmp/kubeconfig-293271353 exec --namespace=e2e-tests-statefulset-8wpp9 ss2-1 -- /bin/sh -c mv -v /usr/share/nginx/html/index.html /tmp/ || true'
+Jul  2 13:34:00.906: INFO: stderr: ""
+Jul  2 13:34:00.906: INFO: stdout: "'/usr/share/nginx/html/index.html' -> '/tmp/index.html'\n"
+Jul  2 13:34:00.906: INFO: stdout of mv -v /usr/share/nginx/html/index.html /tmp/ || true on ss2-1: '/usr/share/nginx/html/index.html' -> '/tmp/index.html'
+
+Jul  2 13:34:10.937: INFO: Updating stateful set ss2
+STEP: Rolling back update in reverse ordinal order
+Jul  2 13:34:20.953: INFO: Running '/usr/local/bin/kubectl --kubeconfig=/tmp/kubeconfig-293271353 exec --namespace=e2e-tests-statefulset-8wpp9 ss2-1 -- /bin/sh -c mv -v /tmp/index.html /usr/share/nginx/html/ || true'
+Jul  2 13:34:21.371: INFO: stderr: ""
+Jul  2 13:34:21.371: INFO: stdout: "'/tmp/index.html' -> '/usr/share/nginx/html/index.html'\n"
+Jul  2 13:34:21.371: INFO: stdout of mv -v /tmp/index.html /usr/share/nginx/html/ || true on ss2-1: '/tmp/index.html' -> '/usr/share/nginx/html/index.html'
+
+Jul  2 13:34:41.390: INFO: Waiting for StatefulSet e2e-tests-statefulset-8wpp9/ss2 to complete update
+Jul  2 13:34:41.390: INFO: Waiting for Pod e2e-tests-statefulset-8wpp9/ss2-0 to have revision ss2-76cb68b6ff update revision ss2-56dd5fb9c4
+[AfterEach] [k8s.io] Basic StatefulSet functionality [StatefulSetBasic]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/statefulset.go:83
+Jul  2 13:34:51.398: INFO: Deleting all statefulset in ns e2e-tests-statefulset-8wpp9
+Jul  2 13:34:51.475: INFO: Scaling statefulset ss2 to 0
+Jul  2 13:35:11.489: INFO: Waiting for statefulset status.replicas updated to 0
+Jul  2 13:35:11.492: INFO: Deleting statefulset ss2
+[AfterEach] [sig-apps] StatefulSet
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:35:11.502: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-statefulset-8wpp9" for this suite.
+Jul  2 13:35:17.514: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:35:17.545: INFO: namespace: e2e-tests-statefulset-8wpp9, resource: bindings, ignored listing per whitelist
+Jul  2 13:35:17.600: INFO: namespace e2e-tests-statefulset-8wpp9 deletion completed in 6.095139045s
+
+• [SLOW TEST:138.373 seconds]
+[sig-apps] StatefulSet
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/framework.go:22
+  [k8s.io] Basic StatefulSet functionality [StatefulSetBasic]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:679
+    should perform rolling updates and roll backs of template modifications [Conformance]
+    /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+S
+------------------------------
+[sig-api-machinery] Secrets 
+  should be consumable from pods in env vars [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-api-machinery] Secrets
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:35:17.600: INFO: >>> kubeConfig: /tmp/kubeconfig-293271353
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should be consumable from pods in env vars [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating secret with name secret-test-c21dd40f-7dfc-11e8-b0f5-565e625ec9a3
+STEP: Creating a pod to test consume secrets
+Jul  2 13:35:17.684: INFO: Waiting up to 5m0s for pod "pod-secrets-c21e4d61-7dfc-11e8-b0f5-565e625ec9a3" in namespace "e2e-tests-secrets-q4jm9" to be "success or failure"
+Jul  2 13:35:17.686: INFO: Pod "pod-secrets-c21e4d61-7dfc-11e8-b0f5-565e625ec9a3": Phase="Pending", Reason="", readiness=false. Elapsed: 2.0225ms
+Jul  2 13:35:19.690: INFO: Pod "pod-secrets-c21e4d61-7dfc-11e8-b0f5-565e625ec9a3": Phase="Pending", Reason="", readiness=false. Elapsed: 2.005790306s
+Jul  2 13:35:21.693: INFO: Pod "pod-secrets-c21e4d61-7dfc-11e8-b0f5-565e625ec9a3": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.009508431s
+STEP: Saw pod success
+Jul  2 13:35:21.693: INFO: Pod "pod-secrets-c21e4d61-7dfc-11e8-b0f5-565e625ec9a3" satisfied condition "success or failure"
+Jul  2 13:35:21.696: INFO: Trying to get logs from node shoot--core--confgcp-worker-o1cev-z1-f757498dc-jzlxf pod pod-secrets-c21e4d61-7dfc-11e8-b0f5-565e625ec9a3 container secret-env-test: <nil>
+STEP: delete the pod
+Jul  2 13:35:21.717: INFO: Waiting for pod pod-secrets-c21e4d61-7dfc-11e8-b0f5-565e625ec9a3 to disappear
+Jul  2 13:35:21.720: INFO: Pod pod-secrets-c21e4d61-7dfc-11e8-b0f5-565e625ec9a3 no longer exists
+[AfterEach] [sig-api-machinery] Secrets
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:35:21.720: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-secrets-q4jm9" for this suite.
+Jul  2 13:35:27.738: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:35:27.804: INFO: namespace: e2e-tests-secrets-q4jm9, resource: bindings, ignored listing per whitelist
+Jul  2 13:35:27.828: INFO: namespace e2e-tests-secrets-q4jm9 deletion completed in 6.099937204s
+
+• [SLOW TEST:10.228 seconds]
+[sig-api-machinery] Secrets
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/secrets.go:30
+  should be consumable from pods in env vars [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+[sig-storage] EmptyDir volumes 
+  should support (non-root,0777,tmpfs) [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-storage] EmptyDir volumes
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:35:27.828: INFO: >>> kubeConfig: /tmp/kubeconfig-293271353
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should support (non-root,0777,tmpfs) [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating a pod to test emptydir 0777 on tmpfs
+Jul  2 13:35:27.908: INFO: Waiting up to 5m0s for pod "pod-c8366cfc-7dfc-11e8-b0f5-565e625ec9a3" in namespace "e2e-tests-emptydir-mx9bb" to be "success or failure"
+Jul  2 13:35:27.911: INFO: Pod "pod-c8366cfc-7dfc-11e8-b0f5-565e625ec9a3": Phase="Pending", Reason="", readiness=false. Elapsed: 2.143952ms
+Jul  2 13:35:29.914: INFO: Pod "pod-c8366cfc-7dfc-11e8-b0f5-565e625ec9a3": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.005370824s
+STEP: Saw pod success
+Jul  2 13:35:29.914: INFO: Pod "pod-c8366cfc-7dfc-11e8-b0f5-565e625ec9a3" satisfied condition "success or failure"
+Jul  2 13:35:29.917: INFO: Trying to get logs from node shoot--core--confgcp-worker-o1cev-z1-f757498dc-jzlxf pod pod-c8366cfc-7dfc-11e8-b0f5-565e625ec9a3 container test-container: <nil>
+STEP: delete the pod
+Jul  2 13:35:29.932: INFO: Waiting for pod pod-c8366cfc-7dfc-11e8-b0f5-565e625ec9a3 to disappear
+Jul  2 13:35:29.935: INFO: Pod pod-c8366cfc-7dfc-11e8-b0f5-565e625ec9a3 no longer exists
+[AfterEach] [sig-storage] EmptyDir volumes
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:35:29.935: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-emptydir-mx9bb" for this suite.
+Jul  2 13:35:35.948: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:35:35.970: INFO: namespace: e2e-tests-emptydir-mx9bb, resource: bindings, ignored listing per whitelist
+Jul  2 13:35:36.036: INFO: namespace e2e-tests-emptydir-mx9bb deletion completed in 6.097477564s
+
+• [SLOW TEST:8.208 seconds]
+[sig-storage] EmptyDir volumes
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/empty_dir.go:40
+  should support (non-root,0777,tmpfs) [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSSSSSSSS
+------------------------------
+[sig-apps] ReplicaSet 
+  should serve a basic image on each replica with a public image  [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-apps] ReplicaSet
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:35:36.037: INFO: >>> kubeConfig: /tmp/kubeconfig-293271353
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should serve a basic image on each replica with a public image  [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+Jul  2 13:35:36.110: INFO: Creating ReplicaSet my-hostname-basic-cd1a92c7-7dfc-11e8-b0f5-565e625ec9a3
+Jul  2 13:35:36.116: INFO: Pod name my-hostname-basic-cd1a92c7-7dfc-11e8-b0f5-565e625ec9a3: Found 0 pods out of 1
+Jul  2 13:35:41.120: INFO: Pod name my-hostname-basic-cd1a92c7-7dfc-11e8-b0f5-565e625ec9a3: Found 1 pods out of 1
+Jul  2 13:35:41.120: INFO: Ensuring a pod for ReplicaSet "my-hostname-basic-cd1a92c7-7dfc-11e8-b0f5-565e625ec9a3" is running
+Jul  2 13:35:41.123: INFO: Pod "my-hostname-basic-cd1a92c7-7dfc-11e8-b0f5-565e625ec9a3-z9zjm" is running (conditions: [{Type:Initialized Status:True LastProbeTime:0001-01-01 00:00:00 +0000 UTC LastTransitionTime:2018-07-02 13:35:36 +0000 UTC Reason: Message:} {Type:Ready Status:True LastProbeTime:0001-01-01 00:00:00 +0000 UTC LastTransitionTime:2018-07-02 13:35:37 +0000 UTC Reason: Message:} {Type:ContainersReady Status:True LastProbeTime:0001-01-01 00:00:00 +0000 UTC LastTransitionTime:0001-01-01 00:00:00 +0000 UTC Reason: Message:} {Type:PodScheduled Status:True LastProbeTime:0001-01-01 00:00:00 +0000 UTC LastTransitionTime:2018-07-02 13:35:36 +0000 UTC Reason: Message:}])
+Jul  2 13:35:41.123: INFO: Trying to dial the pod
+Jul  2 13:35:46.219: INFO: Controller my-hostname-basic-cd1a92c7-7dfc-11e8-b0f5-565e625ec9a3: Got expected result from replica 1 [my-hostname-basic-cd1a92c7-7dfc-11e8-b0f5-565e625ec9a3-z9zjm]: "my-hostname-basic-cd1a92c7-7dfc-11e8-b0f5-565e625ec9a3-z9zjm", 1 of 1 required successes so far
+[AfterEach] [sig-apps] ReplicaSet
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:35:46.219: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-replicaset-vfdz4" for this suite.
+Jul  2 13:35:52.276: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:35:52.296: INFO: namespace: e2e-tests-replicaset-vfdz4, resource: bindings, ignored listing per whitelist
+Jul  2 13:35:52.398: INFO: namespace e2e-tests-replicaset-vfdz4 deletion completed in 6.175005168s
+
+• [SLOW TEST:16.361 seconds]
+[sig-apps] ReplicaSet
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/framework.go:22
+  should serve a basic image on each replica with a public image  [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SS
+------------------------------
+[sig-storage] Secrets 
+  should be consumable in multiple volumes in a pod [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-storage] Secrets
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:35:52.398: INFO: >>> kubeConfig: /tmp/kubeconfig-293271353
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should be consumable in multiple volumes in a pod [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating secret with name secret-test-d6dc1412-7dfc-11e8-b0f5-565e625ec9a3
+STEP: Creating a pod to test consume secrets
+Jul  2 13:35:52.485: INFO: Waiting up to 5m0s for pod "pod-secrets-d6dc9137-7dfc-11e8-b0f5-565e625ec9a3" in namespace "e2e-tests-secrets-rvtgd" to be "success or failure"
+Jul  2 13:35:52.487: INFO: Pod "pod-secrets-d6dc9137-7dfc-11e8-b0f5-565e625ec9a3": Phase="Pending", Reason="", readiness=false. Elapsed: 2.084087ms
+Jul  2 13:35:54.491: INFO: Pod "pod-secrets-d6dc9137-7dfc-11e8-b0f5-565e625ec9a3": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.005703888s
+STEP: Saw pod success
+Jul  2 13:35:54.491: INFO: Pod "pod-secrets-d6dc9137-7dfc-11e8-b0f5-565e625ec9a3" satisfied condition "success or failure"
+Jul  2 13:35:54.493: INFO: Trying to get logs from node shoot--core--confgcp-worker-o1cev-z1-f757498dc-jzlxf pod pod-secrets-d6dc9137-7dfc-11e8-b0f5-565e625ec9a3 container secret-volume-test: <nil>
+STEP: delete the pod
+Jul  2 13:35:54.509: INFO: Waiting for pod pod-secrets-d6dc9137-7dfc-11e8-b0f5-565e625ec9a3 to disappear
+Jul  2 13:35:54.511: INFO: Pod pod-secrets-d6dc9137-7dfc-11e8-b0f5-565e625ec9a3 no longer exists
+[AfterEach] [sig-storage] Secrets
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:35:54.511: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-secrets-rvtgd" for this suite.
+Jul  2 13:36:00.526: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:36:00.546: INFO: namespace: e2e-tests-secrets-rvtgd, resource: bindings, ignored listing per whitelist
+Jul  2 13:36:00.615: INFO: namespace e2e-tests-secrets-rvtgd deletion completed in 6.100434186s
+
+• [SLOW TEST:8.217 seconds]
+[sig-storage] Secrets
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/secrets_volume.go:33
+  should be consumable in multiple volumes in a pod [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSSSSS
+------------------------------
+[sig-storage] ConfigMap 
+  optional updates should be reflected in volume [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-storage] ConfigMap
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:36:00.615: INFO: >>> kubeConfig: /tmp/kubeconfig-293271353
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] optional updates should be reflected in volume [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating configMap with name cm-test-opt-del-dbc17226-7dfc-11e8-b0f5-565e625ec9a3
+STEP: Creating configMap with name cm-test-opt-upd-dbc17258-7dfc-11e8-b0f5-565e625ec9a3
+STEP: Creating the pod
+STEP: Deleting configmap cm-test-opt-del-dbc17226-7dfc-11e8-b0f5-565e625ec9a3
+STEP: Updating configmap cm-test-opt-upd-dbc17258-7dfc-11e8-b0f5-565e625ec9a3
+STEP: Creating configMap with name cm-test-opt-create-dbc17278-7dfc-11e8-b0f5-565e625ec9a3
+STEP: waiting to observe update in volume
+[AfterEach] [sig-storage] ConfigMap
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:36:05.035: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-configmap-kvnjt" for this suite.
+Jul  2 13:36:27.053: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:36:27.109: INFO: namespace: e2e-tests-configmap-kvnjt, resource: bindings, ignored listing per whitelist
+Jul  2 13:36:27.144: INFO: namespace e2e-tests-configmap-kvnjt deletion completed in 22.104266197s
+
+• [SLOW TEST:26.529 seconds]
+[sig-storage] ConfigMap
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/configmap_volume.go:32
+  optional updates should be reflected in volume [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSSSSSSS
+------------------------------
+[k8s.io] Probing container 
+  should *not* be restarted with a exec "cat /tmp/health" liveness probe [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [k8s.io] Probing container
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:36:27.144: INFO: >>> kubeConfig: /tmp/kubeconfig-293271353
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [k8s.io] Probing container
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/container_probe.go:48
+[It] should *not* be restarted with a exec "cat /tmp/health" liveness probe [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating pod liveness-exec in namespace e2e-tests-container-probe-nd5pw
+Jul  2 13:36:31.235: INFO: Started pod liveness-exec in namespace e2e-tests-container-probe-nd5pw
+STEP: checking the pod's current state and verifying that restartCount is present
+Jul  2 13:36:31.238: INFO: Initial restart count of pod liveness-exec is 0
+STEP: deleting the pod
+[AfterEach] [k8s.io] Probing container
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:40:32.577: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-container-probe-nd5pw" for this suite.
+Jul  2 13:40:38.674: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:40:38.783: INFO: namespace: e2e-tests-container-probe-nd5pw, resource: bindings, ignored listing per whitelist
+Jul  2 13:40:38.848: INFO: namespace e2e-tests-container-probe-nd5pw deletion completed in 6.268623721s
+
+• [SLOW TEST:251.704 seconds]
+[k8s.io] Probing container
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:679
+  should *not* be restarted with a exec "cat /tmp/health" liveness probe [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSSSSSSSSSSSSSS
+------------------------------
+[k8s.io] Probing container 
+  should have monotonically increasing restart count [Slow][NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [k8s.io] Probing container
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:40:38.849: INFO: >>> kubeConfig: /tmp/kubeconfig-293271353
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [k8s.io] Probing container
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/container_probe.go:48
+[It] should have monotonically increasing restart count [Slow][NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating pod liveness-http in namespace e2e-tests-container-probe-88mxf
+Jul  2 13:40:40.941: INFO: Started pod liveness-http in namespace e2e-tests-container-probe-88mxf
+STEP: checking the pod's current state and verifying that restartCount is present
+Jul  2 13:40:40.943: INFO: Initial restart count of pod liveness-http is 0
+Jul  2 13:40:56.990: INFO: Restart count of pod e2e-tests-container-probe-88mxf/liveness-http is now 1 (16.046679431s elapsed)
+Jul  2 13:41:17.032: INFO: Restart count of pod e2e-tests-container-probe-88mxf/liveness-http is now 2 (36.089022458s elapsed)
+Jul  2 13:41:37.081: INFO: Restart count of pod e2e-tests-container-probe-88mxf/liveness-http is now 3 (56.13816253s elapsed)
+Jul  2 13:41:57.119: INFO: Restart count of pod e2e-tests-container-probe-88mxf/liveness-http is now 4 (1m16.175399226s elapsed)
+Jul  2 13:43:03.335: INFO: Restart count of pod e2e-tests-container-probe-88mxf/liveness-http is now 5 (2m22.391951989s elapsed)
+STEP: deleting the pod
+[AfterEach] [k8s.io] Probing container
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:43:03.344: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-container-probe-88mxf" for this suite.
+Jul  2 13:43:09.375: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:43:09.411: INFO: namespace: e2e-tests-container-probe-88mxf, resource: bindings, ignored listing per whitelist
+Jul  2 13:43:09.476: INFO: namespace e2e-tests-container-probe-88mxf deletion completed in 6.128471579s
+
+• [SLOW TEST:150.627 seconds]
+[k8s.io] Probing container
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:679
+  should have monotonically increasing restart count [Slow][NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+S
+------------------------------
+[sig-storage] Projected 
+  should be consumable in multiple volumes in the same pod [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:43:09.476: INFO: >>> kubeConfig: /tmp/kubeconfig-293271353
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:858
+[It] should be consumable in multiple volumes in the same pod [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating configMap with name projected-configmap-test-volume-db60dab7-7dfd-11e8-b0f5-565e625ec9a3
+STEP: Creating a pod to test consume configMaps
+Jul  2 13:43:09.564: INFO: Waiting up to 5m0s for pod "pod-projected-configmaps-db615780-7dfd-11e8-b0f5-565e625ec9a3" in namespace "e2e-tests-projected-4vd9k" to be "success or failure"
+Jul  2 13:43:09.566: INFO: Pod "pod-projected-configmaps-db615780-7dfd-11e8-b0f5-565e625ec9a3": Phase="Pending", Reason="", readiness=false. Elapsed: 2.277689ms
+Jul  2 13:43:11.570: INFO: Pod "pod-projected-configmaps-db615780-7dfd-11e8-b0f5-565e625ec9a3": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.005619708s
+STEP: Saw pod success
+Jul  2 13:43:11.570: INFO: Pod "pod-projected-configmaps-db615780-7dfd-11e8-b0f5-565e625ec9a3" satisfied condition "success or failure"
+Jul  2 13:43:11.572: INFO: Trying to get logs from node shoot--core--confgcp-worker-o1cev-z1-f757498dc-jzlxf pod pod-projected-configmaps-db615780-7dfd-11e8-b0f5-565e625ec9a3 container projected-configmap-volume-test: <nil>
+STEP: delete the pod
+Jul  2 13:43:11.592: INFO: Waiting for pod pod-projected-configmaps-db615780-7dfd-11e8-b0f5-565e625ec9a3 to disappear
+Jul  2 13:43:11.594: INFO: Pod pod-projected-configmaps-db615780-7dfd-11e8-b0f5-565e625ec9a3 no longer exists
+[AfterEach] [sig-storage] Projected
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:43:11.595: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-4vd9k" for this suite.
+Jul  2 13:43:17.611: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:43:17.653: INFO: namespace: e2e-tests-projected-4vd9k, resource: bindings, ignored listing per whitelist
+Jul  2 13:43:17.700: INFO: namespace e2e-tests-projected-4vd9k deletion completed in 6.098597982s
+
+• [SLOW TEST:8.224 seconds]
+[sig-storage] Projected
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:34
+  should be consumable in multiple volumes in the same pod [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSSSSSSSSSSSSSSSS
+------------------------------
+[sig-storage] EmptyDir volumes 
+  should support (root,0666,default) [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-storage] EmptyDir volumes
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:43:17.700: INFO: >>> kubeConfig: /tmp/kubeconfig-293271353
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should support (root,0666,default) [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating a pod to test emptydir 0666 on node default medium
+Jul  2 13:43:17.787: INFO: Waiting up to 5m0s for pod "pod-e048128d-7dfd-11e8-b0f5-565e625ec9a3" in namespace "e2e-tests-emptydir-hdcrt" to be "success or failure"
+Jul  2 13:43:17.789: INFO: Pod "pod-e048128d-7dfd-11e8-b0f5-565e625ec9a3": Phase="Pending", Reason="", readiness=false. Elapsed: 2.445167ms
+Jul  2 13:43:19.794: INFO: Pod "pod-e048128d-7dfd-11e8-b0f5-565e625ec9a3": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.006502386s
+STEP: Saw pod success
+Jul  2 13:43:19.794: INFO: Pod "pod-e048128d-7dfd-11e8-b0f5-565e625ec9a3" satisfied condition "success or failure"
+Jul  2 13:43:19.802: INFO: Trying to get logs from node shoot--core--confgcp-worker-o1cev-z1-f757498dc-jzlxf pod pod-e048128d-7dfd-11e8-b0f5-565e625ec9a3 container test-container: <nil>
+STEP: delete the pod
+Jul  2 13:43:19.819: INFO: Waiting for pod pod-e048128d-7dfd-11e8-b0f5-565e625ec9a3 to disappear
+Jul  2 13:43:19.822: INFO: Pod pod-e048128d-7dfd-11e8-b0f5-565e625ec9a3 no longer exists
+[AfterEach] [sig-storage] EmptyDir volumes
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:43:19.822: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-emptydir-hdcrt" for this suite.
+Jul  2 13:43:25.835: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:43:25.875: INFO: namespace: e2e-tests-emptydir-hdcrt, resource: bindings, ignored listing per whitelist
+Jul  2 13:43:25.954: INFO: namespace e2e-tests-emptydir-hdcrt deletion completed in 6.12810406s
+
+• [SLOW TEST:8.254 seconds]
+[sig-storage] EmptyDir volumes
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/empty_dir.go:40
+  should support (root,0666,default) [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSS
+------------------------------
+[k8s.io] [sig-node] PreStop 
+  should call prestop when killing a pod  [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [k8s.io] [sig-node] PreStop
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:43:25.954: INFO: >>> kubeConfig: /tmp/kubeconfig-293271353
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should call prestop when killing a pod  [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating server pod server in namespace e2e-tests-prestop-6dddb
+STEP: Waiting for pods to come up.
+STEP: Creating tester pod tester in namespace e2e-tests-prestop-6dddb
+STEP: Deleting pre-stop pod
+Jul  2 13:43:39.154: INFO: Saw: {
+	"Hostname": "server",
+	"Sent": null,
+	"Received": {
+		"prestop": 1
+	},
+	"Errors": null,
+	"Log": [
+		"default/nettest has 0 endpoints ([]), which is less than 8 as expected. Waiting for all endpoints to come up.",
+		"default/nettest has 0 endpoints ([]), which is less than 8 as expected. Waiting for all endpoints to come up.",
+		"default/nettest has 0 endpoints ([]), which is less than 8 as expected. Waiting for all endpoints to come up."
+	],
+	"StillContactingPeers": true
+}
+STEP: Deleting the server pod
+[AfterEach] [k8s.io] [sig-node] PreStop
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:43:39.162: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-prestop-6dddb" for this suite.
+Jul  2 13:44:17.180: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:44:17.272: INFO: namespace: e2e-tests-prestop-6dddb, resource: bindings, ignored listing per whitelist
+Jul  2 13:44:17.418: INFO: namespace e2e-tests-prestop-6dddb deletion completed in 38.251934782s
+
+• [SLOW TEST:51.464 seconds]
+[k8s.io] [sig-node] PreStop
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:679
+  should call prestop when killing a pod  [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSSSSSSSS
+------------------------------
+[sig-storage] Downward API volume 
+  should provide container's memory request [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:44:17.419: INFO: >>> kubeConfig: /tmp/kubeconfig-293271353
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downwardapi_volume.go:38
+[It] should provide container's memory request [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating a pod to test downward API volume plugin
+Jul  2 13:44:17.627: INFO: Waiting up to 5m0s for pod "downwardapi-volume-03ef864e-7dfe-11e8-b0f5-565e625ec9a3" in namespace "e2e-tests-downward-api-nlw5v" to be "success or failure"
+Jul  2 13:44:17.635: INFO: Pod "downwardapi-volume-03ef864e-7dfe-11e8-b0f5-565e625ec9a3": Phase="Pending", Reason="", readiness=false. Elapsed: 7.792137ms
+Jul  2 13:44:19.639: INFO: Pod "downwardapi-volume-03ef864e-7dfe-11e8-b0f5-565e625ec9a3": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.01248549s
+STEP: Saw pod success
+Jul  2 13:44:19.639: INFO: Pod "downwardapi-volume-03ef864e-7dfe-11e8-b0f5-565e625ec9a3" satisfied condition "success or failure"
+Jul  2 13:44:19.642: INFO: Trying to get logs from node shoot--core--confgcp-worker-o1cev-z1-f757498dc-qrtzr pod downwardapi-volume-03ef864e-7dfe-11e8-b0f5-565e625ec9a3 container client-container: <nil>
+STEP: delete the pod
+Jul  2 13:44:19.659: INFO: Waiting for pod downwardapi-volume-03ef864e-7dfe-11e8-b0f5-565e625ec9a3 to disappear
+Jul  2 13:44:19.662: INFO: Pod downwardapi-volume-03ef864e-7dfe-11e8-b0f5-565e625ec9a3 no longer exists
+[AfterEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:44:19.662: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-downward-api-nlw5v" for this suite.
+Jul  2 13:44:25.674: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:44:25.808: INFO: namespace: e2e-tests-downward-api-nlw5v, resource: bindings, ignored listing per whitelist
+Jul  2 13:44:25.847: INFO: namespace e2e-tests-downward-api-nlw5v deletion completed in 6.182603223s
+
+• [SLOW TEST:8.429 seconds]
+[sig-storage] Downward API volume
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downwardapi_volume.go:33
+  should provide container's memory request [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSSSSSSSSSSSSSSSSSSS
+------------------------------
+[sig-api-machinery] Downward API 
+  should provide pod name, namespace and IP address as env vars [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-api-machinery] Downward API
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:44:25.848: INFO: >>> kubeConfig: /tmp/kubeconfig-293271353
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should provide pod name, namespace and IP address as env vars [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating a pod to test downward api env vars
+Jul  2 13:44:25.926: INFO: Waiting up to 5m0s for pod "downward-api-08e53735-7dfe-11e8-b0f5-565e625ec9a3" in namespace "e2e-tests-downward-api-thbtq" to be "success or failure"
+Jul  2 13:44:25.928: INFO: Pod "downward-api-08e53735-7dfe-11e8-b0f5-565e625ec9a3": Phase="Pending", Reason="", readiness=false. Elapsed: 2.089027ms
+Jul  2 13:44:27.932: INFO: Pod "downward-api-08e53735-7dfe-11e8-b0f5-565e625ec9a3": Phase="Pending", Reason="", readiness=false. Elapsed: 2.006139166s
+Jul  2 13:44:29.978: INFO: Pod "downward-api-08e53735-7dfe-11e8-b0f5-565e625ec9a3": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.05205802s
+STEP: Saw pod success
+Jul  2 13:44:29.978: INFO: Pod "downward-api-08e53735-7dfe-11e8-b0f5-565e625ec9a3" satisfied condition "success or failure"
+Jul  2 13:44:29.981: INFO: Trying to get logs from node shoot--core--confgcp-worker-o1cev-z1-f757498dc-jzlxf pod downward-api-08e53735-7dfe-11e8-b0f5-565e625ec9a3 container dapi-container: <nil>
+STEP: delete the pod
+Jul  2 13:44:29.998: INFO: Waiting for pod downward-api-08e53735-7dfe-11e8-b0f5-565e625ec9a3 to disappear
+Jul  2 13:44:30.000: INFO: Pod downward-api-08e53735-7dfe-11e8-b0f5-565e625ec9a3 no longer exists
+[AfterEach] [sig-api-machinery] Downward API
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:44:30.009: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-downward-api-thbtq" for this suite.
+Jul  2 13:44:36.023: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:44:36.061: INFO: namespace: e2e-tests-downward-api-thbtq, resource: bindings, ignored listing per whitelist
+Jul  2 13:44:36.109: INFO: namespace e2e-tests-downward-api-thbtq deletion completed in 6.096213689s
+
+• [SLOW TEST:10.262 seconds]
+[sig-api-machinery] Downward API
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downward_api.go:37
+  should provide pod name, namespace and IP address as env vars [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSSSS
+------------------------------
+[sig-api-machinery] Garbage collector 
+  should delete pods created by rc when not orphaning [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-api-machinery] Garbage collector
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:44:36.110: INFO: >>> kubeConfig: /tmp/kubeconfig-293271353
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should delete pods created by rc when not orphaning [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: create the rc
+STEP: delete the rc
+STEP: wait for all pods to be garbage collected
+STEP: Gathering metrics
+W0702 13:44:46.214044      18 metrics_grabber.go:81] Master node is not registered. Grabbing metrics from Scheduler, ControllerManager and ClusterAutoscaler is disabled.
+Jul  2 13:44:46.214: INFO: For apiserver_request_count:
+For apiserver_request_latencies_summary:
+For etcd_helper_cache_entry_count:
+For etcd_helper_cache_hit_count:
+For etcd_helper_cache_miss_count:
+For etcd_request_cache_add_latencies_summary:
+For etcd_request_cache_get_latencies_summary:
+For etcd_request_latencies_summary:
+For garbage_collector_attempt_to_delete_queue_latency:
+For garbage_collector_attempt_to_delete_work_duration:
+For garbage_collector_attempt_to_orphan_queue_latency:
+For garbage_collector_attempt_to_orphan_work_duration:
+For garbage_collector_dirty_processing_latency_microseconds:
+For garbage_collector_event_processing_latency_microseconds:
+For garbage_collector_graph_changes_queue_latency:
+For garbage_collector_graph_changes_work_duration:
+For garbage_collector_orphan_processing_latency_microseconds:
+For namespace_queue_latency:
+For namespace_queue_latency_sum:
+For namespace_queue_latency_count:
+For namespace_retries:
+For namespace_work_duration:
+For namespace_work_duration_sum:
+For namespace_work_duration_count:
+For function_duration_seconds:
+For errors_total:
+For evicted_pods_total:
+
+[AfterEach] [sig-api-machinery] Garbage collector
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:44:46.214: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-gc-lfsz8" for this suite.
+Jul  2 13:44:52.276: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:44:52.300: INFO: namespace: e2e-tests-gc-lfsz8, resource: bindings, ignored listing per whitelist
+Jul  2 13:44:52.367: INFO: namespace e2e-tests-gc-lfsz8 deletion completed in 6.150701629s
+
+• [SLOW TEST:16.258 seconds]
+[sig-api-machinery] Garbage collector
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apimachinery/framework.go:22
+  should delete pods created by rc when not orphaning [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSSSS
+------------------------------
+[sig-storage] Projected 
+  should update annotations on modification [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:44:52.368: INFO: >>> kubeConfig: /tmp/kubeconfig-293271353
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:858
+[It] should update annotations on modification [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating the pod
+Jul  2 13:44:54.981: INFO: Successfully updated pod "annotationupdate18b4c6ba-7dfe-11e8-b0f5-565e625ec9a3"
+[AfterEach] [sig-storage] Projected
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:44:59.104: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-5spgv" for this suite.
+Jul  2 13:45:21.117: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:45:21.171: INFO: namespace: e2e-tests-projected-5spgv, resource: bindings, ignored listing per whitelist
+Jul  2 13:45:21.200: INFO: namespace e2e-tests-projected-5spgv deletion completed in 22.092700539s
+
+• [SLOW TEST:28.833 seconds]
+[sig-storage] Projected
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:34
+  should update annotations on modification [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+S
+------------------------------
+[sig-storage] Projected 
+  should be consumable from pods in volume with mappings [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:45:21.200: INFO: >>> kubeConfig: /tmp/kubeconfig-293271353
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:858
+[It] should be consumable from pods in volume with mappings [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating configMap with name projected-configmap-test-volume-map-29e4a97a-7dfe-11e8-b0f5-565e625ec9a3
+STEP: Creating a pod to test consume configMaps
+Jul  2 13:45:21.295: INFO: Waiting up to 5m0s for pod "pod-projected-configmaps-29e52549-7dfe-11e8-b0f5-565e625ec9a3" in namespace "e2e-tests-projected-qtvr2" to be "success or failure"
+Jul  2 13:45:21.298: INFO: Pod "pod-projected-configmaps-29e52549-7dfe-11e8-b0f5-565e625ec9a3": Phase="Pending", Reason="", readiness=false. Elapsed: 2.357576ms
+Jul  2 13:45:23.301: INFO: Pod "pod-projected-configmaps-29e52549-7dfe-11e8-b0f5-565e625ec9a3": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.006073488s
+STEP: Saw pod success
+Jul  2 13:45:23.301: INFO: Pod "pod-projected-configmaps-29e52549-7dfe-11e8-b0f5-565e625ec9a3" satisfied condition "success or failure"
+Jul  2 13:45:23.304: INFO: Trying to get logs from node shoot--core--confgcp-worker-o1cev-z1-f757498dc-jzlxf pod pod-projected-configmaps-29e52549-7dfe-11e8-b0f5-565e625ec9a3 container projected-configmap-volume-test: <nil>
+STEP: delete the pod
+Jul  2 13:45:23.322: INFO: Waiting for pod pod-projected-configmaps-29e52549-7dfe-11e8-b0f5-565e625ec9a3 to disappear
+Jul  2 13:45:23.324: INFO: Pod pod-projected-configmaps-29e52549-7dfe-11e8-b0f5-565e625ec9a3 no longer exists
+[AfterEach] [sig-storage] Projected
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:45:23.324: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-qtvr2" for this suite.
+Jul  2 13:45:29.337: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:45:29.381: INFO: namespace: e2e-tests-projected-qtvr2, resource: bindings, ignored listing per whitelist
+Jul  2 13:45:29.466: INFO: namespace e2e-tests-projected-qtvr2 deletion completed in 6.138210961s
+
+• [SLOW TEST:8.266 seconds]
+[sig-storage] Projected
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:34
+  should be consumable from pods in volume with mappings [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+[sig-api-machinery] Watchers 
+  should be able to restart watching from the last resource version observed by the previous watch [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-api-machinery] Watchers
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:45:29.466: INFO: >>> kubeConfig: /tmp/kubeconfig-293271353
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should be able to restart watching from the last resource version observed by the previous watch [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: creating a watch on configmaps
+STEP: creating a new configmap
+STEP: modifying the configmap once
+STEP: closing the watch once it receives two notifications
+Jul  2 13:45:29.550: INFO: Got : ADDED &ConfigMap{ObjectMeta:k8s_io_apimachinery_pkg_apis_meta_v1.ObjectMeta{Name:e2e-watch-test-watch-closed,GenerateName:,Namespace:e2e-tests-watch-r9xtj,SelfLink:/api/v1/namespaces/e2e-tests-watch-r9xtj/configmaps/e2e-watch-test-watch-closed,UID:2ed5b133-7dfe-11e8-876c-5e517afbca85,ResourceVersion:10702,Generation:0,CreationTimestamp:2018-07-02 13:45:29 +0000 UTC,DeletionTimestamp:<nil>,DeletionGracePeriodSeconds:nil,Labels:map[string]string{watch-this-configmap: watch-closed-and-restarted,},Annotations:map[string]string{},OwnerReferences:[],Finalizers:[],ClusterName:,Initializers:nil,},Data:map[string]string{},BinaryData:map[string][]byte{},}
+Jul  2 13:45:29.550: INFO: Got : MODIFIED &ConfigMap{ObjectMeta:k8s_io_apimachinery_pkg_apis_meta_v1.ObjectMeta{Name:e2e-watch-test-watch-closed,GenerateName:,Namespace:e2e-tests-watch-r9xtj,SelfLink:/api/v1/namespaces/e2e-tests-watch-r9xtj/configmaps/e2e-watch-test-watch-closed,UID:2ed5b133-7dfe-11e8-876c-5e517afbca85,ResourceVersion:10703,Generation:0,CreationTimestamp:2018-07-02 13:45:29 +0000 UTC,DeletionTimestamp:<nil>,DeletionGracePeriodSeconds:nil,Labels:map[string]string{watch-this-configmap: watch-closed-and-restarted,},Annotations:map[string]string{},OwnerReferences:[],Finalizers:[],ClusterName:,Initializers:nil,},Data:map[string]string{mutation: 1,},BinaryData:map[string][]byte{},}
+STEP: modifying the configmap a second time, while the watch is closed
+STEP: creating a new watch on configmaps from the last resource version observed by the first watch
+STEP: deleting the configmap
+STEP: Expecting to observe notifications for all changes to the configmap since the first watch closed
+Jul  2 13:45:29.563: INFO: Got : MODIFIED &ConfigMap{ObjectMeta:k8s_io_apimachinery_pkg_apis_meta_v1.ObjectMeta{Name:e2e-watch-test-watch-closed,GenerateName:,Namespace:e2e-tests-watch-r9xtj,SelfLink:/api/v1/namespaces/e2e-tests-watch-r9xtj/configmaps/e2e-watch-test-watch-closed,UID:2ed5b133-7dfe-11e8-876c-5e517afbca85,ResourceVersion:10704,Generation:0,CreationTimestamp:2018-07-02 13:45:29 +0000 UTC,DeletionTimestamp:<nil>,DeletionGracePeriodSeconds:nil,Labels:map[string]string{watch-this-configmap: watch-closed-and-restarted,},Annotations:map[string]string{},OwnerReferences:[],Finalizers:[],ClusterName:,Initializers:nil,},Data:map[string]string{mutation: 2,},BinaryData:map[string][]byte{},}
+Jul  2 13:45:29.563: INFO: Got : DELETED &ConfigMap{ObjectMeta:k8s_io_apimachinery_pkg_apis_meta_v1.ObjectMeta{Name:e2e-watch-test-watch-closed,GenerateName:,Namespace:e2e-tests-watch-r9xtj,SelfLink:/api/v1/namespaces/e2e-tests-watch-r9xtj/configmaps/e2e-watch-test-watch-closed,UID:2ed5b133-7dfe-11e8-876c-5e517afbca85,ResourceVersion:10705,Generation:0,CreationTimestamp:2018-07-02 13:45:29 +0000 UTC,DeletionTimestamp:<nil>,DeletionGracePeriodSeconds:nil,Labels:map[string]string{watch-this-configmap: watch-closed-and-restarted,},Annotations:map[string]string{},OwnerReferences:[],Finalizers:[],ClusterName:,Initializers:nil,},Data:map[string]string{mutation: 2,},BinaryData:map[string][]byte{},}
+[AfterEach] [sig-api-machinery] Watchers
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:45:29.563: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-watch-r9xtj" for this suite.
+Jul  2 13:45:35.577: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:45:35.591: INFO: namespace: e2e-tests-watch-r9xtj, resource: bindings, ignored listing per whitelist
+Jul  2 13:45:35.665: INFO: namespace e2e-tests-watch-r9xtj deletion completed in 6.098756484s
+
+• [SLOW TEST:6.199 seconds]
+[sig-api-machinery] Watchers
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apimachinery/framework.go:22
+  should be able to restart watching from the last resource version observed by the previous watch [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSSSSS
+------------------------------
+[sig-network] Services 
+  should serve multiport endpoints from pods  [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-network] Services
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:45:35.666: INFO: >>> kubeConfig: /tmp/kubeconfig-293271353
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-network] Services
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/network/service.go:83
+[It] should serve multiport endpoints from pods  [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: creating service multi-endpoint-test in namespace e2e-tests-services-2gcxz
+STEP: waiting up to 3m0s for service multi-endpoint-test in namespace e2e-tests-services-2gcxz to expose endpoints map[]
+Jul  2 13:45:35.752: INFO: Get endpoints failed (2.56974ms elapsed, ignoring for 5s): endpoints "multi-endpoint-test" not found
+Jul  2 13:45:36.755: INFO: successfully validated that service multi-endpoint-test in namespace e2e-tests-services-2gcxz exposes endpoints map[] (1.006405396s elapsed)
+STEP: Creating pod pod1 in namespace e2e-tests-services-2gcxz
+STEP: waiting up to 3m0s for service multi-endpoint-test in namespace e2e-tests-services-2gcxz to expose endpoints map[pod1:[100]]
+Jul  2 13:45:38.781: INFO: successfully validated that service multi-endpoint-test in namespace e2e-tests-services-2gcxz exposes endpoints map[pod1:[100]] (2.020017649s elapsed)
+STEP: Creating pod pod2 in namespace e2e-tests-services-2gcxz
+STEP: waiting up to 3m0s for service multi-endpoint-test in namespace e2e-tests-services-2gcxz to expose endpoints map[pod2:[101] pod1:[100]]
+Jul  2 13:45:42.076: INFO: successfully validated that service multi-endpoint-test in namespace e2e-tests-services-2gcxz exposes endpoints map[pod1:[100] pod2:[101]] (3.200361904s elapsed)
+STEP: Deleting pod pod1 in namespace e2e-tests-services-2gcxz
+STEP: waiting up to 3m0s for service multi-endpoint-test in namespace e2e-tests-services-2gcxz to expose endpoints map[pod2:[101]]
+Jul  2 13:45:43.092: INFO: successfully validated that service multi-endpoint-test in namespace e2e-tests-services-2gcxz exposes endpoints map[pod2:[101]] (1.010141098s elapsed)
+STEP: Deleting pod pod2 in namespace e2e-tests-services-2gcxz
+STEP: waiting up to 3m0s for service multi-endpoint-test in namespace e2e-tests-services-2gcxz to expose endpoints map[]
+Jul  2 13:45:44.102: INFO: successfully validated that service multi-endpoint-test in namespace e2e-tests-services-2gcxz exposes endpoints map[] (1.006698192s elapsed)
+[AfterEach] [sig-network] Services
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:45:44.114: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-services-2gcxz" for this suite.
+Jul  2 13:45:50.127: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:45:50.194: INFO: namespace: e2e-tests-services-2gcxz, resource: bindings, ignored listing per whitelist
+Jul  2 13:45:50.217: INFO: namespace e2e-tests-services-2gcxz deletion completed in 6.099161473s
+[AfterEach] [sig-network] Services
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/network/service.go:88
+
+• [SLOW TEST:14.551 seconds]
+[sig-network] Services
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/network/framework.go:22
+  should serve multiport endpoints from pods  [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+[k8s.io] Docker Containers 
+  should be able to override the image's default arguments (docker cmd) [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [k8s.io] Docker Containers
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:45:50.217: INFO: >>> kubeConfig: /tmp/kubeconfig-293271353
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should be able to override the image's default arguments (docker cmd) [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating a pod to test override arguments
+Jul  2 13:45:50.306: INFO: Waiting up to 5m0s for pod "client-containers-3b30a3b2-7dfe-11e8-b0f5-565e625ec9a3" in namespace "e2e-tests-containers-rddm6" to be "success or failure"
+Jul  2 13:45:50.308: INFO: Pod "client-containers-3b30a3b2-7dfe-11e8-b0f5-565e625ec9a3": Phase="Pending", Reason="", readiness=false. Elapsed: 2.137403ms
+Jul  2 13:45:52.312: INFO: Pod "client-containers-3b30a3b2-7dfe-11e8-b0f5-565e625ec9a3": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.005961272s
+STEP: Saw pod success
+Jul  2 13:45:52.312: INFO: Pod "client-containers-3b30a3b2-7dfe-11e8-b0f5-565e625ec9a3" satisfied condition "success or failure"
+Jul  2 13:45:52.314: INFO: Trying to get logs from node shoot--core--confgcp-worker-o1cev-z1-f757498dc-jzlxf pod client-containers-3b30a3b2-7dfe-11e8-b0f5-565e625ec9a3 container test-container: <nil>
+STEP: delete the pod
+Jul  2 13:45:52.332: INFO: Waiting for pod client-containers-3b30a3b2-7dfe-11e8-b0f5-565e625ec9a3 to disappear
+Jul  2 13:45:52.335: INFO: Pod client-containers-3b30a3b2-7dfe-11e8-b0f5-565e625ec9a3 no longer exists
+[AfterEach] [k8s.io] Docker Containers
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:45:52.335: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-containers-rddm6" for this suite.
+Jul  2 13:45:58.348: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:45:58.365: INFO: namespace: e2e-tests-containers-rddm6, resource: bindings, ignored listing per whitelist
+Jul  2 13:45:58.510: INFO: namespace e2e-tests-containers-rddm6 deletion completed in 6.171632282s
+
+• [SLOW TEST:8.293 seconds]
+[k8s.io] Docker Containers
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:679
+  should be able to override the image's default arguments (docker cmd) [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSS
+------------------------------
+[sig-storage] Downward API volume 
+  should provide container's memory limit [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:45:58.510: INFO: >>> kubeConfig: /tmp/kubeconfig-293271353
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downwardapi_volume.go:38
+[It] should provide container's memory limit [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating a pod to test downward API volume plugin
+Jul  2 13:45:58.593: INFO: Waiting up to 5m0s for pod "downwardapi-volume-4020b6a4-7dfe-11e8-b0f5-565e625ec9a3" in namespace "e2e-tests-downward-api-qtl4t" to be "success or failure"
+Jul  2 13:45:58.595: INFO: Pod "downwardapi-volume-4020b6a4-7dfe-11e8-b0f5-565e625ec9a3": Phase="Pending", Reason="", readiness=false. Elapsed: 2.452968ms
+Jul  2 13:46:00.599: INFO: Pod "downwardapi-volume-4020b6a4-7dfe-11e8-b0f5-565e625ec9a3": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.00585063s
+STEP: Saw pod success
+Jul  2 13:46:00.599: INFO: Pod "downwardapi-volume-4020b6a4-7dfe-11e8-b0f5-565e625ec9a3" satisfied condition "success or failure"
+Jul  2 13:46:00.602: INFO: Trying to get logs from node shoot--core--confgcp-worker-o1cev-z1-f757498dc-jzlxf pod downwardapi-volume-4020b6a4-7dfe-11e8-b0f5-565e625ec9a3 container client-container: <nil>
+STEP: delete the pod
+Jul  2 13:46:00.620: INFO: Waiting for pod downwardapi-volume-4020b6a4-7dfe-11e8-b0f5-565e625ec9a3 to disappear
+Jul  2 13:46:00.624: INFO: Pod downwardapi-volume-4020b6a4-7dfe-11e8-b0f5-565e625ec9a3 no longer exists
+[AfterEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:46:00.624: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-downward-api-qtl4t" for this suite.
+Jul  2 13:46:06.639: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:46:06.673: INFO: namespace: e2e-tests-downward-api-qtl4t, resource: bindings, ignored listing per whitelist
+Jul  2 13:46:06.728: INFO: namespace e2e-tests-downward-api-qtl4t deletion completed in 6.100024557s
+
+• [SLOW TEST:8.218 seconds]
+[sig-storage] Downward API volume
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downwardapi_volume.go:33
+  should provide container's memory limit [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSSSSSSSSSSSSSS
+------------------------------
+[sig-storage] Projected 
+  updates should be reflected in volume [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:46:06.728: INFO: >>> kubeConfig: /tmp/kubeconfig-293271353
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:858
+[It] updates should be reflected in volume [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating projection with configMap that has name projected-configmap-test-upd-450749f6-7dfe-11e8-b0f5-565e625ec9a3
+STEP: Creating the pod
+STEP: Updating configmap projected-configmap-test-upd-450749f6-7dfe-11e8-b0f5-565e625ec9a3
+STEP: waiting to observe update in volume
+[AfterEach] [sig-storage] Projected
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:46:10.930: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-98ctf" for this suite.
+Jul  2 13:46:32.944: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:46:32.982: INFO: namespace: e2e-tests-projected-98ctf, resource: bindings, ignored listing per whitelist
+Jul  2 13:46:33.079: INFO: namespace e2e-tests-projected-98ctf deletion completed in 22.144775646s
+
+• [SLOW TEST:26.351 seconds]
+[sig-storage] Projected
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:34
+  updates should be reflected in volume [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSS
+------------------------------
+[sig-storage] Projected 
+  should provide node allocatable (memory) as default memory limit if the limit is not set [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:46:33.079: INFO: >>> kubeConfig: /tmp/kubeconfig-293271353
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:858
+[It] should provide node allocatable (memory) as default memory limit if the limit is not set [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating a pod to test downward API volume plugin
+Jul  2 13:46:33.167: INFO: Waiting up to 5m0s for pod "downwardapi-volume-54bcbc50-7dfe-11e8-b0f5-565e625ec9a3" in namespace "e2e-tests-projected-bp9wc" to be "success or failure"
+Jul  2 13:46:33.170: INFO: Pod "downwardapi-volume-54bcbc50-7dfe-11e8-b0f5-565e625ec9a3": Phase="Pending", Reason="", readiness=false. Elapsed: 2.577207ms
+Jul  2 13:46:35.174: INFO: Pod "downwardapi-volume-54bcbc50-7dfe-11e8-b0f5-565e625ec9a3": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.006817435s
+STEP: Saw pod success
+Jul  2 13:46:35.174: INFO: Pod "downwardapi-volume-54bcbc50-7dfe-11e8-b0f5-565e625ec9a3" satisfied condition "success or failure"
+Jul  2 13:46:35.177: INFO: Trying to get logs from node shoot--core--confgcp-worker-o1cev-z1-f757498dc-jzlxf pod downwardapi-volume-54bcbc50-7dfe-11e8-b0f5-565e625ec9a3 container client-container: <nil>
+STEP: delete the pod
+Jul  2 13:46:35.193: INFO: Waiting for pod downwardapi-volume-54bcbc50-7dfe-11e8-b0f5-565e625ec9a3 to disappear
+Jul  2 13:46:35.196: INFO: Pod downwardapi-volume-54bcbc50-7dfe-11e8-b0f5-565e625ec9a3 no longer exists
+[AfterEach] [sig-storage] Projected
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:46:35.196: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-bp9wc" for this suite.
+Jul  2 13:46:41.208: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:46:41.231: INFO: namespace: e2e-tests-projected-bp9wc, resource: bindings, ignored listing per whitelist
+Jul  2 13:46:41.296: INFO: namespace e2e-tests-projected-bp9wc deletion completed in 6.097208596s
+
+• [SLOW TEST:8.217 seconds]
+[sig-storage] Projected
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:34
+  should provide node allocatable (memory) as default memory limit if the limit is not set [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSSSSSSS
+------------------------------
+[sig-apps] StatefulSet [k8s.io] Basic StatefulSet functionality [StatefulSetBasic] 
+  Scaling should happen in predictable order and halt if any stateful pod is unhealthy [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-apps] StatefulSet
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:46:41.296: INFO: >>> kubeConfig: /tmp/kubeconfig-293271353
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-apps] StatefulSet
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/statefulset.go:57
+[BeforeEach] [k8s.io] Basic StatefulSet functionality [StatefulSetBasic]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/statefulset.go:72
+STEP: Creating service test in namespace e2e-tests-statefulset-s9w9b
+[It] Scaling should happen in predictable order and halt if any stateful pod is unhealthy [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Initializing watcher for selector baz=blah,foo=bar
+STEP: Creating stateful set ss in namespace e2e-tests-statefulset-s9w9b
+STEP: Waiting until all stateful set ss replicas will be running in namespace e2e-tests-statefulset-s9w9b
+Jul  2 13:46:41.383: INFO: Found 0 stateful pods, waiting for 1
+Jul  2 13:46:51.388: INFO: Waiting for pod ss-0 to enter Running - Ready=true, currently Running - Ready=true
+STEP: Confirming that stateful set scale up will halt with unhealthy stateful pod
+Jul  2 13:46:51.392: INFO: Running '/usr/local/bin/kubectl --kubeconfig=/tmp/kubeconfig-293271353 exec --namespace=e2e-tests-statefulset-s9w9b ss-0 -- /bin/sh -c mv -v /usr/share/nginx/html/index.html /tmp/ || true'
+Jul  2 13:46:51.862: INFO: stderr: ""
+Jul  2 13:46:51.862: INFO: stdout: "'/usr/share/nginx/html/index.html' -> '/tmp/index.html'\n"
+Jul  2 13:46:51.862: INFO: stdout of mv -v /usr/share/nginx/html/index.html /tmp/ || true on ss-0: '/usr/share/nginx/html/index.html' -> '/tmp/index.html'
+
+Jul  2 13:46:51.878: INFO: Waiting for pod ss-0 to enter Running - Ready=false, currently Running - Ready=true
+Jul  2 13:47:01.883: INFO: Waiting for pod ss-0 to enter Running - Ready=false, currently Running - Ready=false
+Jul  2 13:47:01.883: INFO: Waiting for statefulset status.replicas updated to 0
+Jul  2 13:47:01.986: INFO: Verifying statefulset ss doesn't scale past 1 for another 9.999999675s
+Jul  2 13:47:02.991: INFO: Verifying statefulset ss doesn't scale past 1 for another 8.995606545s
+Jul  2 13:47:03.995: INFO: Verifying statefulset ss doesn't scale past 1 for another 7.991115876s
+Jul  2 13:47:04.999: INFO: Verifying statefulset ss doesn't scale past 1 for another 6.986846499s
+Jul  2 13:47:06.004: INFO: Verifying statefulset ss doesn't scale past 1 for another 5.982474875s
+Jul  2 13:47:07.077: INFO: Verifying statefulset ss doesn't scale past 1 for another 4.978126607s
+Jul  2 13:47:08.082: INFO: Verifying statefulset ss doesn't scale past 1 for another 3.90486274s
+Jul  2 13:47:09.179: INFO: Verifying statefulset ss doesn't scale past 1 for another 2.900228054s
+Jul  2 13:47:10.183: INFO: Verifying statefulset ss doesn't scale past 1 for another 1.803177437s
+Jul  2 13:47:11.187: INFO: Verifying statefulset ss doesn't scale past 1 for another 799.171075ms
+STEP: Scaling up stateful set ss to 3 replicas and waiting until all of them will be running in namespace e2e-tests-statefulset-s9w9b
+Jul  2 13:47:12.192: INFO: Running '/usr/local/bin/kubectl --kubeconfig=/tmp/kubeconfig-293271353 exec --namespace=e2e-tests-statefulset-s9w9b ss-0 -- /bin/sh -c mv -v /tmp/index.html /usr/share/nginx/html/ || true'
+Jul  2 13:47:12.704: INFO: stderr: ""
+Jul  2 13:47:12.704: INFO: stdout: "'/tmp/index.html' -> '/usr/share/nginx/html/index.html'\n"
+Jul  2 13:47:12.704: INFO: stdout of mv -v /tmp/index.html /usr/share/nginx/html/ || true on ss-0: '/tmp/index.html' -> '/usr/share/nginx/html/index.html'
+
+Jul  2 13:47:12.708: INFO: Found 1 stateful pods, waiting for 3
+Jul  2 13:47:22.713: INFO: Waiting for pod ss-0 to enter Running - Ready=true, currently Running - Ready=true
+Jul  2 13:47:22.713: INFO: Waiting for pod ss-1 to enter Running - Ready=true, currently Running - Ready=true
+Jul  2 13:47:22.713: INFO: Waiting for pod ss-2 to enter Running - Ready=true, currently Running - Ready=true
+STEP: Verifying that stateful set ss was scaled up in order
+STEP: Scale down will halt with unhealthy stateful pod
+Jul  2 13:47:22.776: INFO: Running '/usr/local/bin/kubectl --kubeconfig=/tmp/kubeconfig-293271353 exec --namespace=e2e-tests-statefulset-s9w9b ss-0 -- /bin/sh -c mv -v /usr/share/nginx/html/index.html /tmp/ || true'
+Jul  2 13:47:23.248: INFO: stderr: ""
+Jul  2 13:47:23.248: INFO: stdout: "'/usr/share/nginx/html/index.html' -> '/tmp/index.html'\n"
+Jul  2 13:47:23.248: INFO: stdout of mv -v /usr/share/nginx/html/index.html /tmp/ || true on ss-0: '/usr/share/nginx/html/index.html' -> '/tmp/index.html'
+
+Jul  2 13:47:23.248: INFO: Running '/usr/local/bin/kubectl --kubeconfig=/tmp/kubeconfig-293271353 exec --namespace=e2e-tests-statefulset-s9w9b ss-1 -- /bin/sh -c mv -v /usr/share/nginx/html/index.html /tmp/ || true'
+Jul  2 13:47:23.677: INFO: stderr: ""
+Jul  2 13:47:23.677: INFO: stdout: "'/usr/share/nginx/html/index.html' -> '/tmp/index.html'\n"
+Jul  2 13:47:23.677: INFO: stdout of mv -v /usr/share/nginx/html/index.html /tmp/ || true on ss-1: '/usr/share/nginx/html/index.html' -> '/tmp/index.html'
+
+Jul  2 13:47:23.677: INFO: Running '/usr/local/bin/kubectl --kubeconfig=/tmp/kubeconfig-293271353 exec --namespace=e2e-tests-statefulset-s9w9b ss-2 -- /bin/sh -c mv -v /usr/share/nginx/html/index.html /tmp/ || true'
+Jul  2 13:47:24.180: INFO: stderr: ""
+Jul  2 13:47:24.180: INFO: stdout: "'/usr/share/nginx/html/index.html' -> '/tmp/index.html'\n"
+Jul  2 13:47:24.180: INFO: stdout of mv -v /usr/share/nginx/html/index.html /tmp/ || true on ss-2: '/usr/share/nginx/html/index.html' -> '/tmp/index.html'
+
+Jul  2 13:47:24.180: INFO: Waiting for statefulset status.replicas updated to 0
+Jul  2 13:47:24.184: INFO: Waiting for stateful set status.readyReplicas to become 0, currently 2
+Jul  2 13:47:34.280: INFO: Waiting for pod ss-0 to enter Running - Ready=false, currently Running - Ready=false
+Jul  2 13:47:34.280: INFO: Waiting for pod ss-1 to enter Running - Ready=false, currently Running - Ready=false
+Jul  2 13:47:34.280: INFO: Waiting for pod ss-2 to enter Running - Ready=false, currently Running - Ready=false
+Jul  2 13:47:34.290: INFO: Verifying statefulset ss doesn't scale past 3 for another 9.999999711s
+Jul  2 13:47:35.295: INFO: Verifying statefulset ss doesn't scale past 3 for another 8.996314761s
+Jul  2 13:47:36.299: INFO: Verifying statefulset ss doesn't scale past 3 for another 7.99154124s
+Jul  2 13:47:37.304: INFO: Verifying statefulset ss doesn't scale past 3 for another 6.986895314s
+Jul  2 13:47:38.378: INFO: Verifying statefulset ss doesn't scale past 3 for another 5.98210663s
+Jul  2 13:47:39.383: INFO: Verifying statefulset ss doesn't scale past 3 for another 4.908103367s
+Jul  2 13:47:40.389: INFO: Verifying statefulset ss doesn't scale past 3 for another 3.90346095s
+Jul  2 13:47:41.394: INFO: Verifying statefulset ss doesn't scale past 3 for another 2.897125656s
+Jul  2 13:47:42.398: INFO: Verifying statefulset ss doesn't scale past 3 for another 1.892215709s
+Jul  2 13:47:43.402: INFO: Verifying statefulset ss doesn't scale past 3 for another 888.156895ms
+STEP: Scaling down stateful set ss to 0 replicas and waiting until none of pods will run in namespacee2e-tests-statefulset-s9w9b
+Jul  2 13:47:44.406: INFO: Running '/usr/local/bin/kubectl --kubeconfig=/tmp/kubeconfig-293271353 exec --namespace=e2e-tests-statefulset-s9w9b ss-0 -- /bin/sh -c mv -v /tmp/index.html /usr/share/nginx/html/ || true'
+Jul  2 13:47:44.873: INFO: stderr: ""
+Jul  2 13:47:44.873: INFO: stdout: "'/tmp/index.html' -> '/usr/share/nginx/html/index.html'\n"
+Jul  2 13:47:44.873: INFO: stdout of mv -v /tmp/index.html /usr/share/nginx/html/ || true on ss-0: '/tmp/index.html' -> '/usr/share/nginx/html/index.html'
+
+Jul  2 13:47:44.873: INFO: Running '/usr/local/bin/kubectl --kubeconfig=/tmp/kubeconfig-293271353 exec --namespace=e2e-tests-statefulset-s9w9b ss-1 -- /bin/sh -c mv -v /tmp/index.html /usr/share/nginx/html/ || true'
+Jul  2 13:47:45.379: INFO: stderr: ""
+Jul  2 13:47:45.379: INFO: stdout: "'/tmp/index.html' -> '/usr/share/nginx/html/index.html'\n"
+Jul  2 13:47:45.379: INFO: stdout of mv -v /tmp/index.html /usr/share/nginx/html/ || true on ss-1: '/tmp/index.html' -> '/usr/share/nginx/html/index.html'
+
+Jul  2 13:47:45.380: INFO: Running '/usr/local/bin/kubectl --kubeconfig=/tmp/kubeconfig-293271353 exec --namespace=e2e-tests-statefulset-s9w9b ss-2 -- /bin/sh -c mv -v /tmp/index.html /usr/share/nginx/html/ || true'
+Jul  2 13:47:45.872: INFO: stderr: ""
+Jul  2 13:47:45.873: INFO: stdout: "'/tmp/index.html' -> '/usr/share/nginx/html/index.html'\n"
+Jul  2 13:47:45.873: INFO: stdout of mv -v /tmp/index.html /usr/share/nginx/html/ || true on ss-2: '/tmp/index.html' -> '/usr/share/nginx/html/index.html'
+
+Jul  2 13:47:45.873: INFO: Scaling statefulset ss to 0
+STEP: Verifying that stateful set ss was scaled down in reverse order
+[AfterEach] [k8s.io] Basic StatefulSet functionality [StatefulSetBasic]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/statefulset.go:83
+Jul  2 13:48:05.888: INFO: Deleting all statefulset in ns e2e-tests-statefulset-s9w9b
+Jul  2 13:48:05.891: INFO: Scaling statefulset ss to 0
+Jul  2 13:48:05.900: INFO: Waiting for statefulset status.replicas updated to 0
+Jul  2 13:48:05.902: INFO: Deleting statefulset ss
+[AfterEach] [sig-apps] StatefulSet
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:48:05.913: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-statefulset-s9w9b" for this suite.
+Jul  2 13:48:11.926: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:48:12.013: INFO: namespace: e2e-tests-statefulset-s9w9b, resource: bindings, ignored listing per whitelist
+Jul  2 13:48:12.057: INFO: namespace e2e-tests-statefulset-s9w9b deletion completed in 6.141059326s
+
+• [SLOW TEST:90.761 seconds]
+[sig-apps] StatefulSet
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/framework.go:22
+  [k8s.io] Basic StatefulSet functionality [StatefulSetBasic]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:679
+    Scaling should happen in predictable order and halt if any stateful pod is unhealthy [Conformance]
+    /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+[sig-storage] ConfigMap 
+  updates should be reflected in volume [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-storage] ConfigMap
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:48:12.057: INFO: >>> kubeConfig: /tmp/kubeconfig-293271353
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] updates should be reflected in volume [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating configMap with name configmap-test-upd-8fbb23f4-7dfe-11e8-b0f5-565e625ec9a3
+STEP: Creating the pod
+STEP: Updating configmap configmap-test-upd-8fbb23f4-7dfe-11e8-b0f5-565e625ec9a3
+STEP: waiting to observe update in volume
+[AfterEach] [sig-storage] ConfigMap
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:49:35.479: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-configmap-9s8jl" for this suite.
+Jul  2 13:49:57.494: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:49:57.577: INFO: namespace: e2e-tests-configmap-9s8jl, resource: bindings, ignored listing per whitelist
+Jul  2 13:49:57.600: INFO: namespace e2e-tests-configmap-9s8jl deletion completed in 22.117136944s
+
+• [SLOW TEST:105.542 seconds]
+[sig-storage] ConfigMap
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/configmap_volume.go:32
+  updates should be reflected in volume [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSSSS
+------------------------------
+[sig-storage] Projected 
+  should be consumable from pods in volume with defaultMode set [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:49:57.600: INFO: >>> kubeConfig: /tmp/kubeconfig-293271353
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:858
+[It] should be consumable from pods in volume with defaultMode set [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating configMap with name projected-configmap-test-volume-cea44347-7dfe-11e8-b0f5-565e625ec9a3
+STEP: Creating a pod to test consume configMaps
+Jul  2 13:49:57.693: INFO: Waiting up to 5m0s for pod "pod-projected-configmaps-cea4f1e0-7dfe-11e8-b0f5-565e625ec9a3" in namespace "e2e-tests-projected-d9fw2" to be "success or failure"
+Jul  2 13:49:57.695: INFO: Pod "pod-projected-configmaps-cea4f1e0-7dfe-11e8-b0f5-565e625ec9a3": Phase="Pending", Reason="", readiness=false. Elapsed: 2.327755ms
+Jul  2 13:49:59.701: INFO: Pod "pod-projected-configmaps-cea4f1e0-7dfe-11e8-b0f5-565e625ec9a3": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.008095661s
+STEP: Saw pod success
+Jul  2 13:49:59.701: INFO: Pod "pod-projected-configmaps-cea4f1e0-7dfe-11e8-b0f5-565e625ec9a3" satisfied condition "success or failure"
+Jul  2 13:49:59.777: INFO: Trying to get logs from node shoot--core--confgcp-worker-o1cev-z1-f757498dc-jzlxf pod pod-projected-configmaps-cea4f1e0-7dfe-11e8-b0f5-565e625ec9a3 container projected-configmap-volume-test: <nil>
+STEP: delete the pod
+Jul  2 13:49:59.793: INFO: Waiting for pod pod-projected-configmaps-cea4f1e0-7dfe-11e8-b0f5-565e625ec9a3 to disappear
+Jul  2 13:49:59.796: INFO: Pod pod-projected-configmaps-cea4f1e0-7dfe-11e8-b0f5-565e625ec9a3 no longer exists
+[AfterEach] [sig-storage] Projected
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:49:59.796: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-d9fw2" for this suite.
+Jul  2 13:50:05.811: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:50:05.923: INFO: namespace: e2e-tests-projected-d9fw2, resource: bindings, ignored listing per whitelist
+Jul  2 13:50:05.955: INFO: namespace e2e-tests-projected-d9fw2 deletion completed in 6.15636365s
+
+• [SLOW TEST:8.355 seconds]
+[sig-storage] Projected
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:34
+  should be consumable from pods in volume with defaultMode set [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSSSSS
+------------------------------
+[sig-storage] Projected 
+  should project all components that make up the projection API [Projection][NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:50:05.956: INFO: >>> kubeConfig: /tmp/kubeconfig-293271353
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:858
+[It] should project all components that make up the projection API [Projection][NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating configMap with name configmap-projected-all-test-volume-d39ddbb5-7dfe-11e8-b0f5-565e625ec9a3
+STEP: Creating secret with name secret-projected-all-test-volume-d39ddb9e-7dfe-11e8-b0f5-565e625ec9a3
+STEP: Creating a pod to test Check all projections for projected volume plugin
+Jul  2 13:50:06.042: INFO: Waiting up to 5m0s for pod "projected-volume-d39ddb6e-7dfe-11e8-b0f5-565e625ec9a3" in namespace "e2e-tests-projected-672ch" to be "success or failure"
+Jul  2 13:50:06.045: INFO: Pod "projected-volume-d39ddb6e-7dfe-11e8-b0f5-565e625ec9a3": Phase="Pending", Reason="", readiness=false. Elapsed: 2.732319ms
+Jul  2 13:50:08.049: INFO: Pod "projected-volume-d39ddb6e-7dfe-11e8-b0f5-565e625ec9a3": Phase="Pending", Reason="", readiness=false. Elapsed: 2.007124832s
+Jul  2 13:50:10.054: INFO: Pod "projected-volume-d39ddb6e-7dfe-11e8-b0f5-565e625ec9a3": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.011547759s
+STEP: Saw pod success
+Jul  2 13:50:10.054: INFO: Pod "projected-volume-d39ddb6e-7dfe-11e8-b0f5-565e625ec9a3" satisfied condition "success or failure"
+Jul  2 13:50:10.078: INFO: Trying to get logs from node shoot--core--confgcp-worker-o1cev-z1-f757498dc-jzlxf pod projected-volume-d39ddb6e-7dfe-11e8-b0f5-565e625ec9a3 container projected-all-volume-test: <nil>
+STEP: delete the pod
+Jul  2 13:50:10.095: INFO: Waiting for pod projected-volume-d39ddb6e-7dfe-11e8-b0f5-565e625ec9a3 to disappear
+Jul  2 13:50:10.097: INFO: Pod projected-volume-d39ddb6e-7dfe-11e8-b0f5-565e625ec9a3 no longer exists
+[AfterEach] [sig-storage] Projected
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:50:10.097: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-672ch" for this suite.
+Jul  2 13:50:16.116: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:50:16.197: INFO: namespace: e2e-tests-projected-672ch, resource: bindings, ignored listing per whitelist
+Jul  2 13:50:16.210: INFO: namespace e2e-tests-projected-672ch deletion completed in 6.106301843s
+
+• [SLOW TEST:10.254 seconds]
+[sig-storage] Projected
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:34
+  should project all components that make up the projection API [Projection][NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSSSSSSS
+------------------------------
+[sig-storage] Secrets 
+  should be consumable from pods in volume with mappings [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-storage] Secrets
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:50:16.210: INFO: >>> kubeConfig: /tmp/kubeconfig-293271353
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should be consumable from pods in volume with mappings [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating secret with name secret-test-map-d9bac2e2-7dfe-11e8-b0f5-565e625ec9a3
+STEP: Creating a pod to test consume secrets
+Jul  2 13:50:16.293: INFO: Waiting up to 5m0s for pod "pod-secrets-d9bb3395-7dfe-11e8-b0f5-565e625ec9a3" in namespace "e2e-tests-secrets-qhmqc" to be "success or failure"
+Jul  2 13:50:16.296: INFO: Pod "pod-secrets-d9bb3395-7dfe-11e8-b0f5-565e625ec9a3": Phase="Pending", Reason="", readiness=false. Elapsed: 2.299676ms
+Jul  2 13:50:18.300: INFO: Pod "pod-secrets-d9bb3395-7dfe-11e8-b0f5-565e625ec9a3": Phase="Pending", Reason="", readiness=false. Elapsed: 2.006232531s
+Jul  2 13:50:20.303: INFO: Pod "pod-secrets-d9bb3395-7dfe-11e8-b0f5-565e625ec9a3": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.009789375s
+STEP: Saw pod success
+Jul  2 13:50:20.303: INFO: Pod "pod-secrets-d9bb3395-7dfe-11e8-b0f5-565e625ec9a3" satisfied condition "success or failure"
+Jul  2 13:50:20.381: INFO: Trying to get logs from node shoot--core--confgcp-worker-o1cev-z1-f757498dc-jzlxf pod pod-secrets-d9bb3395-7dfe-11e8-b0f5-565e625ec9a3 container secret-volume-test: <nil>
+STEP: delete the pod
+Jul  2 13:50:20.400: INFO: Waiting for pod pod-secrets-d9bb3395-7dfe-11e8-b0f5-565e625ec9a3 to disappear
+Jul  2 13:50:20.406: INFO: Pod pod-secrets-d9bb3395-7dfe-11e8-b0f5-565e625ec9a3 no longer exists
+[AfterEach] [sig-storage] Secrets
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:50:20.406: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-secrets-qhmqc" for this suite.
+Jul  2 13:50:26.426: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:50:26.439: INFO: namespace: e2e-tests-secrets-qhmqc, resource: bindings, ignored listing per whitelist
+Jul  2 13:50:26.534: INFO: namespace e2e-tests-secrets-qhmqc deletion completed in 6.120714361s
+
+• [SLOW TEST:10.324 seconds]
+[sig-storage] Secrets
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/secrets_volume.go:33
+  should be consumable from pods in volume with mappings [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SS
+------------------------------
+[k8s.io] Docker Containers 
+  should use the image defaults if command and args are blank [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [k8s.io] Docker Containers
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:50:26.534: INFO: >>> kubeConfig: /tmp/kubeconfig-293271353
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should use the image defaults if command and args are blank [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating a pod to test use defaults
+Jul  2 13:50:26.675: INFO: Waiting up to 5m0s for pod "client-containers-dfeb3b5e-7dfe-11e8-b0f5-565e625ec9a3" in namespace "e2e-tests-containers-f9vmr" to be "success or failure"
+Jul  2 13:50:26.677: INFO: Pod "client-containers-dfeb3b5e-7dfe-11e8-b0f5-565e625ec9a3": Phase="Pending", Reason="", readiness=false. Elapsed: 2.49762ms
+Jul  2 13:50:28.681: INFO: Pod "client-containers-dfeb3b5e-7dfe-11e8-b0f5-565e625ec9a3": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.006475836s
+STEP: Saw pod success
+Jul  2 13:50:28.681: INFO: Pod "client-containers-dfeb3b5e-7dfe-11e8-b0f5-565e625ec9a3" satisfied condition "success or failure"
+Jul  2 13:50:28.684: INFO: Trying to get logs from node shoot--core--confgcp-worker-o1cev-z1-f757498dc-jzlxf pod client-containers-dfeb3b5e-7dfe-11e8-b0f5-565e625ec9a3 container test-container: <nil>
+STEP: delete the pod
+Jul  2 13:50:28.701: INFO: Waiting for pod client-containers-dfeb3b5e-7dfe-11e8-b0f5-565e625ec9a3 to disappear
+Jul  2 13:50:28.704: INFO: Pod client-containers-dfeb3b5e-7dfe-11e8-b0f5-565e625ec9a3 no longer exists
+[AfterEach] [k8s.io] Docker Containers
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:50:28.704: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-containers-f9vmr" for this suite.
+Jul  2 13:50:34.717: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:50:34.849: INFO: namespace: e2e-tests-containers-f9vmr, resource: bindings, ignored listing per whitelist
+Jul  2 13:50:34.849: INFO: namespace e2e-tests-containers-f9vmr deletion completed in 6.142021566s
+
+• [SLOW TEST:8.315 seconds]
+[k8s.io] Docker Containers
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:679
+  should use the image defaults if command and args are blank [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SS
+------------------------------
+[sig-storage] Secrets 
+  should be consumable from pods in volume as non-root with defaultMode and fsGroup set [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-storage] Secrets
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:50:34.849: INFO: >>> kubeConfig: /tmp/kubeconfig-293271353
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should be consumable from pods in volume as non-root with defaultMode and fsGroup set [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating secret with name secret-test-e4d6defe-7dfe-11e8-b0f5-565e625ec9a3
+STEP: Creating a pod to test consume secrets
+Jul  2 13:50:34.933: INFO: Waiting up to 5m0s for pod "pod-secrets-e4d75b48-7dfe-11e8-b0f5-565e625ec9a3" in namespace "e2e-tests-secrets-nx4jm" to be "success or failure"
+Jul  2 13:50:34.936: INFO: Pod "pod-secrets-e4d75b48-7dfe-11e8-b0f5-565e625ec9a3": Phase="Pending", Reason="", readiness=false. Elapsed: 2.814312ms
+Jul  2 13:50:36.940: INFO: Pod "pod-secrets-e4d75b48-7dfe-11e8-b0f5-565e625ec9a3": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.00661763s
+STEP: Saw pod success
+Jul  2 13:50:36.940: INFO: Pod "pod-secrets-e4d75b48-7dfe-11e8-b0f5-565e625ec9a3" satisfied condition "success or failure"
+Jul  2 13:50:36.942: INFO: Trying to get logs from node shoot--core--confgcp-worker-o1cev-z1-f757498dc-jzlxf pod pod-secrets-e4d75b48-7dfe-11e8-b0f5-565e625ec9a3 container secret-volume-test: <nil>
+STEP: delete the pod
+Jul  2 13:50:36.957: INFO: Waiting for pod pod-secrets-e4d75b48-7dfe-11e8-b0f5-565e625ec9a3 to disappear
+Jul  2 13:50:36.960: INFO: Pod pod-secrets-e4d75b48-7dfe-11e8-b0f5-565e625ec9a3 no longer exists
+[AfterEach] [sig-storage] Secrets
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:50:36.960: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-secrets-nx4jm" for this suite.
+Jul  2 13:50:42.972: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:50:42.998: INFO: namespace: e2e-tests-secrets-nx4jm, resource: bindings, ignored listing per whitelist
+Jul  2 13:50:43.057: INFO: namespace e2e-tests-secrets-nx4jm deletion completed in 6.094285915s
+
+• [SLOW TEST:8.208 seconds]
+[sig-storage] Secrets
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/secrets_volume.go:33
+  should be consumable from pods in volume as non-root with defaultMode and fsGroup set [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+S
+------------------------------
+[sig-storage] Secrets 
+  optional updates should be reflected in volume [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-storage] Secrets
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:50:43.057: INFO: >>> kubeConfig: /tmp/kubeconfig-293271353
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] optional updates should be reflected in volume [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating secret with name s-test-opt-del-e9bc2198-7dfe-11e8-b0f5-565e625ec9a3
+STEP: Creating secret with name s-test-opt-upd-e9bc21e0-7dfe-11e8-b0f5-565e625ec9a3
+STEP: Creating the pod
+STEP: Deleting secret s-test-opt-del-e9bc2198-7dfe-11e8-b0f5-565e625ec9a3
+STEP: Updating secret s-test-opt-upd-e9bc21e0-7dfe-11e8-b0f5-565e625ec9a3
+STEP: Creating secret with name s-test-opt-create-e9bc2210-7dfe-11e8-b0f5-565e625ec9a3
+STEP: waiting to observe update in volume
+[AfterEach] [sig-storage] Secrets
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:50:47.651: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-secrets-hf2ww" for this suite.
+Jul  2 13:51:09.666: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:51:09.750: INFO: namespace: e2e-tests-secrets-hf2ww, resource: bindings, ignored listing per whitelist
+Jul  2 13:51:09.780: INFO: namespace e2e-tests-secrets-hf2ww deletion completed in 22.125456802s
+
+• [SLOW TEST:26.723 seconds]
+[sig-storage] Secrets
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/secrets_volume.go:33
+  optional updates should be reflected in volume [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSSSSSSS
+------------------------------
+[sig-network] Networking Granular Checks: Pods 
+  should function for node-pod communication: udp [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-network] Networking
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:51:09.780: INFO: >>> kubeConfig: /tmp/kubeconfig-293271353
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should function for node-pod communication: udp [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Performing setup for networking test in namespace e2e-tests-pod-network-test-nzjqc
+STEP: creating a selector
+STEP: Creating the service pods in kubernetes
+Jul  2 13:51:09.857: INFO: Waiting up to 10m0s for all (but 0) nodes to be schedulable
+STEP: Creating test pods
+Jul  2 13:51:27.984: INFO: ExecWithOptions {Command:[/bin/sh -c echo 'hostName' | timeout -t 2 nc -w 1 -u 100.96.1.173 8081 | grep -v '^\s*$'] Namespace:e2e-tests-pod-network-test-nzjqc PodName:host-test-container-pod ContainerName:hostexec Stdin:<nil> CaptureStdout:true CaptureStderr:true PreserveWhitespace:false}
+Jul  2 13:51:27.984: INFO: >>> kubeConfig: /tmp/kubeconfig-293271353
+Jul  2 13:51:29.410: INFO: Found all expected endpoints: [netserver-0]
+Jul  2 13:51:29.414: INFO: ExecWithOptions {Command:[/bin/sh -c echo 'hostName' | timeout -t 2 nc -w 1 -u 100.96.0.47 8081 | grep -v '^\s*$'] Namespace:e2e-tests-pod-network-test-nzjqc PodName:host-test-container-pod ContainerName:hostexec Stdin:<nil> CaptureStdout:true CaptureStderr:true PreserveWhitespace:false}
+Jul  2 13:51:29.414: INFO: >>> kubeConfig: /tmp/kubeconfig-293271353
+Jul  2 13:51:30.770: INFO: Found all expected endpoints: [netserver-1]
+[AfterEach] [sig-network] Networking
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:51:30.770: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-pod-network-test-nzjqc" for this suite.
+Jul  2 13:51:52.789: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:51:52.897: INFO: namespace: e2e-tests-pod-network-test-nzjqc, resource: bindings, ignored listing per whitelist
+Jul  2 13:51:53.019: INFO: namespace e2e-tests-pod-network-test-nzjqc deletion completed in 22.240566861s
+
+• [SLOW TEST:43.239 seconds]
+[sig-network] Networking
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/networking.go:25
+  Granular Checks: Pods
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/networking.go:28
+    should function for node-pod communication: udp [NodeConformance] [Conformance]
+    /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSS
+------------------------------
+[sig-storage] ConfigMap 
+  should be consumable from pods in volume with mappings [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-storage] ConfigMap
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:51:53.020: INFO: >>> kubeConfig: /tmp/kubeconfig-293271353
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should be consumable from pods in volume with mappings [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating configMap with name configmap-test-volume-map-13706c40-7dff-11e8-b0f5-565e625ec9a3
+STEP: Creating a pod to test consume configMaps
+Jul  2 13:51:53.116: INFO: Waiting up to 5m0s for pod "pod-configmaps-1370e57c-7dff-11e8-b0f5-565e625ec9a3" in namespace "e2e-tests-configmap-knv6h" to be "success or failure"
+Jul  2 13:51:53.120: INFO: Pod "pod-configmaps-1370e57c-7dff-11e8-b0f5-565e625ec9a3": Phase="Pending", Reason="", readiness=false. Elapsed: 4.474665ms
+Jul  2 13:51:55.124: INFO: Pod "pod-configmaps-1370e57c-7dff-11e8-b0f5-565e625ec9a3": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.008308275s
+STEP: Saw pod success
+Jul  2 13:51:55.124: INFO: Pod "pod-configmaps-1370e57c-7dff-11e8-b0f5-565e625ec9a3" satisfied condition "success or failure"
+Jul  2 13:51:55.127: INFO: Trying to get logs from node shoot--core--confgcp-worker-o1cev-z1-f757498dc-jzlxf pod pod-configmaps-1370e57c-7dff-11e8-b0f5-565e625ec9a3 container configmap-volume-test: <nil>
+STEP: delete the pod
+Jul  2 13:51:55.144: INFO: Waiting for pod pod-configmaps-1370e57c-7dff-11e8-b0f5-565e625ec9a3 to disappear
+Jul  2 13:51:55.146: INFO: Pod pod-configmaps-1370e57c-7dff-11e8-b0f5-565e625ec9a3 no longer exists
+[AfterEach] [sig-storage] ConfigMap
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:51:55.146: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-configmap-knv6h" for this suite.
+Jul  2 13:52:01.163: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:52:01.209: INFO: namespace: e2e-tests-configmap-knv6h, resource: bindings, ignored listing per whitelist
+Jul  2 13:52:01.287: INFO: namespace e2e-tests-configmap-knv6h deletion completed in 6.13478279s
+
+• [SLOW TEST:8.267 seconds]
+[sig-storage] ConfigMap
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/configmap_volume.go:32
+  should be consumable from pods in volume with mappings [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSS
+------------------------------
+[k8s.io] Variable Expansion 
+  should allow substituting values in a container's command [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [k8s.io] Variable Expansion
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:52:01.287: INFO: >>> kubeConfig: /tmp/kubeconfig-293271353
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should allow substituting values in a container's command [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating a pod to test substitution in container's command
+Jul  2 13:52:01.365: INFO: Waiting up to 5m0s for pod "var-expansion-185bb92f-7dff-11e8-b0f5-565e625ec9a3" in namespace "e2e-tests-var-expansion-6p8zj" to be "success or failure"
+Jul  2 13:52:01.368: INFO: Pod "var-expansion-185bb92f-7dff-11e8-b0f5-565e625ec9a3": Phase="Pending", Reason="", readiness=false. Elapsed: 2.512865ms
+Jul  2 13:52:03.371: INFO: Pod "var-expansion-185bb92f-7dff-11e8-b0f5-565e625ec9a3": Phase="Pending", Reason="", readiness=false. Elapsed: 2.006368573s
+Jul  2 13:52:05.375: INFO: Pod "var-expansion-185bb92f-7dff-11e8-b0f5-565e625ec9a3": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.010256977s
+STEP: Saw pod success
+Jul  2 13:52:05.375: INFO: Pod "var-expansion-185bb92f-7dff-11e8-b0f5-565e625ec9a3" satisfied condition "success or failure"
+Jul  2 13:52:05.379: INFO: Trying to get logs from node shoot--core--confgcp-worker-o1cev-z1-f757498dc-jzlxf pod var-expansion-185bb92f-7dff-11e8-b0f5-565e625ec9a3 container dapi-container: <nil>
+STEP: delete the pod
+Jul  2 13:52:05.396: INFO: Waiting for pod var-expansion-185bb92f-7dff-11e8-b0f5-565e625ec9a3 to disappear
+Jul  2 13:52:05.400: INFO: Pod var-expansion-185bb92f-7dff-11e8-b0f5-565e625ec9a3 no longer exists
+[AfterEach] [k8s.io] Variable Expansion
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:52:05.400: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-var-expansion-6p8zj" for this suite.
+Jul  2 13:52:11.416: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:52:11.503: INFO: namespace: e2e-tests-var-expansion-6p8zj, resource: bindings, ignored listing per whitelist
+Jul  2 13:52:11.534: INFO: namespace e2e-tests-var-expansion-6p8zj deletion completed in 6.129405413s
+
+• [SLOW TEST:10.247 seconds]
+[k8s.io] Variable Expansion
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:679
+  should allow substituting values in a container's command [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSSSSSSSSSSSSSS
+------------------------------
+[k8s.io] Pods 
+  should be submitted and removed [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [k8s.io] Pods
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:52:11.535: INFO: >>> kubeConfig: /tmp/kubeconfig-293271353
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [k8s.io] Pods
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/pods.go:127
+[It] should be submitted and removed [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: creating the pod
+STEP: setting up watch
+STEP: submitting the pod to kubernetes
+STEP: verifying the pod is in kubernetes
+STEP: verifying pod creation was observed
+Jul  2 13:52:13.635: INFO: running pod: &v1.Pod{TypeMeta:v1.TypeMeta{Kind:"", APIVersion:""}, ObjectMeta:v1.ObjectMeta{Name:"pod-submit-remove-1e7861dc-7dff-11e8-b0f5-565e625ec9a3", GenerateName:"", Namespace:"e2e-tests-pods-gl9vr", SelfLink:"/api/v1/namespaces/e2e-tests-pods-gl9vr/pods/pod-submit-remove-1e7861dc-7dff-11e8-b0f5-565e625ec9a3", UID:"1e7d9614-7dff-11e8-876c-5e517afbca85", ResourceVersion:"11944", Generation:0, CreationTimestamp:v1.Time{Time:time.Time{wall:0x0, ext:63666136331, loc:(*time.Location)(0x642c9a0)}}, DeletionTimestamp:(*v1.Time)(nil), DeletionGracePeriodSeconds:(*int64)(nil), Labels:map[string]string{"name":"foo", "time":"613850820"}, Annotations:map[string]string{"cni.projectcalico.org/podIP":"100.96.1.177/32"}, OwnerReferences:[]v1.OwnerReference(nil), Initializers:(*v1.Initializers)(nil), Finalizers:[]string(nil), ClusterName:""}, Spec:v1.PodSpec{Volumes:[]v1.Volume{v1.Volume{Name:"default-token-xcstv", VolumeSource:v1.VolumeSource{HostPath:(*v1.HostPathVolumeSource)(nil), EmptyDir:(*v1.EmptyDirVolumeSource)(nil), GCEPersistentDisk:(*v1.GCEPersistentDiskVolumeSource)(nil), AWSElasticBlockStore:(*v1.AWSElasticBlockStoreVolumeSource)(nil), GitRepo:(*v1.GitRepoVolumeSource)(nil), Secret:(*v1.SecretVolumeSource)(0xc4217db3c0), NFS:(*v1.NFSVolumeSource)(nil), ISCSI:(*v1.ISCSIVolumeSource)(nil), Glusterfs:(*v1.GlusterfsVolumeSource)(nil), PersistentVolumeClaim:(*v1.PersistentVolumeClaimVolumeSource)(nil), RBD:(*v1.RBDVolumeSource)(nil), FlexVolume:(*v1.FlexVolumeSource)(nil), Cinder:(*v1.CinderVolumeSource)(nil), CephFS:(*v1.CephFSVolumeSource)(nil), Flocker:(*v1.FlockerVolumeSource)(nil), DownwardAPI:(*v1.DownwardAPIVolumeSource)(nil), FC:(*v1.FCVolumeSource)(nil), AzureFile:(*v1.AzureFileVolumeSource)(nil), ConfigMap:(*v1.ConfigMapVolumeSource)(nil), VsphereVolume:(*v1.VsphereVirtualDiskVolumeSource)(nil), Quobyte:(*v1.QuobyteVolumeSource)(nil), AzureDisk:(*v1.AzureDiskVolumeSource)(nil), PhotonPersistentDisk:(*v1.PhotonPersistentDiskVolumeSource)(nil), Projected:(*v1.ProjectedVolumeSource)(nil), PortworxVolume:(*v1.PortworxVolumeSource)(nil), ScaleIO:(*v1.ScaleIOVolumeSource)(nil), StorageOS:(*v1.StorageOSVolumeSource)(nil)}}}, InitContainers:[]v1.Container(nil), Containers:[]v1.Container{v1.Container{Name:"nginx", Image:"k8s.gcr.io/nginx-slim-amd64:0.20", Command:[]string(nil), Args:[]string(nil), WorkingDir:"", Ports:[]v1.ContainerPort(nil), EnvFrom:[]v1.EnvFromSource(nil), Env:[]v1.EnvVar(nil), Resources:v1.ResourceRequirements{Limits:v1.ResourceList(nil), Requests:v1.ResourceList(nil)}, VolumeMounts:[]v1.VolumeMount{v1.VolumeMount{Name:"default-token-xcstv", ReadOnly:true, MountPath:"/var/run/secrets/kubernetes.io/serviceaccount", SubPath:"", MountPropagation:(*v1.MountPropagationMode)(nil)}}, VolumeDevices:[]v1.VolumeDevice(nil), LivenessProbe:(*v1.Probe)(nil), ReadinessProbe:(*v1.Probe)(nil), Lifecycle:(*v1.Lifecycle)(nil), TerminationMessagePath:"/dev/termination-log", TerminationMessagePolicy:"File", ImagePullPolicy:"IfNotPresent", SecurityContext:(*v1.SecurityContext)(nil), Stdin:false, StdinOnce:false, TTY:false}}, RestartPolicy:"Always", TerminationGracePeriodSeconds:(*int64)(0xc42112af08), ActiveDeadlineSeconds:(*int64)(nil), DNSPolicy:"ClusterFirst", NodeSelector:map[string]string(nil), ServiceAccountName:"default", DeprecatedServiceAccount:"default", AutomountServiceAccountToken:(*bool)(nil), NodeName:"shoot--core--confgcp-worker-o1cev-z1-f757498dc-jzlxf", HostNetwork:false, HostPID:false, HostIPC:false, ShareProcessNamespace:(*bool)(nil), SecurityContext:(*v1.PodSecurityContext)(0xc42194e8a0), ImagePullSecrets:[]v1.LocalObjectReference(nil), Hostname:"", Subdomain:"", Affinity:(*v1.Affinity)(nil), SchedulerName:"default-scheduler", Tolerations:[]v1.Toleration{v1.Toleration{Key:"node.kubernetes.io/not-ready", Operator:"Exists", Value:"", Effect:"NoExecute", TolerationSeconds:(*int64)(0xc42112afd0)}, v1.Toleration{Key:"node.kubernetes.io/unreachable", Operator:"Exists", Value:"", Effect:"NoExecute", TolerationSeconds:(*int64)(0xc42112aff0)}}, HostAliases:[]v1.HostAlias(nil), PriorityClassName:"", Priority:(*int32)(nil), DNSConfig:(*v1.PodDNSConfig)(nil), ReadinessGates:[]v1.PodReadinessGate(nil)}, Status:v1.PodStatus{Phase:"Running", Conditions:[]v1.PodCondition{v1.PodCondition{Type:"Initialized", Status:"True", LastProbeTime:v1.Time{Time:time.Time{wall:0x0, ext:0, loc:(*time.Location)(nil)}}, LastTransitionTime:v1.Time{Time:time.Time{wall:0x0, ext:63666136331, loc:(*time.Location)(0x642c9a0)}}, Reason:"", Message:""}, v1.PodCondition{Type:"Ready", Status:"True", LastProbeTime:v1.Time{Time:time.Time{wall:0x0, ext:0, loc:(*time.Location)(nil)}}, LastTransitionTime:v1.Time{Time:time.Time{wall:0x0, ext:63666136333, loc:(*time.Location)(0x642c9a0)}}, Reason:"", Message:""}, v1.PodCondition{Type:"ContainersReady", Status:"True", LastProbeTime:v1.Time{Time:time.Time{wall:0x0, ext:0, loc:(*time.Location)(nil)}}, LastTransitionTime:v1.Time{Time:time.Time{wall:0x0, ext:0, loc:(*time.Location)(nil)}}, Reason:"", Message:""}, v1.PodCondition{Type:"PodScheduled", Status:"True", LastProbeTime:v1.Time{Time:time.Time{wall:0x0, ext:0, loc:(*time.Location)(nil)}}, LastTransitionTime:v1.Time{Time:time.Time{wall:0x0, ext:63666136331, loc:(*time.Location)(0x642c9a0)}}, Reason:"", Message:""}}, Message:"", Reason:"", NominatedNodeName:"", HostIP:"10.250.0.2", PodIP:"100.96.1.177", StartTime:(*v1.Time)(0xc420cf16e0), InitContainerStatuses:[]v1.ContainerStatus(nil), ContainerStatuses:[]v1.ContainerStatus{v1.ContainerStatus{Name:"nginx", State:v1.ContainerState{Waiting:(*v1.ContainerStateWaiting)(nil), Running:(*v1.ContainerStateRunning)(0xc420cf1700), Terminated:(*v1.ContainerStateTerminated)(nil)}, LastTerminationState:v1.ContainerState{Waiting:(*v1.ContainerStateWaiting)(nil), Running:(*v1.ContainerStateRunning)(nil), Terminated:(*v1.ContainerStateTerminated)(nil)}, Ready:true, RestartCount:0, Image:"k8s.gcr.io/nginx-slim-amd64:0.20", ImageID:"docker-pullable://k8s.gcr.io/nginx-slim-amd64@sha256:6654db6d4028756062edac466454ee5c9cf9b20ef79e35a81e3c840031eb1e2b", ContainerID:"docker://239ff9746988022804ac834d522d65540f535ca3b596764a8b77371a7c1102ca"}}, QOSClass:"BestEffort"}}
+STEP: deleting the pod gracefully
+STEP: verifying the kubelet observed the termination notice
+STEP: verifying pod deletion was observed
+[AfterEach] [k8s.io] Pods
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:52:19.861: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-pods-gl9vr" for this suite.
+Jul  2 13:52:25.881: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:52:25.958: INFO: namespace: e2e-tests-pods-gl9vr, resource: bindings, ignored listing per whitelist
+Jul  2 13:52:25.961: INFO: namespace e2e-tests-pods-gl9vr deletion completed in 6.09514705s
+
+• [SLOW TEST:14.426 seconds]
+[k8s.io] Pods
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:679
+  should be submitted and removed [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSS
+------------------------------
+[sig-network] Service endpoints latency 
+  should not be very high  [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-network] Service endpoints latency
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:52:25.961: INFO: >>> kubeConfig: /tmp/kubeconfig-293271353
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should not be very high  [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: creating replication controller svc-latency-rc in namespace e2e-tests-svc-latency-trjxd
+I0702 13:52:26.039489      18 runners.go:177] Created replication controller with name: svc-latency-rc, namespace: e2e-tests-svc-latency-trjxd, replica count: 1
+I0702 13:52:27.089914      18 runners.go:177] svc-latency-rc Pods: 1 out of 1 created, 0 running, 1 pending, 0 waiting, 0 inactive, 0 terminating, 0 unknown, 0 runningButNotReady 
+I0702 13:52:28.090196      18 runners.go:177] svc-latency-rc Pods: 1 out of 1 created, 1 running, 0 pending, 0 waiting, 0 inactive, 0 terminating, 0 unknown, 0 runningButNotReady 
+Jul  2 13:52:28.198: INFO: Created: latency-svc-vxqz6
+Jul  2 13:52:28.207: INFO: Got endpoints: latency-svc-vxqz6 [16.719317ms]
+Jul  2 13:52:28.215: INFO: Created: latency-svc-m9hhv
+Jul  2 13:52:28.218: INFO: Got endpoints: latency-svc-m9hhv [11.133313ms]
+Jul  2 13:52:28.222: INFO: Created: latency-svc-p8wgd
+Jul  2 13:52:28.228: INFO: Created: latency-svc-c5tht
+Jul  2 13:52:28.228: INFO: Got endpoints: latency-svc-p8wgd [21.109873ms]
+Jul  2 13:52:28.233: INFO: Got endpoints: latency-svc-c5tht [26.168694ms]
+Jul  2 13:52:28.233: INFO: Created: latency-svc-rkwv9
+Jul  2 13:52:28.236: INFO: Got endpoints: latency-svc-rkwv9 [29.015304ms]
+Jul  2 13:52:28.240: INFO: Created: latency-svc-j8sfq
+Jul  2 13:52:28.244: INFO: Got endpoints: latency-svc-j8sfq [37.492701ms]
+Jul  2 13:52:28.245: INFO: Created: latency-svc-wcfbk
+Jul  2 13:52:28.247: INFO: Got endpoints: latency-svc-wcfbk [40.122547ms]
+Jul  2 13:52:28.258: INFO: Created: latency-svc-s48h7
+Jul  2 13:52:28.266: INFO: Got endpoints: latency-svc-s48h7 [59.225153ms]
+Jul  2 13:52:28.269: INFO: Created: latency-svc-fjkpj
+Jul  2 13:52:28.271: INFO: Got endpoints: latency-svc-fjkpj [64.247697ms]
+Jul  2 13:52:28.275: INFO: Created: latency-svc-fhvnc
+Jul  2 13:52:28.280: INFO: Got endpoints: latency-svc-fhvnc [73.027158ms]
+Jul  2 13:52:28.281: INFO: Created: latency-svc-rzd8m
+Jul  2 13:52:28.289: INFO: Got endpoints: latency-svc-rzd8m [81.569314ms]
+Jul  2 13:52:28.291: INFO: Created: latency-svc-ll4fq
+Jul  2 13:52:28.294: INFO: Got endpoints: latency-svc-ll4fq [86.701146ms]
+Jul  2 13:52:28.305: INFO: Created: latency-svc-p5vj2
+Jul  2 13:52:28.330: INFO: Got endpoints: latency-svc-p5vj2 [122.541871ms]
+Jul  2 13:52:28.332: INFO: Created: latency-svc-b5bj7
+Jul  2 13:52:28.338: INFO: Got endpoints: latency-svc-b5bj7 [131.407823ms]
+Jul  2 13:52:28.340: INFO: Created: latency-svc-jzzvr
+Jul  2 13:52:28.345: INFO: Got endpoints: latency-svc-jzzvr [137.69282ms]
+Jul  2 13:52:28.345: INFO: Created: latency-svc-z7t9w
+Jul  2 13:52:28.353: INFO: Got endpoints: latency-svc-z7t9w [146.462869ms]
+Jul  2 13:52:28.357: INFO: Created: latency-svc-xkjh6
+Jul  2 13:52:28.360: INFO: Got endpoints: latency-svc-xkjh6 [141.595188ms]
+Jul  2 13:52:28.372: INFO: Created: latency-svc-6vmtz
+Jul  2 13:52:28.379: INFO: Created: latency-svc-8289z
+Jul  2 13:52:28.379: INFO: Got endpoints: latency-svc-6vmtz [150.758146ms]
+Jul  2 13:52:28.386: INFO: Got endpoints: latency-svc-8289z [153.087798ms]
+Jul  2 13:52:28.390: INFO: Created: latency-svc-bfhfr
+Jul  2 13:52:28.392: INFO: Got endpoints: latency-svc-bfhfr [155.573479ms]
+Jul  2 13:52:28.402: INFO: Created: latency-svc-2mvpm
+Jul  2 13:52:28.410: INFO: Got endpoints: latency-svc-2mvpm [165.808746ms]
+Jul  2 13:52:28.415: INFO: Created: latency-svc-glzcd
+Jul  2 13:52:28.418: INFO: Got endpoints: latency-svc-glzcd [170.281906ms]
+Jul  2 13:52:28.422: INFO: Created: latency-svc-jtqct
+Jul  2 13:52:28.440: INFO: Got endpoints: latency-svc-jtqct [173.601086ms]
+Jul  2 13:52:28.442: INFO: Created: latency-svc-qfzbn
+Jul  2 13:52:28.444: INFO: Got endpoints: latency-svc-qfzbn [172.778098ms]
+Jul  2 13:52:28.448: INFO: Created: latency-svc-nktjp
+Jul  2 13:52:28.451: INFO: Got endpoints: latency-svc-nktjp [170.308582ms]
+Jul  2 13:52:28.456: INFO: Created: latency-svc-dkp9b
+Jul  2 13:52:28.464: INFO: Got endpoints: latency-svc-dkp9b [175.830101ms]
+Jul  2 13:52:28.479: INFO: Created: latency-svc-bvmws
+Jul  2 13:52:28.479: INFO: Got endpoints: latency-svc-bvmws [185.005443ms]
+Jul  2 13:52:28.482: INFO: Created: latency-svc-bpg89
+Jul  2 13:52:28.495: INFO: Got endpoints: latency-svc-bpg89 [165.493835ms]
+Jul  2 13:52:28.495: INFO: Created: latency-svc-dzkk6
+Jul  2 13:52:28.501: INFO: Got endpoints: latency-svc-dzkk6 [162.468308ms]
+Jul  2 13:52:28.502: INFO: Created: latency-svc-frbcb
+Jul  2 13:52:28.509: INFO: Got endpoints: latency-svc-frbcb [164.026364ms]
+Jul  2 13:52:28.512: INFO: Created: latency-svc-zmznq
+Jul  2 13:52:28.514: INFO: Got endpoints: latency-svc-zmznq [160.627363ms]
+Jul  2 13:52:28.519: INFO: Created: latency-svc-dgt7j
+Jul  2 13:52:28.521: INFO: Got endpoints: latency-svc-dgt7j [161.354971ms]
+Jul  2 13:52:28.526: INFO: Created: latency-svc-8cts9
+Jul  2 13:52:28.533: INFO: Got endpoints: latency-svc-8cts9 [154.640919ms]
+Jul  2 13:52:28.536: INFO: Created: latency-svc-rjg5v
+Jul  2 13:52:28.556: INFO: Got endpoints: latency-svc-rjg5v [170.026438ms]
+Jul  2 13:52:28.557: INFO: Created: latency-svc-dpjzf
+Jul  2 13:52:28.564: INFO: Created: latency-svc-vr4t4
+Jul  2 13:52:28.564: INFO: Got endpoints: latency-svc-dpjzf [172.56498ms]
+Jul  2 13:52:28.568: INFO: Got endpoints: latency-svc-vr4t4 [158.009484ms]
+Jul  2 13:52:28.569: INFO: Created: latency-svc-zlf5s
+Jul  2 13:52:28.577: INFO: Got endpoints: latency-svc-zlf5s [159.222835ms]
+Jul  2 13:52:28.580: INFO: Created: latency-svc-7hj2w
+Jul  2 13:52:28.586: INFO: Created: latency-svc-nkq5k
+Jul  2 13:52:28.594: INFO: Created: latency-svc-nvftk
+Jul  2 13:52:28.603: INFO: Got endpoints: latency-svc-7hj2w [163.405499ms]
+Jul  2 13:52:28.614: INFO: Created: latency-svc-cbr84
+Jul  2 13:52:28.620: INFO: Created: latency-svc-dstcj
+Jul  2 13:52:28.626: INFO: Created: latency-svc-zmzpb
+Jul  2 13:52:28.638: INFO: Created: latency-svc-bl6qh
+Jul  2 13:52:28.645: INFO: Created: latency-svc-4cq54
+Jul  2 13:52:28.655: INFO: Got endpoints: latency-svc-nkq5k [211.337737ms]
+Jul  2 13:52:28.656: INFO: Created: latency-svc-csvk6
+Jul  2 13:52:28.675: INFO: Created: latency-svc-7g42p
+Jul  2 13:52:28.690: INFO: Created: latency-svc-xlghz
+Jul  2 13:52:28.697: INFO: Created: latency-svc-wvhrj
+Jul  2 13:52:28.703: INFO: Created: latency-svc-7nmqx
+Jul  2 13:52:28.711: INFO: Got endpoints: latency-svc-nvftk [260.315044ms]
+Jul  2 13:52:28.714: INFO: Created: latency-svc-7jg88
+Jul  2 13:52:28.721: INFO: Created: latency-svc-2zhrk
+Jul  2 13:52:28.727: INFO: Created: latency-svc-xj2jt
+Jul  2 13:52:28.739: INFO: Created: latency-svc-l228t
+Jul  2 13:52:28.746: INFO: Created: latency-svc-p6g75
+Jul  2 13:52:28.755: INFO: Got endpoints: latency-svc-cbr84 [290.769223ms]
+Jul  2 13:52:28.767: INFO: Created: latency-svc-knlnl
+Jul  2 13:52:28.805: INFO: Got endpoints: latency-svc-dstcj [325.646484ms]
+Jul  2 13:52:28.817: INFO: Created: latency-svc-jxn5q
+Jul  2 13:52:28.854: INFO: Got endpoints: latency-svc-zmzpb [358.552577ms]
+Jul  2 13:52:28.865: INFO: Created: latency-svc-jsc2t
+Jul  2 13:52:28.904: INFO: Got endpoints: latency-svc-bl6qh [402.30921ms]
+Jul  2 13:52:28.914: INFO: Created: latency-svc-5f4hd
+Jul  2 13:52:28.954: INFO: Got endpoints: latency-svc-4cq54 [444.74093ms]
+Jul  2 13:52:28.964: INFO: Created: latency-svc-lss9g
+Jul  2 13:52:29.004: INFO: Got endpoints: latency-svc-csvk6 [489.638171ms]
+Jul  2 13:52:29.014: INFO: Created: latency-svc-xstvx
+Jul  2 13:52:29.053: INFO: Got endpoints: latency-svc-7g42p [532.43003ms]
+Jul  2 13:52:29.064: INFO: Created: latency-svc-bflkj
+Jul  2 13:52:29.104: INFO: Got endpoints: latency-svc-xlghz [570.857263ms]
+Jul  2 13:52:29.120: INFO: Created: latency-svc-mngpq
+Jul  2 13:52:29.154: INFO: Got endpoints: latency-svc-wvhrj [597.206367ms]
+Jul  2 13:52:29.165: INFO: Created: latency-svc-ccss6
+Jul  2 13:52:29.205: INFO: Got endpoints: latency-svc-7nmqx [640.375382ms]
+Jul  2 13:52:29.215: INFO: Created: latency-svc-hp5lp
+Jul  2 13:52:29.254: INFO: Got endpoints: latency-svc-7jg88 [685.336212ms]
+Jul  2 13:52:29.264: INFO: Created: latency-svc-2p52r
+Jul  2 13:52:29.304: INFO: Got endpoints: latency-svc-2zhrk [726.923532ms]
+Jul  2 13:52:29.315: INFO: Created: latency-svc-8gntt
+Jul  2 13:52:29.355: INFO: Got endpoints: latency-svc-xj2jt [751.03817ms]
+Jul  2 13:52:29.367: INFO: Created: latency-svc-5t9dt
+Jul  2 13:52:29.404: INFO: Got endpoints: latency-svc-l228t [748.215479ms]
+Jul  2 13:52:29.416: INFO: Created: latency-svc-m7wtw
+Jul  2 13:52:29.454: INFO: Got endpoints: latency-svc-p6g75 [742.52952ms]
+Jul  2 13:52:29.464: INFO: Created: latency-svc-mdgjp
+Jul  2 13:52:29.504: INFO: Got endpoints: latency-svc-knlnl [748.52981ms]
+Jul  2 13:52:29.525: INFO: Created: latency-svc-5kdlb
+Jul  2 13:52:29.583: INFO: Got endpoints: latency-svc-jxn5q [778.12688ms]
+Jul  2 13:52:29.593: INFO: Created: latency-svc-rngs2
+Jul  2 13:52:29.603: INFO: Got endpoints: latency-svc-jsc2t [749.34269ms]
+Jul  2 13:52:29.632: INFO: Created: latency-svc-rxt6l
+Jul  2 13:52:29.653: INFO: Got endpoints: latency-svc-5f4hd [749.672295ms]
+Jul  2 13:52:29.663: INFO: Created: latency-svc-59kwv
+Jul  2 13:52:29.704: INFO: Got endpoints: latency-svc-lss9g [749.975096ms]
+Jul  2 13:52:29.713: INFO: Created: latency-svc-qwd5z
+Jul  2 13:52:29.754: INFO: Got endpoints: latency-svc-xstvx [749.737268ms]
+Jul  2 13:52:29.763: INFO: Created: latency-svc-h5lm2
+Jul  2 13:52:29.803: INFO: Got endpoints: latency-svc-bflkj [749.43874ms]
+Jul  2 13:52:29.812: INFO: Created: latency-svc-f64cl
+Jul  2 13:52:29.853: INFO: Got endpoints: latency-svc-mngpq [748.276822ms]
+Jul  2 13:52:29.862: INFO: Created: latency-svc-6tnrh
+Jul  2 13:52:29.905: INFO: Got endpoints: latency-svc-ccss6 [751.156645ms]
+Jul  2 13:52:29.917: INFO: Created: latency-svc-jrpcd
+Jul  2 13:52:29.954: INFO: Got endpoints: latency-svc-hp5lp [748.822882ms]
+Jul  2 13:52:29.965: INFO: Created: latency-svc-f99gz
+Jul  2 13:52:30.004: INFO: Got endpoints: latency-svc-2p52r [750.075401ms]
+Jul  2 13:52:30.014: INFO: Created: latency-svc-8vkkj
+Jul  2 13:52:30.053: INFO: Got endpoints: latency-svc-8gntt [749.549345ms]
+Jul  2 13:52:30.064: INFO: Created: latency-svc-vkd65
+Jul  2 13:52:30.103: INFO: Got endpoints: latency-svc-5t9dt [747.958533ms]
+Jul  2 13:52:30.113: INFO: Created: latency-svc-sx4m8
+Jul  2 13:52:30.155: INFO: Got endpoints: latency-svc-m7wtw [751.156868ms]
+Jul  2 13:52:30.169: INFO: Created: latency-svc-vxssj
+Jul  2 13:52:30.205: INFO: Got endpoints: latency-svc-mdgjp [751.149013ms]
+Jul  2 13:52:30.215: INFO: Created: latency-svc-6vxmf
+Jul  2 13:52:30.254: INFO: Got endpoints: latency-svc-5kdlb [750.501199ms]
+Jul  2 13:52:30.264: INFO: Created: latency-svc-j6dck
+Jul  2 13:52:30.304: INFO: Got endpoints: latency-svc-rngs2 [720.839931ms]
+Jul  2 13:52:30.314: INFO: Created: latency-svc-h7xh6
+Jul  2 13:52:30.353: INFO: Got endpoints: latency-svc-rxt6l [750.144287ms]
+Jul  2 13:52:30.364: INFO: Created: latency-svc-c9kzp
+Jul  2 13:52:30.403: INFO: Got endpoints: latency-svc-59kwv [749.719536ms]
+Jul  2 13:52:30.413: INFO: Created: latency-svc-75tgr
+Jul  2 13:52:30.454: INFO: Got endpoints: latency-svc-qwd5z [749.800827ms]
+Jul  2 13:52:30.466: INFO: Created: latency-svc-r5nwn
+Jul  2 13:52:30.504: INFO: Got endpoints: latency-svc-h5lm2 [750.027917ms]
+Jul  2 13:52:30.512: INFO: Created: latency-svc-zp8pd
+Jul  2 13:52:30.554: INFO: Got endpoints: latency-svc-f64cl [750.757851ms]
+Jul  2 13:52:30.563: INFO: Created: latency-svc-ksv6g
+Jul  2 13:52:30.603: INFO: Got endpoints: latency-svc-6tnrh [749.812686ms]
+Jul  2 13:52:30.612: INFO: Created: latency-svc-tmsjx
+Jul  2 13:52:30.653: INFO: Got endpoints: latency-svc-jrpcd [748.257715ms]
+Jul  2 13:52:30.664: INFO: Created: latency-svc-cj9dh
+Jul  2 13:52:30.703: INFO: Got endpoints: latency-svc-f99gz [749.203436ms]
+Jul  2 13:52:30.712: INFO: Created: latency-svc-tpt24
+Jul  2 13:52:30.754: INFO: Got endpoints: latency-svc-8vkkj [749.493081ms]
+Jul  2 13:52:30.764: INFO: Created: latency-svc-rc924
+Jul  2 13:52:30.804: INFO: Got endpoints: latency-svc-vkd65 [750.242452ms]
+Jul  2 13:52:30.816: INFO: Created: latency-svc-f5s4g
+Jul  2 13:52:30.854: INFO: Got endpoints: latency-svc-sx4m8 [750.632655ms]
+Jul  2 13:52:30.863: INFO: Created: latency-svc-qsssp
+Jul  2 13:52:30.904: INFO: Got endpoints: latency-svc-vxssj [748.671345ms]
+Jul  2 13:52:30.913: INFO: Created: latency-svc-gplzl
+Jul  2 13:52:30.954: INFO: Got endpoints: latency-svc-6vxmf [749.097888ms]
+Jul  2 13:52:30.964: INFO: Created: latency-svc-f9kkk
+Jul  2 13:52:31.004: INFO: Got endpoints: latency-svc-j6dck [749.42258ms]
+Jul  2 13:52:31.013: INFO: Created: latency-svc-2mjzf
+Jul  2 13:52:31.055: INFO: Got endpoints: latency-svc-h7xh6 [750.845112ms]
+Jul  2 13:52:31.066: INFO: Created: latency-svc-hp54c
+Jul  2 13:52:31.104: INFO: Got endpoints: latency-svc-c9kzp [750.114099ms]
+Jul  2 13:52:31.113: INFO: Created: latency-svc-h99vt
+Jul  2 13:52:31.154: INFO: Got endpoints: latency-svc-75tgr [750.330536ms]
+Jul  2 13:52:31.164: INFO: Created: latency-svc-dvg79
+Jul  2 13:52:31.204: INFO: Got endpoints: latency-svc-r5nwn [749.912288ms]
+Jul  2 13:52:31.213: INFO: Created: latency-svc-2gnfd
+Jul  2 13:52:31.253: INFO: Got endpoints: latency-svc-zp8pd [749.733073ms]
+Jul  2 13:52:31.263: INFO: Created: latency-svc-5g64r
+Jul  2 13:52:31.307: INFO: Got endpoints: latency-svc-ksv6g [753.379225ms]
+Jul  2 13:52:31.316: INFO: Created: latency-svc-z87gv
+Jul  2 13:52:31.354: INFO: Got endpoints: latency-svc-tmsjx [751.396862ms]
+Jul  2 13:52:31.364: INFO: Created: latency-svc-dzjjw
+Jul  2 13:52:31.404: INFO: Got endpoints: latency-svc-cj9dh [750.281108ms]
+Jul  2 13:52:31.418: INFO: Created: latency-svc-9wqp7
+Jul  2 13:52:31.455: INFO: Got endpoints: latency-svc-tpt24 [751.685324ms]
+Jul  2 13:52:31.466: INFO: Created: latency-svc-5c42w
+Jul  2 13:52:31.548: INFO: Got endpoints: latency-svc-rc924 [794.419582ms]
+Jul  2 13:52:31.552: INFO: Got endpoints: latency-svc-f5s4g [748.54949ms]
+Jul  2 13:52:31.558: INFO: Created: latency-svc-8f7gh
+Jul  2 13:52:31.564: INFO: Created: latency-svc-7sb97
+Jul  2 13:52:31.604: INFO: Got endpoints: latency-svc-qsssp [750.445151ms]
+Jul  2 13:52:31.614: INFO: Created: latency-svc-88wnw
+Jul  2 13:52:31.654: INFO: Got endpoints: latency-svc-gplzl [749.812182ms]
+Jul  2 13:52:31.664: INFO: Created: latency-svc-sdgr4
+Jul  2 13:52:31.704: INFO: Got endpoints: latency-svc-f9kkk [749.605671ms]
+Jul  2 13:52:31.714: INFO: Created: latency-svc-gvwwr
+Jul  2 13:52:31.754: INFO: Got endpoints: latency-svc-2mjzf [750.473812ms]
+Jul  2 13:52:31.773: INFO: Created: latency-svc-j2g8t
+Jul  2 13:52:31.803: INFO: Got endpoints: latency-svc-hp54c [748.164566ms]
+Jul  2 13:52:31.814: INFO: Created: latency-svc-s657q
+Jul  2 13:52:31.854: INFO: Got endpoints: latency-svc-h99vt [749.940628ms]
+Jul  2 13:52:31.863: INFO: Created: latency-svc-4mmx9
+Jul  2 13:52:31.904: INFO: Got endpoints: latency-svc-dvg79 [749.910735ms]
+Jul  2 13:52:31.912: INFO: Created: latency-svc-qfbx2
+Jul  2 13:52:31.953: INFO: Got endpoints: latency-svc-2gnfd [749.325618ms]
+Jul  2 13:52:31.962: INFO: Created: latency-svc-ml2vv
+Jul  2 13:52:32.004: INFO: Got endpoints: latency-svc-5g64r [750.059682ms]
+Jul  2 13:52:32.014: INFO: Created: latency-svc-qlm96
+Jul  2 13:52:32.054: INFO: Got endpoints: latency-svc-z87gv [746.229764ms]
+Jul  2 13:52:32.063: INFO: Created: latency-svc-4ds88
+Jul  2 13:52:32.103: INFO: Got endpoints: latency-svc-dzjjw [749.245447ms]
+Jul  2 13:52:32.112: INFO: Created: latency-svc-2h5mr
+Jul  2 13:52:32.154: INFO: Got endpoints: latency-svc-9wqp7 [749.798046ms]
+Jul  2 13:52:32.163: INFO: Created: latency-svc-s42gx
+Jul  2 13:52:32.204: INFO: Got endpoints: latency-svc-5c42w [748.672736ms]
+Jul  2 13:52:32.213: INFO: Created: latency-svc-9x5cd
+Jul  2 13:52:32.255: INFO: Got endpoints: latency-svc-8f7gh [706.896889ms]
+Jul  2 13:52:32.266: INFO: Created: latency-svc-47ftw
+Jul  2 13:52:32.304: INFO: Got endpoints: latency-svc-7sb97 [751.173499ms]
+Jul  2 13:52:32.313: INFO: Created: latency-svc-ttt95
+Jul  2 13:52:32.356: INFO: Got endpoints: latency-svc-88wnw [752.225861ms]
+Jul  2 13:52:32.367: INFO: Created: latency-svc-mcnn7
+Jul  2 13:52:32.404: INFO: Got endpoints: latency-svc-sdgr4 [749.949076ms]
+Jul  2 13:52:32.417: INFO: Created: latency-svc-tjn4k
+Jul  2 13:52:32.454: INFO: Got endpoints: latency-svc-gvwwr [749.958415ms]
+Jul  2 13:52:32.467: INFO: Created: latency-svc-dtwnq
+Jul  2 13:52:32.504: INFO: Got endpoints: latency-svc-j2g8t [749.193868ms]
+Jul  2 13:52:32.514: INFO: Created: latency-svc-h4x97
+Jul  2 13:52:32.554: INFO: Got endpoints: latency-svc-s657q [750.784322ms]
+Jul  2 13:52:32.565: INFO: Created: latency-svc-b7d8b
+Jul  2 13:52:32.604: INFO: Got endpoints: latency-svc-4mmx9 [749.85392ms]
+Jul  2 13:52:32.613: INFO: Created: latency-svc-2njdz
+Jul  2 13:52:32.653: INFO: Got endpoints: latency-svc-qfbx2 [749.776149ms]
+Jul  2 13:52:32.663: INFO: Created: latency-svc-x2z6j
+Jul  2 13:52:32.704: INFO: Got endpoints: latency-svc-ml2vv [750.623917ms]
+Jul  2 13:52:32.713: INFO: Created: latency-svc-l8w6d
+Jul  2 13:52:32.754: INFO: Got endpoints: latency-svc-qlm96 [749.760433ms]
+Jul  2 13:52:32.767: INFO: Created: latency-svc-bl95j
+Jul  2 13:52:32.804: INFO: Got endpoints: latency-svc-4ds88 [750.07108ms]
+Jul  2 13:52:32.813: INFO: Created: latency-svc-zfsc7
+Jul  2 13:52:32.854: INFO: Got endpoints: latency-svc-2h5mr [750.375288ms]
+Jul  2 13:52:32.864: INFO: Created: latency-svc-pfbx4
+Jul  2 13:52:32.904: INFO: Got endpoints: latency-svc-s42gx [750.013927ms]
+Jul  2 13:52:32.913: INFO: Created: latency-svc-xvjsh
+Jul  2 13:52:32.953: INFO: Got endpoints: latency-svc-9x5cd [749.680037ms]
+Jul  2 13:52:32.963: INFO: Created: latency-svc-787pf
+Jul  2 13:52:33.004: INFO: Got endpoints: latency-svc-47ftw [748.465314ms]
+Jul  2 13:52:33.013: INFO: Created: latency-svc-dtbwg
+Jul  2 13:52:33.055: INFO: Got endpoints: latency-svc-ttt95 [751.38874ms]
+Jul  2 13:52:33.067: INFO: Created: latency-svc-dvpp9
+Jul  2 13:52:33.104: INFO: Got endpoints: latency-svc-mcnn7 [747.997145ms]
+Jul  2 13:52:33.114: INFO: Created: latency-svc-8mtgx
+Jul  2 13:52:33.154: INFO: Got endpoints: latency-svc-tjn4k [750.116609ms]
+Jul  2 13:52:33.164: INFO: Created: latency-svc-snf4z
+Jul  2 13:52:33.204: INFO: Got endpoints: latency-svc-dtwnq [749.923011ms]
+Jul  2 13:52:33.214: INFO: Created: latency-svc-vgm24
+Jul  2 13:52:33.254: INFO: Got endpoints: latency-svc-h4x97 [749.929126ms]
+Jul  2 13:52:33.264: INFO: Created: latency-svc-qc6sw
+Jul  2 13:52:33.306: INFO: Got endpoints: latency-svc-b7d8b [751.668098ms]
+Jul  2 13:52:33.317: INFO: Created: latency-svc-wzvsr
+Jul  2 13:52:33.355: INFO: Got endpoints: latency-svc-2njdz [751.377238ms]
+Jul  2 13:52:33.367: INFO: Created: latency-svc-h8g2w
+Jul  2 13:52:33.404: INFO: Got endpoints: latency-svc-x2z6j [750.062ms]
+Jul  2 13:52:33.422: INFO: Created: latency-svc-rk8l8
+Jul  2 13:52:33.454: INFO: Got endpoints: latency-svc-l8w6d [750.200105ms]
+Jul  2 13:52:33.465: INFO: Created: latency-svc-r8c6d
+Jul  2 13:52:33.504: INFO: Got endpoints: latency-svc-bl95j [749.877239ms]
+Jul  2 13:52:33.517: INFO: Created: latency-svc-96xgw
+Jul  2 13:52:33.554: INFO: Got endpoints: latency-svc-zfsc7 [750.165207ms]
+Jul  2 13:52:33.564: INFO: Created: latency-svc-74tqk
+Jul  2 13:52:33.605: INFO: Got endpoints: latency-svc-pfbx4 [750.558429ms]
+Jul  2 13:52:33.621: INFO: Created: latency-svc-2tvpl
+Jul  2 13:52:33.654: INFO: Got endpoints: latency-svc-xvjsh [749.923ms]
+Jul  2 13:52:33.664: INFO: Created: latency-svc-jfdsm
+Jul  2 13:52:33.704: INFO: Got endpoints: latency-svc-787pf [750.344708ms]
+Jul  2 13:52:33.714: INFO: Created: latency-svc-zlbjf
+Jul  2 13:52:33.754: INFO: Got endpoints: latency-svc-dtbwg [750.342009ms]
+Jul  2 13:52:33.764: INFO: Created: latency-svc-rvrgn
+Jul  2 13:52:33.804: INFO: Got endpoints: latency-svc-dvpp9 [748.631038ms]
+Jul  2 13:52:33.814: INFO: Created: latency-svc-66nlj
+Jul  2 13:52:33.854: INFO: Got endpoints: latency-svc-8mtgx [749.485351ms]
+Jul  2 13:52:33.864: INFO: Created: latency-svc-nh4wk
+Jul  2 13:52:33.904: INFO: Got endpoints: latency-svc-snf4z [749.599434ms]
+Jul  2 13:52:33.914: INFO: Created: latency-svc-2kxm8
+Jul  2 13:52:33.954: INFO: Got endpoints: latency-svc-vgm24 [749.625531ms]
+Jul  2 13:52:33.964: INFO: Created: latency-svc-6dzb8
+Jul  2 13:52:34.004: INFO: Got endpoints: latency-svc-qc6sw [749.87622ms]
+Jul  2 13:52:34.014: INFO: Created: latency-svc-96m8s
+Jul  2 13:52:34.054: INFO: Got endpoints: latency-svc-wzvsr [748.190255ms]
+Jul  2 13:52:34.064: INFO: Created: latency-svc-x8gkc
+Jul  2 13:52:34.103: INFO: Got endpoints: latency-svc-h8g2w [748.120417ms]
+Jul  2 13:52:34.114: INFO: Created: latency-svc-mkkxg
+Jul  2 13:52:34.154: INFO: Got endpoints: latency-svc-rk8l8 [750.217279ms]
+Jul  2 13:52:34.165: INFO: Created: latency-svc-4j5b7
+Jul  2 13:52:34.204: INFO: Got endpoints: latency-svc-r8c6d [749.55381ms]
+Jul  2 13:52:34.214: INFO: Created: latency-svc-cg74h
+Jul  2 13:52:34.254: INFO: Got endpoints: latency-svc-96xgw [750.458879ms]
+Jul  2 13:52:34.266: INFO: Created: latency-svc-qlhwl
+Jul  2 13:52:34.304: INFO: Got endpoints: latency-svc-74tqk [750.305214ms]
+Jul  2 13:52:34.317: INFO: Created: latency-svc-r4grn
+Jul  2 13:52:34.355: INFO: Got endpoints: latency-svc-2tvpl [750.492516ms]
+Jul  2 13:52:34.365: INFO: Created: latency-svc-crw2c
+Jul  2 13:52:34.404: INFO: Got endpoints: latency-svc-jfdsm [750.025906ms]
+Jul  2 13:52:34.414: INFO: Created: latency-svc-mk8fp
+Jul  2 13:52:34.454: INFO: Got endpoints: latency-svc-zlbjf [749.928977ms]
+Jul  2 13:52:34.467: INFO: Created: latency-svc-jhgsg
+Jul  2 13:52:34.504: INFO: Got endpoints: latency-svc-rvrgn [749.684917ms]
+Jul  2 13:52:34.514: INFO: Created: latency-svc-nxsj5
+Jul  2 13:52:34.554: INFO: Got endpoints: latency-svc-66nlj [750.100586ms]
+Jul  2 13:52:34.567: INFO: Created: latency-svc-c7kpf
+Jul  2 13:52:34.604: INFO: Got endpoints: latency-svc-nh4wk [749.769069ms]
+Jul  2 13:52:34.615: INFO: Created: latency-svc-8nkjq
+Jul  2 13:52:34.654: INFO: Got endpoints: latency-svc-2kxm8 [750.334035ms]
+Jul  2 13:52:34.664: INFO: Created: latency-svc-pn668
+Jul  2 13:52:34.704: INFO: Got endpoints: latency-svc-6dzb8 [750.031784ms]
+Jul  2 13:52:34.714: INFO: Created: latency-svc-w22pc
+Jul  2 13:52:34.755: INFO: Got endpoints: latency-svc-96m8s [751.160471ms]
+Jul  2 13:52:34.769: INFO: Created: latency-svc-28xjh
+Jul  2 13:52:34.804: INFO: Got endpoints: latency-svc-x8gkc [750.003759ms]
+Jul  2 13:52:34.814: INFO: Created: latency-svc-4jkdv
+Jul  2 13:52:34.853: INFO: Got endpoints: latency-svc-mkkxg [750.048843ms]
+Jul  2 13:52:34.864: INFO: Created: latency-svc-tjhch
+Jul  2 13:52:34.904: INFO: Got endpoints: latency-svc-4j5b7 [749.775535ms]
+Jul  2 13:52:34.914: INFO: Created: latency-svc-d6nbx
+Jul  2 13:52:34.954: INFO: Got endpoints: latency-svc-cg74h [750.197552ms]
+Jul  2 13:52:34.965: INFO: Created: latency-svc-64gkq
+Jul  2 13:52:35.004: INFO: Got endpoints: latency-svc-qlhwl [749.874889ms]
+Jul  2 13:52:35.015: INFO: Created: latency-svc-h6b4t
+Jul  2 13:52:35.054: INFO: Got endpoints: latency-svc-r4grn [749.093964ms]
+Jul  2 13:52:35.064: INFO: Created: latency-svc-cwsvh
+Jul  2 13:52:35.104: INFO: Got endpoints: latency-svc-crw2c [748.558717ms]
+Jul  2 13:52:35.114: INFO: Created: latency-svc-djj9r
+Jul  2 13:52:35.154: INFO: Got endpoints: latency-svc-mk8fp [749.956589ms]
+Jul  2 13:52:35.164: INFO: Created: latency-svc-ldslj
+Jul  2 13:52:35.204: INFO: Got endpoints: latency-svc-jhgsg [749.678826ms]
+Jul  2 13:52:35.217: INFO: Created: latency-svc-xvnfw
+Jul  2 13:52:35.254: INFO: Got endpoints: latency-svc-nxsj5 [749.95174ms]
+Jul  2 13:52:35.264: INFO: Created: latency-svc-cph9z
+Jul  2 13:52:35.308: INFO: Got endpoints: latency-svc-c7kpf [753.86421ms]
+Jul  2 13:52:35.319: INFO: Created: latency-svc-wpnj7
+Jul  2 13:52:35.354: INFO: Got endpoints: latency-svc-8nkjq [749.819078ms]
+Jul  2 13:52:35.364: INFO: Created: latency-svc-tjlhv
+Jul  2 13:52:35.404: INFO: Got endpoints: latency-svc-pn668 [749.841044ms]
+Jul  2 13:52:35.418: INFO: Created: latency-svc-x58cd
+Jul  2 13:52:35.454: INFO: Got endpoints: latency-svc-w22pc [750.528269ms]
+Jul  2 13:52:35.466: INFO: Created: latency-svc-zvg4d
+Jul  2 13:52:35.504: INFO: Got endpoints: latency-svc-28xjh [748.044094ms]
+Jul  2 13:52:35.520: INFO: Created: latency-svc-g4shr
+Jul  2 13:52:35.554: INFO: Got endpoints: latency-svc-4jkdv [749.734201ms]
+Jul  2 13:52:35.565: INFO: Created: latency-svc-xvgdq
+Jul  2 13:52:35.604: INFO: Got endpoints: latency-svc-tjhch [749.962796ms]
+Jul  2 13:52:35.614: INFO: Created: latency-svc-2b247
+Jul  2 13:52:35.654: INFO: Got endpoints: latency-svc-d6nbx [749.874512ms]
+Jul  2 13:52:35.663: INFO: Created: latency-svc-6jddr
+Jul  2 13:52:35.703: INFO: Got endpoints: latency-svc-64gkq [749.615721ms]
+Jul  2 13:52:35.713: INFO: Created: latency-svc-mzzb9
+Jul  2 13:52:35.754: INFO: Got endpoints: latency-svc-h6b4t [749.579388ms]
+Jul  2 13:52:35.763: INFO: Created: latency-svc-xhbgq
+Jul  2 13:52:35.804: INFO: Got endpoints: latency-svc-cwsvh [749.858357ms]
+Jul  2 13:52:35.814: INFO: Created: latency-svc-9xhbd
+Jul  2 13:52:35.855: INFO: Got endpoints: latency-svc-djj9r [751.184163ms]
+Jul  2 13:52:35.870: INFO: Created: latency-svc-2dqpk
+Jul  2 13:52:35.904: INFO: Got endpoints: latency-svc-ldslj [749.556704ms]
+Jul  2 13:52:35.914: INFO: Created: latency-svc-jsr8c
+Jul  2 13:52:35.954: INFO: Got endpoints: latency-svc-xvnfw [750.382567ms]
+Jul  2 13:52:35.964: INFO: Created: latency-svc-5mtkt
+Jul  2 13:52:36.004: INFO: Got endpoints: latency-svc-cph9z [749.623682ms]
+Jul  2 13:52:36.015: INFO: Created: latency-svc-n8768
+Jul  2 13:52:36.054: INFO: Got endpoints: latency-svc-wpnj7 [745.624895ms]
+Jul  2 13:52:36.104: INFO: Got endpoints: latency-svc-tjlhv [750.090488ms]
+Jul  2 13:52:36.153: INFO: Got endpoints: latency-svc-x58cd [749.58209ms]
+Jul  2 13:52:36.204: INFO: Got endpoints: latency-svc-zvg4d [749.421961ms]
+Jul  2 13:52:36.253: INFO: Got endpoints: latency-svc-g4shr [749.472167ms]
+Jul  2 13:52:36.304: INFO: Got endpoints: latency-svc-xvgdq [750.163407ms]
+Jul  2 13:52:36.354: INFO: Got endpoints: latency-svc-2b247 [750.340402ms]
+Jul  2 13:52:36.404: INFO: Got endpoints: latency-svc-6jddr [750.083469ms]
+Jul  2 13:52:36.454: INFO: Got endpoints: latency-svc-mzzb9 [750.096004ms]
+Jul  2 13:52:36.504: INFO: Got endpoints: latency-svc-xhbgq [750.155744ms]
+Jul  2 13:52:36.554: INFO: Got endpoints: latency-svc-9xhbd [750.03998ms]
+Jul  2 13:52:36.604: INFO: Got endpoints: latency-svc-2dqpk [748.489893ms]
+Jul  2 13:52:36.654: INFO: Got endpoints: latency-svc-jsr8c [749.872981ms]
+Jul  2 13:52:36.704: INFO: Got endpoints: latency-svc-5mtkt [749.623378ms]
+Jul  2 13:52:36.754: INFO: Got endpoints: latency-svc-n8768 [750.019493ms]
+Jul  2 13:52:36.754: INFO: Latencies: [11.133313ms 21.109873ms 26.168694ms 29.015304ms 37.492701ms 40.122547ms 59.225153ms 64.247697ms 73.027158ms 81.569314ms 86.701146ms 122.541871ms 131.407823ms 137.69282ms 141.595188ms 146.462869ms 150.758146ms 153.087798ms 154.640919ms 155.573479ms 158.009484ms 159.222835ms 160.627363ms 161.354971ms 162.468308ms 163.405499ms 164.026364ms 165.493835ms 165.808746ms 170.026438ms 170.281906ms 170.308582ms 172.56498ms 172.778098ms 173.601086ms 175.830101ms 185.005443ms 211.337737ms 260.315044ms 290.769223ms 325.646484ms 358.552577ms 402.30921ms 444.74093ms 489.638171ms 532.43003ms 570.857263ms 597.206367ms 640.375382ms 685.336212ms 706.896889ms 720.839931ms 726.923532ms 742.52952ms 745.624895ms 746.229764ms 747.958533ms 747.997145ms 748.044094ms 748.120417ms 748.164566ms 748.190255ms 748.215479ms 748.257715ms 748.276822ms 748.465314ms 748.489893ms 748.52981ms 748.54949ms 748.558717ms 748.631038ms 748.671345ms 748.672736ms 748.822882ms 749.093964ms 749.097888ms 749.193868ms 749.203436ms 749.245447ms 749.325618ms 749.34269ms 749.421961ms 749.42258ms 749.43874ms 749.472167ms 749.485351ms 749.493081ms 749.549345ms 749.55381ms 749.556704ms 749.579388ms 749.58209ms 749.599434ms 749.605671ms 749.615721ms 749.623378ms 749.623682ms 749.625531ms 749.672295ms 749.678826ms 749.680037ms 749.684917ms 749.719536ms 749.733073ms 749.734201ms 749.737268ms 749.760433ms 749.769069ms 749.775535ms 749.776149ms 749.798046ms 749.800827ms 749.812182ms 749.812686ms 749.819078ms 749.841044ms 749.85392ms 749.858357ms 749.872981ms 749.874512ms 749.874889ms 749.87622ms 749.877239ms 749.910735ms 749.912288ms 749.923ms 749.923011ms 749.928977ms 749.929126ms 749.940628ms 749.949076ms 749.95174ms 749.956589ms 749.958415ms 749.962796ms 749.975096ms 750.003759ms 750.013927ms 750.019493ms 750.025906ms 750.027917ms 750.031784ms 750.03998ms 750.048843ms 750.059682ms 750.062ms 750.07108ms 750.075401ms 750.083469ms 750.090488ms 750.096004ms 750.100586ms 750.114099ms 750.116609ms 750.144287ms 750.155744ms 750.163407ms 750.165207ms 750.197552ms 750.200105ms 750.217279ms 750.242452ms 750.281108ms 750.305214ms 750.330536ms 750.334035ms 750.340402ms 750.342009ms 750.344708ms 750.375288ms 750.382567ms 750.445151ms 750.458879ms 750.473812ms 750.492516ms 750.501199ms 750.528269ms 750.558429ms 750.623917ms 750.632655ms 750.757851ms 750.784322ms 750.845112ms 751.03817ms 751.149013ms 751.156645ms 751.156868ms 751.160471ms 751.173499ms 751.184163ms 751.377238ms 751.38874ms 751.396862ms 751.668098ms 751.685324ms 752.225861ms 753.379225ms 753.86421ms 778.12688ms 794.419582ms]
+Jul  2 13:52:36.754: INFO: 50 %ile: 749.680037ms
+Jul  2 13:52:36.754: INFO: 90 %ile: 750.757851ms
+Jul  2 13:52:36.754: INFO: 99 %ile: 778.12688ms
+Jul  2 13:52:36.754: INFO: Total sample count: 200
+[AfterEach] [sig-network] Service endpoints latency
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:52:36.754: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-svc-latency-trjxd" for this suite.
+Jul  2 13:52:46.769: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:52:46.802: INFO: namespace: e2e-tests-svc-latency-trjxd, resource: bindings, ignored listing per whitelist
+Jul  2 13:52:46.851: INFO: namespace e2e-tests-svc-latency-trjxd deletion completed in 10.093176921s
+
+• [SLOW TEST:20.890 seconds]
+[sig-network] Service endpoints latency
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/network/framework.go:22
+  should not be very high  [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSSS
+------------------------------
+[sig-api-machinery] Watchers 
+  should be able to start watching from a specific resource version [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-api-machinery] Watchers
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:52:46.851: INFO: >>> kubeConfig: /tmp/kubeconfig-293271353
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should be able to start watching from a specific resource version [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: creating a new configmap
+STEP: modifying the configmap once
+STEP: modifying the configmap a second time
+STEP: deleting the configmap
+STEP: creating a watch on configmaps from the resource version returned by the first update
+STEP: Expecting to observe notifications for all changes to the configmap after the first update
+Jul  2 13:52:46.945: INFO: Got : MODIFIED &ConfigMap{ObjectMeta:k8s_io_apimachinery_pkg_apis_meta_v1.ObjectMeta{Name:e2e-watch-test-resource-version,GenerateName:,Namespace:e2e-tests-watch-qbp95,SelfLink:/api/v1/namespaces/e2e-tests-watch-qbp95/configmaps/e2e-watch-test-resource-version,UID:3388e204-7dff-11e8-876c-5e517afbca85,ResourceVersion:13327,Generation:0,CreationTimestamp:2018-07-02 13:52:46 +0000 UTC,DeletionTimestamp:<nil>,DeletionGracePeriodSeconds:nil,Labels:map[string]string{watch-this-configmap: from-resource-version,},Annotations:map[string]string{},OwnerReferences:[],Finalizers:[],ClusterName:,Initializers:nil,},Data:map[string]string{mutation: 2,},BinaryData:map[string][]byte{},}
+Jul  2 13:52:46.945: INFO: Got : DELETED &ConfigMap{ObjectMeta:k8s_io_apimachinery_pkg_apis_meta_v1.ObjectMeta{Name:e2e-watch-test-resource-version,GenerateName:,Namespace:e2e-tests-watch-qbp95,SelfLink:/api/v1/namespaces/e2e-tests-watch-qbp95/configmaps/e2e-watch-test-resource-version,UID:3388e204-7dff-11e8-876c-5e517afbca85,ResourceVersion:13328,Generation:0,CreationTimestamp:2018-07-02 13:52:46 +0000 UTC,DeletionTimestamp:<nil>,DeletionGracePeriodSeconds:nil,Labels:map[string]string{watch-this-configmap: from-resource-version,},Annotations:map[string]string{},OwnerReferences:[],Finalizers:[],ClusterName:,Initializers:nil,},Data:map[string]string{mutation: 2,},BinaryData:map[string][]byte{},}
+[AfterEach] [sig-api-machinery] Watchers
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:52:46.945: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-watch-qbp95" for this suite.
+Jul  2 13:52:52.957: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:52:53.026: INFO: namespace: e2e-tests-watch-qbp95, resource: bindings, ignored listing per whitelist
+Jul  2 13:52:53.047: INFO: namespace e2e-tests-watch-qbp95 deletion completed in 6.098323702s
+
+• [SLOW TEST:6.196 seconds]
+[sig-api-machinery] Watchers
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apimachinery/framework.go:22
+  should be able to start watching from a specific resource version [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSS
+------------------------------
+[k8s.io] Pods 
+  should allow activeDeadlineSeconds to be updated [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [k8s.io] Pods
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:52:53.047: INFO: >>> kubeConfig: /tmp/kubeconfig-293271353
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [k8s.io] Pods
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/pods.go:127
+[It] should allow activeDeadlineSeconds to be updated [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: creating the pod
+STEP: submitting the pod to kubernetes
+STEP: verifying the pod is in kubernetes
+STEP: updating the pod
+Jul  2 13:52:55.641: INFO: Successfully updated pod "pod-update-activedeadlineseconds-3735541c-7dff-11e8-b0f5-565e625ec9a3"
+Jul  2 13:52:55.641: INFO: Waiting up to 5m0s for pod "pod-update-activedeadlineseconds-3735541c-7dff-11e8-b0f5-565e625ec9a3" in namespace "e2e-tests-pods-p2q4g" to be "terminated due to deadline exceeded"
+Jul  2 13:52:55.644: INFO: Pod "pod-update-activedeadlineseconds-3735541c-7dff-11e8-b0f5-565e625ec9a3": Phase="Running", Reason="", readiness=true. Elapsed: 2.420658ms
+Jul  2 13:52:57.647: INFO: Pod "pod-update-activedeadlineseconds-3735541c-7dff-11e8-b0f5-565e625ec9a3": Phase="Running", Reason="", readiness=true. Elapsed: 2.006003507s
+Jul  2 13:52:59.651: INFO: Pod "pod-update-activedeadlineseconds-3735541c-7dff-11e8-b0f5-565e625ec9a3": Phase="Failed", Reason="DeadlineExceeded", readiness=false. Elapsed: 4.009965933s
+Jul  2 13:52:59.651: INFO: Pod "pod-update-activedeadlineseconds-3735541c-7dff-11e8-b0f5-565e625ec9a3" satisfied condition "terminated due to deadline exceeded"
+[AfterEach] [k8s.io] Pods
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:52:59.651: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-pods-p2q4g" for this suite.
+Jul  2 13:53:05.664: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:53:05.795: INFO: namespace: e2e-tests-pods-p2q4g, resource: bindings, ignored listing per whitelist
+Jul  2 13:53:05.813: INFO: namespace e2e-tests-pods-p2q4g deletion completed in 6.158018115s
+
+• [SLOW TEST:12.766 seconds]
+[k8s.io] Pods
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:679
+  should allow activeDeadlineSeconds to be updated [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+[sig-network] Proxy version v1 
+  should proxy logs on node using proxy subresource  [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] version v1
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:53:05.813: INFO: >>> kubeConfig: /tmp/kubeconfig-293271353
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should proxy logs on node using proxy subresource  [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+Jul  2 13:53:05.899: INFO: (0) /api/v1/nodes/shoot--core--confgcp-worker-o1cev-z1-f757498dc-jzlxf/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 6.338165ms)
+Jul  2 13:53:05.942: INFO: (1) /api/v1/nodes/shoot--core--confgcp-worker-o1cev-z1-f757498dc-jzlxf/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 42.597517ms)
+Jul  2 13:53:05.946: INFO: (2) /api/v1/nodes/shoot--core--confgcp-worker-o1cev-z1-f757498dc-jzlxf/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 4.553207ms)
+Jul  2 13:53:05.991: INFO: (3) /api/v1/nodes/shoot--core--confgcp-worker-o1cev-z1-f757498dc-jzlxf/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 44.72481ms)
+Jul  2 13:53:05.997: INFO: (4) /api/v1/nodes/shoot--core--confgcp-worker-o1cev-z1-f757498dc-jzlxf/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 5.781801ms)
+Jul  2 13:53:06.002: INFO: (5) /api/v1/nodes/shoot--core--confgcp-worker-o1cev-z1-f757498dc-jzlxf/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 4.985838ms)
+Jul  2 13:53:06.006: INFO: (6) /api/v1/nodes/shoot--core--confgcp-worker-o1cev-z1-f757498dc-jzlxf/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 4.1876ms)
+Jul  2 13:53:06.011: INFO: (7) /api/v1/nodes/shoot--core--confgcp-worker-o1cev-z1-f757498dc-jzlxf/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 4.611437ms)
+Jul  2 13:53:06.015: INFO: (8) /api/v1/nodes/shoot--core--confgcp-worker-o1cev-z1-f757498dc-jzlxf/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 3.710389ms)
+Jul  2 13:53:06.019: INFO: (9) /api/v1/nodes/shoot--core--confgcp-worker-o1cev-z1-f757498dc-jzlxf/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 3.936507ms)
+Jul  2 13:53:06.022: INFO: (10) /api/v1/nodes/shoot--core--confgcp-worker-o1cev-z1-f757498dc-jzlxf/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 3.839652ms)
+Jul  2 13:53:06.027: INFO: (11) /api/v1/nodes/shoot--core--confgcp-worker-o1cev-z1-f757498dc-jzlxf/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 4.620669ms)
+Jul  2 13:53:06.031: INFO: (12) /api/v1/nodes/shoot--core--confgcp-worker-o1cev-z1-f757498dc-jzlxf/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 3.808009ms)
+Jul  2 13:53:06.035: INFO: (13) /api/v1/nodes/shoot--core--confgcp-worker-o1cev-z1-f757498dc-jzlxf/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 3.70665ms)
+Jul  2 13:53:06.039: INFO: (14) /api/v1/nodes/shoot--core--confgcp-worker-o1cev-z1-f757498dc-jzlxf/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 4.016483ms)
+Jul  2 13:53:06.090: INFO: (15) /api/v1/nodes/shoot--core--confgcp-worker-o1cev-z1-f757498dc-jzlxf/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 50.974949ms)
+Jul  2 13:53:06.094: INFO: (16) /api/v1/nodes/shoot--core--confgcp-worker-o1cev-z1-f757498dc-jzlxf/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 4.474276ms)
+Jul  2 13:53:06.099: INFO: (17) /api/v1/nodes/shoot--core--confgcp-worker-o1cev-z1-f757498dc-jzlxf/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 4.346784ms)
+Jul  2 13:53:06.103: INFO: (18) /api/v1/nodes/shoot--core--confgcp-worker-o1cev-z1-f757498dc-jzlxf/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 4.025488ms)
+Jul  2 13:53:06.107: INFO: (19) /api/v1/nodes/shoot--core--confgcp-worker-o1cev-z1-f757498dc-jzlxf/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 3.944226ms)
+[AfterEach] version v1
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:53:06.107: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-proxy-2lqwv" for this suite.
+Jul  2 13:53:12.187: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:53:12.207: INFO: namespace: e2e-tests-proxy-2lqwv, resource: bindings, ignored listing per whitelist
+Jul  2 13:53:12.323: INFO: namespace e2e-tests-proxy-2lqwv deletion completed in 6.212563035s
+
+• [SLOW TEST:6.510 seconds]
+[sig-network] Proxy
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/network/framework.go:22
+  version v1
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/network/proxy.go:56
+    should proxy logs on node using proxy subresource  [Conformance]
+    /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSSSSS
+------------------------------
+[k8s.io] Docker Containers 
+  should be able to override the image's default command and arguments [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [k8s.io] Docker Containers
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:53:12.323: INFO: >>> kubeConfig: /tmp/kubeconfig-293271353
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should be able to override the image's default command and arguments [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating a pod to test override all
+Jul  2 13:53:12.401: INFO: Waiting up to 5m0s for pod "client-containers-42b2ef2f-7dff-11e8-b0f5-565e625ec9a3" in namespace "e2e-tests-containers-7plvx" to be "success or failure"
+Jul  2 13:53:12.403: INFO: Pod "client-containers-42b2ef2f-7dff-11e8-b0f5-565e625ec9a3": Phase="Pending", Reason="", readiness=false. Elapsed: 2.528715ms
+Jul  2 13:53:14.407: INFO: Pod "client-containers-42b2ef2f-7dff-11e8-b0f5-565e625ec9a3": Phase="Pending", Reason="", readiness=false. Elapsed: 2.006483535s
+Jul  2 13:53:16.411: INFO: Pod "client-containers-42b2ef2f-7dff-11e8-b0f5-565e625ec9a3": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.010498082s
+STEP: Saw pod success
+Jul  2 13:53:16.411: INFO: Pod "client-containers-42b2ef2f-7dff-11e8-b0f5-565e625ec9a3" satisfied condition "success or failure"
+Jul  2 13:53:16.414: INFO: Trying to get logs from node shoot--core--confgcp-worker-o1cev-z1-f757498dc-jzlxf pod client-containers-42b2ef2f-7dff-11e8-b0f5-565e625ec9a3 container test-container: <nil>
+STEP: delete the pod
+Jul  2 13:53:16.434: INFO: Waiting for pod client-containers-42b2ef2f-7dff-11e8-b0f5-565e625ec9a3 to disappear
+Jul  2 13:53:16.436: INFO: Pod client-containers-42b2ef2f-7dff-11e8-b0f5-565e625ec9a3 no longer exists
+[AfterEach] [k8s.io] Docker Containers
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:53:16.436: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-containers-7plvx" for this suite.
+Jul  2 13:53:22.453: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:53:22.499: INFO: namespace: e2e-tests-containers-7plvx, resource: bindings, ignored listing per whitelist
+Jul  2 13:53:22.594: INFO: namespace e2e-tests-containers-7plvx deletion completed in 6.155259983s
+
+• [SLOW TEST:10.271 seconds]
+[k8s.io] Docker Containers
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:679
+  should be able to override the image's default command and arguments [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSSSSS
+------------------------------
+[sig-api-machinery] ConfigMap 
+  should be consumable via environment variable [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-api-machinery] ConfigMap
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:53:22.595: INFO: >>> kubeConfig: /tmp/kubeconfig-293271353
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should be consumable via environment variable [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating configMap e2e-tests-configmap-qxdv4/configmap-test-48d32918-7dff-11e8-b0f5-565e625ec9a3
+STEP: Creating a pod to test consume configMaps
+Jul  2 13:53:22.683: INFO: Waiting up to 5m0s for pod "pod-configmaps-48d3c372-7dff-11e8-b0f5-565e625ec9a3" in namespace "e2e-tests-configmap-qxdv4" to be "success or failure"
+Jul  2 13:53:22.686: INFO: Pod "pod-configmaps-48d3c372-7dff-11e8-b0f5-565e625ec9a3": Phase="Pending", Reason="", readiness=false. Elapsed: 3.102027ms
+Jul  2 13:53:24.694: INFO: Pod "pod-configmaps-48d3c372-7dff-11e8-b0f5-565e625ec9a3": Phase="Pending", Reason="", readiness=false. Elapsed: 2.010813426s
+Jul  2 13:53:26.698: INFO: Pod "pod-configmaps-48d3c372-7dff-11e8-b0f5-565e625ec9a3": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.014846923s
+STEP: Saw pod success
+Jul  2 13:53:26.698: INFO: Pod "pod-configmaps-48d3c372-7dff-11e8-b0f5-565e625ec9a3" satisfied condition "success or failure"
+Jul  2 13:53:26.700: INFO: Trying to get logs from node shoot--core--confgcp-worker-o1cev-z1-f757498dc-jzlxf pod pod-configmaps-48d3c372-7dff-11e8-b0f5-565e625ec9a3 container env-test: <nil>
+STEP: delete the pod
+Jul  2 13:53:26.717: INFO: Waiting for pod pod-configmaps-48d3c372-7dff-11e8-b0f5-565e625ec9a3 to disappear
+Jul  2 13:53:26.719: INFO: Pod pod-configmaps-48d3c372-7dff-11e8-b0f5-565e625ec9a3 no longer exists
+[AfterEach] [sig-api-machinery] ConfigMap
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:53:26.719: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-configmap-qxdv4" for this suite.
+Jul  2 13:53:32.734: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:53:32.821: INFO: namespace: e2e-tests-configmap-qxdv4, resource: bindings, ignored listing per whitelist
+Jul  2 13:53:32.912: INFO: namespace e2e-tests-configmap-qxdv4 deletion completed in 6.188699157s
+
+• [SLOW TEST:10.318 seconds]
+[sig-api-machinery] ConfigMap
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/configmap.go:29
+  should be consumable via environment variable [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+S
+------------------------------
+[sig-storage] EmptyDir volumes 
+  should support (non-root,0644,tmpfs) [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-storage] EmptyDir volumes
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:53:32.913: INFO: >>> kubeConfig: /tmp/kubeconfig-293271353
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should support (non-root,0644,tmpfs) [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating a pod to test emptydir 0644 on tmpfs
+Jul  2 13:53:33.005: INFO: Waiting up to 5m0s for pod "pod-4efaff17-7dff-11e8-b0f5-565e625ec9a3" in namespace "e2e-tests-emptydir-wj494" to be "success or failure"
+Jul  2 13:53:33.008: INFO: Pod "pod-4efaff17-7dff-11e8-b0f5-565e625ec9a3": Phase="Pending", Reason="", readiness=false. Elapsed: 2.23201ms
+Jul  2 13:53:35.012: INFO: Pod "pod-4efaff17-7dff-11e8-b0f5-565e625ec9a3": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.005999241s
+STEP: Saw pod success
+Jul  2 13:53:35.012: INFO: Pod "pod-4efaff17-7dff-11e8-b0f5-565e625ec9a3" satisfied condition "success or failure"
+Jul  2 13:53:35.014: INFO: Trying to get logs from node shoot--core--confgcp-worker-o1cev-z1-f757498dc-jzlxf pod pod-4efaff17-7dff-11e8-b0f5-565e625ec9a3 container test-container: <nil>
+STEP: delete the pod
+Jul  2 13:53:35.032: INFO: Waiting for pod pod-4efaff17-7dff-11e8-b0f5-565e625ec9a3 to disappear
+Jul  2 13:53:35.034: INFO: Pod pod-4efaff17-7dff-11e8-b0f5-565e625ec9a3 no longer exists
+[AfterEach] [sig-storage] EmptyDir volumes
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:53:35.034: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-emptydir-wj494" for this suite.
+Jul  2 13:53:41.047: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:53:41.075: INFO: namespace: e2e-tests-emptydir-wj494, resource: bindings, ignored listing per whitelist
+Jul  2 13:53:41.137: INFO: namespace e2e-tests-emptydir-wj494 deletion completed in 6.100258302s
+
+• [SLOW TEST:8.225 seconds]
+[sig-storage] EmptyDir volumes
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/empty_dir.go:40
+  should support (non-root,0644,tmpfs) [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SS
+------------------------------
+[sig-storage] EmptyDir volumes 
+  should support (non-root,0777,default) [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-storage] EmptyDir volumes
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:53:41.137: INFO: >>> kubeConfig: /tmp/kubeconfig-293271353
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should support (non-root,0777,default) [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating a pod to test emptydir 0777 on node default medium
+Jul  2 13:53:41.217: INFO: Waiting up to 5m0s for pod "pod-53dff4ee-7dff-11e8-b0f5-565e625ec9a3" in namespace "e2e-tests-emptydir-kwl95" to be "success or failure"
+Jul  2 13:53:41.220: INFO: Pod "pod-53dff4ee-7dff-11e8-b0f5-565e625ec9a3": Phase="Pending", Reason="", readiness=false. Elapsed: 2.647429ms
+Jul  2 13:53:43.224: INFO: Pod "pod-53dff4ee-7dff-11e8-b0f5-565e625ec9a3": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.006501317s
+STEP: Saw pod success
+Jul  2 13:53:43.224: INFO: Pod "pod-53dff4ee-7dff-11e8-b0f5-565e625ec9a3" satisfied condition "success or failure"
+Jul  2 13:53:43.227: INFO: Trying to get logs from node shoot--core--confgcp-worker-o1cev-z1-f757498dc-jzlxf pod pod-53dff4ee-7dff-11e8-b0f5-565e625ec9a3 container test-container: <nil>
+STEP: delete the pod
+Jul  2 13:53:43.244: INFO: Waiting for pod pod-53dff4ee-7dff-11e8-b0f5-565e625ec9a3 to disappear
+Jul  2 13:53:43.246: INFO: Pod pod-53dff4ee-7dff-11e8-b0f5-565e625ec9a3 no longer exists
+[AfterEach] [sig-storage] EmptyDir volumes
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:53:43.247: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-emptydir-kwl95" for this suite.
+Jul  2 13:53:49.279: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:53:49.320: INFO: namespace: e2e-tests-emptydir-kwl95, resource: bindings, ignored listing per whitelist
+Jul  2 13:53:49.413: INFO: namespace e2e-tests-emptydir-kwl95 deletion completed in 6.163656031s
+
+• [SLOW TEST:8.276 seconds]
+[sig-storage] EmptyDir volumes
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/empty_dir.go:40
+  should support (non-root,0777,default) [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+[sig-storage] ConfigMap 
+  should be consumable in multiple volumes in the same pod [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-storage] ConfigMap
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:53:49.414: INFO: >>> kubeConfig: /tmp/kubeconfig-293271353
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should be consumable in multiple volumes in the same pod [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating configMap with name configmap-test-volume-58cfa16f-7dff-11e8-b0f5-565e625ec9a3
+STEP: Creating a pod to test consume configMaps
+Jul  2 13:53:49.507: INFO: Waiting up to 5m0s for pod "pod-configmaps-58d031ba-7dff-11e8-b0f5-565e625ec9a3" in namespace "e2e-tests-configmap-5f7q6" to be "success or failure"
+Jul  2 13:53:49.510: INFO: Pod "pod-configmaps-58d031ba-7dff-11e8-b0f5-565e625ec9a3": Phase="Pending", Reason="", readiness=false. Elapsed: 3.786918ms
+Jul  2 13:53:51.514: INFO: Pod "pod-configmaps-58d031ba-7dff-11e8-b0f5-565e625ec9a3": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.007514242s
+STEP: Saw pod success
+Jul  2 13:53:51.514: INFO: Pod "pod-configmaps-58d031ba-7dff-11e8-b0f5-565e625ec9a3" satisfied condition "success or failure"
+Jul  2 13:53:51.579: INFO: Trying to get logs from node shoot--core--confgcp-worker-o1cev-z1-f757498dc-jzlxf pod pod-configmaps-58d031ba-7dff-11e8-b0f5-565e625ec9a3 container configmap-volume-test: <nil>
+STEP: delete the pod
+Jul  2 13:53:51.691: INFO: Waiting for pod pod-configmaps-58d031ba-7dff-11e8-b0f5-565e625ec9a3 to disappear
+Jul  2 13:53:51.694: INFO: Pod pod-configmaps-58d031ba-7dff-11e8-b0f5-565e625ec9a3 no longer exists
+[AfterEach] [sig-storage] ConfigMap
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:53:51.695: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-configmap-5f7q6" for this suite.
+Jul  2 13:53:57.709: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:53:57.779: INFO: namespace: e2e-tests-configmap-5f7q6, resource: bindings, ignored listing per whitelist
+Jul  2 13:53:57.885: INFO: namespace e2e-tests-configmap-5f7q6 deletion completed in 6.186724515s
+
+• [SLOW TEST:8.471 seconds]
+[sig-storage] ConfigMap
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/configmap_volume.go:32
+  should be consumable in multiple volumes in the same pod [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SS
+------------------------------
+[sig-storage] EmptyDir volumes 
+  should support (root,0644,default) [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-storage] EmptyDir volumes
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:53:57.885: INFO: >>> kubeConfig: /tmp/kubeconfig-293271353
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should support (root,0644,default) [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating a pod to test emptydir 0644 on node default medium
+Jul  2 13:53:57.964: INFO: Waiting up to 5m0s for pod "pod-5ddb66bf-7dff-11e8-b0f5-565e625ec9a3" in namespace "e2e-tests-emptydir-c7wbd" to be "success or failure"
+Jul  2 13:53:57.967: INFO: Pod "pod-5ddb66bf-7dff-11e8-b0f5-565e625ec9a3": Phase="Pending", Reason="", readiness=false. Elapsed: 2.67281ms
+Jul  2 13:53:59.979: INFO: Pod "pod-5ddb66bf-7dff-11e8-b0f5-565e625ec9a3": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.015135366s
+STEP: Saw pod success
+Jul  2 13:53:59.979: INFO: Pod "pod-5ddb66bf-7dff-11e8-b0f5-565e625ec9a3" satisfied condition "success or failure"
+Jul  2 13:53:59.982: INFO: Trying to get logs from node shoot--core--confgcp-worker-o1cev-z1-f757498dc-jzlxf pod pod-5ddb66bf-7dff-11e8-b0f5-565e625ec9a3 container test-container: <nil>
+STEP: delete the pod
+Jul  2 13:53:59.999: INFO: Waiting for pod pod-5ddb66bf-7dff-11e8-b0f5-565e625ec9a3 to disappear
+Jul  2 13:54:00.007: INFO: Pod pod-5ddb66bf-7dff-11e8-b0f5-565e625ec9a3 no longer exists
+[AfterEach] [sig-storage] EmptyDir volumes
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:54:00.007: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-emptydir-c7wbd" for this suite.
+Jul  2 13:54:06.021: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:54:06.139: INFO: namespace: e2e-tests-emptydir-c7wbd, resource: bindings, ignored listing per whitelist
+Jul  2 13:54:06.159: INFO: namespace e2e-tests-emptydir-c7wbd deletion completed in 6.147864597s
+
+• [SLOW TEST:8.274 seconds]
+[sig-storage] EmptyDir volumes
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/empty_dir.go:40
+  should support (root,0644,default) [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+[sig-api-machinery] Garbage collector 
+  should delete RS created by deployment when not orphaning [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-api-machinery] Garbage collector
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:54:06.159: INFO: >>> kubeConfig: /tmp/kubeconfig-293271353
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should delete RS created by deployment when not orphaning [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: create the deployment
+STEP: Wait for the Deployment to create new ReplicaSet
+STEP: delete the deployment
+STEP: wait for all rs to be garbage collected
+STEP: expected 0 rs, got 1 rs
+STEP: expected 0 Pods, got 2 Pods
+STEP: Gathering metrics
+W0702 13:54:07.304140      18 metrics_grabber.go:81] Master node is not registered. Grabbing metrics from Scheduler, ControllerManager and ClusterAutoscaler is disabled.
+Jul  2 13:54:07.304: INFO: For apiserver_request_count:
+For apiserver_request_latencies_summary:
+For etcd_helper_cache_entry_count:
+For etcd_helper_cache_hit_count:
+For etcd_helper_cache_miss_count:
+For etcd_request_cache_add_latencies_summary:
+For etcd_request_cache_get_latencies_summary:
+For etcd_request_latencies_summary:
+For garbage_collector_attempt_to_delete_queue_latency:
+For garbage_collector_attempt_to_delete_work_duration:
+For garbage_collector_attempt_to_orphan_queue_latency:
+For garbage_collector_attempt_to_orphan_work_duration:
+For garbage_collector_dirty_processing_latency_microseconds:
+For garbage_collector_event_processing_latency_microseconds:
+For garbage_collector_graph_changes_queue_latency:
+For garbage_collector_graph_changes_work_duration:
+For garbage_collector_orphan_processing_latency_microseconds:
+For namespace_queue_latency:
+For namespace_queue_latency_sum:
+For namespace_queue_latency_count:
+For namespace_retries:
+For namespace_work_duration:
+For namespace_work_duration_sum:
+For namespace_work_duration_count:
+For function_duration_seconds:
+For errors_total:
+For evicted_pods_total:
+
+[AfterEach] [sig-api-machinery] Garbage collector
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:54:07.304: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-gc-qq29l" for this suite.
+Jul  2 13:54:13.318: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:54:13.404: INFO: namespace: e2e-tests-gc-qq29l, resource: bindings, ignored listing per whitelist
+Jul  2 13:54:13.404: INFO: namespace e2e-tests-gc-qq29l deletion completed in 6.096766514s
+
+• [SLOW TEST:7.245 seconds]
+[sig-api-machinery] Garbage collector
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apimachinery/framework.go:22
+  should delete RS created by deployment when not orphaning [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSS
+------------------------------
+[sig-storage] Downward API volume 
+  should provide container's cpu limit [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:54:13.404: INFO: >>> kubeConfig: /tmp/kubeconfig-293271353
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downwardapi_volume.go:38
+[It] should provide container's cpu limit [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating a pod to test downward API volume plugin
+Jul  2 13:54:13.487: INFO: Waiting up to 5m0s for pod "downwardapi-volume-671b7344-7dff-11e8-b0f5-565e625ec9a3" in namespace "e2e-tests-downward-api-vjkkb" to be "success or failure"
+Jul  2 13:54:13.489: INFO: Pod "downwardapi-volume-671b7344-7dff-11e8-b0f5-565e625ec9a3": Phase="Pending", Reason="", readiness=false. Elapsed: 2.384493ms
+Jul  2 13:54:15.493: INFO: Pod "downwardapi-volume-671b7344-7dff-11e8-b0f5-565e625ec9a3": Phase="Pending", Reason="", readiness=false. Elapsed: 2.006213945s
+Jul  2 13:54:17.497: INFO: Pod "downwardapi-volume-671b7344-7dff-11e8-b0f5-565e625ec9a3": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.010153033s
+STEP: Saw pod success
+Jul  2 13:54:17.497: INFO: Pod "downwardapi-volume-671b7344-7dff-11e8-b0f5-565e625ec9a3" satisfied condition "success or failure"
+Jul  2 13:54:17.499: INFO: Trying to get logs from node shoot--core--confgcp-worker-o1cev-z1-f757498dc-jzlxf pod downwardapi-volume-671b7344-7dff-11e8-b0f5-565e625ec9a3 container client-container: <nil>
+STEP: delete the pod
+Jul  2 13:54:17.514: INFO: Waiting for pod downwardapi-volume-671b7344-7dff-11e8-b0f5-565e625ec9a3 to disappear
+Jul  2 13:54:17.517: INFO: Pod downwardapi-volume-671b7344-7dff-11e8-b0f5-565e625ec9a3 no longer exists
+[AfterEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:54:17.517: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-downward-api-vjkkb" for this suite.
+Jul  2 13:54:23.531: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:54:23.679: INFO: namespace: e2e-tests-downward-api-vjkkb, resource: bindings, ignored listing per whitelist
+Jul  2 13:54:23.700: INFO: namespace e2e-tests-downward-api-vjkkb deletion completed in 6.179955934s
+
+• [SLOW TEST:10.296 seconds]
+[sig-storage] Downward API volume
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downwardapi_volume.go:33
+  should provide container's cpu limit [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+[sig-storage] ConfigMap 
+  should be consumable from pods in volume [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-storage] ConfigMap
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:54:23.700: INFO: >>> kubeConfig: /tmp/kubeconfig-293271353
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should be consumable from pods in volume [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating configMap with name configmap-test-volume-6d401c9e-7dff-11e8-b0f5-565e625ec9a3
+STEP: Creating a pod to test consume configMaps
+Jul  2 13:54:23.792: INFO: Waiting up to 5m0s for pod "pod-configmaps-6d4090be-7dff-11e8-b0f5-565e625ec9a3" in namespace "e2e-tests-configmap-4ktl5" to be "success or failure"
+Jul  2 13:54:23.795: INFO: Pod "pod-configmaps-6d4090be-7dff-11e8-b0f5-565e625ec9a3": Phase="Pending", Reason="", readiness=false. Elapsed: 2.464631ms
+Jul  2 13:54:25.799: INFO: Pod "pod-configmaps-6d4090be-7dff-11e8-b0f5-565e625ec9a3": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.006360517s
+STEP: Saw pod success
+Jul  2 13:54:25.799: INFO: Pod "pod-configmaps-6d4090be-7dff-11e8-b0f5-565e625ec9a3" satisfied condition "success or failure"
+Jul  2 13:54:25.801: INFO: Trying to get logs from node shoot--core--confgcp-worker-o1cev-z1-f757498dc-jzlxf pod pod-configmaps-6d4090be-7dff-11e8-b0f5-565e625ec9a3 container configmap-volume-test: <nil>
+STEP: delete the pod
+Jul  2 13:54:25.819: INFO: Waiting for pod pod-configmaps-6d4090be-7dff-11e8-b0f5-565e625ec9a3 to disappear
+Jul  2 13:54:25.823: INFO: Pod pod-configmaps-6d4090be-7dff-11e8-b0f5-565e625ec9a3 no longer exists
+[AfterEach] [sig-storage] ConfigMap
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:54:25.824: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-configmap-4ktl5" for this suite.
+Jul  2 13:54:31.879: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:54:31.926: INFO: namespace: e2e-tests-configmap-4ktl5, resource: bindings, ignored listing per whitelist
+Jul  2 13:54:31.970: INFO: namespace e2e-tests-configmap-4ktl5 deletion completed in 6.142316001s
+
+• [SLOW TEST:8.269 seconds]
+[sig-storage] ConfigMap
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/configmap_volume.go:32
+  should be consumable from pods in volume [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+S
+------------------------------
+[sig-storage] Downward API volume 
+  should set DefaultMode on files [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:54:31.970: INFO: >>> kubeConfig: /tmp/kubeconfig-293271353
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downwardapi_volume.go:38
+[It] should set DefaultMode on files [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating a pod to test downward API volume plugin
+Jul  2 13:54:32.050: INFO: Waiting up to 5m0s for pod "downwardapi-volume-722c6ab9-7dff-11e8-b0f5-565e625ec9a3" in namespace "e2e-tests-downward-api-q6576" to be "success or failure"
+Jul  2 13:54:32.052: INFO: Pod "downwardapi-volume-722c6ab9-7dff-11e8-b0f5-565e625ec9a3": Phase="Pending", Reason="", readiness=false. Elapsed: 2.361316ms
+Jul  2 13:54:34.056: INFO: Pod "downwardapi-volume-722c6ab9-7dff-11e8-b0f5-565e625ec9a3": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.006265628s
+STEP: Saw pod success
+Jul  2 13:54:34.056: INFO: Pod "downwardapi-volume-722c6ab9-7dff-11e8-b0f5-565e625ec9a3" satisfied condition "success or failure"
+Jul  2 13:54:34.059: INFO: Trying to get logs from node shoot--core--confgcp-worker-o1cev-z1-f757498dc-jzlxf pod downwardapi-volume-722c6ab9-7dff-11e8-b0f5-565e625ec9a3 container client-container: <nil>
+STEP: delete the pod
+Jul  2 13:54:34.080: INFO: Waiting for pod downwardapi-volume-722c6ab9-7dff-11e8-b0f5-565e625ec9a3 to disappear
+Jul  2 13:54:34.083: INFO: Pod downwardapi-volume-722c6ab9-7dff-11e8-b0f5-565e625ec9a3 no longer exists
+[AfterEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:54:34.083: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-downward-api-q6576" for this suite.
+Jul  2 13:54:40.097: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:54:40.180: INFO: namespace: e2e-tests-downward-api-q6576, resource: bindings, ignored listing per whitelist
+Jul  2 13:54:40.187: INFO: namespace e2e-tests-downward-api-q6576 deletion completed in 6.099484521s
+
+• [SLOW TEST:8.217 seconds]
+[sig-storage] Downward API volume
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downwardapi_volume.go:33
+  should set DefaultMode on files [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSSSSSSSSS
+------------------------------
+[sig-storage] Projected 
+  should be consumable from pods in volume as non-root [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:54:40.187: INFO: >>> kubeConfig: /tmp/kubeconfig-293271353
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:858
+[It] should be consumable from pods in volume as non-root [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating configMap with name projected-configmap-test-volume-7712afdb-7dff-11e8-b0f5-565e625ec9a3
+STEP: Creating a pod to test consume configMaps
+Jul  2 13:54:40.273: INFO: Waiting up to 5m0s for pod "pod-projected-configmaps-77132d1f-7dff-11e8-b0f5-565e625ec9a3" in namespace "e2e-tests-projected-xltlm" to be "success or failure"
+Jul  2 13:54:40.276: INFO: Pod "pod-projected-configmaps-77132d1f-7dff-11e8-b0f5-565e625ec9a3": Phase="Pending", Reason="", readiness=false. Elapsed: 2.469475ms
+Jul  2 13:54:42.280: INFO: Pod "pod-projected-configmaps-77132d1f-7dff-11e8-b0f5-565e625ec9a3": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.006574251s
+STEP: Saw pod success
+Jul  2 13:54:42.280: INFO: Pod "pod-projected-configmaps-77132d1f-7dff-11e8-b0f5-565e625ec9a3" satisfied condition "success or failure"
+Jul  2 13:54:42.282: INFO: Trying to get logs from node shoot--core--confgcp-worker-o1cev-z1-f757498dc-jzlxf pod pod-projected-configmaps-77132d1f-7dff-11e8-b0f5-565e625ec9a3 container projected-configmap-volume-test: <nil>
+STEP: delete the pod
+Jul  2 13:54:42.299: INFO: Waiting for pod pod-projected-configmaps-77132d1f-7dff-11e8-b0f5-565e625ec9a3 to disappear
+Jul  2 13:54:42.302: INFO: Pod pod-projected-configmaps-77132d1f-7dff-11e8-b0f5-565e625ec9a3 no longer exists
+[AfterEach] [sig-storage] Projected
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:54:42.302: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-xltlm" for this suite.
+Jul  2 13:54:48.314: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:54:48.440: INFO: namespace: e2e-tests-projected-xltlm, resource: bindings, ignored listing per whitelist
+Jul  2 13:54:48.462: INFO: namespace e2e-tests-projected-xltlm deletion completed in 6.157766s
+
+• [SLOW TEST:8.276 seconds]
+[sig-storage] Projected
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:34
+  should be consumable from pods in volume as non-root [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSSSS
+------------------------------
+[sig-storage] Projected 
+  optional updates should be reflected in volume [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:54:48.462: INFO: >>> kubeConfig: /tmp/kubeconfig-293271353
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:858
+[It] optional updates should be reflected in volume [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating secret with name s-test-opt-del-7c029904-7dff-11e8-b0f5-565e625ec9a3
+STEP: Creating secret with name s-test-opt-upd-7c029942-7dff-11e8-b0f5-565e625ec9a3
+STEP: Creating the pod
+STEP: Deleting secret s-test-opt-del-7c029904-7dff-11e8-b0f5-565e625ec9a3
+STEP: Updating secret s-test-opt-upd-7c029942-7dff-11e8-b0f5-565e625ec9a3
+STEP: Creating secret with name s-test-opt-create-7c029957-7dff-11e8-b0f5-565e625ec9a3
+STEP: waiting to observe update in volume
+[AfterEach] [sig-storage] Projected
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:54:52.893: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-2fbxv" for this suite.
+Jul  2 13:55:14.907: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:55:15.083: INFO: namespace: e2e-tests-projected-2fbxv, resource: bindings, ignored listing per whitelist
+Jul  2 13:55:15.115: INFO: namespace e2e-tests-projected-2fbxv deletion completed in 22.2174867s
+
+• [SLOW TEST:26.652 seconds]
+[sig-storage] Projected
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:34
+  optional updates should be reflected in volume [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSSSSSSSSSSSSSSS
+------------------------------
+[sig-storage] Projected 
+  should provide container's memory request [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:55:15.115: INFO: >>> kubeConfig: /tmp/kubeconfig-293271353
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:858
+[It] should provide container's memory request [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating a pod to test downward API volume plugin
+Jul  2 13:55:15.200: INFO: Waiting up to 5m0s for pod "downwardapi-volume-8be499dc-7dff-11e8-b0f5-565e625ec9a3" in namespace "e2e-tests-projected-qk5h2" to be "success or failure"
+Jul  2 13:55:15.202: INFO: Pod "downwardapi-volume-8be499dc-7dff-11e8-b0f5-565e625ec9a3": Phase="Pending", Reason="", readiness=false. Elapsed: 2.360273ms
+Jul  2 13:55:17.206: INFO: Pod "downwardapi-volume-8be499dc-7dff-11e8-b0f5-565e625ec9a3": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.006144197s
+STEP: Saw pod success
+Jul  2 13:55:17.206: INFO: Pod "downwardapi-volume-8be499dc-7dff-11e8-b0f5-565e625ec9a3" satisfied condition "success or failure"
+Jul  2 13:55:17.209: INFO: Trying to get logs from node shoot--core--confgcp-worker-o1cev-z1-f757498dc-qrtzr pod downwardapi-volume-8be499dc-7dff-11e8-b0f5-565e625ec9a3 container client-container: <nil>
+STEP: delete the pod
+Jul  2 13:55:17.298: INFO: Waiting for pod downwardapi-volume-8be499dc-7dff-11e8-b0f5-565e625ec9a3 to disappear
+Jul  2 13:55:17.301: INFO: Pod downwardapi-volume-8be499dc-7dff-11e8-b0f5-565e625ec9a3 no longer exists
+[AfterEach] [sig-storage] Projected
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:55:17.301: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-qk5h2" for this suite.
+Jul  2 13:55:23.315: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:55:23.380: INFO: namespace: e2e-tests-projected-qk5h2, resource: bindings, ignored listing per whitelist
+Jul  2 13:55:23.406: INFO: namespace e2e-tests-projected-qk5h2 deletion completed in 6.101956545s
+
+• [SLOW TEST:8.292 seconds]
+[sig-storage] Projected
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:34
+  should provide container's memory request [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+Jul  2 13:55:23.406: INFO: Running AfterSuite actions on all node
+Jul  2 13:55:23.407: INFO: Running AfterSuite actions on node 1
+Jul  2 13:55:23.407: INFO: Skipping dumping logs from cluster
+
+Ran 143 of 998 Specs in 3655.755 seconds
+SUCCESS! -- 143 Passed | 0 Failed | 0 Pending | 855 Skipped PASS
+
+Ginkgo ran 1 suite in 1h0m56.250338867s
+Test Suite Passed

--- a/v1.11/gardener-gcp/junit_01.xml
+++ b/v1.11/gardener-gcp/junit_01.xml
@@ -1,0 +1,2711 @@
+<?xml version="1.0" encoding="UTF-8"?>
+  <testsuite tests="143" failures="0" time="3655.755134677">
+      <testcase name="[sig-storage] Subpath [Volume type: gcePDPVC] should support restarting containers using file as subpath [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] StatefulSet [k8s.io] Basic StatefulSet functionality [StatefulSetBasic] Burst scaling should run to completion even with unhealthy pods [Conformance]" classname="Kubernetes e2e suite" time="60.20372229"></testcase>
+      <testcase name="[sig-storage] Volume Provisioning On Clustered Datastore [Feature:vsphere] verify static provisioning on clustered datastore" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-instrumentation] Logging soak [Performance] [Slow] [Disruptive] should survive logging 1KB every 1s seconds, for a duration of 2m0s, scaling up to 1 pods per node" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volume plugin streaming [Slow] Ceph-RBD [Feature:Volumes] should write files of various sizes, verify size, validate content" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Projected should be consumable from pods in volume with mappings and Item Mode set [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="10.416313315"></testcase>
+      <testcase name="[sig-storage] ConfigMap should be consumable from pods in volume as non-root with defaultMode and fsGroup set [NodeFeature:FSGroup]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-auth] Advanced Audit should audit API calls [DisabledForLargeClusters]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Pods should get a host IP [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="24.190609103"></testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: block] [Feature:BlockVolume] Set fsGroup for local volume should not set different fsGroups for two pods simultaneously" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] CustomResourceDefinition resources Simple CustomResourceDefinition creating/deleting custom resource definition objects works  [Conformance]" classname="Kubernetes e2e suite" time="7.464313499"></testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: emptyDir] should support non-existent path" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] SchedulerPredicates [Serial] validates that NodeSelector is respected if matching  [Conformance]" classname="Kubernetes e2e suite" time="86.514917794"></testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: hostPath] should support readOnly file specified in the volumeMount" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Kubectl create quota should create a quota without scopes" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] should increase cluster size if pod requesting volume is pending [Feature:ClusterSizeAutoscalingScaleUp]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] EmptyDir volumes should support (root,0777,default) [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="8.249292236"></testcase>
+      <testcase name="[sig-apps] ReplicationController should release no longer matching pods" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Services should provide secure master service  [Conformance]" classname="Kubernetes e2e suite" time="6.17579504"></testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: emptyDir] should unmount if pod is gracefully deleted while kubelet is down [Disruptive][Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [sig-node] AppArmor load AppArmor profiles can disable an AppArmor profile, using unconfined" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Kubectl create quota should create a quota with scopes" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Pods should be updated [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="24.829190495"></testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] should disable node pool autoscaling [Feature:ClusterSizeAutoscalingScaleUp]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Secrets should be consumable from pods in volume with defaultMode set [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="10.261595637"></testcase>
+      <testcase name="[k8s.io] Docker Containers should be able to override the image&#39;s default command (docker entrypoint) [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="10.250556725"></testcase>
+      <testcase name="[sig-cluster-lifecycle] [Feature:BootstrapTokens] should not delete the token secret when the secret is not expired" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] Shouldn&#39;t perform scale up operation and should list unhealthy status if most of the cluster is broken[Feature:ClusterSizeAutoscalingScaleUp]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Probing container with readiness probe should not be ready before initial delay and never restart [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="46.369840424"></testcase>
+      <testcase name="[sig-network] DNS should support configurable pod resolv.conf" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-service-catalog] [Feature:PodPreset] PodPreset should create a pod preset" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Garbage collector should orphan pods created by rc if delete options say so [Conformance]" classname="Kubernetes e2e suite" time="46.360608137"></testcase>
+      <testcase name="[k8s.io] [Feature:Example] [k8s.io] Downward API should create a pod that prints his name and namespace" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Pod Disks detach in a disrupted environment [Slow] [Disruptive] when node is deleted" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [sig-node] Kubelet [Serial] [Slow] [k8s.io] [sig-node] regular resource usage tracking resource tracking for 0 pods per node" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: gce-localssd-scsi-fs] [Serial] One pod requesting one prebound PVC should be able to mount volume and write from pod1" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scalability] Density [Feature:ManualPerformance] should allow starting 30 pods per node using { ReplicationController} with 0 secrets, 0 configmaps and 0 daemons with quotas" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] GKE local SSD [Feature:GKELocalSSD] should write and read from node local SSD [Feature:GKELocalSSD]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scalability] Density [Feature:ManualPerformance] should allow starting 3 pods per node using { ReplicationController} with 0 secrets, 0 configmaps and 0 daemons" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] DisruptionController evictions: enough pods, replicaSet, percentage =&gt; should allow an eviction" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cluster-lifecycle] HA-master [Feature:HAMaster] survive addition/removal replicas multizone workers [Serial][Disruptive]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scalability] Load capacity [Feature:ManualPerformance] should be able to handle 30 pods per node {extensions Deployment} with 2 secrets, 0 configmaps and 0 daemons" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] NFSPersistentVolumes[Disruptive][Flaky] when kube-controller-manager restarts should delete a bound PVC from a clientPod, restart the kube-control-manager, and ensure the kube-controller-manager does not crash" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes:vsphere should test that deleting the Namespace of a PVC and Pod causes the successful detach of vsphere volume" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Proxy server should support proxy with --port 0  [Conformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: dir-bindmounted] Two pods mounting a local volume at the same time should be able to write from pod1 and read from pod2" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: dir-bindmounted] Set fsGroup for local volume should set fsGroup for one pod" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: nfsPVC] should support existing directory" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] CronJob should schedule multiple jobs concurrently" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-auth] ServiceAccounts should ensure a single API token exists" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Deployment RollingUpdateDeployment should delete old pods and create new ones" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes NFS with multiple PVs and PVCs all in same ns should create 3 PVs and 3 PVCs: test write access" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-instrumentation] Stackdriver Monitoring should run Stackdriver Metadata Agent [Feature:StackdriverMetadataAgent]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] DisruptionController should create a PodDisruptionBudget" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] EmptyDir volumes should support (root,0777,tmpfs) [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="10.238474488"></testcase>
+      <testcase name="[k8s.io] [sig-node] kubelet [k8s.io] [sig-node] host cleanup with volume mounts [sig-storage][HostCleanup][Flaky] Host cleanup after disrupting NFS volume [NFS] after stopping the nfs-server and deleting the (sleeping) client pod, the NFS mount and the pod&#39;s UID directory should be removed." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Downward API volume should update labels on modification [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="24.842274728"></testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: hostPath] should support existing directories when readOnly specified in the volumeSource" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] StatefulSet [k8s.io] Basic StatefulSet functionality [StatefulSetBasic] should not deadlock when a pod&#39;s predecessor fails" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Daemon set [Serial] should run and stop complex daemon [Conformance]" classname="Kubernetes e2e suite" time="18.969057617"></testcase>
+      <testcase name="[sig-network] Services should be able to change the type from ExternalName to ClusterIP" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-instrumentation] [Feature:PrometheusMonitoring] Prometheus should scrape container metrics from all nodes." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] [HPA] Horizontal pod autoscaling (scale resource: CPU) [sig-autoscaling] ReplicationController light Should scale from 1 pod to 2 pods" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: dir-link-bindmounted] Two pods mounting a local volume one after the other should be able to write from pod1 and read from pod2" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: tmpfs] Set fsGroup for local volume should set different fsGroup for second pod if first pod is deleted" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Pods should support retrieving logs from the container over websockets [NodeConformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cluster-lifecycle] [Feature:BootstrapTokens] should resign the bootstrap tokens when the clusterInfo ConfigMap updated [Serial][Disruptive]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Update Demo should create and stop a replication controller  [Conformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] EmptyDir volumes volume on tmpfs should have the correct mode [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="8.474675262"></testcase>
+      <testcase name="[sig-network] Loadbalancing: L7 GCE [Slow] [Feature:Ingress] should update ingress while sync failures occur on other ingresses" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] Multi-AZ Clusters should spread the pods of a replication controller across zones" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Kubectl describe should check if kubectl describe prints relevant information for rc and pods  [Conformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Garbage collector should not be blocked by dependency circle [Conformance]" classname="Kubernetes e2e suite" time="11.498236967"></testcase>
+      <testcase name="[sig-network] Services should be able to change the type from ClusterIP to ExternalName" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-auth] PodSecurityPolicy should allow pods under the privileged policy.PodSecurityPolicy" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] CSI Volumes CSI plugin test using CSI driver: [Feature: GCE PD CSI Plugin] gcePD should provision storage" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Servers with support for Table transformation should return generic metadata details across all namespaces for nodes" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] DisruptionController evictions: maxUnavailable deny evictions, integer =&gt; should not allow an eviction" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] NetworkPolicy NetworkPolicy between server and client should enforce policy based on Ports [Feature:NetworkPolicy]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] vsphere statefulset vsphere statefulset testing" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: nfs] should fail if subpath with backstepping is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volume plugin streaming [Slow] NFS should write files of various sizes, verify size, validate content" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] SchedulerPredicates [Serial] validates MaxPods limit number of pods that are allowed to run [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] DisruptionController evictions: maxUnavailable allow single eviction, percentage =&gt; should allow an eviction" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-ui] Kubernetes Dashboard should check that the kubernetes-dashboard instance is alive" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Simple pod should support port-forward" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] [HPA] Horizontal pod autoscaling (scale resource: CPU) [sig-autoscaling] [Serial] [Slow] ReplicaSet Should scale from 1 pod to 3 pods and from 3 to 5" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cluster-lifecycle] Upgrade [Feature:Upgrade] node upgrade should maintain a functioning cluster [Feature:NodeUpgrade]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: gce-localssd-scsi-fs] [Serial] Set fsGroup for local volume should set different fsGroup for second pod if first pod is deleted" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: hostPathSymlink] should support existing single file" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Node Poweroff [Feature:vsphere] [Slow] [Disruptive] verify volume status after node power off" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scalability] Load capacity [Feature:Performance] should be able to handle 30 pods per node { ReplicationController} with 0 secrets, 0 configmaps and 0 daemons" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-instrumentation] Cadvisor should be healthy on every node." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Simple pod should support exec through kubectl proxy" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: hostPath] should support restarting containers using directory as subpath [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] LimitRange should create a LimitRange with defaults and ensure pod has those defaults applied." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gcePDPVC] should fail if subpath directory is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] GCP Volumes GlusterFS should be mountable" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gluster] should support file as subpath" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scalability] Load capacity [Feature:ManualPerformance] should be able to handle 30 pods per node { ReplicationController} with 0 secrets, 0 configmaps and 0 daemons with quotas" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [sig-node] Security Context [Feature:SecurityContext] should support container.SecurityContext.RunAsUser And container.SecurityContext.RunAsGroup [Feature:RunAsGroup]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] Should scale up GPU pool from 0 [GpuType:nvidia-tesla-v100] [Feature:ClusterSizeAutoscalingGpu]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] shouldn&#39;t scale down when non expendable pod is running [Feature:ClusterSizeAutoscalingScaleDown]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-instrumentation] Cluster level logging implemented by Stackdriver should ingest system logs from all nodes [Feature:StackdriverLogging]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Dynamic Provisioning DynamicProvisioner should provision storage with mount options" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Services should preserve source pod IP for traffic thru service cluster IP" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] GKE node pools [Feature:GKENodePool] should create a cluster with multiple node pools [Feature:GKENodePool]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: dir] One pod requesting one prebound PVC should be able to mount volume and read from pod1" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Kubectl apply apply set/view last-applied" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Daemon set [Serial] should rollback without unnecessary restarts [Conformance]" classname="Kubernetes e2e suite" time="6.22640685">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: emptyDir] should fail for new directories when readOnly specified in the volumeSource" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] NFSPersistentVolumes[Disruptive][Flaky] when kubelet restarts Should test that a volume mounted to a pod that is force deleted while the kubelet is down unmounts when the kubelet returns." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: block] [Feature:BlockVolume] Set fsGroup for local volume should set fsGroup for one pod" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Projected should set DefaultMode on files [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="8.20984832"></testcase>
+      <testcase name="[sig-cluster-lifecycle] Reboot [Disruptive] [Feature:Reboot] each node by switching off the network interface and ensure they function upon switch on" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [Feature:Example] [k8s.io] RethinkDB should create and stop rethinkdb servers" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Flexvolumes [Disruptive] should install plugin without kubelet restart" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Sysctls [NodeFeature:Sysctls] should reject invalid sysctls" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] [HPA] Horizontal pod autoscaling (scale resource: Custom Metrics from Stackdriver) should scale down with Custom Metric of type Object from Stackdriver [Feature:CustomMetricsAutoscaling]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Networking Granular Checks: Services [Slow] should function for endpoint-Service: http" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] should be able to scale down when rescheduling a pod is required and pdb allows for it[Feature:ClusterSizeAutoscalingScaleDown]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] HostPath should support existing single file subPath" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Storage Policy Based Volume Provisioning [Feature:vsphere] verify clean up of stale dummy VM for dynamically provisioned pvc using SPBM policy" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gcePDPVC] should fail for new directories when readOnly specified in the volumeSource" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cluster-lifecycle] Reboot [Disruptive] [Feature:Reboot] each node by ordering unclean reboot and ensure they function upon restart" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Storage Policy Based Volume Provisioning [Feature:vsphere] verify an existing and compatible SPBM policy is honored for dynamically provisioned pvc using storageclass" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Storage Policy Based Volume Provisioning [Feature:vsphere] verify if a non-existing SPBM policy is not honored for dynamically provisioned pvc using storageclass" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [sig-node] Pod garbage collector [Feature:PodGarbageCollector] [Slow] should handle the creation of 1000 pods" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volumes PD should be mountable with xfs" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Projected should provide container&#39;s cpu request [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="8.356543881"></testcase>
+      <testcase name="[sig-storage] Pod Disks schedule pods each with a PD, delete pod and verify detach [Slow] for RW PD with pod delete grace period of &#34;default (30s)&#34;" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl Port forwarding [k8s.io] With a server listening on localhost [k8s.io] that expects NO client request should support a client that connects, sends DATA, and disconnects" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-auth] [Feature:NodeAuthorizer] A node shouldn&#39;t be able to create another node" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-instrumentation] [Feature:PrometheusMonitoring] Prometheus should successfully scrape all targets" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: hostPath] should support creating multiple subpath from same volumes [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] NoSNAT [Feature:NoSNAT] [Slow] Should be able to send traffic between Pods without SNAT" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] ResourceQuota should create a ResourceQuota and capture the life of a pod." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: emptyDir] should fail if subpath directory is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: dir-link] Two pods mounting a local volume at the same time should be able to write from pod1 and read from pod2" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scalability] Load capacity [Feature:ManualPerformance] should be able to handle 3 pods per node { ReplicationController} with 0 secrets, 0 configmaps and 0 daemons" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Servers with support for API chunking should return chunks of results for list calls" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: gce-localssd-scsi-fs] [Serial] Set fsGroup for local volume should not set different fsGroups for two pods simultaneously" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] InitContainer [NodeConformance] should invoke init containers on a RestartNever pod" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volumes iSCSI [Feature:Volumes] should be mountable" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Dynamic Provisioning DynamicProvisioner Default should be disabled by changing the default annotation [Serial] [Disruptive]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volumes ConfigMap should be mountable" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] NetworkPolicy NetworkPolicy between server and client should enforce policy based on PodSelector [Feature:NetworkPolicy]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volumes Cinder [Feature:Volumes] should be mountable" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Probing container should be restarted with a /healthz http liveness probe [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="26.238596622"></testcase>
+      <testcase name="[sig-storage] HostPath should support existing directory subPath" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Sysctls [NodeFeature:Sysctls] should support sysctls" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] EmptyDir volumes should support (non-root,0644,default) [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="8.217420743"></testcase>
+      <testcase name="[sig-network] Networking should check kube-proxy urls" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volumes GlusterFS should be mountable" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Ephemeralstorage When pod refers to non-existent ephemeral storage should allow deletion of pod with invalid volume : projected" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cluster-lifecycle] Reboot [Disruptive] [Feature:Reboot] each node by triggering kernel panic and ensure they function upon restart" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: nfs] should unmount if pod is gracefully deleted while kubelet is down [Disruptive][Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] EmptyDir volumes volume on default medium should have the correct mode [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="8.218471666"></testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gcePDPartitioned] should support restarting containers using file as subpath [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: hostPathSymlink] should fail for new directories when readOnly specified in the volumeSource" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: emptyDir] should support existing single file" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PVC Protection Verify that scheduling of a pod that uses PVC that is being deleted fails and the pod becomes Unschedulable" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volume FStype [Feature:vsphere] verify fstype - default value should be ext4" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl alpha client [k8s.io] Kubectl run CronJob should create a CronJob" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volume Operations Storm [Feature:vsphere] should create pod with many volumes and verify no attach call fails" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [sig-node] AppArmor load AppArmor profiles should enforce an AppArmor profile" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Networking should provide Internet connection for containers [Feature:Networking-IPv6][Experimental]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Services should serve a basic endpoint from pods  [Conformance]" classname="Kubernetes e2e suite" time="29.485626487"></testcase>
+      <testcase name="[sig-scalability] Load capacity [Feature:ManualPerformance] should be able to handle 30 pods per node { Random} with 0 secrets, 0 configmaps and 0 daemons" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] NetworkPolicy NetworkPolicy between server and client should allow egress access on one named port [Feature:NetworkPolicy]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] should correctly scale down after a node is not needed [Feature:ClusterSizeAutoscalingScaleDown]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] EmptyDir volumes should support (non-root,0666,default) [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="8.21803025"></testcase>
+      <testcase name="[sig-network] Services should be able to change the type from ExternalName to NodePort" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: emptyDir] should support readOnly file specified in the volumeMount" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: tmpfs] Set fsGroup for local volume should set same fsGroup for two pods simultaneously" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Ephemeralstorage When pod refers to non-existent ephemeral storage should allow deletion of pod with invalid volume : configmap" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Projected should be consumable from pods in volume as non-root with defaultMode and fsGroup set [NodeFeature:FSGroup]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes NFS with Single PV - PVC pairs should create a non-pre-bound PV and PVC: test write access " classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: nfs] should support restarting containers using directory as subpath [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gluster] should fail if non-existent subpath is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Network Partition [Disruptive] [Slow] [k8s.io] Pods should be evicted from unready Node [Feature:TaintEviction] All pods on the unreachable node should be marked as NotReady upon the node turn NotReady AND all pods should be evicted after eviction timeout passes" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gcePDPartitioned] should support restarting containers using directory as subpath [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Loadbalancing: L7 GCE [Slow] [Feature:NEG] should be able to create a ClusterIP service [Unreleased]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Networking Granular Checks: Services [Slow] should function for endpoint-Service: udp" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Kubectl run default should create an rc or deployment from an image  [Conformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] EmptyDir volumes when FSGroup is specified [NodeFeature:FSGroup] new files should be created with FSGroup ownership when container is non-root" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gcePDPartitioned] should support existing directories when readOnly specified in the volumeSource" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Downward API should provide host IP as an env var [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="10.361780548"></testcase>
+      <testcase name="[sig-api-machinery] Garbage collector should keep the rc around until all its pods are deleted if the deleteOptions says so [Conformance]" classname="Kubernetes e2e suite" time="12.206615053"></testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gluster] should support creating multiple subpath from same volumes [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-instrumentation] [Feature:PrometheusMonitoring] Prometheus should scrape metrics from annotated pods." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Garbage collector should support cascading deletion of custom resources" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] SchedulerPredicates [Serial] validates that there exists conflict between pods with same hostPort and protocol but one using 0.0.0.0 hostIP" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Network Partition [Disruptive] [Slow] [k8s.io] Pods should return to running and ready state after network partition is healed All pods on the unreachable node should be marked as NotReady upon the node turn NotReady AND all pods should be mark back to Ready when the node get back to Ready before pod eviction timeout" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] ConfigMap should be consumable from pods in volume as non-root [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="8.314907281"></testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] Should not scale GPU pool up if pod does not require GPUs [GpuType:nvidia-tesla-p100] [Feature:ClusterSizeAutoscalingGpu]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Garbage collector should not delete dependents that have both valid owner and owner that&#39;s waiting for dependents to be deleted [Conformance]" classname="Kubernetes e2e suite" time="16.227777116"></testcase>
+      <testcase name="[sig-scalability] Load capacity [Feature:ManualPerformance] should be able to handle 30 pods per node { Random} with 0 secrets, 0 configmaps and 0 daemons with quotas" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [Feature:Example] [k8s.io] CassandraStatefulSet should create statefulset" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-auth] ServiceAccounts should mount an API token into pods  [Conformance]" classname="Kubernetes e2e suite" time="19.097120038"></testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: nfs] should fail for new directories when readOnly specified in the volumeSource" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] EquivalenceCache [Serial] validates GeneralPredicates is properly invalidated when a pod is scheduled [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-auth] ServiceAccounts should allow opting out of API token automount  [Conformance]" classname="Kubernetes e2e suite" time="6.799299654"></testcase>
+      <testcase name="[sig-apps] DisruptionController evictions: too few pods, absolute =&gt; should not allow an eviction" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: dir-link-bindmounted] Set fsGroup for local volume should not set different fsGroups for two pods simultaneously" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Networking IPerf IPv4 [Experimental] [Feature:Networking-IPv4] [Slow] [Feature:Networking-Performance] should transfer ~ 1GB onto the service endpoint 1 servers (maximum of 1 clients)" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Projected should update labels on modification [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="28.726392986"></testcase>
+      <testcase name="[sig-api-machinery] Downward API should provide pod UID as env vars [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="10.377083487"></testcase>
+      <testcase name="[sig-network] Loadbalancing: L7 GCE [Slow] [Feature:Ingress] should be able to switch between HTTPS and HTTP2 modes" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Storage Policy Based Volume Provisioning [Feature:vsphere] verify VSAN storage capability with invalid capability name objectSpaceReserve is not honored for dynamically provisioned pvc using storageclass" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: hostPath] should support non-existent path" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: block] [Feature:BlockVolume] Two pods mounting a local volume one after the other should be able to write from pod1 and read from pod2" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Variable Expansion should allow substituting values in a container&#39;s args [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="10.228536514"></testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] should increase cluster size if pending pods are small and there is another node pool that is not autoscaled [Feature:ClusterSizeAutoscalingScaleUp]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-auth] [Feature:NodeAuthorizer] Getting a non-existent secret should exit with the Forbidden error, not a NotFound error" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: hostPathSymlink] should unmount if pod is force deleted while kubelet is down [Disruptive][Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: hostPathSymlink] should support file as subpath" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Network Partition [Disruptive] [Slow] [k8s.io] [StatefulSet] should come back up if node goes down [Slow] [Disruptive]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Garbage collector should orphan pods created by rc if deleteOptions.OrphanDependents is nil" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath Atomic writer volumes should support subpaths with configmap pod with mountPath of existing file" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: nfsPVC] should fail if non-existent subpath is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cluster-lifecycle] Downgrade [Feature:Downgrade] cluster downgrade should maintain a functioning cluster [Feature:ClusterDowngrade]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] EmptyDir volumes should support (non-root,0666,tmpfs) [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="8.225264708"></testcase>
+      <testcase name="[sig-apps] ReplicationController should surface a failure condition on a common issue like exceeded quota" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Kubectl run --rm job should create a job from an image, then delete the job  [Conformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Regional PD RegionalPD should failover to a different zone when all nodes in one zone become unreachable [Slow] [Disruptive]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] PodPriorityResolution [Serial] [Feature:PodPreemption] validates critical system priorities are created and resolved" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Loadbalancing: L7 GCE [Slow] [Feature:kubemci] should conform to Ingress spec" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [Feature:Example] [k8s.io] Secret should create a pod that reads a secret" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volumes NFS should be mountable" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: block] [Feature:BlockVolume] One pod requesting one prebound PVC should be able to mount volume and read from pod1" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Networking Granular Checks: Services [Slow] should update nodePort: udp [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] [Feature:GPUDevicePlugin] run Nvidia GPU Device Plugin tests on Container Optimized OS only" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] shouldn&#39;t scale up if cores limit too low, should scale up after limit is changed [Feature:ClusterSizeAutoscalingScaleWithNAP]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Projected should provide node allocatable (cpu) as default cpu limit if the limit is not set [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="8.215898459"></testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: hostPath] should unmount if pod is gracefully deleted while kubelet is down [Disruptive][Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] DisruptionController should update PodDisruptionBudget status" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volumes Ceph RBD [Feature:Volumes] should be mountable" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volume Placement test back to back pod creation and deletion with different volume sources on the same worker node" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scalability] Density [Feature:ManualPerformance] should allow starting 100 pods per node using { ReplicationController} with 0 secrets, 0 configmaps and 0 daemons" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes [Feature:ReclaimPolicy] [sig-storage] persistentvolumereclaim:vsphere should delete persistent volume when reclaimPolicy set to delete and associated claim is deleted" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes [Feature:ReclaimPolicy] [sig-storage] persistentvolumereclaim:vsphere should not detach and unmount PV when associated pvc with delete as reclaimPolicy is deleted when it is in use by the pod" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] DisruptionController evictions: enough pods, absolute =&gt; should allow an eviction" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: nfsPVC] should support readOnly file specified in the volumeMount" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Daemon set [Serial] should update pod when spec was updated and update strategy is RollingUpdate [Conformance]" classname="Kubernetes e2e suite" time="22.767677125"></testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: hostPathSymlink] should support existing directory" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cluster-lifecycle] Reboot [Disruptive] [Feature:Reboot] each node by dropping all inbound packets for a while and ensure they function afterwards" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Firewall rule should have correct firewall rules for e2e cluster" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Loadbalancing: L7 GCE [Slow] [Feature:kubemci] single and multi-cluster ingresses should be able to exist together" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Pod Disks should be able to delete a non-existent PD without error" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: hostPath] should support file as subpath" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: emptyDir] should support restarting containers using file as subpath [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] [Feature:ClusterSizeAutoscalingScaleUp] [Slow] Autoscaling [sig-autoscaling] Autoscaling a service from 1 pod and 3 nodes to 8 pods and &gt;=4 nodes takes less than 15 minutes" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: dir] One pod requesting one prebound PVC should be able to mount volume and write from pod1" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] SchedulerPriorities [Serial] Pod should perfer to scheduled to nodes pod can tolerate" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: nfsPVC] should fail if subpath file is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] [Serial] Volume metrics PVController should create unbound pvc count metrics for pvc controller after creating pvc only" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] SchedulerPredicates [Serial] validates that there is no conflict between pods with same hostPort but different hostIP and protocol" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Downward API volume should provide container&#39;s cpu request [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="8.269006672"></testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: dir] Set fsGroup for local volume should set different fsGroup for second pod if first pod is deleted" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: tmpfs] Set fsGroup for local volume should not set different fsGroups for two pods simultaneously" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: nfsPVC] should fail if subpath directory is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] Should scale up GPU pool from 0 [GpuType:nvidia-tesla-p100] [Feature:ClusterSizeAutoscalingGpu]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Networking Granular Checks: Services [Slow] should update endpoints: udp" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] EmptyDir wrapper volumes should not conflict" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Projected should provide container&#39;s memory limit [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="8.263984745"></testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Update Demo should do a rolling update of a replication controller  [Conformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] DNS should provide DNS for the cluster  [Conformance]" classname="Kubernetes e2e suite" time="27.642311062"></testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Kubectl taint [Serial] should update the taint on a node" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volume expand [Slow] Verify if editing PVC allows resize" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] AdmissionWebhook Should mutate configmap" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Kubectl apply should apply a new configuration to an existing RC" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Services should check NodePort out-of-range" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] AdmissionWebhook Should unconditionally reject operations on fail closed webhook" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: nfs] should fail if non-existent subpath is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Kubectl create quota should reject quota with invalid scopes" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PVC Protection Verify that PVC in active use by a pod is not removed immediately" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  Local volume that cannot be mounted [Slow] should fail due to wrong node" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Guestbook application should create and stop a working application  [Conformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] StatefulSet [k8s.io] Deploy clustered applications [Feature:StatefulSet] [Slow] should creating a working redis cluster" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gluster] should support readOnly directory specified in the volumeMount" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Storage Policy Based Volume Provisioning [Feature:vsphere] verify VSAN storage capability with invalid diskStripes value is not honored for dynamically provisioned pvc using storageclass" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cluster-lifecycle] [Feature:BootstrapTokens] should delete the token secret when the secret expired" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Networking Granular Checks: Pods should function for intra-pod communication: udp [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="45.197149976"></testcase>
+      <testcase name="[k8s.io] [sig-node] Events should be sent by kubelets and the scheduler about pods scheduling and running  [Conformance]" classname="Kubernetes e2e suite" time="28.342354543"></testcase>
+      <testcase name="[sig-apps] Network Partition [Disruptive] [Slow] [k8s.io] [StatefulSet] should not reschedule stateful pods if there is a network partition [Slow] [Disruptive]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] CronJob should not schedule new jobs when ForbidConcurrent [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Kubectl api-versions should check if v1 is in available api versions  [Conformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Loadbalancing: L7 GCE [Slow] [Feature:Ingress] should create ingress with pre-shared certificate" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] should increase cluster size if pod requesting EmptyDir volume is pending [Feature:ClusterSizeAutoscalingScaleUp]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: nfs] should support restarting containers using file as subpath [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes:vsphere should test that a vspehre volume mounted to a pod that is deleted while the kubelet is down unmounts when the kubelet returns [Disruptive]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Verify Volume Attach Through vpxd Restart [Feature:vsphere][Serial][Disruptive] verify volume remains attached through vpxd restart" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] EmptyDir volumes should support (root,0644,tmpfs) [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="8.241507025"></testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gcePDPVC] should support existing single file" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] should create new node if there is no node for node selector [Feature:ClusterSizeAutoscalingScaleWithNAP]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] ESIPP [Slow] [DisabledForLargeClusters] should work for type=NodePort" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Projected should be consumable from pods in volume with mappings and Item mode set [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="8.217922118"></testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gcePDPartitioned] should fail if subpath file is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: dir-link] One pod requesting one prebound PVC should be able to mount volume and write from pod1" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] DaemonRestart [Disruptive] Controller Manager should not create/delete replicas across restart" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Probing container with readiness probe that fails should never be ready and never restart [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="82.224808842"></testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: dir-bindmounted] One pod requesting one prebound PVC should be able to mount volume and write from pod1" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volumes vsphere [Feature:Volumes] should be mountable" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] Should scale down GPU pool from 1 [GpuType:nvidia-tesla-p100] [Feature:ClusterSizeAutoscalingGpu]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [sig-node] Security Context [Feature:SecurityContext] should support seccomp alpha runtime/default annotation [Feature:Seccomp]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] CronJob should not schedule jobs when suspended [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: tmpfs] Set fsGroup for local volume should set fsGroup for one pod" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] GenericPersistentVolume[Disruptive] When kubelet restarts Should test that a volume mounted to a pod that is force deleted while the kubelet is down unmounts when the kubelet returns." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes NFS with Single PV - PVC pairs create a PV and a pre-bound PVC: test write access" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gluster] should support restarting containers using directory as subpath [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: emptyDir] should support readOnly directory specified in the volumeMount" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] GenericPersistentVolume[Disruptive] When kubelet restarts Should test that a volume mounted to a pod that is deleted while the kubelet is down unmounts when the kubelet returns." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] ConfigMap should be consumable from pods in volume as non-root with FSGroup [NodeFeature:FSGroup]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [sig-node] Security Context [Feature:SecurityContext] should support volume SELinux relabeling" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] Multi-AZ Clusters should spread the pods of a service across zones" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volumes Azure Disk [Feature:Volumes] should be mountable [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Sysctls [NodeFeature:Sysctls] should not launch unsafe, but not explicitly enabled sysctls on the node" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: gce-localssd-scsi-fs] [Serial] Set fsGroup for local volume should set same fsGroup for two pods simultaneously" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Dynamic Provisioning DynamicProvisioner should provision storage with non-default reclaim policy Retain" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gcePDPartitioned] should unmount if pod is gracefully deleted while kubelet is down [Disruptive][Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: dir-bindmounted] Two pods mounting a local volume one after the other should be able to write from pod1 and read from pod2" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: nfsPVC] should unmount if pod is force deleted while kubelet is down [Disruptive][Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] ResourceQuota should create a ResourceQuota and ensure its status is promptly calculated." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] ESIPP [Slow] [DisabledForLargeClusters] should handle updates to ExternalTrafficPolicy field" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] should correctly scale down after a node is not needed when there is non autoscaled pool[Feature:ClusterSizeAutoscalingScaleDown]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: dir-link] Set fsGroup for local volume should not set different fsGroups for two pods simultaneously" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: nfs] should support creating multiple subpath from same volumes [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cluster-lifecycle] HA-master [Feature:HAMaster] survive addition/removal replicas same zone [Serial][Disruptive]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Kubectl apply should reuse port when apply to an existing SVC" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Projected optional updates should be reflected in volume [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="114.262168061"></testcase>
+      <testcase name="[sig-network] NetworkPolicy NetworkPolicy between server and client should allow ingress access on one named port [Feature:NetworkPolicy]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] EmptyDir volumes when FSGroup is specified [NodeFeature:FSGroup] volume on tmpfs should have the correct mode using FSGroup" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Services should be able to switch session affinity for LoadBalancer service with ESIPP off [Slow] [DisabledForLargeClusters]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-instrumentation] Cluster level logging implemented by Stackdriver should ingest logs" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] should add node to the particular mig [Feature:ClusterSizeAutoscalingScaleUp]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gluster] should support readOnly file specified in the volumeMount" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  StatefulSet with pod anti-affinity should use volumes spread across nodes" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Simple pod should support exec" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes NFS when invoking the Recycle reclaim policy should test that a PV becomes Available and is clean after the PVC is deleted." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Job should run a job to completion when tasks succeed" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] Should not scale GPU pool up if pod does not require GPUs [GpuType:nvidia-tesla-k80] [Feature:ClusterSizeAutoscalingGpu]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PV Protection Verify that PV bound to a PVC is not removed immediately" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Kubectl run pod should create a pod from an image when restart is Never  [Conformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl Port forwarding [k8s.io] With a server listening on localhost [k8s.io] that expects a client request should support a client that connects, sends NO DATA, and disconnects" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: dir-link-bindmounted] Set fsGroup for local volume should set different fsGroup for second pod if first pod is deleted" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Probing container should be restarted with a exec &#34;cat /tmp/health&#34; liveness probe [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="58.380410289"></testcase>
+      <testcase name="[sig-network] DNS configMap nameserver Change stubDomain should be able to change stubDomain configuration [Slow][Serial]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Cluster size autoscaler scalability [Slow] shouldn&#39;t scale down with underutilized nodes due to host port conflicts [Feature:ClusterAutoscalerScalability5]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: hostPathSymlink] should support readOnly directory specified in the volumeMount" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: dir] Set fsGroup for local volume should not set different fsGroups for two pods simultaneously" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Watchers should observe add, update, and delete watch notifications on configmaps [Conformance]" classname="Kubernetes e2e suite" time="66.817799712"></testcase>
+      <testcase name="[sig-api-machinery] Etcd failure [Disruptive] should recover from SIGKILL" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: dir-link] Set fsGroup for local volume should set different fsGroup for second pod if first pod is deleted" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] ResourceQuota should create a ResourceQuota and capture the life of a persistent volume claim. [sig-storage]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Services should have session affinity work for LoadBalancer service with ESIPP on [Slow] [DisabledForLargeClusters]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: dir] Set fsGroup for local volume should set same fsGroup for two pods simultaneously" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cluster-lifecycle] etcd Upgrade [Feature:EtcdUpgrade] etcd upgrade should maintain a functioning cluster" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] ConfigMap should be consumable from pods in volume with mappings as non-root [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="8.426828055"></testcase>
+      <testcase name="[sig-network] Services should work after restarting apiserver [Disruptive]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Loadbalancing: L7 GCE [Slow] [Feature:NEG] should be able to switch between IG and NEG modes" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [sig-node] Security Context [Feature:SecurityContext] should support pod.Spec.SecurityContext.SupplementalGroups" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gcePDPVC] should support creating multiple subpath from same volumes [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Variable Expansion should allow composing env vars into new env vars [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="10.330092106"></testcase>
+      <testcase name="[k8s.io] InitContainer [NodeConformance] should not start app containers if init containers fail on a RestartAlways pod" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] EmptyDir wrapper volumes should not cause race condition when used for git_repo [Serial] [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Services should have session affinity work for service with type clusterIP" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Generated clientset should create pods, set the deletionTimestamp and deletionGracePeriodSeconds of the pod" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes NFS with Single PV - PVC pairs create a PVC and a pre-bound PV: test write access" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath Atomic writer volumes should support subpaths with secret pod" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gcePDPVC] should fail if subpath with backstepping is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gluster] should support non-existent path" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] ConfigMap should be consumable from pods in volume with defaultMode set [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="8.342690425"></testcase>
+      <testcase name="[sig-storage] Downward API volume should provide node allocatable (cpu) as default cpu limit if the limit is not set [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="8.284089764"></testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] should increase cluster size if pods are pending due to host port conflict [Feature:ClusterSizeAutoscalingScaleUp]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: nfsPVC] should fail if subpath with backstepping is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: nfs] should support readOnly directory specified in the volumeMount" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Initializers [Feature:Initializers] should dynamically register and apply initializers to pods [Serial]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [sig-node] Kubelet [Serial] [Slow] [k8s.io] [sig-node] experimental resource usage tracking [Feature:ExperimentalResourceUsageTracking] resource tracking for 100 pods per node" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Kubectl run job should create a job from an image when restart is OnFailure  [Conformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] shouldn&#39;t be able to scale down when rescheduling a pod is required, but pdb doesn&#39;t allow drain[Feature:ClusterSizeAutoscalingScaleDown]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] ReplicationController should serve a basic image on each replica with a public image  [Conformance]" classname="Kubernetes e2e suite" time="16.443729153"></testcase>
+      <testcase name="[sig-network] Services should be able to change the type from NodePort to ExternalName" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volume Placement should create and delete pod with the same volume source on the same worker node" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Kubectl expose should create services for rc  [Conformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Loadbalancing: L7 GCE [Slow] [Feature:Ingress] multicluster ingress should get instance group annotation" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Network Partition [Disruptive] [Slow] [k8s.io] [ReplicationController] should recreate pods scheduled on the unreachable node AND allow scheduling of pods on a node after it rejoins the cluster" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Loadbalancing: L7 GCE [Slow] [Feature:Ingress] should support multiple TLS certs" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] StatefulSet [k8s.io] Basic StatefulSet functionality [StatefulSetBasic] should perform canary updates and phased rolling updates of template modifications [Conformance]" classname="Kubernetes e2e suite" time="116.60775771"></testcase>
+      <testcase name="[sig-storage] Secrets should be consumable from pods in volume with mappings and Item Mode set [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="8.330868313"></testcase>
+      <testcase name="[k8s.io] [Feature:Example] [k8s.io] Hazelcast should create and scale hazelcast" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Projected should be able to mount in a volume regardless of a different secret existing with same name in different namespace [NodeConformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cluster-lifecycle] Nodes [Disruptive] Resize [Slow] should be able to delete nodes" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-instrumentation] Cluster level logging implemented by Stackdriver should ingest events" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [sig-node] Security Context [Feature:SecurityContext] should support container.SecurityContext.RunAsUser" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: nfsPVC] should support file as subpath" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] InitContainer [NodeConformance] should not start app containers and fail the pod if init containers fail on a RestartNever pod" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Job should run a job to completion when tasks sometimes fail and are not locally restarted" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] should scale up when non expendable pod is created [Feature:ClusterSizeAutoscalingScaleUp]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gcePDPartitioned] should fail if non-existent subpath is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [sig-node] Security Context [Feature:SecurityContext] should support pod.Spec.SecurityContext.RunAsUser" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] ResourceQuota should verify ResourceQuota with best effort scope." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Dynamic Provisioning Block volume provisioning [Feature:BlockVolume] should create and delete block persistent volumes" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: nfs] should support existing directories when readOnly specified in the volumeSource" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: gce-localssd-scsi-fs] [Serial] Two pods mounting a local volume at the same time should be able to write from pod1 and read from pod2" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Downward API volume should provide node allocatable (memory) as default memory limit if the limit is not set [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="10.23049979"></testcase>
+      <testcase name="[sig-storage] Projected should be consumable from pods in volume [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="8.216388924"></testcase>
+      <testcase name="[sig-auth] [Feature:NodeAuthorizer] Getting an existing configmap should exit with the Forbidden error" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] AdmissionWebhook Should mutate custom resource" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: hostPathSymlink] should support creating multiple subpath from same volumes [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scalability] Density [Feature:ManualPerformance] should allow starting 50 pods per node using { ReplicationController} with 0 secrets, 0 configmaps and 0 daemons" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] StatefulSet [k8s.io] Basic StatefulSet functionality [StatefulSetBasic] should adopt matching orphans and release non-matching pods" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cluster-lifecycle] kube-proxy migration [Feature:KubeProxyDaemonSetMigration] Downgrade kube-proxy from a DaemonSet to static pods should maintain a functioning cluster [Feature:KubeProxyDaemonSetDowngrade]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Garbage collector should orphan RS created by deployment when deleteOptions.PropagationPolicy is Orphan [Conformance]" classname="Kubernetes e2e suite" time="36.826259457"></testcase>
+      <testcase name="[sig-storage] Projected should be consumable from pods in volume with mappings as non-root [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="8.306728319"></testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gcePDPVC] should support non-existent path" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Loadbalancing: L7 GCE [Slow] [Feature:NEG] rolling update backend pods should not cause service disruption" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Services should be able to change the type and ports of a service [Slow] [DisabledForLargeClusters]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Projected should provide podname only [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="8.237298365000001"></testcase>
+      <testcase name="[sig-storage] EmptyDir volumes should support (root,0666,tmpfs) [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="8.293197264"></testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gcePDPartitioned] should unmount if pod is force deleted while kubelet is down [Disruptive][Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Deployment deployment should delete old replica sets" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Projected should provide container&#39;s cpu limit [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="8.255356009"></testcase>
+      <testcase name="[sig-storage] vcp at scale [Feature:vsphere]  vsphere scale tests" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volumes CephFS [Feature:Volumes] should be mountable" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [sig-node] Pods Extended [k8s.io] Pods Set QOS Class should be submitted and removed  [Conformance]" classname="Kubernetes e2e suite" time="22.178309312"></testcase>
+      <testcase name="[sig-network] Networking IPerf IPv6 [Experimental] [Feature:Networking-IPv6] [Slow] [Feature:Networking-Performance] should transfer ~ 1GB onto the service endpoint 1 servers (maximum of 1 clients)" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: gce-localssd-scsi-fs] [Serial] Two pods mounting a local volume one after the other should be able to write from pod1 and read from pod2" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] shouldn&#39;t add new node group if not needed [Feature:ClusterSizeAutoscalingScaleWithNAP]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Probing container should be restarted with a docker exec liveness probe with timeout " classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  Local volume provisioner [Serial] should not create local persistent volume for filesystem volume that was not bind mounted" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: dir-link-bindmounted] Set fsGroup for local volume should set same fsGroup for two pods simultaneously" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] EmptyDir volumes when FSGroup is specified [NodeFeature:FSGroup] nonexistent volume subPath should have the correct mode and owner using FSGroup" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] shouldn&#39;t trigger additional scale-ups during processing scale-up [Feature:ClusterSizeAutoscalingScaleUp]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] Should scale up GPU pool from 1 [GpuType:nvidia-tesla-v100] [Feature:ClusterSizeAutoscalingGpu]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gcePDPartitioned] should support file as subpath" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Pods should support remote command execution over websockets [NodeConformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gcePDPartitioned] should fail if subpath with backstepping is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] HostPath should support r/w [NodeConformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: nfsPVC] should support non-existent path" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Pod Disks detach in a disrupted environment [Slow] [Disruptive] when node&#39;s API object is deleted" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  Local volume that cannot be mounted [Slow] should fail due to non-existent path" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Daemon set [Serial] should run and stop simple daemon [Conformance]" classname="Kubernetes e2e suite" time="25.143849451"></testcase>
+      <testcase name="[sig-storage] Storage Policy Based Volume Provisioning [Feature:vsphere] verify if a SPBM policy is not honored on a non-compatible datastore for dynamically provisioned pvc using storageclass" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: emptyDir] should support existing directory" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Etcd failure [Disruptive] should recover from network partition with master" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: nfs] should support existing single file" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-instrumentation] Cluster level logging using Elasticsearch [Feature:Elasticsearch] should check that logs from containers are ingested into Elasticsearch" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Kubectl rolling-update should support rolling-update to same image  [Conformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Namespaces [Serial] should ensure that all pods are removed when a namespace is deleted." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volume Placement should create and delete pod with the same volume source attach/detach to different worker nodes" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volumes PD should be mountable with ext3" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gcePDPVC] should support existing directory" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] [HPA] Horizontal pod autoscaling (scale resource: Custom Metrics from Stackdriver) should scale down with Custom Metric of type Pod from Stackdriver with Prometheus [Feature:CustomMetricsAutoscaling]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Dynamic Provisioning DynamicProvisioner should test that deleting a claim before the volume is provisioned deletes the volume." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath Atomic writer volumes should support subpaths with projected pod" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-instrumentation] MetricsGrabber should grab all metrics from a Scheduler." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Networking Granular Checks: Services [Slow] should function for client IP based session affinity: http" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-auth] Certificates API should support building a client with a CSR" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scalability] Load capacity [Feature:ManualPerformance] should be able to handle 30 pods per node {extensions Deployment} with 0 secrets, 0 configmaps and 0 daemons" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: tmpfs] One pod requesting one prebound PVC should be able to mount volume and read from pod1" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Networking Granular Checks: Services [Slow] should function for node-Service: http" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Job should run a job to completion when tasks sometimes fail and are locally restarted" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  Local volume provisioner [Serial] should create and recreate local persistent volume" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] [HPA] Horizontal pod autoscaling (scale resource: CPU) [sig-autoscaling] [Serial] [Slow] Deployment Should scale from 5 pods to 3 pods and from 3 to 1" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] StatefulSet [k8s.io] Basic StatefulSet functionality [StatefulSetBasic] Should recreate evicted statefulset [Conformance]" classname="Kubernetes e2e suite" time="24.29321756"></testcase>
+      <testcase name="[sig-storage] Volume Provisioning On Clustered Datastore [Feature:vsphere] verify dynamic provision with default parameter on clustered datastore" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] should be able to scale down by draining system pods with pdb[Feature:ClusterSizeAutoscalingScaleDown]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] ConfigMap binary data should be reflected in volume [NodeConformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [sig-node] Kubelet [Serial] [Slow] [k8s.io] [sig-node] regular resource usage tracking resource tracking for 100 pods per node" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Networking Granular Checks: Pods should function for intra-pod communication: http [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="45.09934886"></testcase>
+      <testcase name="[sig-storage] Flexvolumes [Disruptive] should be mountable when non-attachable" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: nfs] should support file as subpath" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volume FStype [Feature:vsphere] verify invalid fstype" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] NetworkPolicy NetworkPolicy between server and client should support a &#39;default-deny&#39; policy [Feature:NetworkPolicy]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] ConfigMap should be consumable from pods in volume with mappings as non-root with FSGroup [NodeFeature:FSGroup]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Probing container should *not* be restarted with a /healthz http liveness probe [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="249.3354578"></testcase>
+      <testcase name="[sig-api-machinery] CustomResourceDefinition Watch CustomResourceDefinition Watch watch on custom resource definition objects" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: dir-link] Set fsGroup for local volume should set fsGroup for one pod" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] Should not scale GPU pool up if pod does not require GPUs [GpuType:nvidia-tesla-v100] [Feature:ClusterSizeAutoscalingGpu]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: dir-link-bindmounted] Two pods mounting a local volume at the same time should be able to write from pod1 and read from pod2" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] ReplicationController should serve a basic image on each replica with a private image" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] ESIPP [Slow] [DisabledForLargeClusters] should work from pods" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [sig-node] Security Context [Feature:SecurityContext] should support seccomp alpha unconfined annotation on the container [Feature:Seccomp]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] should increase cluster size if pending pods are small and one node is broken [Feature:ClusterSizeAutoscalingScaleUp]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gcePDPartitioned] should support existing directory" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Services should prevent NodePort collisions" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Downward API volume should update annotations on modification [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="29.000588491"></testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] Should scale up GPU pool from 0 [GpuType:nvidia-tesla-k80] [Feature:ClusterSizeAutoscalingGpu]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] ResourceQuota should create a ResourceQuota and capture the life of a service." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Mounted volume expand[Slow] Should verify mounted devices can be resized" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: dir] Two pods mounting a local volume one after the other should be able to write from pod1 and read from pod2" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Dynamic Provisioning [k8s.io] GlusterDynamicProvisioner should create and delete persistent volumes [fast]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cluster-lifecycle] [Feature:BootstrapTokens] should delete the signed bootstrap tokens from clusterInfo ConfigMap when bootstrap token is deleted" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: dir-link-bindmounted] One pod requesting one prebound PVC should be able to mount volume and write from pod1" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Storage Policy Based Volume Provisioning [Feature:vsphere] verify VSAN storage capability with valid diskStripes and objectSpaceReservation values and a VSAN datastore is honored for dynamically provisioned pvc using storageclass" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Dynamic Provisioning DynamicProvisioner External should let an external dynamic provisioner create and delete persistent volumes [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] StatefulSet [k8s.io] Basic StatefulSet functionality [StatefulSetBasic] should implement legacy replacement when the update strategy is OnDelete" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gcePDPVC] should unmount if pod is force deleted while kubelet is down [Disruptive][Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: gce-localssd-scsi-fs] [Serial] Set fsGroup for local volume should set fsGroup for one pod" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Projected should be consumable from pods in volume with mappings as non-root with FSGroup [NodeFeature:FSGroup]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Projected should set mode on item file [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="8.363667975"></testcase>
+      <testcase name="[sig-apps] Deployment deployment should support proportional scaling" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Projected should be consumable from pods in volume [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="10.243612005"></testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gluster] should fail if subpath with backstepping is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Kubectl patch should add annotations for pods in rc  [Conformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volume Disk Size [Feature:vsphere] verify dynamically provisioned pv using storageclass with an invalid disk size fails" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: block] [Feature:BlockVolume] Two pods mounting a local volume at the same time should be able to write from pod1 and read from pod2" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Storage Policy Based Volume Provisioning [Feature:vsphere] verify VSAN storage capability with invalid hostFailuresToTolerate value is not honored for dynamically provisioned pvc using storageclass" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: blockfs] Set fsGroup for local volume should set different fsGroup for second pod if first pod is deleted" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: nfs] should fail if subpath file is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: hostPathSymlink] should unmount if pod is gracefully deleted while kubelet is down [Disruptive][Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Pod Disks schedule pods each with a PD, delete pod and verify detach [Slow] for RW PD with pod delete grace period of &#34;immediate (0s)&#34;" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Cluster size autoscaler scalability [Slow] should scale up twice [Feature:ClusterAutoscalerScalability2]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] GCP Volumes NFSv4 should be mountable for NFSv4" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] DNS configMap federations should be able to change federation configuration [Slow][Serial]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: dir-bindmounted] Set fsGroup for local volume should not set different fsGroups for two pods simultaneously" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: blockfs] One pod requesting one prebound PVC should be able to mount volume and read from pod1" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Watchers should observe an object deletion if it stops meeting the requirements of the selector [Conformance]" classname="Kubernetes e2e suite" time="16.533008814"></testcase>
+      <testcase name="[sig-instrumentation] MetricsGrabber should grab all metrics from API server." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Cluster size autoscaler scalability [Slow] should scale up at all [Feature:ClusterAutoscalerScalability1]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] StatefulSet [k8s.io] Deploy clustered applications [Feature:StatefulSet] [Slow] should creating a working mysql cluster" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Deployment deployment reaping should cascade to its replica sets and pods" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] EmptyDir wrapper volumes should not cause race condition when used for configmaps [Serial] [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scalability] Load capacity [Feature:ManualPerformance] should be able to handle 30 pods per node { ReplicationController} with 0 secrets, 0 configmaps and 2 daemons" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Servers with support for Table transformation should return pod details" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Kubectl version should check is all data is printed  [Conformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Variable Expansion should fail substituting values in a volume subpath with absolute path [Feature:VolumeSubpathEnvExpansion][NodeAlphaFeature:VolumeSubpathEnvExpansion][Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: hostPathSymlink] should support non-existent path" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cluster-lifecycle] [Feature:BootstrapTokens] should sign the new added bootstrap tokens" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Pod Disks schedule a pod w/ RW PD(s) mounted to 1 or more containers, write to PD, verify content, delete pod, and repeat in rapid succession [Slow] using 1 containers and 2 PDs" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Secrets should be able to mount in a volume regardless of a different secret existing with same name in different namespace [NodeConformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gcePDPartitioned] should support readOnly file specified in the volumeMount" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Projected should provide podname as non-root with fsgroup and defaultMode [NodeFeature:FSGroup]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Variable Expansion should fail substituting values in a volume subpath with backticks [Feature:VolumeSubpathEnvExpansion][NodeAlphaFeature:VolumeSubpathEnvExpansion][Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Servers with support for Table transformation should return a 406 for a backend which does not implement metadata" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] NetworkPolicy NetworkPolicy between server and client should enforce multiple, stacked policies with overlapping podSelectors [Feature:NetworkPolicy]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cluster-lifecycle] Upgrade [Feature:Upgrade] master upgrade should maintain a functioning cluster [Feature:MasterUpgrade]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Simple pod should handle in-cluster config" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] should increase cluster size if pods are pending due to pod anti-affinity [Feature:ClusterSizeAutoscalingScaleUp]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Pods should have their auto-restart back-off timer reset on image update [Slow][NodeConformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: hostPath] should fail if non-existent subpath is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: dir-link] One pod requesting one prebound PVC should be able to mount volume and read from pod1" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Sysctls [NodeFeature:Sysctls] should support unsafe sysctls which are actually whitelisted" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] ConfigMap should be consumable from pods in volume with mappings and Item mode set [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="8.222769741"></testcase>
+      <testcase name="[sig-storage] Subpath Atomic writer volumes should support subpaths with configmap pod" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes NFS with Single PV - PVC pairs create a PVC and non-pre-bound PV: test write access" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Daemon set [Serial] should retry creating failed daemon pods [Conformance]" classname="Kubernetes e2e suite" time="17.644985947"></testcase>
+      <testcase name="[sig-storage] Dynamic Provisioning DynamicProvisioner Default should be disabled by removing the default annotation [Serial] [Disruptive]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Services should be able to create a functioning NodePort service" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Pod Disks schedule a pod w/ RW PD(s) mounted to 1 or more containers, write to PD, verify content, delete pod, and repeat in rapid succession [Slow] using 4 containers and 1 PDs" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] DNS should provide DNS for services  [Conformance]" classname="Kubernetes e2e suite" time="22.133694423"></testcase>
+      <testcase name="[k8s.io] EquivalenceCache [Serial] validates pod affinity works properly when new replica pod is scheduled" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: hostPath] should support readOnly directory specified in the volumeMount" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes GCEPD should test that deleting a PVC before the pod does not cause pod deletion to fail on PD detach" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] ClusterDns [Feature:Example] should create pod that uses dns" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Proxy version v1 should proxy through a service and a pod  [Conformance]" classname="Kubernetes e2e suite" time="17.824197996"></testcase>
+      <testcase name="[sig-scheduling] SchedulerPredicates [Serial] validates that NodeAffinity is respected if not matching" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] [Feature:PerformanceDNS] Should answer DNS query for maximum number of services per cluster" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes:vsphere should test that deleting a PVC before the pod does not cause pod deletion to fail on vsphere volume detach" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Dynamic Provisioning DynamicProvisioner deletion should be idempotent" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] ConfigMap should be consumable via the environment [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="10.27014029"></testcase>
+      <testcase name="[sig-cluster-lifecycle] gpu Upgrade [Feature:GPUUpgrade] cluster upgrade should be able to run gpu pod after upgrade [Feature:GPUClusterUpgrade]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Proxy server should support --unix-socket=/path  [Conformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] DisruptionController evictions: too few pods, replicaSet, percentage =&gt; should not allow an eviction" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] AdmissionWebhook Should deny crd creation" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: emptyDir] should support restarting containers using directory as subpath [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Job should exceed backoffLimit" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] should be able to scale down by draining multiple pods one by one as dictated by pdb[Feature:ClusterSizeAutoscalingScaleDown]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: emptyDir] should support file as subpath" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Proxy version v1 should proxy logs on node with explicit kubelet port using proxy subresource  [Conformance]" classname="Kubernetes e2e suite" time="6.432012921"></testcase>
+      <testcase name="[sig-apps] CronJob should not emit unexpected warnings" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gcePDPVC] should support readOnly file specified in the volumeMount" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Aggregator Should be able to support the 1.7 Sample API Server using the current Aggregator" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Deployment test Deployment ReplicaSet orphaning and adoption regarding controllerRef" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Loadbalancing: L7 GCE [Slow] [Feature:Ingress] should create ingress with given static-ip" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [sig-node] kubelet [k8s.io] [sig-node] Clean up pods on node kubelet should be able to delete 10 pods per node in 1m0s." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Downward API should provide container&#39;s limits.cpu/memory and requests.cpu/memory as env vars [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="10.218227598"></testcase>
+      <testcase name="[sig-storage] EmptyDir volumes when FSGroup is specified [NodeFeature:FSGroup] new files should be created with FSGroup ownership when container is root" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Secrets should be consumable via the environment [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="10.308918499"></testcase>
+      <testcase name="[k8s.io] [Feature:Example] [k8s.io] Liveness liveness pods should be automatically restarted" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  Stress with local volume provisioner [Serial] should use be able to process many pods and reuse local volumes" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Pod Disks schedule pods each with a PD, delete pod and verify detach [Slow] for read-only PD with pod delete grace period of &#34;default (30s)&#34;" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-auth] PodSecurityPolicy should enforce the restricted extensions.PodSecurityPolicy" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: hostPath] should unmount if pod is force deleted while kubelet is down [Disruptive][Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Secrets should be consumable from pods in volume [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="8.214051447"></testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gluster] should fail if subpath file is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] EmptyDir volumes when FSGroup is specified [NodeFeature:FSGroup] volume on default medium should have the correct mode using FSGroup" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Update Demo should scale a replication controller  [Conformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-auth] [Feature:NodeAuthorizer] A node shouldn&#39;t be able to delete another node" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] SchedulerPriorities [Serial] Pod should be schedule to node that don&#39;t match the PodAntiAffinity terms" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Generated clientset should create v1beta1 cronJobs, delete cronJobs, watch cronJobs" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] stateful Upgrade [Feature:StatefulUpgrade] [k8s.io] stateful upgrade should maintain a functioning cluster" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Network should set TCP CLOSE_WAIT timeout" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] [Serial] Volume metrics PVController should create none metrics for pvc controller before creating any PV or PVC" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] EquivalenceCache [Serial] validates pod anti-affinity works properly when new replica pod is scheduled" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Projected should be consumable from pods in volume with mappings [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="8.235277199"></testcase>
+      <testcase name="[sig-apps] CronJob should remove from active list jobs that have been deleted" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Projected should be consumable from pods in volume as non-root with defaultMode and fsGroup set [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="8.249536319"></testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  Pod with node different from PV&#39;s NodeAffinity should fail scheduling due to different NodeAffinity" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volume plugin streaming [Slow] GlusterFS should write files of various sizes, verify size, validate content" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes:vsphere should test that deleting the PV before the pod does not cause pod deletion to fail on vspehre volume detach" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] AdmissionWebhook Should not be able to prevent deleting validating-webhook-configurations or mutating-webhook-configurations" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scalability] Density [Feature:ManualPerformance] should allow starting 30 pods per node using { ReplicationController} with 0 secrets, 0 configmaps and 2 daemons" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Projected should be consumable from pods in volume with defaultMode set [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="8.341234873"></testcase>
+      <testcase name="[k8s.io] KubeletManagedEtcHosts should test kubelet managed /etc/hosts file [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="56.296664541"></testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gcePDPVC] should support file as subpath" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cluster-lifecycle] Reboot [Disruptive] [Feature:Reboot] each node by ordering clean reboot and ensure they function upon restart" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cluster-lifecycle] Reboot [Disruptive] [Feature:Reboot] each node by dropping all outbound packets for a while and ensure they function afterwards" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gcePDPVC] should support readOnly directory specified in the volumeMount" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Regional PD RegionalPD should provision storage [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] DNS configMap nameserver Forward external name lookup should forward externalname lookup to upstream nameserver [Slow][Serial]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] HostPath should give a volume the correct mode [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="8.229854363"></testcase>
+      <testcase name="[sig-storage] Downward API volume should provide podname as non-root with fsgroup [NodeFeature:FSGroup]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Services should be able to switch session affinity for NodePort service" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Services should use same NodePort with same port but different protocols" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Job should exceed active deadline" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Downward API should provide default limits.cpu/memory from node allocatable [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="10.289805457"></testcase>
+      <testcase name="[k8s.io] [sig-node] Security Context [Feature:SecurityContext] should support seccomp alpha unconfined annotation on the pod [Feature:Seccomp]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volume Placement should create and delete pod with multiple volumes from same datastore" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] InitContainer [NodeConformance] should invoke init containers on a RestartAlways pod" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: hostPath] should fail if subpath directory is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Network Partition [Disruptive] [Slow] [k8s.io] [ReplicationController] should eagerly create replacement pod during network partition when termination grace is non-zero" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: nfsPVC] should support existing single file" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] CronJob should replace jobs when ReplaceConcurrent" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes [Feature:ReclaimPolicy] [sig-storage] persistentvolumereclaim:vsphere should retain persistent volume when reclaimPolicy set to retain when associated claim is deleted" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Job should adopt matching orphans and release non-matching pods" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Services should be able to switch session affinity for service with type clusterIP" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Networking Granular Checks: Services [Slow] should function for client IP based session affinity: udp" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl Port forwarding [k8s.io] With a server listening on 0.0.0.0 should support forwarding over websockets" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Daemon set [Serial] should run and stop complex daemon with node affinity" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] DNS should provide DNS for ExternalName services" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-instrumentation] [Feature:PrometheusMonitoring] Prometheus should scrape metrics from annotated services." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Initializers [Feature:Initializers] should be invisible to controllers by default" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cluster-lifecycle] Nodes [Disruptive] Resize [Slow] should be able to add nodes" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: tmpfs] Two pods mounting a local volume one after the other should be able to write from pod1 and read from pod2" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Downward API volume should set mode on item file [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="8.366565268"></testcase>
+      <testcase name="[sig-scheduling] SchedulerPredicates [Serial] validates that taints-tolerations is respected if not matching" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Loadbalancing: L7 GCE [Slow] [Feature:kubemci] should remove clusters as expected" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Deployment deployment should support rollover" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Loadbalancing: L7 GCE [Slow] [Feature:kubemci] should support https-only annotation" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] AdmissionWebhook Should mutate pod and apply defaults after mutation" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] StatefulSet [k8s.io] Deploy clustered applications [Feature:StatefulSet] [Slow] should creating a working CockroachDB cluster" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] [HPA] Horizontal pod autoscaling (scale resource: CPU) [sig-autoscaling] [Serial] [Slow] ReplicaSet Should scale from 5 pods to 3 pods and from 3 to 1" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gluster] should fail for new directories when readOnly specified in the volumeSource" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Storage Policy Based Volume Provisioning [Feature:vsphere] verify VSAN storage capability with valid hostFailuresToTolerate and cacheReservation values is honored for dynamically provisioned pvc using storageclass" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Networking Granular Checks: Services [Slow] should update endpoints: http" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gcePDPartitioned] should support non-existent path" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Kubectl replace should update a single-container pod&#39;s image  [Conformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Projected should be consumable in multiple volumes in a pod [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="8.205496829"></testcase>
+      <testcase name="[k8s.io] [sig-node] Pods Extended [k8s.io] Delete Grace Period should be submitted and removed  [Flaky] [Conformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Node Unregister [Feature:vsphere] [Slow] [Disruptive] node unregister" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] SchedulerPredicates [Serial] validates resource limits of pods that are allowed to run  [Conformance]" classname="Kubernetes e2e suite" time="85.464265169"></testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] Should scale down GPU pool from 1 [GpuType:nvidia-tesla-k80] [Feature:ClusterSizeAutoscalingGpu]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Pods should contain environment variables for services [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="28.422601828"></testcase>
+      <testcase name="[sig-storage] Projected should provide podname as non-root with fsgroup [NodeFeature:FSGroup]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] SchedulerPredicates [Serial] validates that taints-tolerations is respected if matching" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] shouldn&#39;t scale up when expendable pod is preempted [Feature:ClusterSizeAutoscalingScaleUp]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cluster-lifecycle] HA-master [Feature:HAMaster] survive addition/removal replicas different zones [Serial][Disruptive]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] SchedulerPredicates [Serial] validates that NodeSelector is respected if not matching  [Conformance]" classname="Kubernetes e2e suite" time="83.351040937"></testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: nfsPVC] should support existing directories when readOnly specified in the volumeSource" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-instrumentation] [Feature:PrometheusMonitoring] Prometheus should contain correct container CPU metric." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Downward API volume should provide podname only [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="8.308971971"></testcase>
+      <testcase name="[sig-cli] Kubectl Port forwarding [k8s.io] With a server listening on localhost [k8s.io] that expects a client request should support a client that connects, sends DATA, and disconnects" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] AdmissionWebhook Should be able to deny custom resource creation" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] CronJob should delete successful finished jobs with limit of one successful job" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Networking Granular Checks: Pods should function for node-pod communication: http [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="47.260135162"></testcase>
+      <testcase name="[sig-scheduling] Multi-AZ Cluster Volumes [sig-storage] should only be allowed to provision PDs in zones where nodes exist" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] StatefulSet [k8s.io] Basic StatefulSet functionality [StatefulSetBasic] should provide basic identity" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] [Serial] Volume metrics PVController should create bound pv/pvc count metrics for pvc controller after creating both pv and pvc" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] StatefulSet [k8s.io] Basic StatefulSet functionality [StatefulSetBasic] should perform rolling updates and roll backs of template modifications [Conformance]" classname="Kubernetes e2e suite" time="138.372763126"></testcase>
+      <testcase name="[sig-storage] Volume Disk Format [Feature:vsphere] verify disk format type - zeroedthick is honored for dynamically provisioned pv using storageclass" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Secrets should be consumable from pods in env vars [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="10.22794636"></testcase>
+      <testcase name="[sig-storage] EmptyDir volumes should support (non-root,0777,tmpfs) [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="8.207989739"></testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] Should scale down GPU pool from 1 [GpuType:nvidia-tesla-v100] [Feature:ClusterSizeAutoscalingGpu]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: gce-localssd-scsi-fs] [Serial] One pod requesting one prebound PVC should be able to mount volume and read from pod1" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Pod Disks detach in a disrupted environment [Slow] [Disruptive] when pod is evicted" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] ResourceQuota should create a ResourceQuota and capture the life of a replication controller." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: blockfs] Two pods mounting a local volume one after the other should be able to write from pod1 and read from pod2" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Storage Policy Based Volume Provisioning [Feature:vsphere] verify an if a SPBM policy and VSAN capabilities cannot be honored for dynamically provisioned pvc using storageclass" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] AdmissionWebhook Should be able to deny pod and configmap creation" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gluster] should support existing single file" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scalability] Density [Feature:ManualPerformance] should allow starting 30 pods per node using {extensions Deployment} with 0 secrets, 2 configmaps and 0 daemons" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] DisruptionController evictions: no PDB =&gt; should allow an eviction" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] ReplicaSet should serve a basic image on each replica with a public image  [Conformance]" classname="Kubernetes e2e suite" time="16.361022001"></testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: block] [Feature:BlockVolume] One pod requesting one prebound PVC should be able to mount volume and write from pod1" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] ResourceQuota should create a ResourceQuota and capture the life of a persistent volume claim with a storage class. [sig-storage]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Secrets should be consumable in multiple volumes in a pod [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="8.216930581"></testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: dir-link] Two pods mounting a local volume one after the other should be able to write from pod1 and read from pod2" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Servers with support for Table transformation should return chunks of table results for list calls" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes NFS with multiple PVs and PVCs all in same ns should create 2 PVs and 4 PVCs: test write access" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volume Disk Format [Feature:vsphere] verify disk format type - eagerzeroedthick is honored for dynamically provisioned pv using storageclass" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-auth] [Feature:NodeAuthorizer] Getting an existing secret should exit with the Forbidden error" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: emptyDir] should fail if subpath with backstepping is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] Rescheduler [Serial] should ensure that critical pod is scheduled in case there is no resources available" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] ConfigMap optional updates should be reflected in volume [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="26.529097327"></testcase>
+      <testcase name="[sig-auth] [Feature:NodeAuthorizer] Getting a secret for a workload the node has access to should succeed" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Loadbalancing: L7 GCE [Slow] [Feature:NEG] should sync endpoints to NEG" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Cluster size autoscaler scalability [Slow] CA ignores unschedulable pods while scheduling schedulable pods [Feature:ClusterAutoscalerScalability6]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] CSI Volumes CSI plugin test using CSI driver: hostPath should provision storage" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Downward API [Serial] [Disruptive] [NodeFeature:EphemeralStorage] Downward API tests for local ephemeral storage should provide default limits.ephemeral-storage from node allocatable" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Job should delete a job" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scalability] Density [Feature:ManualPerformance] should allow starting 30 pods per node using {extensions Deployment} with 2 secrets, 0 configmaps and 0 daemons" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Initializers [Feature:Initializers] will be set to nil if a patch removes the last pending initializer" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Loadbalancing: L7 GCE [Slow] [Feature:Ingress] should not reconcile manually modified health check for ingress" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Probing container should *not* be restarted with a exec &#34;cat /tmp/health&#34; liveness probe [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="251.704383545"></testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: block] [Feature:BlockVolume] Set fsGroup for local volume should set same fsGroup for two pods simultaneously" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volume Placement should create and delete pod with multiple volumes from different datastore" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Dynamic Provisioning DynamicProvisioner should provision storage with different parameters [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cluster-lifecycle] ingress Downgrade [Feature:IngressDowngrade] ingress downgrade should maintain a functioning ingress" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [sig-node] kubelet [k8s.io] [sig-node] host cleanup with volume mounts [sig-storage][HostCleanup][Flaky] Host cleanup after disrupting NFS volume [NFS] after stopping the nfs-server and deleting the (active) client pod, the NFS mount and the pod&#39;s UID directory should be removed." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: dir-link-bindmounted] Set fsGroup for local volume should set fsGroup for one pod" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: blockfs] Set fsGroup for local volume should set fsGroup for one pod" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] shouldn&#39;t increase cluster size if pending pod is too large [Feature:ClusterSizeAutoscalingScaleUp]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: blockfs] Set fsGroup for local volume should set same fsGroup for two pods simultaneously" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: nfs] should support non-existent path" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Dynamic Provisioning DynamicProvisioner Default should create and delete default persistent volumes [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cluster-lifecycle] Addon update should propagate add-on file changes [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] ReplicaSet should adopt matching pods on creation and release no longer matching pods" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] GCP Volumes NFSv3 should be mountable for NFSv3" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gcePDPVC] should unmount if pod is gracefully deleted while kubelet is down [Disruptive][Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: nfsPVC] should unmount if pod is gracefully deleted while kubelet is down [Disruptive][Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Probing container should have monotonically increasing restart count [Slow][NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="150.627048529"></testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: block] [Feature:BlockVolume] Set fsGroup for local volume should set different fsGroup for second pod if first pod is deleted" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Projected should be consumable in multiple volumes in the same pod [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="8.223803361"></testcase>
+      <testcase name="[sig-instrumentation] Stackdriver Monitoring should have accelerator metrics [Feature:StackdriverAcceleratorMonitoring]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: hostPathSymlink] should support restarting containers using directory as subpath [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Simple pod should support exec through an HTTP proxy" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  Local volume provisioner [Serial] should discover dynamicly created local persistent volume mountpoint in discovery directory" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: hostPath] should fail for new directories when readOnly specified in the volumeSource" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Kubectl run rc should create an rc from an image  [Conformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] [HPA] Horizontal pod autoscaling (scale resource: CPU) [sig-autoscaling] [Serial] [Slow] ReplicationController Should scale from 5 pods to 3 pods and from 3 to 1 and verify decision stability" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: hostPath] should fail if subpath with backstepping is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Services should be able to up and down services" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Networking should provide Internet connection for containers [Feature:Networking-IPv4]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-auth] PodSecurityPolicy should forbid pod creation when no PSP is available" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] Should be able to scale a node group down to 0[Feature:ClusterSizeAutoscalingScaleDown]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] ESIPP [Slow] [DisabledForLargeClusters] should work for type=LoadBalancer" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Networking Granular Checks: Services [Slow] should function for node-Service: udp" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scalability] Empty [Feature:Empty] starts a pod" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Kubectl run deployment should create a deployment from an image  [Conformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Networking Granular Checks: Services [Slow] should function for pod-Service: udp" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] [HPA] Horizontal pod autoscaling (scale resource: CPU) [sig-autoscaling] ReplicationController light Should scale from 2 pods to 1 pod" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] EmptyDir volumes should support (root,0666,default) [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="8.254204906"></testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: emptyDir] should fail if subpath file is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Network Partition [Disruptive] [Slow] [k8s.io] [Job] should create new pods when node is partitioned" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes NFS with multiple PVs and PVCs all in same ns should create 4 PVs and 2 PVCs: test write access [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scalability] Density [Feature:Performance] should allow starting 30 pods per node using { ReplicationController} with 0 secrets, 0 configmaps and 0 daemons" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [sig-node] PreStop should call prestop when killing a pod  [Conformance]" classname="Kubernetes e2e suite" time="51.464134967"></testcase>
+      <testcase name="[sig-network] ServiceLoadBalancer [Feature:ServiceLoadBalancer] should support simple GET on Ingress ips" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] [HPA] Horizontal pod autoscaling (scale resource: Custom Metrics from Stackdriver) should scale down with External Metric with target value from Stackdriver [Feature:CustomMetricsAutoscaling]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] DaemonRestart [Disruptive] Scheduler should continue assigning pods to nodes across restart" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: blockfs] Two pods mounting a local volume at the same time should be able to write from pod1 and read from pod2" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: nfs] should support existing directory" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: nfs] should fail if subpath directory is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: hostPath] should support existing single file" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] shouldn&#39;t scale up when expendable pod is created [Feature:ClusterSizeAutoscalingScaleUp]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-instrumentation] MetricsGrabber should grab all metrics from a Kubelet." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] [Serial] Volume metrics PVController should create unbound pv count metrics for pvc controller after creating pv only" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Downward API volume should provide container&#39;s memory request [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="8.428905152"></testcase>
+      <testcase name="[sig-cli] Kubectl Port forwarding [k8s.io] With a server listening on 0.0.0.0 [k8s.io] that expects a client request should support a client that connects, sends NO DATA, and disconnects" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl Port forwarding [k8s.io] With a server listening on 0.0.0.0 [k8s.io] that expects NO client request should support a client that connects, sends DATA, and disconnects" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] DNS horizontal autoscaling [DisabledForLargeClusters] kube-dns-autoscaler should scale kube-dns pods in both nonfaulty and faulty scenarios" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] DaemonRestart [Disruptive] Kubelet should not restart containers across restart" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Services should only allow access from service loadbalancer source ranges [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] [HPA] Horizontal pod autoscaling (scale resource: Custom Metrics from Stackdriver) should scale down with Custom Metric of type Pod from Stackdriver [Feature:CustomMetricsAutoscaling]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Deployment RecreateDeployment should delete old pods and create new ones" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Daemon set [Serial] should not update pod when spec was updated and update strategy is OnDelete" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: dir-bindmounted] Set fsGroup for local volume should set same fsGroup for two pods simultaneously" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: nfsPVC] should support creating multiple subpath from same volumes [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  Pod with node different from PV&#39;s NodeAffinity should fail scheduling due to different NodeSelector" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Kubectl logs should be able to retrieve and filter logs  [Conformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] ReplicaSet should serve a basic image on each replica with a private image" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Loadbalancing: L7 GCE [Slow] [Feature:Ingress] should conform to Ingress spec" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gluster] should unmount if pod is gracefully deleted while kubelet is down [Disruptive][Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] should scale up correct target pool [Feature:ClusterSizeAutoscalingScaleUp]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: emptyDir] should support creating multiple subpath from same volumes [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [sig-node] Security Context [Feature:SecurityContext] should support seccomp default which is unconfined [Feature:Seccomp]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: dir] Two pods mounting a local volume at the same time should be able to write from pod1 and read from pod2" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-auth] PodSecurityPolicy should enforce the restricted policy.PodSecurityPolicy" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [Feature:Example] [k8s.io] Cassandra should create and scale cassandra" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Downward API should provide pod name, namespace and IP address as env vars [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="10.261855995"></testcase>
+      <testcase name="[sig-autoscaling] [HPA] Horizontal pod autoscaling (scale resource: CPU) [sig-autoscaling] [Serial] [Slow] ReplicationController Should scale from 1 pod to 3 pods and from 3 to 5 and verify decision stability" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: hostPath] should support restarting containers using file as subpath [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes GCEPD should test that deleting the Namespace of a PVC and Pod causes the successful detach of Persistent Disk" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [sig-node] Security Context [Feature:SecurityContext] should support volume SELinux relabeling when using hostPID" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: nfsPVC] should support restarting containers using file as subpath [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: hostPathSymlink] should fail if non-existent subpath is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Garbage collector should delete pods created by rc when not orphaning [Conformance]" classname="Kubernetes e2e suite" time="16.257767868"></testcase>
+      <testcase name="[sig-storage] EmptyDir volumes when FSGroup is specified [NodeFeature:FSGroup] files with FSGroup ownership should support (root,0644,tmpfs)" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Storage Policy Based Volume Provisioning [Feature:vsphere] verify VSAN storage capability with non-vsan datastore is not honored for dynamically provisioned pvc using storageclass" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] GenericPersistentVolume[Disruptive] When kubelet restarts Should test that a file written to the mount before kubelet restart is readable after restart." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gcePDPartitioned] should fail if subpath directory is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Kubectl cluster-info should check if Kubernetes master services is included in cluster-info  [Conformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Services should be able to create an internal type load balancer [Slow] [DisabledForLargeClusters]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Projected should update annotations on modification [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="28.832822659"></testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: tmpfs] One pod requesting one prebound PVC should be able to mount volume and write from pod1" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Projected should be consumable from pods in volume with mappings [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="8.265623825"></testcase>
+      <testcase name="[sig-api-machinery] Watchers should be able to restart watching from the last resource version observed by the previous watch [Conformance]" classname="Kubernetes e2e suite" time="6.199198557"></testcase>
+      <testcase name="[sig-storage] Volume Disk Format [Feature:vsphere] verify disk format type - thin is honored for dynamically provisioned pv using storageclass" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: hostPathSymlink] should support readOnly file specified in the volumeMount" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gluster] should support restarting containers using file as subpath [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] [HPA] Horizontal pod autoscaling (scale resource: Custom Metrics from Stackdriver) should scale up with two External metrics from Stackdriver [Feature:CustomMetricsAutoscaling]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Storage Policy Based Volume Provisioning [Feature:vsphere] verify VSAN storage capability with valid objectSpaceReservation and iopsLimit values is honored for dynamically provisioned pvc using storageclass" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: emptyDir] should unmount if pod is force deleted while kubelet is down [Disruptive][Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-instrumentation] Monitoring should verify monitoring pods and all cluster nodes are available on influxdb using heapster [Feature:InfluxdbMonitoring]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Services should serve multiport endpoints from pods  [Conformance]" classname="Kubernetes e2e suite" time="14.551331959"></testcase>
+      <testcase name="[k8s.io] Docker Containers should be able to override the image&#39;s default arguments (docker cmd) [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="8.292638926"></testcase>
+      <testcase name="[sig-instrumentation] Kibana Logging Instances Is Alive [Feature:Elasticsearch] should check that the Kibana logging instance is alive" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gcePDPartitioned] should support readOnly directory specified in the volumeMount" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [sig-node] Mount propagation should propagate mounts to the host" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Downward API volume should provide container&#39;s memory limit [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="8.217762547"></testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: hostPathSymlink] should fail if subpath with backstepping is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Services should be able to update NodePorts with two same port numbers but different protocols" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Downward API [Serial] [Disruptive] [NodeFeature:EphemeralStorage] Downward API tests for local ephemeral storage should provide container&#39;s limits.ephemeral-storage and requests.ephemeral-storage as env vars" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Deployment deployment should support rollback" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PV Protection Verify &#34;immediate&#34; deletion of a PV that is not bound to a PVC" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl Port forwarding [k8s.io] With a server listening on 0.0.0.0 [k8s.io] that expects a client request should support a client that connects, sends DATA, and disconnects" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: dir-bindmounted] One pod requesting one prebound PVC should be able to mount volume and read from pod1" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volume Provisioning On Clustered Datastore [Feature:vsphere] verify dynamic provision with spbm policy on clustered datastore" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Services should have session affinity work for LoadBalancer service with ESIPP off [Slow] [DisabledForLargeClusters]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] Should scale up GPU pool from 1 [GpuType:nvidia-tesla-k80] [Feature:ClusterSizeAutoscalingGpu]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Namespaces [Serial] should always delete fast (ALL of 100 namespaces in 150 seconds) [Feature:ComprehensiveNamespaceDraining]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Firewall rule [Slow] [Serial] should create valid firewall rules for LoadBalancer type service" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: hostPathSymlink] should support existing directories when readOnly specified in the volumeSource" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-instrumentation] Stackdriver Monitoring should have cluster metrics [Feature:StackdriverMonitoring]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Loadbalancing: L7 GCE [Slow] [Feature:NEG] should conform to Ingress spec" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Variable Expansion should allow substituting values in a volume subpath [Feature:VolumeSubpathEnvExpansion][NodeAlphaFeature:VolumeSubpathEnvExpansion]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Projected updates should be reflected in volume [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="26.350820554"></testcase>
+      <testcase name="[sig-storage] PersistentVolumes [Feature:LabelSelector] [sig-storage] Selector-Label Volume Binding:vsphere should bind volume with claim for given label" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: dir-bindmounted] Set fsGroup for local volume should set different fsGroup for second pod if first pod is deleted" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scalability] Density [Feature:ManualPerformance] should allow starting 30 pods per node using {extensions Deployment} with 0 secrets, 0 configmaps and 0 daemons" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Projected should provide node allocatable (memory) as default memory limit if the limit is not set [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="8.217323733"></testcase>
+      <testcase name="[sig-storage] NFSPersistentVolumes[Disruptive][Flaky] when kubelet restarts Should test that a file written to the mount before kubelet restart is readable after restart." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] NFSPersistentVolumes[Disruptive][Flaky] when kubelet restarts Should test that a volume mounted to a pod that is deleted while the kubelet is down unmounts when the kubelet returns." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PVC Protection Verify &#34;immediate&#34; deletion of a PVC that is not in active use by a pod" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: nfsPVC] should support restarting containers using directory as subpath [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cluster-lifecycle] gpu Upgrade [Feature:GPUUpgrade] master upgrade should NOT disrupt gpu pod [Feature:GPUMasterUpgrade]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] [HPA] Horizontal pod autoscaling (scale resource: CPU) [sig-autoscaling] [Serial] [Slow] Deployment Should scale from 1 pod to 3 pods and from 3 to 5" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gluster] should support existing directory" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-auth] [Feature:NodeAuthorizer] Getting a non-existent configmap should exit with the Forbidden error, not a NotFound error" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-instrumentation] MetricsGrabber should grab all metrics from a ControllerManager." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] StatefulSet [k8s.io] Basic StatefulSet functionality [StatefulSetBasic] Scaling should happen in predictable order and halt if any stateful pod is unhealthy [Conformance]" classname="Kubernetes e2e suite" time="90.761144609"></testcase>
+      <testcase name="[sig-storage] ConfigMap updates should be reflected in volume [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="105.54238921"></testcase>
+      <testcase name="[k8s.io] [Feature:Example] [k8s.io] Storm should create and stop Zookeeper, Nimbus and Storm worker servers" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Garbage collector should delete jobs and pods created by cronjob" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [Feature:Example] [k8s.io] Spark should start spark master, driver and workers" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Namespaces [Serial] should delete fast enough (90 percent of 100 namespaces in 150 seconds)" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scalability] Load capacity [Feature:ManualPerformance] should be able to handle 30 pods per node {batch Job} with 0 secrets, 0 configmaps and 0 daemons" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Cluster size autoscaler scalability [Slow] should scale down underutilized nodes [Feature:ClusterAutoscalerScalability4]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Projected should be consumable from pods in volume with defaultMode set [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="8.355213468"></testcase>
+      <testcase name="[sig-storage] vcp-performance [Feature:vsphere] vcp performance tests" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gluster] should support existing directories when readOnly specified in the volumeSource" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [sig-node] Security Context [Feature:SecurityContext] should support pod.Spec.SecurityContext.RunAsUser And pod.Spec.SecurityContext.RunAsGroup [Feature:RunAsGroup]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] ResourceQuota should create a ResourceQuota and capture the life of a replica set." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Storage Policy Based Volume Provisioning [Feature:vsphere] verify VSAN storage capability with valid diskStripes and objectSpaceReservation values is honored for dynamically provisioned pvc using storageclass" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-instrumentation] Stackdriver Monitoring should run Custom Metrics - Stackdriver Adapter for external metrics [Feature:StackdriverExternalMetrics]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gcePDPartitioned] should support creating multiple subpath from same volumes [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Projected should project all components that make up the projection API [Projection][NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="10.254063999"></testcase>
+      <testcase name="[sig-storage] Pod Disks schedule pods each with a PD, delete pod and verify detach [Slow] for read-only PD with pod delete grace period of &#34;immediate (0s)&#34;" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Loadbalancing: L7 GCE [Slow] [Feature:kubemci] should create ingress with pre-shared certificate" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Pods should cap back-off at MaxContainerBackOff [Slow][NodeConformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: nfs] should unmount if pod is force deleted while kubelet is down [Disruptive][Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Ephemeralstorage When pod refers to non-existent ephemeral storage should allow deletion of pod with invalid volume : secret" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] should add new node and new node pool on too big pod, scale down to 1 and scale down to 0 [Feature:ClusterSizeAutoscalingScaleWithNAP]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] [HPA] Horizontal pod autoscaling (scale resource: Custom Metrics from Stackdriver) should scale down with External Metric with target average value from Stackdriver [Feature:CustomMetricsAutoscaling]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] [Serial] Volume metrics should create prometheus metrics for volume provisioning and attach/detach" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Networking Granular Checks: Services [Slow] should function for pod-Service: http" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Secrets should be consumable from pods in volume with mappings [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="10.324481551"></testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gluster] should unmount if pod is force deleted while kubelet is down [Disruptive][Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volumes PD should be mountable with ext4" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Docker Containers should use the image defaults if command and args are blank [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="8.314763844"></testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Kubectl run CronJob should create a CronJob" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] DNS horizontal autoscaling [Serial] [Slow] kube-dns-autoscaler should scale kube-dns pods when cluster size changed" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Secrets should be consumable from pods in volume as non-root with defaultMode and fsGroup set [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="8.208000733"></testcase>
+      <testcase name="[sig-api-machinery] Garbage collector should support orphan deletion of custom resources" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Secrets optional updates should be reflected in volume [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="26.722733088"></testcase>
+      <testcase name="[sig-scheduling] ResourceQuota [Feature:Initializers] should create a ResourceQuota and capture the life of an uninitialized pod." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Deployment iterative rollouts should eventually progress" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cluster-lifecycle] kube-proxy migration [Feature:KubeProxyDaemonSetMigration] Upgrade kube-proxy from static pods to a DaemonSet should maintain a functioning cluster [Feature:KubeProxyDaemonSetUpgrade]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] SchedulerPreemption [Serial] [Feature:PodPreemption] validates lower priority pod preemption by critical pod" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] [HPA] Horizontal pod autoscaling (scale resource: Custom Metrics from Stackdriver) should scale up with two metrics of type Pod from Stackdriver [Feature:CustomMetricsAutoscaling]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: emptyDir] should fail if non-existent subpath is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Loadbalancing: L7 [Slow] Nginx should conform to Ingress spec" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-instrumentation] Cluster level logging implemented by Stackdriver [Feature:StackdriverLogging] [Soak] should ingest logs from applications running for a prolonged amount of time" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: tmpfs] Two pods mounting a local volume at the same time should be able to write from pod1 and read from pod2" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Networking Granular Checks: Pods should function for node-pod communication: udp [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="43.239237253"></testcase>
+      <testcase name="[sig-storage] Projected should be consumable from pods in volume as non-root with FSGroup [NodeFeature:FSGroup]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Flexvolumes [Disruptive] should be mountable when attachable" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] ResourceQuota should create a ResourceQuota and capture the life of a secret." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] ConfigMap should be consumable from pods in volume with mappings [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="8.266990823"></testcase>
+      <testcase name="[sig-cluster-lifecycle] Upgrade [Feature:Upgrade] cluster upgrade should maintain a functioning cluster [Feature:ClusterUpgrade]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: dir-link] Set fsGroup for local volume should set same fsGroup for two pods simultaneously" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scalability] Load capacity [Feature:ManualPerformance] should be able to handle 30 pods per node {extensions Deployment} with 0 secrets, 2 configmaps and 0 daemons" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Variable Expansion should allow substituting values in a container&#39;s command [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="10.247421699"></testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Kubectl label should update the label on a resource  [Conformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Services should create endpoints for unready pods" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: dir-link-bindmounted] One pod requesting one prebound PVC should be able to mount volume and read from pod1" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cluster-lifecycle] ingress Upgrade [Feature:IngressUpgrade] ingress upgrade should maintain a functioning ingress" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: hostPath] should support existing directory" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Simple pod should support inline execution and attach" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] NetworkPolicy NetworkPolicy between server and client should support allow-all policy [Feature:NetworkPolicy]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes GCEPD should test that deleting the PV before the pod does not cause pod deletion to fail on PD detach" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volume plugin streaming [Slow] iSCSI [Feature:Volumes] should write files of various sizes, verify size, validate content" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: blockfs] One pod requesting one prebound PVC should be able to mount volume and write from pod1" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] ReplicationController should adopt matching pods on creation" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] HostPath should support subPath [NodeConformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] Should scale up GPU pool from 1 [GpuType:nvidia-tesla-p100] [Feature:ClusterSizeAutoscalingGpu]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] ESIPP [Slow] [DisabledForLargeClusters] should only target nodes with endpoints" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] NetworkPolicy NetworkPolicy between server and client should enforce policy based on NamespaceSelector [Feature:NetworkPolicy]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-auth] Metadata Concealment should run a check-metadata-concealment job to completion" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Pods should be submitted and removed [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="14.426083515"></testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: hostPathSymlink] should support restarting containers using file as subpath [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: nfs] should support readOnly file specified in the volumeMount" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] PrivilegedPod [NodeConformance] should enable privileged commands" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] SchedulerPriorities [Serial] Pod should avoid to schedule to node that have avoidPod annotation" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Service endpoints latency should not be very high  [Conformance]" classname="Kubernetes e2e suite" time="20.890038935"></testcase>
+      <testcase name="[sig-instrumentation] Stackdriver Monitoring should run Custom Metrics - Stackdriver Adapter for old resource model [Feature:StackdriverCustomMetrics]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: hostPathSymlink] should fail if subpath file is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] vsphere cloud provider stress [Feature:vsphere] vsphere stress tests" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Cluster size autoscaler scalability [Slow] should scale down empty nodes [Feature:ClusterAutoscalerScalability3]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [Feature:Example] [k8s.io] Redis should create and stop redis servers" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Watchers should be able to start watching from a specific resource version [Conformance]" classname="Kubernetes e2e suite" time="6.195935087"></testcase>
+      <testcase name="[sig-apps] StatefulSet [k8s.io] Deploy clustered applications [Feature:StatefulSet] [Slow] should creating a working zookeeper cluster" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] ResourceQuota should verify ResourceQuota with terminating scopes." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cluster-lifecycle] Restart [Disruptive] should restart all nodes and ensure all nodes and pods recover" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Pods should allow activeDeadlineSeconds to be updated [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="12.765973823"></testcase>
+      <testcase name="[sig-network] Proxy version v1 should proxy logs on node using proxy subresource  [Conformance]" classname="Kubernetes e2e suite" time="6.50963625"></testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: emptyDir] should support existing directories when readOnly specified in the volumeSource" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] Should be able to scale a node group up from 0[Feature:ClusterSizeAutoscalingScaleUp]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] should scale down when expendable pod is running [Feature:ClusterSizeAutoscalingScaleDown]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath Atomic writer volumes should support subpaths with downward pod" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] [Serial] Volume metrics should create volume metrics with the correct PVC ref" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Loadbalancing: L7 GCE [Slow] [Feature:kubemci] should create ingress with backend HTTPS" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Services [Feature:GCEAlphaFeature][Slow] should be able to create and tear down a standard-tier load balancer [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Docker Containers should be able to override the image&#39;s default command and arguments [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="10.271404943"></testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: hostPathSymlink] should fail if subpath directory is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gcePDPVC] should support existing directories when readOnly specified in the volumeSource" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [sig-node] Security Context [Feature:SecurityContext] should support volume SELinux relabeling when using hostIPC" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Services should work after restarting kube-proxy [Disruptive]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Downward API volume should provide podname as non-root with fsgroup and defaultMode [NodeFeature:FSGroup]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-service-catalog] [Feature:PodPreset] PodPreset should not modify the pod on conflict" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [sig-node] SSH should SSH to all nodes and run commands" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] ConfigMap should be consumable via environment variable [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="10.317816731"></testcase>
+      <testcase name="[sig-scheduling] ResourceQuota should create a ResourceQuota and capture the life of a configMap." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] EmptyDir volumes should support (non-root,0644,tmpfs) [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="8.224835761"></testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Simple pod should return command exit codes" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Networking should provide unchanging, static URL paths for kubernetes api services" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] EmptyDir volumes should support (non-root,0777,default) [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="8.275987072"></testcase>
+      <testcase name="[sig-storage] ConfigMap should be consumable in multiple volumes in the same pod [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="8.471162559"></testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: blockfs] Set fsGroup for local volume should not set different fsGroups for two pods simultaneously" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Namespaces [Serial] should ensure that all services are removed when a namespace is deleted." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] EmptyDir volumes should support (root,0644,default) [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="8.274011994"></testcase>
+      <testcase name="[sig-api-machinery] Garbage collector should delete RS created by deployment when not orphaning [Conformance]" classname="Kubernetes e2e suite" time="7.245442493"></testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: nfsPVC] should support readOnly directory specified in the volumeMount" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Services should be able to switch session affinity for LoadBalancer service with ESIPP on [Slow] [DisabledForLargeClusters]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gluster] should fail if subpath directory is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Downward API volume should provide container&#39;s cpu limit [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="10.2957317"></testcase>
+      <testcase name="[sig-storage] ConfigMap should be consumable from pods in volume [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="8.269316616"></testcase>
+      <testcase name="[sig-storage] Volume Attach Verify [Feature:vsphere][Serial][Disruptive] verify volume remains attached after master kubelet restart" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Downward API volume should set DefaultMode on files [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="8.216929032"></testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: dir] Set fsGroup for local volume should set fsGroup for one pod" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] Multi-AZ Cluster Volumes [sig-storage] should schedule pods in the same zones as statically provisioned PVs" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scalability] Density [Feature:HighDensityPerformance] should allow starting 95 pods per node using { ReplicationController} with 0 secrets, 0 configmaps and 0 daemons" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] SchedulerPredicates [Serial] validates that required NodeAffinity setting is respected if matching" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gcePDPartitioned] should support existing single file" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Kubectl taint [Serial] should remove all the taints with the same key off a node" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] SchedulerPreemption [Serial] [Feature:PodPreemption] validates pod anti-affinity works in preemption" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gcePDPVC] should fail if non-existent subpath is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Loadbalancing: L7 Scalability GCE [Slow] [Serial] [Feature:IngressScale] Creating and updating ingresses should happen promptly with small/medium/large amount of ingresses" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Services should have session affinity work for NodePort service" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gcePDPVC] should fail if subpath file is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Projected should be consumable from pods in volume as non-root [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="8.275571355"></testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: hostPath] should fail if subpath file is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-instrumentation] Stackdriver Monitoring should run Custom Metrics - Stackdriver Adapter for new resource model [Feature:StackdriverCustomMetrics]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl Port forwarding [k8s.io] With a server listening on localhost should support forwarding over websockets" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volume FStype [Feature:vsphere] verify fstype - ext3 formatted volume" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] DNS should provide DNS for pods for Hostname and Subdomain" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] DNS configMap nameserver Forward PTR lookup should forward PTR records lookup to upstream nameserver [Slow][Serial]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Projected optional updates should be reflected in volume [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="26.652162525"></testcase>
+      <testcase name="[sig-scalability] Density [Feature:ManualPerformance] should allow starting 30 pods per node using {batch Job} with 0 secrets, 0 configmaps and 0 daemons" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volume Provisioning on Datastore [Feature:vsphere] verify dynamically provisioned pv using storageclass fails on an invalid datastore" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] SchedulerPredicates [Serial] validates local ephemeral storage resource limits of pods that are allowed to run [Feature:LocalStorageCapacityIsolation]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] ReplicaSet should surface a failure condition on a common issue like exceeded quota" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Initializers [Feature:Initializers] don&#39;t cause replicaset controller creating extra pods if the initializer is not handled [Serial]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Dynamic Provisioning DynamicProvisioner should not provision a volume in an unmanaged GCE zone." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] SchedulerPreemption [Serial] [Feature:PodPreemption] validates basic preemption works" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Loadbalancing: L7 GCE [Slow] [Feature:Ingress] should create ingress with backend HTTPS" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes:vsphere should test that a file written to the vspehre volume mount before kubelet restart can be read after restart [Disruptive]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-auth] PodSecurityPolicy should allow pods under the privileged extensions.PodSecurityPolicy" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Services should release NodePorts on delete" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Networking Granular Checks: Services [Slow] should update nodePort: http [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] should increase cluster size if pending pods are small [Feature:ClusterSizeAutoscalingScaleUp]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gcePDPartitioned] should fail for new directories when readOnly specified in the volumeSource" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gcePDPVC] should support restarting containers using directory as subpath [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] should correctly scale down after a node is not needed and one node is broken [Feature:ClusterSizeAutoscalingScaleDown]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: nfsPVC] should fail for new directories when readOnly specified in the volumeSource" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Projected should provide container&#39;s memory request [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="8.291601772"></testcase>
+  </testsuite>

--- a/v1.11/gardener-gcp/version.txt
+++ b/v1.11/gardener-gcp/version.txt
@@ -1,0 +1,2 @@
+Client Version: version.Info{Major:"1", Minor:"11", GitVersion:"v1.11.0", GitCommit:"91e7b4fd31fcd3d5f436da26c980becec37ceefe", GitTreeState:"clean", BuildDate:"2018-06-27T20:17:28Z", GoVersion:"go1.10.2", Compiler:"gc", Platform:"linux/amd64"}
+Server Version: version.Info{Major:"1", Minor:"11", GitVersion:"v1.11.0", GitCommit:"91e7b4fd31fcd3d5f436da26c980becec37ceefe", GitTreeState:"clean", BuildDate:"2018-06-27T20:08:34Z", GoVersion:"go1.10.2", Compiler:"gc", Platform:"linux/amd64"}

--- a/v1.11/gardener-openstack/PRODUCT.yaml
+++ b/v1.11/gardener-openstack/PRODUCT.yaml
@@ -1,0 +1,8 @@
+vendor: SAP
+name: Gardener (https://github.com/gardener/gardener) shoot cluster deployed on Openstack
+version: 0.8.0
+website_url: https://gardener.cloud
+documentation_url: https://github.com/gardener/documentation/wiki
+product_logo_url: https://raw.githubusercontent.com/gardener/documentation/master/images/logo_w_saplogo.svg
+type: installer
+description: The Gardener implements automated management and operation of Kubernetes clusters as a service and aims to support that service on multiple Cloud providers.

--- a/v1.11/gardener-openstack/README.md
+++ b/v1.11/gardener-openstack/README.md
@@ -1,0 +1,43 @@
+# To reproduce:
+
+## Create Kubernetes Cluster
+
+Login to SAP Gardener Dashboard to create a Kubernetes Clusters on Amazon Web Services, Microsoft Azure, Google Cloud Platform, or OpenStack cloud provider.
+
+After the creation completed, copy the cluster's kubeconfig, which is provided by the Gardener Dashboard in the cluster's detail view, to ~/.kube/config and launch the Kubernetes E2E conformance tests.
+
+## Launch E2E Conformance Tests
+1. Launch e2e pod and sonobuoy master under namespace `sonobuoy`   
+    ```shell
+    curl -L https://raw.githubusercontent.com/cncf/k8s-conformance/master/sonobuoy-conformance.yaml | kubectl apply -f -
+    ```
+
+2. Check logs of `sonobuoy` pod to see when test can be finished   
+Run
+
+    ```shell
+    kubectl logs -f -n sonobuoy sonobuoy
+    ```
+    and wait for line `no-exit was specified, sonobuoy is now blocking`.
+
+3. Use `kubectl cp` to copy the results to the client   
+Get the name of the <result archive> from the log output in step 2.
+
+    ```shell
+    kubectl cp sonobuoy/sonobuoy:/tmp/sonobuoy/<result archive> /home/result
+    ```
+
+4. Delete the conformance test resources
+
+    ```shell
+    curl -L https://raw.githubusercontent.com/cncf/k8s-conformance/master/sonobuoy-conformance.yaml | kubectl delete -f -
+    ```
+
+5. Untar the tarball
+
+    ```shell
+    cd /home/result
+    tar -xzf *_sonobuoy_*.tar.gz
+    ```
+
+    The result files `e2e.log` and `junit_01.xml` are located in the in the directory `plugins/e2e/results/`.

--- a/v1.11/gardener-openstack/e2e.log
+++ b/v1.11/gardener-openstack/e2e.log
@@ -1,0 +1,7124 @@
+Jul  2 12:54:09.620: INFO: Overriding default scale value of zero to 1
+Jul  2 12:54:09.621: INFO: Overriding default milliseconds value of zero to 5000
+I0702 12:54:09.788801      16 test_context.go:382] Using a temporary kubeconfig file from in-cluster config : /tmp/kubeconfig-575984058
+I0702 12:54:09.789069      16 e2e.go:333] Starting e2e run "02ff6281-7df7-11e8-b7a8-22e3071d17c7" on Ginkgo node 1
+Running Suite: Kubernetes e2e suite
+===================================
+Random Seed: 1530536049 - Will randomize all specs
+Will run 144 of 998 specs
+
+Jul  2 12:54:09.872: INFO: >>> kubeConfig: /tmp/kubeconfig-575984058
+Jul  2 12:54:09.874: INFO: Waiting up to 30m0s for all (but 0) nodes to be schedulable
+Jul  2 12:54:09.888: INFO: Waiting up to 10m0s for all pods (need at least 0) in namespace 'kube-system' to be running and ready
+Jul  2 12:54:09.919: INFO: 14 / 14 pods in namespace 'kube-system' are running and ready (0 seconds elapsed)
+Jul  2 12:54:09.919: INFO: expected 8 pod replicas in namespace 'kube-system', 8 are Running and Ready.
+Jul  2 12:54:09.925: INFO: Waiting for pods to enter Success, but no pods in "kube-system" match label map[name:e2e-image-puller]
+Jul  2 12:54:09.925: INFO: Dumping network health container logs from all nodes to file /tmp/results/nethealth.txt
+Jul  2 12:54:09.930: INFO: e2e test version: v1.11.0
+Jul  2 12:54:09.932: INFO: kube-apiserver version: v1.11.0
+SSSSSSSSSSSS
+------------------------------
+[sig-storage] Projected 
+  should provide container's cpu limit [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 12:54:09.932: INFO: >>> kubeConfig: /tmp/kubeconfig-575984058
+STEP: Building a namespace api object
+Jul  2 12:54:10.021: INFO: No PodSecurityPolicies found; assuming PodSecurityPolicy is disabled.
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:858
+[It] should provide container's cpu limit [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating a pod to test downward API volume plugin
+Jul  2 12:54:10.029: INFO: Waiting up to 5m0s for pod "downwardapi-volume-0347f09d-7df7-11e8-b7a8-22e3071d17c7" in namespace "e2e-tests-projected-5l982" to be "success or failure"
+Jul  2 12:54:10.033: INFO: Pod "downwardapi-volume-0347f09d-7df7-11e8-b7a8-22e3071d17c7": Phase="Pending", Reason="", readiness=false. Elapsed: 3.117074ms
+Jul  2 12:54:12.046: INFO: Pod "downwardapi-volume-0347f09d-7df7-11e8-b7a8-22e3071d17c7": Phase="Pending", Reason="", readiness=false. Elapsed: 2.016352656s
+Jul  2 12:54:14.050: INFO: Pod "downwardapi-volume-0347f09d-7df7-11e8-b7a8-22e3071d17c7": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.02064807s
+STEP: Saw pod success
+Jul  2 12:54:14.050: INFO: Pod "downwardapi-volume-0347f09d-7df7-11e8-b7a8-22e3071d17c7" satisfied condition "success or failure"
+Jul  2 12:54:14.077: INFO: Trying to get logs from node shoot--core--confos-worker-w6oh6-z1-59946c4f6c-2w6kp pod downwardapi-volume-0347f09d-7df7-11e8-b7a8-22e3071d17c7 container client-container: <nil>
+STEP: delete the pod
+Jul  2 12:54:14.223: INFO: Waiting for pod downwardapi-volume-0347f09d-7df7-11e8-b7a8-22e3071d17c7 to disappear
+Jul  2 12:54:14.227: INFO: Pod downwardapi-volume-0347f09d-7df7-11e8-b7a8-22e3071d17c7 no longer exists
+[AfterEach] [sig-storage] Projected
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 12:54:14.227: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-5l982" for this suite.
+Jul  2 12:54:20.244: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 12:54:20.289: INFO: namespace: e2e-tests-projected-5l982, resource: bindings, ignored listing per whitelist
+Jul  2 12:54:20.395: INFO: namespace e2e-tests-projected-5l982 deletion completed in 6.164513606s
+
+• [SLOW TEST:10.463 seconds]
+[sig-storage] Projected
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:34
+  should provide container's cpu limit [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSS
+------------------------------
+[sig-storage] ConfigMap 
+  updates should be reflected in volume [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-storage] ConfigMap
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 12:54:20.395: INFO: >>> kubeConfig: /tmp/kubeconfig-575984058
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] updates should be reflected in volume [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating configMap with name configmap-test-upd-09835d2f-7df7-11e8-b7a8-22e3071d17c7
+STEP: Creating the pod
+STEP: Updating configmap configmap-test-upd-09835d2f-7df7-11e8-b7a8-22e3071d17c7
+STEP: waiting to observe update in volume
+[AfterEach] [sig-storage] ConfigMap
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 12:54:24.603: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-configmap-46wg8" for this suite.
+Jul  2 12:54:46.621: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 12:54:46.771: INFO: namespace: e2e-tests-configmap-46wg8, resource: bindings, ignored listing per whitelist
+Jul  2 12:54:46.779: INFO: namespace e2e-tests-configmap-46wg8 deletion completed in 22.172604133s
+
+• [SLOW TEST:26.385 seconds]
+[sig-storage] ConfigMap
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/configmap_volume.go:32
+  updates should be reflected in volume [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSSSSSS
+------------------------------
+[sig-storage] ConfigMap 
+  should be consumable from pods in volume with mappings as non-root [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-storage] ConfigMap
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 12:54:46.781: INFO: >>> kubeConfig: /tmp/kubeconfig-575984058
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should be consumable from pods in volume with mappings as non-root [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating configMap with name configmap-test-volume-map-193d9696-7df7-11e8-b7a8-22e3071d17c7
+STEP: Creating a pod to test consume configMaps
+Jul  2 12:54:46.874: INFO: Waiting up to 5m0s for pod "pod-configmaps-193e1aa3-7df7-11e8-b7a8-22e3071d17c7" in namespace "e2e-tests-configmap-pwjtl" to be "success or failure"
+Jul  2 12:54:46.876: INFO: Pod "pod-configmaps-193e1aa3-7df7-11e8-b7a8-22e3071d17c7": Phase="Pending", Reason="", readiness=false. Elapsed: 2.323702ms
+Jul  2 12:54:48.880: INFO: Pod "pod-configmaps-193e1aa3-7df7-11e8-b7a8-22e3071d17c7": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.006665703s
+STEP: Saw pod success
+Jul  2 12:54:48.880: INFO: Pod "pod-configmaps-193e1aa3-7df7-11e8-b7a8-22e3071d17c7" satisfied condition "success or failure"
+Jul  2 12:54:48.883: INFO: Trying to get logs from node shoot--core--confos-worker-w6oh6-z1-59946c4f6c-2w6kp pod pod-configmaps-193e1aa3-7df7-11e8-b7a8-22e3071d17c7 container configmap-volume-test: <nil>
+STEP: delete the pod
+Jul  2 12:54:48.899: INFO: Waiting for pod pod-configmaps-193e1aa3-7df7-11e8-b7a8-22e3071d17c7 to disappear
+Jul  2 12:54:48.901: INFO: Pod pod-configmaps-193e1aa3-7df7-11e8-b7a8-22e3071d17c7 no longer exists
+[AfterEach] [sig-storage] ConfigMap
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 12:54:48.901: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-configmap-pwjtl" for this suite.
+Jul  2 12:54:54.923: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 12:54:55.083: INFO: namespace: e2e-tests-configmap-pwjtl, resource: bindings, ignored listing per whitelist
+Jul  2 12:54:55.185: INFO: namespace e2e-tests-configmap-pwjtl deletion completed in 6.273122314s
+
+• [SLOW TEST:8.404 seconds]
+[sig-storage] ConfigMap
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/configmap_volume.go:32
+  should be consumable from pods in volume with mappings as non-root [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SS
+------------------------------
+[sig-storage] Secrets 
+  should be consumable in multiple volumes in a pod [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-storage] Secrets
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 12:54:55.185: INFO: >>> kubeConfig: /tmp/kubeconfig-575984058
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should be consumable in multiple volumes in a pod [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating secret with name secret-test-1e3fba01-7df7-11e8-b7a8-22e3071d17c7
+STEP: Creating a pod to test consume secrets
+Jul  2 12:54:55.279: INFO: Waiting up to 5m0s for pod "pod-secrets-1e409755-7df7-11e8-b7a8-22e3071d17c7" in namespace "e2e-tests-secrets-kngpf" to be "success or failure"
+Jul  2 12:54:55.281: INFO: Pod "pod-secrets-1e409755-7df7-11e8-b7a8-22e3071d17c7": Phase="Pending", Reason="", readiness=false. Elapsed: 2.627081ms
+Jul  2 12:54:57.285: INFO: Pod "pod-secrets-1e409755-7df7-11e8-b7a8-22e3071d17c7": Phase="Pending", Reason="", readiness=false. Elapsed: 2.006542007s
+Jul  2 12:54:59.290: INFO: Pod "pod-secrets-1e409755-7df7-11e8-b7a8-22e3071d17c7": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.011268427s
+STEP: Saw pod success
+Jul  2 12:54:59.290: INFO: Pod "pod-secrets-1e409755-7df7-11e8-b7a8-22e3071d17c7" satisfied condition "success or failure"
+Jul  2 12:54:59.293: INFO: Trying to get logs from node shoot--core--confos-worker-w6oh6-z1-59946c4f6c-2w6kp pod pod-secrets-1e409755-7df7-11e8-b7a8-22e3071d17c7 container secret-volume-test: <nil>
+STEP: delete the pod
+Jul  2 12:54:59.382: INFO: Waiting for pod pod-secrets-1e409755-7df7-11e8-b7a8-22e3071d17c7 to disappear
+Jul  2 12:54:59.385: INFO: Pod pod-secrets-1e409755-7df7-11e8-b7a8-22e3071d17c7 no longer exists
+[AfterEach] [sig-storage] Secrets
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 12:54:59.385: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-secrets-kngpf" for this suite.
+Jul  2 12:55:05.414: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 12:55:05.426: INFO: namespace: e2e-tests-secrets-kngpf, resource: bindings, ignored listing per whitelist
+Jul  2 12:55:05.565: INFO: namespace e2e-tests-secrets-kngpf deletion completed in 6.173529083s
+
+• [SLOW TEST:10.380 seconds]
+[sig-storage] Secrets
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/secrets_volume.go:33
+  should be consumable in multiple volumes in a pod [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSSS
+------------------------------
+[k8s.io] Variable Expansion 
+  should allow substituting values in a container's args [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [k8s.io] Variable Expansion
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 12:55:05.566: INFO: >>> kubeConfig: /tmp/kubeconfig-575984058
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should allow substituting values in a container's args [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating a pod to test substitution in container's args
+Jul  2 12:55:05.658: INFO: Waiting up to 5m0s for pod "var-expansion-24706640-7df7-11e8-b7a8-22e3071d17c7" in namespace "e2e-tests-var-expansion-dr6fs" to be "success or failure"
+Jul  2 12:55:05.662: INFO: Pod "var-expansion-24706640-7df7-11e8-b7a8-22e3071d17c7": Phase="Pending", Reason="", readiness=false. Elapsed: 3.913421ms
+Jul  2 12:55:07.667: INFO: Pod "var-expansion-24706640-7df7-11e8-b7a8-22e3071d17c7": Phase="Pending", Reason="", readiness=false. Elapsed: 2.008415618s
+Jul  2 12:55:09.671: INFO: Pod "var-expansion-24706640-7df7-11e8-b7a8-22e3071d17c7": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.012449469s
+STEP: Saw pod success
+Jul  2 12:55:09.671: INFO: Pod "var-expansion-24706640-7df7-11e8-b7a8-22e3071d17c7" satisfied condition "success or failure"
+Jul  2 12:55:09.674: INFO: Trying to get logs from node shoot--core--confos-worker-w6oh6-z1-59946c4f6c-2w6kp pod var-expansion-24706640-7df7-11e8-b7a8-22e3071d17c7 container dapi-container: <nil>
+STEP: delete the pod
+Jul  2 12:55:09.699: INFO: Waiting for pod var-expansion-24706640-7df7-11e8-b7a8-22e3071d17c7 to disappear
+Jul  2 12:55:09.703: INFO: Pod var-expansion-24706640-7df7-11e8-b7a8-22e3071d17c7 no longer exists
+[AfterEach] [k8s.io] Variable Expansion
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 12:55:09.704: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-var-expansion-dr6fs" for this suite.
+Jul  2 12:55:15.725: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 12:55:15.798: INFO: namespace: e2e-tests-var-expansion-dr6fs, resource: bindings, ignored listing per whitelist
+Jul  2 12:55:15.879: INFO: namespace e2e-tests-var-expansion-dr6fs deletion completed in 6.169109795s
+
+• [SLOW TEST:10.313 seconds]
+[k8s.io] Variable Expansion
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:679
+  should allow substituting values in a container's args [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+[sig-storage] ConfigMap 
+  should be consumable from pods in volume with defaultMode set [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-storage] ConfigMap
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 12:55:15.879: INFO: >>> kubeConfig: /tmp/kubeconfig-575984058
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should be consumable from pods in volume with defaultMode set [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating configMap with name configmap-test-volume-2a963785-7df7-11e8-b7a8-22e3071d17c7
+STEP: Creating a pod to test consume configMaps
+Jul  2 12:55:15.979: INFO: Waiting up to 5m0s for pod "pod-configmaps-2a96b63a-7df7-11e8-b7a8-22e3071d17c7" in namespace "e2e-tests-configmap-clqwj" to be "success or failure"
+Jul  2 12:55:15.983: INFO: Pod "pod-configmaps-2a96b63a-7df7-11e8-b7a8-22e3071d17c7": Phase="Pending", Reason="", readiness=false. Elapsed: 4.401711ms
+Jul  2 12:55:17.988: INFO: Pod "pod-configmaps-2a96b63a-7df7-11e8-b7a8-22e3071d17c7": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.008976678s
+STEP: Saw pod success
+Jul  2 12:55:17.988: INFO: Pod "pod-configmaps-2a96b63a-7df7-11e8-b7a8-22e3071d17c7" satisfied condition "success or failure"
+Jul  2 12:55:17.991: INFO: Trying to get logs from node shoot--core--confos-worker-w6oh6-z1-59946c4f6c-2w6kp pod pod-configmaps-2a96b63a-7df7-11e8-b7a8-22e3071d17c7 container configmap-volume-test: <nil>
+STEP: delete the pod
+Jul  2 12:55:18.006: INFO: Waiting for pod pod-configmaps-2a96b63a-7df7-11e8-b7a8-22e3071d17c7 to disappear
+Jul  2 12:55:18.008: INFO: Pod pod-configmaps-2a96b63a-7df7-11e8-b7a8-22e3071d17c7 no longer exists
+[AfterEach] [sig-storage] ConfigMap
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 12:55:18.008: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-configmap-clqwj" for this suite.
+Jul  2 12:55:24.033: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 12:55:24.090: INFO: namespace: e2e-tests-configmap-clqwj, resource: bindings, ignored listing per whitelist
+Jul  2 12:55:24.133: INFO: namespace e2e-tests-configmap-clqwj deletion completed in 6.11515404s
+
+• [SLOW TEST:8.255 seconds]
+[sig-storage] ConfigMap
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/configmap_volume.go:32
+  should be consumable from pods in volume with defaultMode set [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSSSS
+------------------------------
+[sig-storage] Projected 
+  should provide podname only [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 12:55:24.135: INFO: >>> kubeConfig: /tmp/kubeconfig-575984058
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:858
+[It] should provide podname only [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating a pod to test downward API volume plugin
+Jul  2 12:55:24.237: INFO: Waiting up to 5m0s for pod "downwardapi-volume-2f8313f8-7df7-11e8-b7a8-22e3071d17c7" in namespace "e2e-tests-projected-6bffd" to be "success or failure"
+Jul  2 12:55:24.270: INFO: Pod "downwardapi-volume-2f8313f8-7df7-11e8-b7a8-22e3071d17c7": Phase="Pending", Reason="", readiness=false. Elapsed: 32.525559ms
+Jul  2 12:55:26.273: INFO: Pod "downwardapi-volume-2f8313f8-7df7-11e8-b7a8-22e3071d17c7": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.036121131s
+STEP: Saw pod success
+Jul  2 12:55:26.274: INFO: Pod "downwardapi-volume-2f8313f8-7df7-11e8-b7a8-22e3071d17c7" satisfied condition "success or failure"
+Jul  2 12:55:26.276: INFO: Trying to get logs from node shoot--core--confos-worker-w6oh6-z1-59946c4f6c-2w6kp pod downwardapi-volume-2f8313f8-7df7-11e8-b7a8-22e3071d17c7 container client-container: <nil>
+STEP: delete the pod
+Jul  2 12:55:26.292: INFO: Waiting for pod downwardapi-volume-2f8313f8-7df7-11e8-b7a8-22e3071d17c7 to disappear
+Jul  2 12:55:26.296: INFO: Pod downwardapi-volume-2f8313f8-7df7-11e8-b7a8-22e3071d17c7 no longer exists
+[AfterEach] [sig-storage] Projected
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 12:55:26.296: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-6bffd" for this suite.
+Jul  2 12:55:32.320: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 12:55:32.416: INFO: namespace: e2e-tests-projected-6bffd, resource: bindings, ignored listing per whitelist
+Jul  2 12:55:32.467: INFO: namespace e2e-tests-projected-6bffd deletion completed in 6.168211803s
+
+• [SLOW TEST:8.332 seconds]
+[sig-storage] Projected
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:34
+  should provide podname only [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSS
+------------------------------
+[sig-storage] Downward API volume 
+  should update annotations on modification [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 12:55:32.468: INFO: >>> kubeConfig: /tmp/kubeconfig-575984058
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downwardapi_volume.go:38
+[It] should update annotations on modification [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating the pod
+Jul  2 12:55:35.101: INFO: Successfully updated pod "annotationupdate347a4d6c-7df7-11e8-b7a8-22e3071d17c7"
+[AfterEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 12:55:39.181: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-downward-api-tl6fq" for this suite.
+Jul  2 12:56:01.283: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 12:56:01.366: INFO: namespace: e2e-tests-downward-api-tl6fq, resource: bindings, ignored listing per whitelist
+Jul  2 12:56:01.381: INFO: namespace e2e-tests-downward-api-tl6fq deletion completed in 22.196666942s
+
+• [SLOW TEST:28.914 seconds]
+[sig-storage] Downward API volume
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downwardapi_volume.go:33
+  should update annotations on modification [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSSSSSSSSSSSSSSSSSS
+------------------------------
+[sig-storage] Projected 
+  should set mode on item file [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 12:56:01.383: INFO: >>> kubeConfig: /tmp/kubeconfig-575984058
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:858
+[It] should set mode on item file [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating a pod to test downward API volume plugin
+Jul  2 12:56:01.496: INFO: Waiting up to 5m0s for pod "downwardapi-volume-45b86997-7df7-11e8-b7a8-22e3071d17c7" in namespace "e2e-tests-projected-99xkw" to be "success or failure"
+Jul  2 12:56:01.610: INFO: Pod "downwardapi-volume-45b86997-7df7-11e8-b7a8-22e3071d17c7": Phase="Pending", Reason="", readiness=false. Elapsed: 114.576459ms
+Jul  2 12:56:03.614: INFO: Pod "downwardapi-volume-45b86997-7df7-11e8-b7a8-22e3071d17c7": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.118671439s
+STEP: Saw pod success
+Jul  2 12:56:03.615: INFO: Pod "downwardapi-volume-45b86997-7df7-11e8-b7a8-22e3071d17c7" satisfied condition "success or failure"
+Jul  2 12:56:03.617: INFO: Trying to get logs from node shoot--core--confos-worker-w6oh6-z1-59946c4f6c-2w6kp pod downwardapi-volume-45b86997-7df7-11e8-b7a8-22e3071d17c7 container client-container: <nil>
+STEP: delete the pod
+Jul  2 12:56:03.633: INFO: Waiting for pod downwardapi-volume-45b86997-7df7-11e8-b7a8-22e3071d17c7 to disappear
+Jul  2 12:56:03.636: INFO: Pod downwardapi-volume-45b86997-7df7-11e8-b7a8-22e3071d17c7 no longer exists
+[AfterEach] [sig-storage] Projected
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 12:56:03.636: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-99xkw" for this suite.
+Jul  2 12:56:09.649: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 12:56:09.674: INFO: namespace: e2e-tests-projected-99xkw, resource: bindings, ignored listing per whitelist
+Jul  2 12:56:09.764: INFO: namespace e2e-tests-projected-99xkw deletion completed in 6.125187672s
+
+• [SLOW TEST:8.381 seconds]
+[sig-storage] Projected
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:34
+  should set mode on item file [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSSSSS
+------------------------------
+[sig-storage] Secrets 
+  should be consumable from pods in volume [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-storage] Secrets
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 12:56:09.765: INFO: >>> kubeConfig: /tmp/kubeconfig-575984058
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should be consumable from pods in volume [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating secret with name secret-test-4ab36fcf-7df7-11e8-b7a8-22e3071d17c7
+STEP: Creating a pod to test consume secrets
+Jul  2 12:56:09.855: INFO: Waiting up to 5m0s for pod "pod-secrets-4ab3e06e-7df7-11e8-b7a8-22e3071d17c7" in namespace "e2e-tests-secrets-jktx8" to be "success or failure"
+Jul  2 12:56:09.858: INFO: Pod "pod-secrets-4ab3e06e-7df7-11e8-b7a8-22e3071d17c7": Phase="Pending", Reason="", readiness=false. Elapsed: 2.586196ms
+Jul  2 12:56:11.862: INFO: Pod "pod-secrets-4ab3e06e-7df7-11e8-b7a8-22e3071d17c7": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.007099799s
+STEP: Saw pod success
+Jul  2 12:56:11.862: INFO: Pod "pod-secrets-4ab3e06e-7df7-11e8-b7a8-22e3071d17c7" satisfied condition "success or failure"
+Jul  2 12:56:11.865: INFO: Trying to get logs from node shoot--core--confos-worker-w6oh6-z1-59946c4f6c-2w6kp pod pod-secrets-4ab3e06e-7df7-11e8-b7a8-22e3071d17c7 container secret-volume-test: <nil>
+STEP: delete the pod
+Jul  2 12:56:11.889: INFO: Waiting for pod pod-secrets-4ab3e06e-7df7-11e8-b7a8-22e3071d17c7 to disappear
+Jul  2 12:56:11.893: INFO: Pod pod-secrets-4ab3e06e-7df7-11e8-b7a8-22e3071d17c7 no longer exists
+[AfterEach] [sig-storage] Secrets
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 12:56:11.893: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-secrets-jktx8" for this suite.
+Jul  2 12:56:17.988: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 12:56:17.998: INFO: namespace: e2e-tests-secrets-jktx8, resource: bindings, ignored listing per whitelist
+Jul  2 12:56:18.086: INFO: namespace e2e-tests-secrets-jktx8 deletion completed in 6.189747823s
+
+• [SLOW TEST:8.322 seconds]
+[sig-storage] Secrets
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/secrets_volume.go:33
+  should be consumable from pods in volume [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSSSSSSSSS
+------------------------------
+[sig-api-machinery] Downward API 
+  should provide host IP as an env var [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-api-machinery] Downward API
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 12:56:18.086: INFO: >>> kubeConfig: /tmp/kubeconfig-575984058
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should provide host IP as an env var [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating a pod to test downward api env vars
+Jul  2 12:56:18.198: INFO: Waiting up to 5m0s for pod "downward-api-4fac16c5-7df7-11e8-b7a8-22e3071d17c7" in namespace "e2e-tests-downward-api-vn8p2" to be "success or failure"
+Jul  2 12:56:18.202: INFO: Pod "downward-api-4fac16c5-7df7-11e8-b7a8-22e3071d17c7": Phase="Pending", Reason="", readiness=false. Elapsed: 3.193233ms
+Jul  2 12:56:20.206: INFO: Pod "downward-api-4fac16c5-7df7-11e8-b7a8-22e3071d17c7": Phase="Pending", Reason="", readiness=false. Elapsed: 2.006509283s
+Jul  2 12:56:22.210: INFO: Pod "downward-api-4fac16c5-7df7-11e8-b7a8-22e3071d17c7": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.010819467s
+STEP: Saw pod success
+Jul  2 12:56:22.210: INFO: Pod "downward-api-4fac16c5-7df7-11e8-b7a8-22e3071d17c7" satisfied condition "success or failure"
+Jul  2 12:56:22.213: INFO: Trying to get logs from node shoot--core--confos-worker-w6oh6-z1-59946c4f6c-2w6kp pod downward-api-4fac16c5-7df7-11e8-b7a8-22e3071d17c7 container dapi-container: <nil>
+STEP: delete the pod
+Jul  2 12:56:22.297: INFO: Waiting for pod downward-api-4fac16c5-7df7-11e8-b7a8-22e3071d17c7 to disappear
+Jul  2 12:56:22.299: INFO: Pod downward-api-4fac16c5-7df7-11e8-b7a8-22e3071d17c7 no longer exists
+[AfterEach] [sig-api-machinery] Downward API
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 12:56:22.299: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-downward-api-vn8p2" for this suite.
+Jul  2 12:56:28.313: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 12:56:28.377: INFO: namespace: e2e-tests-downward-api-vn8p2, resource: bindings, ignored listing per whitelist
+Jul  2 12:56:28.407: INFO: namespace e2e-tests-downward-api-vn8p2 deletion completed in 6.10470279s
+
+• [SLOW TEST:10.321 seconds]
+[sig-api-machinery] Downward API
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downward_api.go:37
+  should provide host IP as an env var [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+S
+------------------------------
+[k8s.io] Probing container 
+  with readiness probe should not be ready before initial delay and never restart [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [k8s.io] Probing container
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 12:56:28.408: INFO: >>> kubeConfig: /tmp/kubeconfig-575984058
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [k8s.io] Probing container
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/container_probe.go:48
+[It] with readiness probe should not be ready before initial delay and never restart [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+Jul  2 12:56:50.579: INFO: Container started at 2018-07-02 12:56:30 +0000 UTC, pod became ready at 2018-07-02 12:56:50 +0000 UTC
+[AfterEach] [k8s.io] Probing container
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 12:56:50.579: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-container-probe-ksr75" for this suite.
+Jul  2 12:57:12.698: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 12:57:12.855: INFO: namespace: e2e-tests-container-probe-ksr75, resource: bindings, ignored listing per whitelist
+Jul  2 12:57:12.861: INFO: namespace e2e-tests-container-probe-ksr75 deletion completed in 22.274202742s
+
+• [SLOW TEST:44.453 seconds]
+[k8s.io] Probing container
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:679
+  with readiness probe should not be ready before initial delay and never restart [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSSSSSSS
+------------------------------
+[sig-storage] EmptyDir volumes 
+  volume on tmpfs should have the correct mode [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-storage] EmptyDir volumes
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 12:57:12.863: INFO: >>> kubeConfig: /tmp/kubeconfig-575984058
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] volume on tmpfs should have the correct mode [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating a pod to test emptydir volume type on tmpfs
+Jul  2 12:57:12.958: INFO: Waiting up to 5m0s for pod "pod-705094c2-7df7-11e8-b7a8-22e3071d17c7" in namespace "e2e-tests-emptydir-lkrr4" to be "success or failure"
+Jul  2 12:57:12.960: INFO: Pod "pod-705094c2-7df7-11e8-b7a8-22e3071d17c7": Phase="Pending", Reason="", readiness=false. Elapsed: 2.259171ms
+Jul  2 12:57:14.988: INFO: Pod "pod-705094c2-7df7-11e8-b7a8-22e3071d17c7": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.03002405s
+STEP: Saw pod success
+Jul  2 12:57:14.988: INFO: Pod "pod-705094c2-7df7-11e8-b7a8-22e3071d17c7" satisfied condition "success or failure"
+Jul  2 12:57:14.991: INFO: Trying to get logs from node shoot--core--confos-worker-w6oh6-z1-59946c4f6c-2w6kp pod pod-705094c2-7df7-11e8-b7a8-22e3071d17c7 container test-container: <nil>
+STEP: delete the pod
+Jul  2 12:57:15.008: INFO: Waiting for pod pod-705094c2-7df7-11e8-b7a8-22e3071d17c7 to disappear
+Jul  2 12:57:15.016: INFO: Pod pod-705094c2-7df7-11e8-b7a8-22e3071d17c7 no longer exists
+[AfterEach] [sig-storage] EmptyDir volumes
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 12:57:15.016: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-emptydir-lkrr4" for this suite.
+Jul  2 12:57:21.031: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 12:57:21.150: INFO: namespace: e2e-tests-emptydir-lkrr4, resource: bindings, ignored listing per whitelist
+Jul  2 12:57:21.152: INFO: namespace e2e-tests-emptydir-lkrr4 deletion completed in 6.132356822s
+
+• [SLOW TEST:8.290 seconds]
+[sig-storage] EmptyDir volumes
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/empty_dir.go:40
+  volume on tmpfs should have the correct mode [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSSS
+------------------------------
+[sig-storage] Downward API volume 
+  should provide container's memory request [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 12:57:21.154: INFO: >>> kubeConfig: /tmp/kubeconfig-575984058
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downwardapi_volume.go:38
+[It] should provide container's memory request [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating a pod to test downward API volume plugin
+Jul  2 12:57:21.241: INFO: Waiting up to 5m0s for pod "downwardapi-volume-754098ff-7df7-11e8-b7a8-22e3071d17c7" in namespace "e2e-tests-downward-api-2b6z4" to be "success or failure"
+Jul  2 12:57:21.245: INFO: Pod "downwardapi-volume-754098ff-7df7-11e8-b7a8-22e3071d17c7": Phase="Pending", Reason="", readiness=false. Elapsed: 3.891363ms
+Jul  2 12:57:23.251: INFO: Pod "downwardapi-volume-754098ff-7df7-11e8-b7a8-22e3071d17c7": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.010017942s
+STEP: Saw pod success
+Jul  2 12:57:23.251: INFO: Pod "downwardapi-volume-754098ff-7df7-11e8-b7a8-22e3071d17c7" satisfied condition "success or failure"
+Jul  2 12:57:23.256: INFO: Trying to get logs from node shoot--core--confos-worker-w6oh6-z1-59946c4f6c-2w6kp pod downwardapi-volume-754098ff-7df7-11e8-b7a8-22e3071d17c7 container client-container: <nil>
+STEP: delete the pod
+Jul  2 12:57:23.274: INFO: Waiting for pod downwardapi-volume-754098ff-7df7-11e8-b7a8-22e3071d17c7 to disappear
+Jul  2 12:57:23.277: INFO: Pod downwardapi-volume-754098ff-7df7-11e8-b7a8-22e3071d17c7 no longer exists
+[AfterEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 12:57:23.277: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-downward-api-2b6z4" for this suite.
+Jul  2 12:57:29.297: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 12:57:29.378: INFO: namespace: e2e-tests-downward-api-2b6z4, resource: bindings, ignored listing per whitelist
+Jul  2 12:57:29.451: INFO: namespace e2e-tests-downward-api-2b6z4 deletion completed in 6.166804899s
+
+• [SLOW TEST:8.297 seconds]
+[sig-storage] Downward API volume
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downwardapi_volume.go:33
+  should provide container's memory request [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSS
+------------------------------
+[sig-storage] EmptyDir volumes 
+  should support (root,0666,tmpfs) [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-storage] EmptyDir volumes
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 12:57:29.451: INFO: >>> kubeConfig: /tmp/kubeconfig-575984058
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should support (root,0666,tmpfs) [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating a pod to test emptydir 0666 on tmpfs
+Jul  2 12:57:29.536: INFO: Waiting up to 5m0s for pod "pod-7a326345-7df7-11e8-b7a8-22e3071d17c7" in namespace "e2e-tests-emptydir-pnvc6" to be "success or failure"
+Jul  2 12:57:29.541: INFO: Pod "pod-7a326345-7df7-11e8-b7a8-22e3071d17c7": Phase="Pending", Reason="", readiness=false. Elapsed: 4.172441ms
+Jul  2 12:57:31.544: INFO: Pod "pod-7a326345-7df7-11e8-b7a8-22e3071d17c7": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.007960606s
+STEP: Saw pod success
+Jul  2 12:57:31.544: INFO: Pod "pod-7a326345-7df7-11e8-b7a8-22e3071d17c7" satisfied condition "success or failure"
+Jul  2 12:57:31.547: INFO: Trying to get logs from node shoot--core--confos-worker-w6oh6-z1-59946c4f6c-2w6kp pod pod-7a326345-7df7-11e8-b7a8-22e3071d17c7 container test-container: <nil>
+STEP: delete the pod
+Jul  2 12:57:31.564: INFO: Waiting for pod pod-7a326345-7df7-11e8-b7a8-22e3071d17c7 to disappear
+Jul  2 12:57:31.566: INFO: Pod pod-7a326345-7df7-11e8-b7a8-22e3071d17c7 no longer exists
+[AfterEach] [sig-storage] EmptyDir volumes
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 12:57:31.566: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-emptydir-pnvc6" for this suite.
+Jul  2 12:57:37.583: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 12:57:37.623: INFO: namespace: e2e-tests-emptydir-pnvc6, resource: bindings, ignored listing per whitelist
+Jul  2 12:57:37.684: INFO: namespace e2e-tests-emptydir-pnvc6 deletion completed in 6.114215556s
+
+• [SLOW TEST:8.233 seconds]
+[sig-storage] EmptyDir volumes
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/empty_dir.go:40
+  should support (root,0666,tmpfs) [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSSSS
+------------------------------
+[sig-storage] EmptyDir volumes 
+  should support (root,0644,tmpfs) [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-storage] EmptyDir volumes
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 12:57:37.685: INFO: >>> kubeConfig: /tmp/kubeconfig-575984058
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should support (root,0644,tmpfs) [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating a pod to test emptydir 0644 on tmpfs
+Jul  2 12:57:37.770: INFO: Waiting up to 5m0s for pod "pod-7f1aa025-7df7-11e8-b7a8-22e3071d17c7" in namespace "e2e-tests-emptydir-g6mj7" to be "success or failure"
+Jul  2 12:57:37.772: INFO: Pod "pod-7f1aa025-7df7-11e8-b7a8-22e3071d17c7": Phase="Pending", Reason="", readiness=false. Elapsed: 2.733778ms
+Jul  2 12:57:39.777: INFO: Pod "pod-7f1aa025-7df7-11e8-b7a8-22e3071d17c7": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.006805207s
+STEP: Saw pod success
+Jul  2 12:57:39.777: INFO: Pod "pod-7f1aa025-7df7-11e8-b7a8-22e3071d17c7" satisfied condition "success or failure"
+Jul  2 12:57:39.779: INFO: Trying to get logs from node shoot--core--confos-worker-w6oh6-z1-59946c4f6c-2w6kp pod pod-7f1aa025-7df7-11e8-b7a8-22e3071d17c7 container test-container: <nil>
+STEP: delete the pod
+Jul  2 12:57:39.976: INFO: Waiting for pod pod-7f1aa025-7df7-11e8-b7a8-22e3071d17c7 to disappear
+Jul  2 12:57:39.981: INFO: Pod pod-7f1aa025-7df7-11e8-b7a8-22e3071d17c7 no longer exists
+[AfterEach] [sig-storage] EmptyDir volumes
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 12:57:39.981: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-emptydir-g6mj7" for this suite.
+Jul  2 12:57:45.995: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 12:57:46.075: INFO: namespace: e2e-tests-emptydir-g6mj7, resource: bindings, ignored listing per whitelist
+Jul  2 12:57:46.179: INFO: namespace e2e-tests-emptydir-g6mj7 deletion completed in 6.194320261s
+
+• [SLOW TEST:8.495 seconds]
+[sig-storage] EmptyDir volumes
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/empty_dir.go:40
+  should support (root,0644,tmpfs) [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSSS
+------------------------------
+[sig-storage] Projected 
+  should be consumable from pods in volume with mappings as non-root [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 12:57:46.181: INFO: >>> kubeConfig: /tmp/kubeconfig-575984058
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:858
+[It] should be consumable from pods in volume with mappings as non-root [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating configMap with name projected-configmap-test-volume-map-842c0847-7df7-11e8-b7a8-22e3071d17c7
+STEP: Creating a pod to test consume configMaps
+Jul  2 12:57:46.276: INFO: Waiting up to 5m0s for pod "pod-projected-configmaps-842c9a08-7df7-11e8-b7a8-22e3071d17c7" in namespace "e2e-tests-projected-mb2w2" to be "success or failure"
+Jul  2 12:57:46.279: INFO: Pod "pod-projected-configmaps-842c9a08-7df7-11e8-b7a8-22e3071d17c7": Phase="Pending", Reason="", readiness=false. Elapsed: 3.147831ms
+Jul  2 12:57:48.283: INFO: Pod "pod-projected-configmaps-842c9a08-7df7-11e8-b7a8-22e3071d17c7": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.007193722s
+STEP: Saw pod success
+Jul  2 12:57:48.283: INFO: Pod "pod-projected-configmaps-842c9a08-7df7-11e8-b7a8-22e3071d17c7" satisfied condition "success or failure"
+Jul  2 12:57:48.286: INFO: Trying to get logs from node shoot--core--confos-worker-w6oh6-z1-59946c4f6c-2w6kp pod pod-projected-configmaps-842c9a08-7df7-11e8-b7a8-22e3071d17c7 container projected-configmap-volume-test: <nil>
+STEP: delete the pod
+Jul  2 12:57:48.303: INFO: Waiting for pod pod-projected-configmaps-842c9a08-7df7-11e8-b7a8-22e3071d17c7 to disappear
+Jul  2 12:57:48.317: INFO: Pod pod-projected-configmaps-842c9a08-7df7-11e8-b7a8-22e3071d17c7 no longer exists
+[AfterEach] [sig-storage] Projected
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 12:57:48.317: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-mb2w2" for this suite.
+Jul  2 12:57:54.333: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 12:57:54.397: INFO: namespace: e2e-tests-projected-mb2w2, resource: bindings, ignored listing per whitelist
+Jul  2 12:57:54.435: INFO: namespace e2e-tests-projected-mb2w2 deletion completed in 6.112795142s
+
+• [SLOW TEST:8.255 seconds]
+[sig-storage] Projected
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:34
+  should be consumable from pods in volume with mappings as non-root [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+S
+------------------------------
+[sig-storage] Projected 
+  should set DefaultMode on files [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 12:57:54.436: INFO: >>> kubeConfig: /tmp/kubeconfig-575984058
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:858
+[It] should set DefaultMode on files [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating a pod to test downward API volume plugin
+Jul  2 12:57:54.526: INFO: Waiting up to 5m0s for pod "downwardapi-volume-891773bc-7df7-11e8-b7a8-22e3071d17c7" in namespace "e2e-tests-projected-qv5dm" to be "success or failure"
+Jul  2 12:57:54.531: INFO: Pod "downwardapi-volume-891773bc-7df7-11e8-b7a8-22e3071d17c7": Phase="Pending", Reason="", readiness=false. Elapsed: 4.881394ms
+Jul  2 12:57:56.573: INFO: Pod "downwardapi-volume-891773bc-7df7-11e8-b7a8-22e3071d17c7": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.047052647s
+STEP: Saw pod success
+Jul  2 12:57:56.573: INFO: Pod "downwardapi-volume-891773bc-7df7-11e8-b7a8-22e3071d17c7" satisfied condition "success or failure"
+Jul  2 12:57:56.582: INFO: Trying to get logs from node shoot--core--confos-worker-w6oh6-z1-59946c4f6c-2w6kp pod downwardapi-volume-891773bc-7df7-11e8-b7a8-22e3071d17c7 container client-container: <nil>
+STEP: delete the pod
+Jul  2 12:57:56.599: INFO: Waiting for pod downwardapi-volume-891773bc-7df7-11e8-b7a8-22e3071d17c7 to disappear
+Jul  2 12:57:56.612: INFO: Pod downwardapi-volume-891773bc-7df7-11e8-b7a8-22e3071d17c7 no longer exists
+[AfterEach] [sig-storage] Projected
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 12:57:56.612: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-qv5dm" for this suite.
+Jul  2 12:58:02.628: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 12:58:02.690: INFO: namespace: e2e-tests-projected-qv5dm, resource: bindings, ignored listing per whitelist
+Jul  2 12:58:02.752: INFO: namespace e2e-tests-projected-qv5dm deletion completed in 6.134334527s
+
+• [SLOW TEST:8.316 seconds]
+[sig-storage] Projected
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:34
+  should set DefaultMode on files [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+[sig-storage] Projected 
+  should provide container's memory limit [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 12:58:02.752: INFO: >>> kubeConfig: /tmp/kubeconfig-575984058
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:858
+[It] should provide container's memory limit [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating a pod to test downward API volume plugin
+Jul  2 12:58:02.852: INFO: Waiting up to 5m0s for pod "downwardapi-volume-8e0dce8b-7df7-11e8-b7a8-22e3071d17c7" in namespace "e2e-tests-projected-njd92" to be "success or failure"
+Jul  2 12:58:02.856: INFO: Pod "downwardapi-volume-8e0dce8b-7df7-11e8-b7a8-22e3071d17c7": Phase="Pending", Reason="", readiness=false. Elapsed: 3.664249ms
+Jul  2 12:58:04.860: INFO: Pod "downwardapi-volume-8e0dce8b-7df7-11e8-b7a8-22e3071d17c7": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.007890644s
+STEP: Saw pod success
+Jul  2 12:58:04.860: INFO: Pod "downwardapi-volume-8e0dce8b-7df7-11e8-b7a8-22e3071d17c7" satisfied condition "success or failure"
+Jul  2 12:58:04.863: INFO: Trying to get logs from node shoot--core--confos-worker-w6oh6-z1-59946c4f6c-2w6kp pod downwardapi-volume-8e0dce8b-7df7-11e8-b7a8-22e3071d17c7 container client-container: <nil>
+STEP: delete the pod
+Jul  2 12:58:04.885: INFO: Waiting for pod downwardapi-volume-8e0dce8b-7df7-11e8-b7a8-22e3071d17c7 to disappear
+Jul  2 12:58:04.888: INFO: Pod downwardapi-volume-8e0dce8b-7df7-11e8-b7a8-22e3071d17c7 no longer exists
+[AfterEach] [sig-storage] Projected
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 12:58:04.888: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-njd92" for this suite.
+Jul  2 12:58:10.902: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 12:58:11.042: INFO: namespace: e2e-tests-projected-njd92, resource: bindings, ignored listing per whitelist
+Jul  2 12:58:11.057: INFO: namespace e2e-tests-projected-njd92 deletion completed in 6.165669337s
+
+• [SLOW TEST:8.306 seconds]
+[sig-storage] Projected
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:34
+  should provide container's memory limit [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSSSS
+------------------------------
+[sig-auth] ServiceAccounts 
+  should mount an API token into pods  [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-auth] ServiceAccounts
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 12:58:11.058: INFO: >>> kubeConfig: /tmp/kubeconfig-575984058
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should mount an API token into pods  [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: getting the auto-created API token
+STEP: Creating a pod to test consume service account token
+Jul  2 12:58:11.655: INFO: Waiting up to 5m0s for pod "pod-service-account-934d2804-7df7-11e8-b7a8-22e3071d17c7-gwvzn" in namespace "e2e-tests-svcaccounts-279wk" to be "success or failure"
+Jul  2 12:58:11.658: INFO: Pod "pod-service-account-934d2804-7df7-11e8-b7a8-22e3071d17c7-gwvzn": Phase="Pending", Reason="", readiness=false. Elapsed: 2.684972ms
+Jul  2 12:58:13.662: INFO: Pod "pod-service-account-934d2804-7df7-11e8-b7a8-22e3071d17c7-gwvzn": Phase="Pending", Reason="", readiness=false. Elapsed: 2.006866835s
+Jul  2 12:58:15.666: INFO: Pod "pod-service-account-934d2804-7df7-11e8-b7a8-22e3071d17c7-gwvzn": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.011121989s
+STEP: Saw pod success
+Jul  2 12:58:15.666: INFO: Pod "pod-service-account-934d2804-7df7-11e8-b7a8-22e3071d17c7-gwvzn" satisfied condition "success or failure"
+Jul  2 12:58:15.669: INFO: Trying to get logs from node shoot--core--confos-worker-w6oh6-z1-59946c4f6c-2w6kp pod pod-service-account-934d2804-7df7-11e8-b7a8-22e3071d17c7-gwvzn container token-test: <nil>
+STEP: delete the pod
+Jul  2 12:58:15.691: INFO: Waiting for pod pod-service-account-934d2804-7df7-11e8-b7a8-22e3071d17c7-gwvzn to disappear
+Jul  2 12:58:15.697: INFO: Pod pod-service-account-934d2804-7df7-11e8-b7a8-22e3071d17c7-gwvzn no longer exists
+STEP: Creating a pod to test consume service account root CA
+Jul  2 12:58:15.701: INFO: Waiting up to 5m0s for pod "pod-service-account-934d2804-7df7-11e8-b7a8-22e3071d17c7-bs962" in namespace "e2e-tests-svcaccounts-279wk" to be "success or failure"
+Jul  2 12:58:15.704: INFO: Pod "pod-service-account-934d2804-7df7-11e8-b7a8-22e3071d17c7-bs962": Phase="Pending", Reason="", readiness=false. Elapsed: 2.873682ms
+Jul  2 12:58:17.708: INFO: Pod "pod-service-account-934d2804-7df7-11e8-b7a8-22e3071d17c7-bs962": Phase="Pending", Reason="", readiness=false. Elapsed: 2.007215725s
+Jul  2 12:58:19.712: INFO: Pod "pod-service-account-934d2804-7df7-11e8-b7a8-22e3071d17c7-bs962": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.011245508s
+STEP: Saw pod success
+Jul  2 12:58:19.712: INFO: Pod "pod-service-account-934d2804-7df7-11e8-b7a8-22e3071d17c7-bs962" satisfied condition "success or failure"
+Jul  2 12:58:19.715: INFO: Trying to get logs from node shoot--core--confos-worker-w6oh6-z1-59946c4f6c-2w6kp pod pod-service-account-934d2804-7df7-11e8-b7a8-22e3071d17c7-bs962 container root-ca-test: <nil>
+STEP: delete the pod
+Jul  2 12:58:19.800: INFO: Waiting for pod pod-service-account-934d2804-7df7-11e8-b7a8-22e3071d17c7-bs962 to disappear
+Jul  2 12:58:19.805: INFO: Pod pod-service-account-934d2804-7df7-11e8-b7a8-22e3071d17c7-bs962 no longer exists
+STEP: Creating a pod to test consume service account namespace
+Jul  2 12:58:19.809: INFO: Waiting up to 5m0s for pod "pod-service-account-934d2804-7df7-11e8-b7a8-22e3071d17c7-kskp4" in namespace "e2e-tests-svcaccounts-279wk" to be "success or failure"
+Jul  2 12:58:19.811: INFO: Pod "pod-service-account-934d2804-7df7-11e8-b7a8-22e3071d17c7-kskp4": Phase="Pending", Reason="", readiness=false. Elapsed: 2.777305ms
+Jul  2 12:58:21.873: INFO: Pod "pod-service-account-934d2804-7df7-11e8-b7a8-22e3071d17c7-kskp4": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.064604796s
+STEP: Saw pod success
+Jul  2 12:58:21.874: INFO: Pod "pod-service-account-934d2804-7df7-11e8-b7a8-22e3071d17c7-kskp4" satisfied condition "success or failure"
+Jul  2 12:58:21.877: INFO: Trying to get logs from node shoot--core--confos-worker-w6oh6-z1-59946c4f6c-2w6kp pod pod-service-account-934d2804-7df7-11e8-b7a8-22e3071d17c7-kskp4 container namespace-test: <nil>
+STEP: delete the pod
+Jul  2 12:58:21.892: INFO: Waiting for pod pod-service-account-934d2804-7df7-11e8-b7a8-22e3071d17c7-kskp4 to disappear
+Jul  2 12:58:21.895: INFO: Pod pod-service-account-934d2804-7df7-11e8-b7a8-22e3071d17c7-kskp4 no longer exists
+[AfterEach] [sig-auth] ServiceAccounts
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 12:58:21.895: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-svcaccounts-279wk" for this suite.
+Jul  2 12:58:27.909: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 12:58:27.987: INFO: namespace: e2e-tests-svcaccounts-279wk, resource: bindings, ignored listing per whitelist
+Jul  2 12:58:28.009: INFO: namespace e2e-tests-svcaccounts-279wk deletion completed in 6.110896501s
+
+• [SLOW TEST:16.951 seconds]
+[sig-auth] ServiceAccounts
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/auth/framework.go:22
+  should mount an API token into pods  [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSSSSSSSSSSSS
+------------------------------
+[sig-apps] StatefulSet [k8s.io] Basic StatefulSet functionality [StatefulSetBasic] 
+  Scaling should happen in predictable order and halt if any stateful pod is unhealthy [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-apps] StatefulSet
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 12:58:28.011: INFO: >>> kubeConfig: /tmp/kubeconfig-575984058
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-apps] StatefulSet
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/statefulset.go:57
+[BeforeEach] [k8s.io] Basic StatefulSet functionality [StatefulSetBasic]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/statefulset.go:72
+STEP: Creating service test in namespace e2e-tests-statefulset-wlzmx
+[It] Scaling should happen in predictable order and halt if any stateful pod is unhealthy [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Initializing watcher for selector baz=blah,foo=bar
+STEP: Creating stateful set ss in namespace e2e-tests-statefulset-wlzmx
+STEP: Waiting until all stateful set ss replicas will be running in namespace e2e-tests-statefulset-wlzmx
+Jul  2 12:58:28.111: INFO: Found 0 stateful pods, waiting for 1
+Jul  2 12:58:38.116: INFO: Waiting for pod ss-0 to enter Running - Ready=true, currently Running - Ready=true
+STEP: Confirming that stateful set scale up will halt with unhealthy stateful pod
+Jul  2 12:58:38.119: INFO: Running '/usr/local/bin/kubectl --kubeconfig=/tmp/kubeconfig-575984058 exec --namespace=e2e-tests-statefulset-wlzmx ss-0 -- /bin/sh -c mv -v /usr/share/nginx/html/index.html /tmp/ || true'
+Jul  2 12:58:38.592: INFO: stderr: ""
+Jul  2 12:58:38.592: INFO: stdout: "'/usr/share/nginx/html/index.html' -> '/tmp/index.html'\n"
+Jul  2 12:58:38.592: INFO: stdout of mv -v /usr/share/nginx/html/index.html /tmp/ || true on ss-0: '/usr/share/nginx/html/index.html' -> '/tmp/index.html'
+
+Jul  2 12:58:38.596: INFO: Waiting for pod ss-0 to enter Running - Ready=false, currently Running - Ready=true
+Jul  2 12:58:48.601: INFO: Waiting for pod ss-0 to enter Running - Ready=false, currently Running - Ready=false
+Jul  2 12:58:48.601: INFO: Waiting for statefulset status.replicas updated to 0
+Jul  2 12:58:48.676: INFO: Verifying statefulset ss doesn't scale past 1 for another 9.99999955s
+Jul  2 12:58:49.680: INFO: Verifying statefulset ss doesn't scale past 1 for another 8.996042292s
+Jul  2 12:58:50.684: INFO: Verifying statefulset ss doesn't scale past 1 for another 7.991446476s
+Jul  2 12:58:51.689: INFO: Verifying statefulset ss doesn't scale past 1 for another 6.987216671s
+Jul  2 12:58:52.694: INFO: Verifying statefulset ss doesn't scale past 1 for another 5.982965237s
+Jul  2 12:58:53.771: INFO: Verifying statefulset ss doesn't scale past 1 for another 4.977977223s
+Jul  2 12:58:54.871: INFO: Verifying statefulset ss doesn't scale past 1 for another 3.900518199s
+Jul  2 12:58:55.876: INFO: Verifying statefulset ss doesn't scale past 1 for another 2.800257555s
+Jul  2 12:58:56.972: INFO: Verifying statefulset ss doesn't scale past 1 for another 1.796102423s
+Jul  2 12:58:57.976: INFO: Verifying statefulset ss doesn't scale past 1 for another 699.731085ms
+STEP: Scaling up stateful set ss to 3 replicas and waiting until all of them will be running in namespace e2e-tests-statefulset-wlzmx
+Jul  2 12:58:58.981: INFO: Running '/usr/local/bin/kubectl --kubeconfig=/tmp/kubeconfig-575984058 exec --namespace=e2e-tests-statefulset-wlzmx ss-0 -- /bin/sh -c mv -v /tmp/index.html /usr/share/nginx/html/ || true'
+Jul  2 12:58:59.458: INFO: stderr: ""
+Jul  2 12:58:59.458: INFO: stdout: "'/tmp/index.html' -> '/usr/share/nginx/html/index.html'\n"
+Jul  2 12:58:59.458: INFO: stdout of mv -v /tmp/index.html /usr/share/nginx/html/ || true on ss-0: '/tmp/index.html' -> '/usr/share/nginx/html/index.html'
+
+Jul  2 12:58:59.462: INFO: Found 1 stateful pods, waiting for 3
+Jul  2 12:59:09.466: INFO: Waiting for pod ss-0 to enter Running - Ready=true, currently Running - Ready=true
+Jul  2 12:59:09.467: INFO: Waiting for pod ss-1 to enter Running - Ready=true, currently Running - Ready=true
+Jul  2 12:59:09.467: INFO: Waiting for pod ss-2 to enter Running - Ready=true, currently Running - Ready=true
+STEP: Verifying that stateful set ss was scaled up in order
+STEP: Scale down will halt with unhealthy stateful pod
+Jul  2 12:59:09.477: INFO: Running '/usr/local/bin/kubectl --kubeconfig=/tmp/kubeconfig-575984058 exec --namespace=e2e-tests-statefulset-wlzmx ss-0 -- /bin/sh -c mv -v /usr/share/nginx/html/index.html /tmp/ || true'
+Jul  2 12:59:10.000: INFO: stderr: ""
+Jul  2 12:59:10.001: INFO: stdout: "'/usr/share/nginx/html/index.html' -> '/tmp/index.html'\n"
+Jul  2 12:59:10.001: INFO: stdout of mv -v /usr/share/nginx/html/index.html /tmp/ || true on ss-0: '/usr/share/nginx/html/index.html' -> '/tmp/index.html'
+
+Jul  2 12:59:10.001: INFO: Running '/usr/local/bin/kubectl --kubeconfig=/tmp/kubeconfig-575984058 exec --namespace=e2e-tests-statefulset-wlzmx ss-1 -- /bin/sh -c mv -v /usr/share/nginx/html/index.html /tmp/ || true'
+Jul  2 12:59:10.524: INFO: stderr: ""
+Jul  2 12:59:10.524: INFO: stdout: "'/usr/share/nginx/html/index.html' -> '/tmp/index.html'\n"
+Jul  2 12:59:10.524: INFO: stdout of mv -v /usr/share/nginx/html/index.html /tmp/ || true on ss-1: '/usr/share/nginx/html/index.html' -> '/tmp/index.html'
+
+Jul  2 12:59:10.525: INFO: Running '/usr/local/bin/kubectl --kubeconfig=/tmp/kubeconfig-575984058 exec --namespace=e2e-tests-statefulset-wlzmx ss-2 -- /bin/sh -c mv -v /usr/share/nginx/html/index.html /tmp/ || true'
+Jul  2 12:59:11.026: INFO: stderr: ""
+Jul  2 12:59:11.026: INFO: stdout: "'/usr/share/nginx/html/index.html' -> '/tmp/index.html'\n"
+Jul  2 12:59:11.026: INFO: stdout of mv -v /usr/share/nginx/html/index.html /tmp/ || true on ss-2: '/usr/share/nginx/html/index.html' -> '/tmp/index.html'
+
+Jul  2 12:59:11.026: INFO: Waiting for statefulset status.replicas updated to 0
+Jul  2 12:59:11.029: INFO: Waiting for stateful set status.readyReplicas to become 0, currently 1
+Jul  2 12:59:21.042: INFO: Waiting for pod ss-0 to enter Running - Ready=false, currently Running - Ready=false
+Jul  2 12:59:21.042: INFO: Waiting for pod ss-1 to enter Running - Ready=false, currently Running - Ready=false
+Jul  2 12:59:21.042: INFO: Waiting for pod ss-2 to enter Running - Ready=false, currently Running - Ready=false
+Jul  2 12:59:21.054: INFO: Verifying statefulset ss doesn't scale past 3 for another 9.999999802s
+Jul  2 12:59:22.060: INFO: Verifying statefulset ss doesn't scale past 3 for another 8.994245945s
+Jul  2 12:59:23.064: INFO: Verifying statefulset ss doesn't scale past 3 for another 7.989285188s
+Jul  2 12:59:24.085: INFO: Verifying statefulset ss doesn't scale past 3 for another 6.984594709s
+Jul  2 12:59:25.089: INFO: Verifying statefulset ss doesn't scale past 3 for another 5.963455649s
+Jul  2 12:59:26.094: INFO: Verifying statefulset ss doesn't scale past 3 for another 4.959336918s
+Jul  2 12:59:27.099: INFO: Verifying statefulset ss doesn't scale past 3 for another 3.954449451s
+Jul  2 12:59:28.105: INFO: Verifying statefulset ss doesn't scale past 3 for another 2.949905332s
+Jul  2 12:59:29.110: INFO: Verifying statefulset ss doesn't scale past 3 for another 1.943956566s
+Jul  2 12:59:30.271: INFO: Verifying statefulset ss doesn't scale past 3 for another 939.226498ms
+STEP: Scaling down stateful set ss to 0 replicas and waiting until none of pods will run in namespacee2e-tests-statefulset-wlzmx
+Jul  2 12:59:31.287: INFO: Running '/usr/local/bin/kubectl --kubeconfig=/tmp/kubeconfig-575984058 exec --namespace=e2e-tests-statefulset-wlzmx ss-0 -- /bin/sh -c mv -v /tmp/index.html /usr/share/nginx/html/ || true'
+Jul  2 12:59:31.747: INFO: stderr: ""
+Jul  2 12:59:31.747: INFO: stdout: "'/tmp/index.html' -> '/usr/share/nginx/html/index.html'\n"
+Jul  2 12:59:31.747: INFO: stdout of mv -v /tmp/index.html /usr/share/nginx/html/ || true on ss-0: '/tmp/index.html' -> '/usr/share/nginx/html/index.html'
+
+Jul  2 12:59:31.747: INFO: Running '/usr/local/bin/kubectl --kubeconfig=/tmp/kubeconfig-575984058 exec --namespace=e2e-tests-statefulset-wlzmx ss-1 -- /bin/sh -c mv -v /tmp/index.html /usr/share/nginx/html/ || true'
+Jul  2 12:59:32.196: INFO: stderr: ""
+Jul  2 12:59:32.196: INFO: stdout: "'/tmp/index.html' -> '/usr/share/nginx/html/index.html'\n"
+Jul  2 12:59:32.196: INFO: stdout of mv -v /tmp/index.html /usr/share/nginx/html/ || true on ss-1: '/tmp/index.html' -> '/usr/share/nginx/html/index.html'
+
+Jul  2 12:59:32.196: INFO: Running '/usr/local/bin/kubectl --kubeconfig=/tmp/kubeconfig-575984058 exec --namespace=e2e-tests-statefulset-wlzmx ss-2 -- /bin/sh -c mv -v /tmp/index.html /usr/share/nginx/html/ || true'
+Jul  2 12:59:32.635: INFO: stderr: ""
+Jul  2 12:59:32.635: INFO: stdout: "'/tmp/index.html' -> '/usr/share/nginx/html/index.html'\n"
+Jul  2 12:59:32.635: INFO: stdout of mv -v /tmp/index.html /usr/share/nginx/html/ || true on ss-2: '/tmp/index.html' -> '/usr/share/nginx/html/index.html'
+
+Jul  2 12:59:32.635: INFO: Scaling statefulset ss to 0
+STEP: Verifying that stateful set ss was scaled down in reverse order
+[AfterEach] [k8s.io] Basic StatefulSet functionality [StatefulSetBasic]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/statefulset.go:83
+Jul  2 12:59:52.649: INFO: Deleting all statefulset in ns e2e-tests-statefulset-wlzmx
+Jul  2 12:59:52.652: INFO: Scaling statefulset ss to 0
+Jul  2 12:59:52.677: INFO: Waiting for statefulset status.replicas updated to 0
+Jul  2 12:59:52.679: INFO: Deleting statefulset ss
+[AfterEach] [sig-apps] StatefulSet
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 12:59:52.690: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-statefulset-wlzmx" for this suite.
+Jul  2 12:59:58.703: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 12:59:58.842: INFO: namespace: e2e-tests-statefulset-wlzmx, resource: bindings, ignored listing per whitelist
+Jul  2 12:59:58.886: INFO: namespace e2e-tests-statefulset-wlzmx deletion completed in 6.192583588s
+
+• [SLOW TEST:90.875 seconds]
+[sig-apps] StatefulSet
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/framework.go:22
+  [k8s.io] Basic StatefulSet functionality [StatefulSetBasic]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:679
+    Scaling should happen in predictable order and halt if any stateful pod is unhealthy [Conformance]
+    /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSSS
+------------------------------
+[sig-storage] Secrets 
+  optional updates should be reflected in volume [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-storage] Secrets
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 12:59:58.886: INFO: >>> kubeConfig: /tmp/kubeconfig-575984058
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] optional updates should be reflected in volume [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating secret with name s-test-opt-del-d345ee0b-7df7-11e8-b7a8-22e3071d17c7
+STEP: Creating secret with name s-test-opt-upd-d345ee45-7df7-11e8-b7a8-22e3071d17c7
+STEP: Creating the pod
+STEP: Deleting secret s-test-opt-del-d345ee0b-7df7-11e8-b7a8-22e3071d17c7
+STEP: Updating secret s-test-opt-upd-d345ee45-7df7-11e8-b7a8-22e3071d17c7
+STEP: Creating secret with name s-test-opt-create-d345ee5b-7df7-11e8-b7a8-22e3071d17c7
+STEP: waiting to observe update in volume
+[AfterEach] [sig-storage] Secrets
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:00:03.433: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-secrets-rntwl" for this suite.
+Jul  2 13:00:25.570: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:00:25.600: INFO: namespace: e2e-tests-secrets-rntwl, resource: bindings, ignored listing per whitelist
+Jul  2 13:00:25.668: INFO: namespace e2e-tests-secrets-rntwl deletion completed in 22.231569561s
+
+• [SLOW TEST:26.783 seconds]
+[sig-storage] Secrets
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/secrets_volume.go:33
+  optional updates should be reflected in volume [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+[sig-api-machinery] Watchers 
+  should be able to start watching from a specific resource version [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-api-machinery] Watchers
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:00:25.668: INFO: >>> kubeConfig: /tmp/kubeconfig-575984058
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should be able to start watching from a specific resource version [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: creating a new configmap
+STEP: modifying the configmap once
+STEP: modifying the configmap a second time
+STEP: deleting the configmap
+STEP: creating a watch on configmaps from the resource version returned by the first update
+STEP: Expecting to observe notifications for all changes to the configmap after the first update
+Jul  2 13:00:25.777: INFO: Got : MODIFIED &ConfigMap{ObjectMeta:k8s_io_apimachinery_pkg_apis_meta_v1.ObjectMeta{Name:e2e-watch-test-resource-version,GenerateName:,Namespace:e2e-tests-watch-mqmmb,SelfLink:/api/v1/namespaces/e2e-tests-watch-mqmmb/configmaps/e2e-watch-test-resource-version,UID:e33fbe54-7df7-11e8-a560-160e0404a9f8,ResourceVersion:2616,Generation:0,CreationTimestamp:2018-07-02 13:00:25 +0000 UTC,DeletionTimestamp:<nil>,DeletionGracePeriodSeconds:nil,Labels:map[string]string{watch-this-configmap: from-resource-version,},Annotations:map[string]string{},OwnerReferences:[],Finalizers:[],ClusterName:,Initializers:nil,},Data:map[string]string{mutation: 2,},BinaryData:map[string][]byte{},}
+Jul  2 13:00:25.777: INFO: Got : DELETED &ConfigMap{ObjectMeta:k8s_io_apimachinery_pkg_apis_meta_v1.ObjectMeta{Name:e2e-watch-test-resource-version,GenerateName:,Namespace:e2e-tests-watch-mqmmb,SelfLink:/api/v1/namespaces/e2e-tests-watch-mqmmb/configmaps/e2e-watch-test-resource-version,UID:e33fbe54-7df7-11e8-a560-160e0404a9f8,ResourceVersion:2617,Generation:0,CreationTimestamp:2018-07-02 13:00:25 +0000 UTC,DeletionTimestamp:<nil>,DeletionGracePeriodSeconds:nil,Labels:map[string]string{watch-this-configmap: from-resource-version,},Annotations:map[string]string{},OwnerReferences:[],Finalizers:[],ClusterName:,Initializers:nil,},Data:map[string]string{mutation: 2,},BinaryData:map[string][]byte{},}
+[AfterEach] [sig-api-machinery] Watchers
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:00:25.777: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-watch-mqmmb" for this suite.
+Jul  2 13:00:31.791: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:00:31.940: INFO: namespace: e2e-tests-watch-mqmmb, resource: bindings, ignored listing per whitelist
+Jul  2 13:00:31.981: INFO: namespace e2e-tests-watch-mqmmb deletion completed in 6.19987648s
+
+• [SLOW TEST:6.312 seconds]
+[sig-api-machinery] Watchers
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apimachinery/framework.go:22
+  should be able to start watching from a specific resource version [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSS
+------------------------------
+[k8s.io] Probing container 
+  should *not* be restarted with a exec "cat /tmp/health" liveness probe [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [k8s.io] Probing container
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:00:31.981: INFO: >>> kubeConfig: /tmp/kubeconfig-575984058
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [k8s.io] Probing container
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/container_probe.go:48
+[It] should *not* be restarted with a exec "cat /tmp/health" liveness probe [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating pod liveness-exec in namespace e2e-tests-container-probe-ksfg9
+Jul  2 13:00:36.081: INFO: Started pod liveness-exec in namespace e2e-tests-container-probe-ksfg9
+STEP: checking the pod's current state and verifying that restartCount is present
+Jul  2 13:00:36.084: INFO: Initial restart count of pod liveness-exec is 0
+STEP: deleting the pod
+[AfterEach] [k8s.io] Probing container
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:04:36.194: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-container-probe-ksfg9" for this suite.
+Jul  2 13:04:42.219: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:04:42.297: INFO: namespace: e2e-tests-container-probe-ksfg9, resource: bindings, ignored listing per whitelist
+Jul  2 13:04:42.354: INFO: namespace e2e-tests-container-probe-ksfg9 deletion completed in 6.153178399s
+
+• [SLOW TEST:250.374 seconds]
+[k8s.io] Probing container
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:679
+  should *not* be restarted with a exec "cat /tmp/health" liveness probe [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSSSSSSSSSSSS
+------------------------------
+[sig-storage] EmptyDir volumes 
+  should support (non-root,0777,tmpfs) [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-storage] EmptyDir volumes
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:04:42.357: INFO: >>> kubeConfig: /tmp/kubeconfig-575984058
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should support (non-root,0777,tmpfs) [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating a pod to test emptydir 0777 on tmpfs
+Jul  2 13:04:42.454: INFO: Waiting up to 5m0s for pod "pod-7c3c4a1c-7df8-11e8-b7a8-22e3071d17c7" in namespace "e2e-tests-emptydir-ldkqb" to be "success or failure"
+Jul  2 13:04:42.457: INFO: Pod "pod-7c3c4a1c-7df8-11e8-b7a8-22e3071d17c7": Phase="Pending", Reason="", readiness=false. Elapsed: 3.338001ms
+Jul  2 13:04:44.463: INFO: Pod "pod-7c3c4a1c-7df8-11e8-b7a8-22e3071d17c7": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.009079224s
+STEP: Saw pod success
+Jul  2 13:04:44.463: INFO: Pod "pod-7c3c4a1c-7df8-11e8-b7a8-22e3071d17c7" satisfied condition "success or failure"
+Jul  2 13:04:44.466: INFO: Trying to get logs from node shoot--core--confos-worker-w6oh6-z1-59946c4f6c-2w6kp pod pod-7c3c4a1c-7df8-11e8-b7a8-22e3071d17c7 container test-container: <nil>
+STEP: delete the pod
+Jul  2 13:04:44.580: INFO: Waiting for pod pod-7c3c4a1c-7df8-11e8-b7a8-22e3071d17c7 to disappear
+Jul  2 13:04:44.584: INFO: Pod pod-7c3c4a1c-7df8-11e8-b7a8-22e3071d17c7 no longer exists
+[AfterEach] [sig-storage] EmptyDir volumes
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:04:44.584: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-emptydir-ldkqb" for this suite.
+Jul  2 13:04:50.665: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:04:50.678: INFO: namespace: e2e-tests-emptydir-ldkqb, resource: bindings, ignored listing per whitelist
+Jul  2 13:04:50.768: INFO: namespace e2e-tests-emptydir-ldkqb deletion completed in 6.180081092s
+
+• [SLOW TEST:8.412 seconds]
+[sig-storage] EmptyDir volumes
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/empty_dir.go:40
+  should support (non-root,0777,tmpfs) [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSS
+------------------------------
+[sig-api-machinery] Watchers 
+  should be able to restart watching from the last resource version observed by the previous watch [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-api-machinery] Watchers
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:04:50.770: INFO: >>> kubeConfig: /tmp/kubeconfig-575984058
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should be able to restart watching from the last resource version observed by the previous watch [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: creating a watch on configmaps
+STEP: creating a new configmap
+STEP: modifying the configmap once
+STEP: closing the watch once it receives two notifications
+Jul  2 13:04:50.868: INFO: Got : ADDED &ConfigMap{ObjectMeta:k8s_io_apimachinery_pkg_apis_meta_v1.ObjectMeta{Name:e2e-watch-test-watch-closed,GenerateName:,Namespace:e2e-tests-watch-nsm5n,SelfLink:/api/v1/namespaces/e2e-tests-watch-nsm5n/configmaps/e2e-watch-test-watch-closed,UID:81443c79-7df8-11e8-a560-160e0404a9f8,ResourceVersion:3191,Generation:0,CreationTimestamp:2018-07-02 13:04:50 +0000 UTC,DeletionTimestamp:<nil>,DeletionGracePeriodSeconds:nil,Labels:map[string]string{watch-this-configmap: watch-closed-and-restarted,},Annotations:map[string]string{},OwnerReferences:[],Finalizers:[],ClusterName:,Initializers:nil,},Data:map[string]string{},BinaryData:map[string][]byte{},}
+Jul  2 13:04:50.868: INFO: Got : MODIFIED &ConfigMap{ObjectMeta:k8s_io_apimachinery_pkg_apis_meta_v1.ObjectMeta{Name:e2e-watch-test-watch-closed,GenerateName:,Namespace:e2e-tests-watch-nsm5n,SelfLink:/api/v1/namespaces/e2e-tests-watch-nsm5n/configmaps/e2e-watch-test-watch-closed,UID:81443c79-7df8-11e8-a560-160e0404a9f8,ResourceVersion:3192,Generation:0,CreationTimestamp:2018-07-02 13:04:50 +0000 UTC,DeletionTimestamp:<nil>,DeletionGracePeriodSeconds:nil,Labels:map[string]string{watch-this-configmap: watch-closed-and-restarted,},Annotations:map[string]string{},OwnerReferences:[],Finalizers:[],ClusterName:,Initializers:nil,},Data:map[string]string{mutation: 1,},BinaryData:map[string][]byte{},}
+STEP: modifying the configmap a second time, while the watch is closed
+STEP: creating a new watch on configmaps from the last resource version observed by the first watch
+STEP: deleting the configmap
+STEP: Expecting to observe notifications for all changes to the configmap since the first watch closed
+Jul  2 13:04:50.880: INFO: Got : MODIFIED &ConfigMap{ObjectMeta:k8s_io_apimachinery_pkg_apis_meta_v1.ObjectMeta{Name:e2e-watch-test-watch-closed,GenerateName:,Namespace:e2e-tests-watch-nsm5n,SelfLink:/api/v1/namespaces/e2e-tests-watch-nsm5n/configmaps/e2e-watch-test-watch-closed,UID:81443c79-7df8-11e8-a560-160e0404a9f8,ResourceVersion:3193,Generation:0,CreationTimestamp:2018-07-02 13:04:50 +0000 UTC,DeletionTimestamp:<nil>,DeletionGracePeriodSeconds:nil,Labels:map[string]string{watch-this-configmap: watch-closed-and-restarted,},Annotations:map[string]string{},OwnerReferences:[],Finalizers:[],ClusterName:,Initializers:nil,},Data:map[string]string{mutation: 2,},BinaryData:map[string][]byte{},}
+Jul  2 13:04:50.880: INFO: Got : DELETED &ConfigMap{ObjectMeta:k8s_io_apimachinery_pkg_apis_meta_v1.ObjectMeta{Name:e2e-watch-test-watch-closed,GenerateName:,Namespace:e2e-tests-watch-nsm5n,SelfLink:/api/v1/namespaces/e2e-tests-watch-nsm5n/configmaps/e2e-watch-test-watch-closed,UID:81443c79-7df8-11e8-a560-160e0404a9f8,ResourceVersion:3194,Generation:0,CreationTimestamp:2018-07-02 13:04:50 +0000 UTC,DeletionTimestamp:<nil>,DeletionGracePeriodSeconds:nil,Labels:map[string]string{watch-this-configmap: watch-closed-and-restarted,},Annotations:map[string]string{},OwnerReferences:[],Finalizers:[],ClusterName:,Initializers:nil,},Data:map[string]string{mutation: 2,},BinaryData:map[string][]byte{},}
+[AfterEach] [sig-api-machinery] Watchers
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:04:50.881: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-watch-nsm5n" for this suite.
+Jul  2 13:04:56.900: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:04:56.913: INFO: namespace: e2e-tests-watch-nsm5n, resource: bindings, ignored listing per whitelist
+Jul  2 13:04:57.046: INFO: namespace e2e-tests-watch-nsm5n deletion completed in 6.16233825s
+
+• [SLOW TEST:6.276 seconds]
+[sig-api-machinery] Watchers
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apimachinery/framework.go:22
+  should be able to restart watching from the last resource version observed by the previous watch [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+S
+------------------------------
+[sig-network] Proxy version v1 
+  should proxy through a service and a pod  [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] version v1
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:04:57.047: INFO: >>> kubeConfig: /tmp/kubeconfig-575984058
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should proxy through a service and a pod  [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: starting an echo server on multiple ports
+STEP: creating replication controller proxy-service-2k9fx in namespace e2e-tests-proxy-l5kqk
+I0702 13:04:57.141464      16 runners.go:177] Created replication controller with name: proxy-service-2k9fx, namespace: e2e-tests-proxy-l5kqk, replica count: 1
+I0702 13:04:58.191952      16 runners.go:177] proxy-service-2k9fx Pods: 1 out of 1 created, 0 running, 1 pending, 0 waiting, 0 inactive, 0 terminating, 0 unknown, 0 runningButNotReady 
+I0702 13:04:59.192129      16 runners.go:177] proxy-service-2k9fx Pods: 1 out of 1 created, 0 running, 1 pending, 0 waiting, 0 inactive, 0 terminating, 0 unknown, 0 runningButNotReady 
+I0702 13:05:00.192406      16 runners.go:177] proxy-service-2k9fx Pods: 1 out of 1 created, 0 running, 0 pending, 0 waiting, 0 inactive, 0 terminating, 0 unknown, 1 runningButNotReady 
+I0702 13:05:01.197181      16 runners.go:177] proxy-service-2k9fx Pods: 1 out of 1 created, 0 running, 0 pending, 0 waiting, 0 inactive, 0 terminating, 0 unknown, 1 runningButNotReady 
+I0702 13:05:02.198118      16 runners.go:177] proxy-service-2k9fx Pods: 1 out of 1 created, 0 running, 0 pending, 0 waiting, 0 inactive, 0 terminating, 0 unknown, 1 runningButNotReady 
+I0702 13:05:03.198322      16 runners.go:177] proxy-service-2k9fx Pods: 1 out of 1 created, 0 running, 0 pending, 0 waiting, 0 inactive, 0 terminating, 0 unknown, 1 runningButNotReady 
+I0702 13:05:04.201145      16 runners.go:177] proxy-service-2k9fx Pods: 1 out of 1 created, 0 running, 0 pending, 0 waiting, 0 inactive, 0 terminating, 0 unknown, 1 runningButNotReady 
+I0702 13:05:05.202325      16 runners.go:177] proxy-service-2k9fx Pods: 1 out of 1 created, 0 running, 0 pending, 0 waiting, 0 inactive, 0 terminating, 0 unknown, 1 runningButNotReady 
+I0702 13:05:06.202549      16 runners.go:177] proxy-service-2k9fx Pods: 1 out of 1 created, 0 running, 0 pending, 0 waiting, 0 inactive, 0 terminating, 0 unknown, 1 runningButNotReady 
+I0702 13:05:07.202796      16 runners.go:177] proxy-service-2k9fx Pods: 1 out of 1 created, 0 running, 0 pending, 0 waiting, 0 inactive, 0 terminating, 0 unknown, 1 runningButNotReady 
+I0702 13:05:08.203007      16 runners.go:177] proxy-service-2k9fx Pods: 1 out of 1 created, 0 running, 0 pending, 0 waiting, 0 inactive, 0 terminating, 0 unknown, 1 runningButNotReady 
+I0702 13:05:09.203243      16 runners.go:177] proxy-service-2k9fx Pods: 1 out of 1 created, 1 running, 0 pending, 0 waiting, 0 inactive, 0 terminating, 0 unknown, 0 runningButNotReady 
+Jul  2 13:05:09.209: INFO: setup took 12.081359908s, starting test cases
+STEP: running 16 cases, 20 attempts per case, 320 total attempts
+Jul  2 13:05:09.287: INFO: (0) /api/v1/namespaces/e2e-tests-proxy-l5kqk/services/proxy-service-2k9fx:portname2/proxy/: bar (200; 77.915064ms)
+Jul  2 13:05:09.287: INFO: (0) /api/v1/namespaces/e2e-tests-proxy-l5kqk/pods/http:proxy-service-2k9fx-mgjjs:162/proxy/: bar (200; 77.894844ms)
+Jul  2 13:05:09.287: INFO: (0) /api/v1/namespaces/e2e-tests-proxy-l5kqk/pods/http:proxy-service-2k9fx-mgjjs:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-l5kqk/pods/http:proxy-service-2k9fx-mgjjs:1080/proxy/... (200; 78.210817ms)
+Jul  2 13:05:09.287: INFO: (0) /api/v1/namespaces/e2e-tests-proxy-l5kqk/pods/proxy-service-2k9fx-mgjjs:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-l5kqk/pods/proxy-service-2k9fx-mgjjs:1080/proxy/rewri... (200; 77.9711ms)
+Jul  2 13:05:09.287: INFO: (0) /api/v1/namespaces/e2e-tests-proxy-l5kqk/pods/proxy-service-2k9fx-mgjjs:162/proxy/: bar (200; 78.088675ms)
+Jul  2 13:05:09.287: INFO: (0) /api/v1/namespaces/e2e-tests-proxy-l5kqk/services/proxy-service-2k9fx:portname1/proxy/: foo (200; 78.464312ms)
+Jul  2 13:05:09.287: INFO: (0) /api/v1/namespaces/e2e-tests-proxy-l5kqk/pods/proxy-service-2k9fx-mgjjs/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-l5kqk/pods/proxy-service-2k9fx-mgjjs/proxy/rewriteme"... (200; 78.247976ms)
+Jul  2 13:05:09.292: INFO: (0) /api/v1/namespaces/e2e-tests-proxy-l5kqk/pods/http:proxy-service-2k9fx-mgjjs:160/proxy/: foo (200; 82.901125ms)
+Jul  2 13:05:09.292: INFO: (0) /api/v1/namespaces/e2e-tests-proxy-l5kqk/pods/proxy-service-2k9fx-mgjjs:160/proxy/: foo (200; 82.896904ms)
+Jul  2 13:05:09.292: INFO: (0) /api/v1/namespaces/e2e-tests-proxy-l5kqk/services/http:proxy-service-2k9fx:portname2/proxy/: bar (200; 82.749363ms)
+Jul  2 13:05:09.292: INFO: (0) /api/v1/namespaces/e2e-tests-proxy-l5kqk/services/http:proxy-service-2k9fx:portname1/proxy/: foo (200; 83.118653ms)
+Jul  2 13:05:09.380: INFO: (0) /api/v1/namespaces/e2e-tests-proxy-l5kqk/pods/https:proxy-service-2k9fx-mgjjs:462/proxy/: tls qux (200; 170.215534ms)
+Jul  2 13:05:09.380: INFO: (0) /api/v1/namespaces/e2e-tests-proxy-l5kqk/pods/https:proxy-service-2k9fx-mgjjs:460/proxy/: tls baz (200; 170.529901ms)
+Jul  2 13:05:09.380: INFO: (0) /api/v1/namespaces/e2e-tests-proxy-l5kqk/services/https:proxy-service-2k9fx:tlsportname2/proxy/: tls qux (200; 170.202655ms)
+Jul  2 13:05:09.381: INFO: (0) /api/v1/namespaces/e2e-tests-proxy-l5kqk/services/https:proxy-service-2k9fx:tlsportname1/proxy/: tls baz (200; 172.097023ms)
+Jul  2 13:05:09.381: INFO: (0) /api/v1/namespaces/e2e-tests-proxy-l5kqk/pods/https:proxy-service-2k9fx-mgjjs:443/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-l5kqk/pods/https:proxy-service-2k9fx-mgjjs:443/proxy/... (200; 172.078203ms)
+Jul  2 13:05:09.468: INFO: (1) /api/v1/namespaces/e2e-tests-proxy-l5kqk/pods/http:proxy-service-2k9fx-mgjjs:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-l5kqk/pods/http:proxy-service-2k9fx-mgjjs:1080/proxy/... (200; 86.847351ms)
+Jul  2 13:05:09.468: INFO: (1) /api/v1/namespaces/e2e-tests-proxy-l5kqk/pods/proxy-service-2k9fx-mgjjs:160/proxy/: foo (200; 86.644299ms)
+Jul  2 13:05:09.468: INFO: (1) /api/v1/namespaces/e2e-tests-proxy-l5kqk/pods/http:proxy-service-2k9fx-mgjjs:160/proxy/: foo (200; 86.793651ms)
+Jul  2 13:05:09.468: INFO: (1) /api/v1/namespaces/e2e-tests-proxy-l5kqk/services/https:proxy-service-2k9fx:tlsportname2/proxy/: tls qux (200; 86.727405ms)
+Jul  2 13:05:09.468: INFO: (1) /api/v1/namespaces/e2e-tests-proxy-l5kqk/pods/https:proxy-service-2k9fx-mgjjs:462/proxy/: tls qux (200; 86.785898ms)
+Jul  2 13:05:09.469: INFO: (1) /api/v1/namespaces/e2e-tests-proxy-l5kqk/pods/https:proxy-service-2k9fx-mgjjs:460/proxy/: tls baz (200; 86.670174ms)
+Jul  2 13:05:09.469: INFO: (1) /api/v1/namespaces/e2e-tests-proxy-l5kqk/pods/proxy-service-2k9fx-mgjjs:162/proxy/: bar (200; 86.826691ms)
+Jul  2 13:05:09.469: INFO: (1) /api/v1/namespaces/e2e-tests-proxy-l5kqk/pods/http:proxy-service-2k9fx-mgjjs:162/proxy/: bar (200; 86.994823ms)
+Jul  2 13:05:09.469: INFO: (1) /api/v1/namespaces/e2e-tests-proxy-l5kqk/pods/proxy-service-2k9fx-mgjjs:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-l5kqk/pods/proxy-service-2k9fx-mgjjs:1080/proxy/rewri... (200; 86.939707ms)
+Jul  2 13:05:09.469: INFO: (1) /api/v1/namespaces/e2e-tests-proxy-l5kqk/services/https:proxy-service-2k9fx:tlsportname1/proxy/: tls baz (200; 87.23131ms)
+Jul  2 13:05:09.469: INFO: (1) /api/v1/namespaces/e2e-tests-proxy-l5kqk/pods/https:proxy-service-2k9fx-mgjjs:443/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-l5kqk/pods/https:proxy-service-2k9fx-mgjjs:443/proxy/... (200; 86.895185ms)
+Jul  2 13:05:09.469: INFO: (1) /api/v1/namespaces/e2e-tests-proxy-l5kqk/pods/proxy-service-2k9fx-mgjjs/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-l5kqk/pods/proxy-service-2k9fx-mgjjs/proxy/rewriteme"... (200; 87.225486ms)
+Jul  2 13:05:09.469: INFO: (1) /api/v1/namespaces/e2e-tests-proxy-l5kqk/services/http:proxy-service-2k9fx:portname1/proxy/: foo (200; 87.484298ms)
+Jul  2 13:05:09.470: INFO: (1) /api/v1/namespaces/e2e-tests-proxy-l5kqk/services/http:proxy-service-2k9fx:portname2/proxy/: bar (200; 88.443283ms)
+Jul  2 13:05:09.470: INFO: (1) /api/v1/namespaces/e2e-tests-proxy-l5kqk/services/proxy-service-2k9fx:portname1/proxy/: foo (200; 88.604916ms)
+Jul  2 13:05:09.470: INFO: (1) /api/v1/namespaces/e2e-tests-proxy-l5kqk/services/proxy-service-2k9fx:portname2/proxy/: bar (200; 88.450164ms)
+Jul  2 13:05:09.478: INFO: (2) /api/v1/namespaces/e2e-tests-proxy-l5kqk/pods/https:proxy-service-2k9fx-mgjjs:462/proxy/: tls qux (200; 7.441751ms)
+Jul  2 13:05:09.478: INFO: (2) /api/v1/namespaces/e2e-tests-proxy-l5kqk/pods/proxy-service-2k9fx-mgjjs/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-l5kqk/pods/proxy-service-2k9fx-mgjjs/proxy/rewriteme"... (200; 6.846967ms)
+Jul  2 13:05:09.478: INFO: (2) /api/v1/namespaces/e2e-tests-proxy-l5kqk/pods/proxy-service-2k9fx-mgjjs:160/proxy/: foo (200; 7.024898ms)
+Jul  2 13:05:09.478: INFO: (2) /api/v1/namespaces/e2e-tests-proxy-l5kqk/pods/proxy-service-2k9fx-mgjjs:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-l5kqk/pods/proxy-service-2k9fx-mgjjs:1080/proxy/rewri... (200; 6.883666ms)
+Jul  2 13:05:09.478: INFO: (2) /api/v1/namespaces/e2e-tests-proxy-l5kqk/pods/http:proxy-service-2k9fx-mgjjs:162/proxy/: bar (200; 7.545527ms)
+Jul  2 13:05:09.478: INFO: (2) /api/v1/namespaces/e2e-tests-proxy-l5kqk/pods/https:proxy-service-2k9fx-mgjjs:460/proxy/: tls baz (200; 7.483484ms)
+Jul  2 13:05:09.478: INFO: (2) /api/v1/namespaces/e2e-tests-proxy-l5kqk/pods/http:proxy-service-2k9fx-mgjjs:160/proxy/: foo (200; 6.970237ms)
+Jul  2 13:05:09.478: INFO: (2) /api/v1/namespaces/e2e-tests-proxy-l5kqk/services/https:proxy-service-2k9fx:tlsportname2/proxy/: tls qux (200; 7.813772ms)
+Jul  2 13:05:09.479: INFO: (2) /api/v1/namespaces/e2e-tests-proxy-l5kqk/pods/https:proxy-service-2k9fx-mgjjs:443/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-l5kqk/pods/https:proxy-service-2k9fx-mgjjs:443/proxy/... (200; 8.556242ms)
+Jul  2 13:05:09.479: INFO: (2) /api/v1/namespaces/e2e-tests-proxy-l5kqk/services/http:proxy-service-2k9fx:portname2/proxy/: bar (200; 8.138383ms)
+Jul  2 13:05:09.479: INFO: (2) /api/v1/namespaces/e2e-tests-proxy-l5kqk/services/https:proxy-service-2k9fx:tlsportname1/proxy/: tls baz (200; 7.781638ms)
+Jul  2 13:05:09.480: INFO: (2) /api/v1/namespaces/e2e-tests-proxy-l5kqk/services/proxy-service-2k9fx:portname2/proxy/: bar (200; 8.156267ms)
+Jul  2 13:05:09.480: INFO: (2) /api/v1/namespaces/e2e-tests-proxy-l5kqk/pods/http:proxy-service-2k9fx-mgjjs:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-l5kqk/pods/http:proxy-service-2k9fx-mgjjs:1080/proxy/... (200; 8.536942ms)
+Jul  2 13:05:09.480: INFO: (2) /api/v1/namespaces/e2e-tests-proxy-l5kqk/services/proxy-service-2k9fx:portname1/proxy/: foo (200; 8.420858ms)
+Jul  2 13:05:09.480: INFO: (2) /api/v1/namespaces/e2e-tests-proxy-l5kqk/services/http:proxy-service-2k9fx:portname1/proxy/: foo (200; 8.619736ms)
+Jul  2 13:05:09.480: INFO: (2) /api/v1/namespaces/e2e-tests-proxy-l5kqk/pods/proxy-service-2k9fx-mgjjs:162/proxy/: bar (200; 8.720168ms)
+Jul  2 13:05:09.497: INFO: (3) /api/v1/namespaces/e2e-tests-proxy-l5kqk/pods/proxy-service-2k9fx-mgjjs/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-l5kqk/pods/proxy-service-2k9fx-mgjjs/proxy/rewriteme"... (200; 16.035853ms)
+Jul  2 13:05:09.497: INFO: (3) /api/v1/namespaces/e2e-tests-proxy-l5kqk/pods/https:proxy-service-2k9fx-mgjjs:462/proxy/: tls qux (200; 15.861739ms)
+Jul  2 13:05:09.497: INFO: (3) /api/v1/namespaces/e2e-tests-proxy-l5kqk/services/http:proxy-service-2k9fx:portname1/proxy/: foo (200; 16.844609ms)
+Jul  2 13:05:09.498: INFO: (3) /api/v1/namespaces/e2e-tests-proxy-l5kqk/pods/http:proxy-service-2k9fx-mgjjs:160/proxy/: foo (200; 16.822581ms)
+Jul  2 13:05:09.498: INFO: (3) /api/v1/namespaces/e2e-tests-proxy-l5kqk/services/http:proxy-service-2k9fx:portname2/proxy/: bar (200; 16.169721ms)
+Jul  2 13:05:09.498: INFO: (3) /api/v1/namespaces/e2e-tests-proxy-l5kqk/pods/proxy-service-2k9fx-mgjjs:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-l5kqk/pods/proxy-service-2k9fx-mgjjs:1080/proxy/rewri... (200; 17.316178ms)
+Jul  2 13:05:09.498: INFO: (3) /api/v1/namespaces/e2e-tests-proxy-l5kqk/services/proxy-service-2k9fx:portname2/proxy/: bar (200; 17.497554ms)
+Jul  2 13:05:09.498: INFO: (3) /api/v1/namespaces/e2e-tests-proxy-l5kqk/services/https:proxy-service-2k9fx:tlsportname1/proxy/: tls baz (200; 17.403513ms)
+Jul  2 13:05:09.498: INFO: (3) /api/v1/namespaces/e2e-tests-proxy-l5kqk/pods/https:proxy-service-2k9fx-mgjjs:460/proxy/: tls baz (200; 17.908764ms)
+Jul  2 13:05:09.498: INFO: (3) /api/v1/namespaces/e2e-tests-proxy-l5kqk/pods/https:proxy-service-2k9fx-mgjjs:443/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-l5kqk/pods/https:proxy-service-2k9fx-mgjjs:443/proxy/... (200; 17.041517ms)
+Jul  2 13:05:09.498: INFO: (3) /api/v1/namespaces/e2e-tests-proxy-l5kqk/services/https:proxy-service-2k9fx:tlsportname2/proxy/: tls qux (200; 18.25046ms)
+Jul  2 13:05:09.499: INFO: (3) /api/v1/namespaces/e2e-tests-proxy-l5kqk/pods/http:proxy-service-2k9fx-mgjjs:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-l5kqk/pods/http:proxy-service-2k9fx-mgjjs:1080/proxy/... (200; 17.469661ms)
+Jul  2 13:05:09.499: INFO: (3) /api/v1/namespaces/e2e-tests-proxy-l5kqk/pods/proxy-service-2k9fx-mgjjs:160/proxy/: foo (200; 17.634098ms)
+Jul  2 13:05:09.499: INFO: (3) /api/v1/namespaces/e2e-tests-proxy-l5kqk/services/proxy-service-2k9fx:portname1/proxy/: foo (200; 17.974731ms)
+Jul  2 13:05:09.499: INFO: (3) /api/v1/namespaces/e2e-tests-proxy-l5kqk/pods/http:proxy-service-2k9fx-mgjjs:162/proxy/: bar (200; 18.196601ms)
+Jul  2 13:05:09.499: INFO: (3) /api/v1/namespaces/e2e-tests-proxy-l5kqk/pods/proxy-service-2k9fx-mgjjs:162/proxy/: bar (200; 17.8633ms)
+Jul  2 13:05:09.504: INFO: (4) /api/v1/namespaces/e2e-tests-proxy-l5kqk/pods/https:proxy-service-2k9fx-mgjjs:460/proxy/: tls baz (200; 4.524929ms)
+Jul  2 13:05:09.505: INFO: (4) /api/v1/namespaces/e2e-tests-proxy-l5kqk/pods/http:proxy-service-2k9fx-mgjjs:162/proxy/: bar (200; 4.692034ms)
+Jul  2 13:05:09.505: INFO: (4) /api/v1/namespaces/e2e-tests-proxy-l5kqk/pods/http:proxy-service-2k9fx-mgjjs:160/proxy/: foo (200; 4.773414ms)
+Jul  2 13:05:09.505: INFO: (4) /api/v1/namespaces/e2e-tests-proxy-l5kqk/pods/proxy-service-2k9fx-mgjjs/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-l5kqk/pods/proxy-service-2k9fx-mgjjs/proxy/rewriteme"... (200; 4.876463ms)
+Jul  2 13:05:09.506: INFO: (4) /api/v1/namespaces/e2e-tests-proxy-l5kqk/pods/https:proxy-service-2k9fx-mgjjs:443/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-l5kqk/pods/https:proxy-service-2k9fx-mgjjs:443/proxy/... (200; 5.363607ms)
+Jul  2 13:05:09.506: INFO: (4) /api/v1/namespaces/e2e-tests-proxy-l5kqk/pods/proxy-service-2k9fx-mgjjs:160/proxy/: foo (200; 5.713181ms)
+Jul  2 13:05:09.506: INFO: (4) /api/v1/namespaces/e2e-tests-proxy-l5kqk/pods/https:proxy-service-2k9fx-mgjjs:462/proxy/: tls qux (200; 5.847289ms)
+Jul  2 13:05:09.506: INFO: (4) /api/v1/namespaces/e2e-tests-proxy-l5kqk/pods/http:proxy-service-2k9fx-mgjjs:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-l5kqk/pods/http:proxy-service-2k9fx-mgjjs:1080/proxy/... (200; 5.957776ms)
+Jul  2 13:05:09.506: INFO: (4) /api/v1/namespaces/e2e-tests-proxy-l5kqk/pods/proxy-service-2k9fx-mgjjs:162/proxy/: bar (200; 5.770737ms)
+Jul  2 13:05:09.506: INFO: (4) /api/v1/namespaces/e2e-tests-proxy-l5kqk/pods/proxy-service-2k9fx-mgjjs:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-l5kqk/pods/proxy-service-2k9fx-mgjjs:1080/proxy/rewri... (200; 5.839286ms)
+Jul  2 13:05:09.506: INFO: (4) /api/v1/namespaces/e2e-tests-proxy-l5kqk/services/proxy-service-2k9fx:portname1/proxy/: foo (200; 6.616047ms)
+Jul  2 13:05:09.507: INFO: (4) /api/v1/namespaces/e2e-tests-proxy-l5kqk/services/https:proxy-service-2k9fx:tlsportname2/proxy/: tls qux (200; 6.705826ms)
+Jul  2 13:05:09.507: INFO: (4) /api/v1/namespaces/e2e-tests-proxy-l5kqk/services/https:proxy-service-2k9fx:tlsportname1/proxy/: tls baz (200; 7.213464ms)
+Jul  2 13:05:09.507: INFO: (4) /api/v1/namespaces/e2e-tests-proxy-l5kqk/services/proxy-service-2k9fx:portname2/proxy/: bar (200; 6.765908ms)
+Jul  2 13:05:09.508: INFO: (4) /api/v1/namespaces/e2e-tests-proxy-l5kqk/services/http:proxy-service-2k9fx:portname1/proxy/: foo (200; 8.181788ms)
+Jul  2 13:05:09.508: INFO: (4) /api/v1/namespaces/e2e-tests-proxy-l5kqk/services/http:proxy-service-2k9fx:portname2/proxy/: bar (200; 8.470421ms)
+Jul  2 13:05:09.521: INFO: (5) /api/v1/namespaces/e2e-tests-proxy-l5kqk/pods/proxy-service-2k9fx-mgjjs:162/proxy/: bar (200; 11.257362ms)
+Jul  2 13:05:09.521: INFO: (5) /api/v1/namespaces/e2e-tests-proxy-l5kqk/pods/proxy-service-2k9fx-mgjjs:160/proxy/: foo (200; 11.59125ms)
+Jul  2 13:05:09.521: INFO: (5) /api/v1/namespaces/e2e-tests-proxy-l5kqk/pods/http:proxy-service-2k9fx-mgjjs:160/proxy/: foo (200; 12.142697ms)
+Jul  2 13:05:09.521: INFO: (5) /api/v1/namespaces/e2e-tests-proxy-l5kqk/pods/https:proxy-service-2k9fx-mgjjs:462/proxy/: tls qux (200; 11.627661ms)
+Jul  2 13:05:09.521: INFO: (5) /api/v1/namespaces/e2e-tests-proxy-l5kqk/pods/https:proxy-service-2k9fx-mgjjs:443/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-l5kqk/pods/https:proxy-service-2k9fx-mgjjs:443/proxy/... (200; 11.802373ms)
+Jul  2 13:05:09.521: INFO: (5) /api/v1/namespaces/e2e-tests-proxy-l5kqk/pods/proxy-service-2k9fx-mgjjs/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-l5kqk/pods/proxy-service-2k9fx-mgjjs/proxy/rewriteme"... (200; 12.578133ms)
+Jul  2 13:05:09.521: INFO: (5) /api/v1/namespaces/e2e-tests-proxy-l5kqk/pods/https:proxy-service-2k9fx-mgjjs:460/proxy/: tls baz (200; 13.010793ms)
+Jul  2 13:05:09.522: INFO: (5) /api/v1/namespaces/e2e-tests-proxy-l5kqk/pods/http:proxy-service-2k9fx-mgjjs:162/proxy/: bar (200; 12.649796ms)
+Jul  2 13:05:09.522: INFO: (5) /api/v1/namespaces/e2e-tests-proxy-l5kqk/pods/proxy-service-2k9fx-mgjjs:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-l5kqk/pods/proxy-service-2k9fx-mgjjs:1080/proxy/rewri... (200; 11.799531ms)
+Jul  2 13:05:09.522: INFO: (5) /api/v1/namespaces/e2e-tests-proxy-l5kqk/services/https:proxy-service-2k9fx:tlsportname1/proxy/: tls baz (200; 13.209754ms)
+Jul  2 13:05:09.522: INFO: (5) /api/v1/namespaces/e2e-tests-proxy-l5kqk/pods/http:proxy-service-2k9fx-mgjjs:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-l5kqk/pods/http:proxy-service-2k9fx-mgjjs:1080/proxy/... (200; 12.790433ms)
+Jul  2 13:05:09.522: INFO: (5) /api/v1/namespaces/e2e-tests-proxy-l5kqk/services/proxy-service-2k9fx:portname2/proxy/: bar (200; 12.594294ms)
+Jul  2 13:05:09.522: INFO: (5) /api/v1/namespaces/e2e-tests-proxy-l5kqk/services/http:proxy-service-2k9fx:portname2/proxy/: bar (200; 13.250534ms)
+Jul  2 13:05:09.522: INFO: (5) /api/v1/namespaces/e2e-tests-proxy-l5kqk/services/https:proxy-service-2k9fx:tlsportname2/proxy/: tls qux (200; 13.319072ms)
+Jul  2 13:05:09.523: INFO: (5) /api/v1/namespaces/e2e-tests-proxy-l5kqk/services/http:proxy-service-2k9fx:portname1/proxy/: foo (200; 14.00975ms)
+Jul  2 13:05:09.523: INFO: (5) /api/v1/namespaces/e2e-tests-proxy-l5kqk/services/proxy-service-2k9fx:portname1/proxy/: foo (200; 13.976028ms)
+Jul  2 13:05:09.531: INFO: (6) /api/v1/namespaces/e2e-tests-proxy-l5kqk/services/https:proxy-service-2k9fx:tlsportname1/proxy/: tls baz (200; 7.710327ms)
+Jul  2 13:05:09.531: INFO: (6) /api/v1/namespaces/e2e-tests-proxy-l5kqk/pods/http:proxy-service-2k9fx-mgjjs:160/proxy/: foo (200; 7.852187ms)
+Jul  2 13:05:09.531: INFO: (6) /api/v1/namespaces/e2e-tests-proxy-l5kqk/pods/proxy-service-2k9fx-mgjjs:160/proxy/: foo (200; 7.694128ms)
+Jul  2 13:05:09.532: INFO: (6) /api/v1/namespaces/e2e-tests-proxy-l5kqk/pods/http:proxy-service-2k9fx-mgjjs:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-l5kqk/pods/http:proxy-service-2k9fx-mgjjs:1080/proxy/... (200; 7.947343ms)
+Jul  2 13:05:09.532: INFO: (6) /api/v1/namespaces/e2e-tests-proxy-l5kqk/pods/proxy-service-2k9fx-mgjjs/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-l5kqk/pods/proxy-service-2k9fx-mgjjs/proxy/rewriteme"... (200; 8.662481ms)
+Jul  2 13:05:09.532: INFO: (6) /api/v1/namespaces/e2e-tests-proxy-l5kqk/pods/http:proxy-service-2k9fx-mgjjs:162/proxy/: bar (200; 8.718627ms)
+Jul  2 13:05:09.532: INFO: (6) /api/v1/namespaces/e2e-tests-proxy-l5kqk/pods/https:proxy-service-2k9fx-mgjjs:443/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-l5kqk/pods/https:proxy-service-2k9fx-mgjjs:443/proxy/... (200; 8.46919ms)
+Jul  2 13:05:09.532: INFO: (6) /api/v1/namespaces/e2e-tests-proxy-l5kqk/pods/proxy-service-2k9fx-mgjjs:162/proxy/: bar (200; 8.586846ms)
+Jul  2 13:05:09.532: INFO: (6) /api/v1/namespaces/e2e-tests-proxy-l5kqk/pods/proxy-service-2k9fx-mgjjs:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-l5kqk/pods/proxy-service-2k9fx-mgjjs:1080/proxy/rewri... (200; 8.308222ms)
+Jul  2 13:05:09.533: INFO: (6) /api/v1/namespaces/e2e-tests-proxy-l5kqk/pods/https:proxy-service-2k9fx-mgjjs:462/proxy/: tls qux (200; 9.120635ms)
+Jul  2 13:05:09.533: INFO: (6) /api/v1/namespaces/e2e-tests-proxy-l5kqk/services/proxy-service-2k9fx:portname2/proxy/: bar (200; 10.373655ms)
+Jul  2 13:05:09.533: INFO: (6) /api/v1/namespaces/e2e-tests-proxy-l5kqk/pods/https:proxy-service-2k9fx-mgjjs:460/proxy/: tls baz (200; 9.06667ms)
+Jul  2 13:05:09.533: INFO: (6) /api/v1/namespaces/e2e-tests-proxy-l5kqk/services/http:proxy-service-2k9fx:portname2/proxy/: bar (200; 9.509795ms)
+Jul  2 13:05:09.533: INFO: (6) /api/v1/namespaces/e2e-tests-proxy-l5kqk/services/proxy-service-2k9fx:portname1/proxy/: foo (200; 10.060092ms)
+Jul  2 13:05:09.534: INFO: (6) /api/v1/namespaces/e2e-tests-proxy-l5kqk/services/http:proxy-service-2k9fx:portname1/proxy/: foo (200; 10.397558ms)
+Jul  2 13:05:09.534: INFO: (6) /api/v1/namespaces/e2e-tests-proxy-l5kqk/services/https:proxy-service-2k9fx:tlsportname2/proxy/: tls qux (200; 10.480273ms)
+Jul  2 13:05:09.542: INFO: (7) /api/v1/namespaces/e2e-tests-proxy-l5kqk/pods/http:proxy-service-2k9fx-mgjjs:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-l5kqk/pods/http:proxy-service-2k9fx-mgjjs:1080/proxy/... (200; 6.921709ms)
+Jul  2 13:05:09.542: INFO: (7) /api/v1/namespaces/e2e-tests-proxy-l5kqk/pods/https:proxy-service-2k9fx-mgjjs:443/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-l5kqk/pods/https:proxy-service-2k9fx-mgjjs:443/proxy/... (200; 7.261188ms)
+Jul  2 13:05:09.542: INFO: (7) /api/v1/namespaces/e2e-tests-proxy-l5kqk/pods/proxy-service-2k9fx-mgjjs/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-l5kqk/pods/proxy-service-2k9fx-mgjjs/proxy/rewriteme"... (200; 7.800764ms)
+Jul  2 13:05:09.543: INFO: (7) /api/v1/namespaces/e2e-tests-proxy-l5kqk/pods/https:proxy-service-2k9fx-mgjjs:462/proxy/: tls qux (200; 8.396749ms)
+Jul  2 13:05:09.543: INFO: (7) /api/v1/namespaces/e2e-tests-proxy-l5kqk/pods/proxy-service-2k9fx-mgjjs:160/proxy/: foo (200; 8.233782ms)
+Jul  2 13:05:09.543: INFO: (7) /api/v1/namespaces/e2e-tests-proxy-l5kqk/pods/http:proxy-service-2k9fx-mgjjs:160/proxy/: foo (200; 8.627956ms)
+Jul  2 13:05:09.544: INFO: (7) /api/v1/namespaces/e2e-tests-proxy-l5kqk/pods/https:proxy-service-2k9fx-mgjjs:460/proxy/: tls baz (200; 8.742011ms)
+Jul  2 13:05:09.544: INFO: (7) /api/v1/namespaces/e2e-tests-proxy-l5kqk/pods/proxy-service-2k9fx-mgjjs:162/proxy/: bar (200; 9.401013ms)
+Jul  2 13:05:09.544: INFO: (7) /api/v1/namespaces/e2e-tests-proxy-l5kqk/pods/proxy-service-2k9fx-mgjjs:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-l5kqk/pods/proxy-service-2k9fx-mgjjs:1080/proxy/rewri... (200; 9.101474ms)
+Jul  2 13:05:09.544: INFO: (7) /api/v1/namespaces/e2e-tests-proxy-l5kqk/pods/http:proxy-service-2k9fx-mgjjs:162/proxy/: bar (200; 9.24041ms)
+Jul  2 13:05:09.544: INFO: (7) /api/v1/namespaces/e2e-tests-proxy-l5kqk/services/http:proxy-service-2k9fx:portname2/proxy/: bar (200; 9.718273ms)
+Jul  2 13:05:09.545: INFO: (7) /api/v1/namespaces/e2e-tests-proxy-l5kqk/services/https:proxy-service-2k9fx:tlsportname2/proxy/: tls qux (200; 9.724861ms)
+Jul  2 13:05:09.545: INFO: (7) /api/v1/namespaces/e2e-tests-proxy-l5kqk/services/https:proxy-service-2k9fx:tlsportname1/proxy/: tls baz (200; 9.856063ms)
+Jul  2 13:05:09.545: INFO: (7) /api/v1/namespaces/e2e-tests-proxy-l5kqk/services/http:proxy-service-2k9fx:portname1/proxy/: foo (200; 10.557136ms)
+Jul  2 13:05:09.545: INFO: (7) /api/v1/namespaces/e2e-tests-proxy-l5kqk/services/proxy-service-2k9fx:portname1/proxy/: foo (200; 10.281707ms)
+Jul  2 13:05:09.545: INFO: (7) /api/v1/namespaces/e2e-tests-proxy-l5kqk/services/proxy-service-2k9fx:portname2/proxy/: bar (200; 10.440369ms)
+Jul  2 13:05:09.553: INFO: (8) /api/v1/namespaces/e2e-tests-proxy-l5kqk/pods/proxy-service-2k9fx-mgjjs/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-l5kqk/pods/proxy-service-2k9fx-mgjjs/proxy/rewriteme"... (200; 6.225696ms)
+Jul  2 13:05:09.553: INFO: (8) /api/v1/namespaces/e2e-tests-proxy-l5kqk/pods/http:proxy-service-2k9fx-mgjjs:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-l5kqk/pods/http:proxy-service-2k9fx-mgjjs:1080/proxy/... (200; 6.4139ms)
+Jul  2 13:05:09.554: INFO: (8) /api/v1/namespaces/e2e-tests-proxy-l5kqk/pods/http:proxy-service-2k9fx-mgjjs:162/proxy/: bar (200; 6.83249ms)
+Jul  2 13:05:09.554: INFO: (8) /api/v1/namespaces/e2e-tests-proxy-l5kqk/pods/https:proxy-service-2k9fx-mgjjs:460/proxy/: tls baz (200; 7.911666ms)
+Jul  2 13:05:09.554: INFO: (8) /api/v1/namespaces/e2e-tests-proxy-l5kqk/services/proxy-service-2k9fx:portname1/proxy/: foo (200; 7.44422ms)
+Jul  2 13:05:09.554: INFO: (8) /api/v1/namespaces/e2e-tests-proxy-l5kqk/pods/proxy-service-2k9fx-mgjjs:162/proxy/: bar (200; 6.30441ms)
+Jul  2 13:05:09.554: INFO: (8) /api/v1/namespaces/e2e-tests-proxy-l5kqk/pods/http:proxy-service-2k9fx-mgjjs:160/proxy/: foo (200; 7.099609ms)
+Jul  2 13:05:09.554: INFO: (8) /api/v1/namespaces/e2e-tests-proxy-l5kqk/services/https:proxy-service-2k9fx:tlsportname1/proxy/: tls baz (200; 7.599939ms)
+Jul  2 13:05:09.554: INFO: (8) /api/v1/namespaces/e2e-tests-proxy-l5kqk/pods/proxy-service-2k9fx-mgjjs:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-l5kqk/pods/proxy-service-2k9fx-mgjjs:1080/proxy/rewri... (200; 5.96828ms)
+Jul  2 13:05:09.554: INFO: (8) /api/v1/namespaces/e2e-tests-proxy-l5kqk/services/https:proxy-service-2k9fx:tlsportname2/proxy/: tls qux (200; 6.061427ms)
+Jul  2 13:05:09.554: INFO: (8) /api/v1/namespaces/e2e-tests-proxy-l5kqk/pods/https:proxy-service-2k9fx-mgjjs:462/proxy/: tls qux (200; 6.542123ms)
+Jul  2 13:05:09.554: INFO: (8) /api/v1/namespaces/e2e-tests-proxy-l5kqk/pods/https:proxy-service-2k9fx-mgjjs:443/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-l5kqk/pods/https:proxy-service-2k9fx-mgjjs:443/proxy/... (200; 6.814221ms)
+Jul  2 13:05:09.554: INFO: (8) /api/v1/namespaces/e2e-tests-proxy-l5kqk/services/http:proxy-service-2k9fx:portname1/proxy/: foo (200; 8.302703ms)
+Jul  2 13:05:09.556: INFO: (8) /api/v1/namespaces/e2e-tests-proxy-l5kqk/services/proxy-service-2k9fx:portname2/proxy/: bar (200; 8.081063ms)
+Jul  2 13:05:09.556: INFO: (8) /api/v1/namespaces/e2e-tests-proxy-l5kqk/pods/proxy-service-2k9fx-mgjjs:160/proxy/: foo (200; 9.081697ms)
+Jul  2 13:05:09.556: INFO: (8) /api/v1/namespaces/e2e-tests-proxy-l5kqk/services/http:proxy-service-2k9fx:portname2/proxy/: bar (200; 8.773308ms)
+Jul  2 13:05:09.562: INFO: (9) /api/v1/namespaces/e2e-tests-proxy-l5kqk/pods/https:proxy-service-2k9fx-mgjjs:443/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-l5kqk/pods/https:proxy-service-2k9fx-mgjjs:443/proxy/... (200; 5.128983ms)
+Jul  2 13:05:09.562: INFO: (9) /api/v1/namespaces/e2e-tests-proxy-l5kqk/pods/proxy-service-2k9fx-mgjjs:160/proxy/: foo (200; 5.283ms)
+Jul  2 13:05:09.562: INFO: (9) /api/v1/namespaces/e2e-tests-proxy-l5kqk/pods/http:proxy-service-2k9fx-mgjjs:160/proxy/: foo (200; 5.271114ms)
+Jul  2 13:05:09.562: INFO: (9) /api/v1/namespaces/e2e-tests-proxy-l5kqk/pods/https:proxy-service-2k9fx-mgjjs:460/proxy/: tls baz (200; 5.49417ms)
+Jul  2 13:05:09.562: INFO: (9) /api/v1/namespaces/e2e-tests-proxy-l5kqk/pods/https:proxy-service-2k9fx-mgjjs:462/proxy/: tls qux (200; 5.607111ms)
+Jul  2 13:05:09.563: INFO: (9) /api/v1/namespaces/e2e-tests-proxy-l5kqk/pods/proxy-service-2k9fx-mgjjs/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-l5kqk/pods/proxy-service-2k9fx-mgjjs/proxy/rewriteme"... (200; 5.561236ms)
+Jul  2 13:05:09.563: INFO: (9) /api/v1/namespaces/e2e-tests-proxy-l5kqk/pods/proxy-service-2k9fx-mgjjs:162/proxy/: bar (200; 5.990302ms)
+Jul  2 13:05:09.563: INFO: (9) /api/v1/namespaces/e2e-tests-proxy-l5kqk/pods/http:proxy-service-2k9fx-mgjjs:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-l5kqk/pods/http:proxy-service-2k9fx-mgjjs:1080/proxy/... (200; 6.070541ms)
+Jul  2 13:05:09.563: INFO: (9) /api/v1/namespaces/e2e-tests-proxy-l5kqk/pods/proxy-service-2k9fx-mgjjs:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-l5kqk/pods/proxy-service-2k9fx-mgjjs:1080/proxy/rewri... (200; 6.309954ms)
+Jul  2 13:05:09.563: INFO: (9) /api/v1/namespaces/e2e-tests-proxy-l5kqk/services/https:proxy-service-2k9fx:tlsportname2/proxy/: tls qux (200; 6.281766ms)
+Jul  2 13:05:09.563: INFO: (9) /api/v1/namespaces/e2e-tests-proxy-l5kqk/services/http:proxy-service-2k9fx:portname2/proxy/: bar (200; 6.194312ms)
+Jul  2 13:05:09.563: INFO: (9) /api/v1/namespaces/e2e-tests-proxy-l5kqk/services/proxy-service-2k9fx:portname2/proxy/: bar (200; 6.475656ms)
+Jul  2 13:05:09.563: INFO: (9) /api/v1/namespaces/e2e-tests-proxy-l5kqk/services/http:proxy-service-2k9fx:portname1/proxy/: foo (200; 6.455089ms)
+Jul  2 13:05:09.563: INFO: (9) /api/v1/namespaces/e2e-tests-proxy-l5kqk/services/proxy-service-2k9fx:portname1/proxy/: foo (200; 6.875636ms)
+Jul  2 13:05:09.564: INFO: (9) /api/v1/namespaces/e2e-tests-proxy-l5kqk/services/https:proxy-service-2k9fx:tlsportname1/proxy/: tls baz (200; 7.344975ms)
+Jul  2 13:05:09.603: INFO: (9) /api/v1/namespaces/e2e-tests-proxy-l5kqk/pods/http:proxy-service-2k9fx-mgjjs:162/proxy/: bar (200; 46.170951ms)
+Jul  2 13:05:09.610: INFO: (10) /api/v1/namespaces/e2e-tests-proxy-l5kqk/pods/http:proxy-service-2k9fx-mgjjs:162/proxy/: bar (200; 6.377704ms)
+Jul  2 13:05:09.610: INFO: (10) /api/v1/namespaces/e2e-tests-proxy-l5kqk/pods/http:proxy-service-2k9fx-mgjjs:160/proxy/: foo (200; 6.503117ms)
+Jul  2 13:05:09.610: INFO: (10) /api/v1/namespaces/e2e-tests-proxy-l5kqk/pods/http:proxy-service-2k9fx-mgjjs:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-l5kqk/pods/http:proxy-service-2k9fx-mgjjs:1080/proxy/... (200; 5.964926ms)
+Jul  2 13:05:09.610: INFO: (10) /api/v1/namespaces/e2e-tests-proxy-l5kqk/pods/https:proxy-service-2k9fx-mgjjs:462/proxy/: tls qux (200; 6.270439ms)
+Jul  2 13:05:09.610: INFO: (10) /api/v1/namespaces/e2e-tests-proxy-l5kqk/pods/https:proxy-service-2k9fx-mgjjs:460/proxy/: tls baz (200; 7.120998ms)
+Jul  2 13:05:09.614: INFO: (10) /api/v1/namespaces/e2e-tests-proxy-l5kqk/services/http:proxy-service-2k9fx:portname2/proxy/: bar (200; 9.830813ms)
+Jul  2 13:05:09.614: INFO: (10) /api/v1/namespaces/e2e-tests-proxy-l5kqk/services/https:proxy-service-2k9fx:tlsportname2/proxy/: tls qux (200; 9.905157ms)
+Jul  2 13:05:09.614: INFO: (10) /api/v1/namespaces/e2e-tests-proxy-l5kqk/pods/proxy-service-2k9fx-mgjjs/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-l5kqk/pods/proxy-service-2k9fx-mgjjs/proxy/rewriteme"... (200; 10.659115ms)
+Jul  2 13:05:09.615: INFO: (10) /api/v1/namespaces/e2e-tests-proxy-l5kqk/pods/proxy-service-2k9fx-mgjjs:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-l5kqk/pods/proxy-service-2k9fx-mgjjs:1080/proxy/rewri... (200; 10.068948ms)
+Jul  2 13:05:09.615: INFO: (10) /api/v1/namespaces/e2e-tests-proxy-l5kqk/pods/proxy-service-2k9fx-mgjjs:162/proxy/: bar (200; 10.812995ms)
+Jul  2 13:05:09.615: INFO: (10) /api/v1/namespaces/e2e-tests-proxy-l5kqk/services/http:proxy-service-2k9fx:portname1/proxy/: foo (200; 11.519431ms)
+Jul  2 13:05:09.615: INFO: (10) /api/v1/namespaces/e2e-tests-proxy-l5kqk/services/proxy-service-2k9fx:portname1/proxy/: foo (200; 11.571515ms)
+Jul  2 13:05:09.615: INFO: (10) /api/v1/namespaces/e2e-tests-proxy-l5kqk/pods/https:proxy-service-2k9fx-mgjjs:443/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-l5kqk/pods/https:proxy-service-2k9fx-mgjjs:443/proxy/... (200; 11.284928ms)
+Jul  2 13:05:09.615: INFO: (10) /api/v1/namespaces/e2e-tests-proxy-l5kqk/services/https:proxy-service-2k9fx:tlsportname1/proxy/: tls baz (200; 11.86596ms)
+Jul  2 13:05:09.616: INFO: (10) /api/v1/namespaces/e2e-tests-proxy-l5kqk/services/proxy-service-2k9fx:portname2/proxy/: bar (200; 11.244821ms)
+Jul  2 13:05:09.617: INFO: (10) /api/v1/namespaces/e2e-tests-proxy-l5kqk/pods/proxy-service-2k9fx-mgjjs:160/proxy/: foo (200; 12.622448ms)
+Jul  2 13:05:09.624: INFO: (11) /api/v1/namespaces/e2e-tests-proxy-l5kqk/pods/https:proxy-service-2k9fx-mgjjs:443/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-l5kqk/pods/https:proxy-service-2k9fx-mgjjs:443/proxy/... (200; 6.638756ms)
+Jul  2 13:05:09.624: INFO: (11) /api/v1/namespaces/e2e-tests-proxy-l5kqk/pods/proxy-service-2k9fx-mgjjs:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-l5kqk/pods/proxy-service-2k9fx-mgjjs:1080/proxy/rewri... (200; 6.751758ms)
+Jul  2 13:05:09.624: INFO: (11) /api/v1/namespaces/e2e-tests-proxy-l5kqk/pods/http:proxy-service-2k9fx-mgjjs:160/proxy/: foo (200; 6.991269ms)
+Jul  2 13:05:09.624: INFO: (11) /api/v1/namespaces/e2e-tests-proxy-l5kqk/pods/https:proxy-service-2k9fx-mgjjs:460/proxy/: tls baz (200; 6.733485ms)
+Jul  2 13:05:09.624: INFO: (11) /api/v1/namespaces/e2e-tests-proxy-l5kqk/pods/proxy-service-2k9fx-mgjjs:162/proxy/: bar (200; 6.788001ms)
+Jul  2 13:05:09.625: INFO: (11) /api/v1/namespaces/e2e-tests-proxy-l5kqk/pods/proxy-service-2k9fx-mgjjs:160/proxy/: foo (200; 7.037363ms)
+Jul  2 13:05:09.625: INFO: (11) /api/v1/namespaces/e2e-tests-proxy-l5kqk/pods/http:proxy-service-2k9fx-mgjjs:162/proxy/: bar (200; 7.230829ms)
+Jul  2 13:05:09.625: INFO: (11) /api/v1/namespaces/e2e-tests-proxy-l5kqk/pods/http:proxy-service-2k9fx-mgjjs:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-l5kqk/pods/http:proxy-service-2k9fx-mgjjs:1080/proxy/... (200; 7.238108ms)
+Jul  2 13:05:09.625: INFO: (11) /api/v1/namespaces/e2e-tests-proxy-l5kqk/pods/proxy-service-2k9fx-mgjjs/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-l5kqk/pods/proxy-service-2k9fx-mgjjs/proxy/rewriteme"... (200; 7.598803ms)
+Jul  2 13:05:09.625: INFO: (11) /api/v1/namespaces/e2e-tests-proxy-l5kqk/pods/https:proxy-service-2k9fx-mgjjs:462/proxy/: tls qux (200; 7.231206ms)
+Jul  2 13:05:09.625: INFO: (11) /api/v1/namespaces/e2e-tests-proxy-l5kqk/services/https:proxy-service-2k9fx:tlsportname1/proxy/: tls baz (200; 8.01042ms)
+Jul  2 13:05:09.625: INFO: (11) /api/v1/namespaces/e2e-tests-proxy-l5kqk/services/https:proxy-service-2k9fx:tlsportname2/proxy/: tls qux (200; 7.783531ms)
+Jul  2 13:05:09.625: INFO: (11) /api/v1/namespaces/e2e-tests-proxy-l5kqk/services/http:proxy-service-2k9fx:portname2/proxy/: bar (200; 8.22947ms)
+Jul  2 13:05:09.626: INFO: (11) /api/v1/namespaces/e2e-tests-proxy-l5kqk/services/proxy-service-2k9fx:portname1/proxy/: foo (200; 9.266108ms)
+Jul  2 13:05:09.627: INFO: (11) /api/v1/namespaces/e2e-tests-proxy-l5kqk/services/proxy-service-2k9fx:portname2/proxy/: bar (200; 9.560517ms)
+Jul  2 13:05:09.627: INFO: (11) /api/v1/namespaces/e2e-tests-proxy-l5kqk/services/http:proxy-service-2k9fx:portname1/proxy/: foo (200; 9.619073ms)
+Jul  2 13:05:09.634: INFO: (12) /api/v1/namespaces/e2e-tests-proxy-l5kqk/pods/https:proxy-service-2k9fx-mgjjs:462/proxy/: tls qux (200; 6.04112ms)
+Jul  2 13:05:09.634: INFO: (12) /api/v1/namespaces/e2e-tests-proxy-l5kqk/pods/http:proxy-service-2k9fx-mgjjs:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-l5kqk/pods/http:proxy-service-2k9fx-mgjjs:1080/proxy/... (200; 6.581404ms)
+Jul  2 13:05:09.634: INFO: (12) /api/v1/namespaces/e2e-tests-proxy-l5kqk/pods/https:proxy-service-2k9fx-mgjjs:443/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-l5kqk/pods/https:proxy-service-2k9fx-mgjjs:443/proxy/... (200; 6.664209ms)
+Jul  2 13:05:09.634: INFO: (12) /api/v1/namespaces/e2e-tests-proxy-l5kqk/pods/http:proxy-service-2k9fx-mgjjs:160/proxy/: foo (200; 7.110301ms)
+Jul  2 13:05:09.634: INFO: (12) /api/v1/namespaces/e2e-tests-proxy-l5kqk/pods/proxy-service-2k9fx-mgjjs:160/proxy/: foo (200; 7.178613ms)
+Jul  2 13:05:09.635: INFO: (12) /api/v1/namespaces/e2e-tests-proxy-l5kqk/pods/proxy-service-2k9fx-mgjjs:162/proxy/: bar (200; 6.895472ms)
+Jul  2 13:05:09.635: INFO: (12) /api/v1/namespaces/e2e-tests-proxy-l5kqk/pods/http:proxy-service-2k9fx-mgjjs:162/proxy/: bar (200; 6.995219ms)
+Jul  2 13:05:09.635: INFO: (12) /api/v1/namespaces/e2e-tests-proxy-l5kqk/pods/proxy-service-2k9fx-mgjjs:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-l5kqk/pods/proxy-service-2k9fx-mgjjs:1080/proxy/rewri... (200; 7.264497ms)
+Jul  2 13:05:09.635: INFO: (12) /api/v1/namespaces/e2e-tests-proxy-l5kqk/pods/https:proxy-service-2k9fx-mgjjs:460/proxy/: tls baz (200; 7.245261ms)
+Jul  2 13:05:09.635: INFO: (12) /api/v1/namespaces/e2e-tests-proxy-l5kqk/pods/proxy-service-2k9fx-mgjjs/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-l5kqk/pods/proxy-service-2k9fx-mgjjs/proxy/rewriteme"... (200; 7.196307ms)
+Jul  2 13:05:09.635: INFO: (12) /api/v1/namespaces/e2e-tests-proxy-l5kqk/services/proxy-service-2k9fx:portname1/proxy/: foo (200; 7.815113ms)
+Jul  2 13:05:09.635: INFO: (12) /api/v1/namespaces/e2e-tests-proxy-l5kqk/services/http:proxy-service-2k9fx:portname2/proxy/: bar (200; 7.778761ms)
+Jul  2 13:05:09.635: INFO: (12) /api/v1/namespaces/e2e-tests-proxy-l5kqk/services/https:proxy-service-2k9fx:tlsportname1/proxy/: tls baz (200; 7.90064ms)
+Jul  2 13:05:09.636: INFO: (12) /api/v1/namespaces/e2e-tests-proxy-l5kqk/services/https:proxy-service-2k9fx:tlsportname2/proxy/: tls qux (200; 7.970748ms)
+Jul  2 13:05:09.636: INFO: (12) /api/v1/namespaces/e2e-tests-proxy-l5kqk/services/http:proxy-service-2k9fx:portname1/proxy/: foo (200; 8.391298ms)
+Jul  2 13:05:09.636: INFO: (12) /api/v1/namespaces/e2e-tests-proxy-l5kqk/services/proxy-service-2k9fx:portname2/proxy/: bar (200; 8.615912ms)
+Jul  2 13:05:09.642: INFO: (13) /api/v1/namespaces/e2e-tests-proxy-l5kqk/pods/http:proxy-service-2k9fx-mgjjs:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-l5kqk/pods/http:proxy-service-2k9fx-mgjjs:1080/proxy/... (200; 6.303567ms)
+Jul  2 13:05:09.643: INFO: (13) /api/v1/namespaces/e2e-tests-proxy-l5kqk/pods/proxy-service-2k9fx-mgjjs:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-l5kqk/pods/proxy-service-2k9fx-mgjjs:1080/proxy/rewri... (200; 6.684668ms)
+Jul  2 13:05:09.643: INFO: (13) /api/v1/namespaces/e2e-tests-proxy-l5kqk/pods/proxy-service-2k9fx-mgjjs/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-l5kqk/pods/proxy-service-2k9fx-mgjjs/proxy/rewriteme"... (200; 6.840876ms)
+Jul  2 13:05:09.643: INFO: (13) /api/v1/namespaces/e2e-tests-proxy-l5kqk/services/proxy-service-2k9fx:portname1/proxy/: foo (200; 6.982836ms)
+Jul  2 13:05:09.644: INFO: (13) /api/v1/namespaces/e2e-tests-proxy-l5kqk/pods/proxy-service-2k9fx-mgjjs:162/proxy/: bar (200; 7.377811ms)
+Jul  2 13:05:09.644: INFO: (13) /api/v1/namespaces/e2e-tests-proxy-l5kqk/pods/http:proxy-service-2k9fx-mgjjs:160/proxy/: foo (200; 7.342006ms)
+Jul  2 13:05:09.644: INFO: (13) /api/v1/namespaces/e2e-tests-proxy-l5kqk/pods/https:proxy-service-2k9fx-mgjjs:443/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-l5kqk/pods/https:proxy-service-2k9fx-mgjjs:443/proxy/... (200; 7.518897ms)
+Jul  2 13:05:09.644: INFO: (13) /api/v1/namespaces/e2e-tests-proxy-l5kqk/services/proxy-service-2k9fx:portname2/proxy/: bar (200; 7.368925ms)
+Jul  2 13:05:09.644: INFO: (13) /api/v1/namespaces/e2e-tests-proxy-l5kqk/services/https:proxy-service-2k9fx:tlsportname2/proxy/: tls qux (200; 7.666959ms)
+Jul  2 13:05:09.644: INFO: (13) /api/v1/namespaces/e2e-tests-proxy-l5kqk/pods/https:proxy-service-2k9fx-mgjjs:462/proxy/: tls qux (200; 8.019074ms)
+Jul  2 13:05:09.644: INFO: (13) /api/v1/namespaces/e2e-tests-proxy-l5kqk/services/https:proxy-service-2k9fx:tlsportname1/proxy/: tls baz (200; 8.213372ms)
+Jul  2 13:05:09.644: INFO: (13) /api/v1/namespaces/e2e-tests-proxy-l5kqk/pods/https:proxy-service-2k9fx-mgjjs:460/proxy/: tls baz (200; 7.842757ms)
+Jul  2 13:05:09.645: INFO: (13) /api/v1/namespaces/e2e-tests-proxy-l5kqk/services/http:proxy-service-2k9fx:portname2/proxy/: bar (200; 8.304205ms)
+Jul  2 13:05:09.645: INFO: (13) /api/v1/namespaces/e2e-tests-proxy-l5kqk/pods/http:proxy-service-2k9fx-mgjjs:162/proxy/: bar (200; 8.200056ms)
+Jul  2 13:05:09.645: INFO: (13) /api/v1/namespaces/e2e-tests-proxy-l5kqk/pods/proxy-service-2k9fx-mgjjs:160/proxy/: foo (200; 8.580911ms)
+Jul  2 13:05:09.645: INFO: (13) /api/v1/namespaces/e2e-tests-proxy-l5kqk/services/http:proxy-service-2k9fx:portname1/proxy/: foo (200; 8.228151ms)
+Jul  2 13:05:09.651: INFO: (14) /api/v1/namespaces/e2e-tests-proxy-l5kqk/pods/http:proxy-service-2k9fx-mgjjs:162/proxy/: bar (200; 6.274514ms)
+Jul  2 13:05:09.651: INFO: (14) /api/v1/namespaces/e2e-tests-proxy-l5kqk/pods/https:proxy-service-2k9fx-mgjjs:462/proxy/: tls qux (200; 6.023815ms)
+Jul  2 13:05:09.652: INFO: (14) /api/v1/namespaces/e2e-tests-proxy-l5kqk/pods/http:proxy-service-2k9fx-mgjjs:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-l5kqk/pods/http:proxy-service-2k9fx-mgjjs:1080/proxy/... (200; 6.257103ms)
+Jul  2 13:05:09.652: INFO: (14) /api/v1/namespaces/e2e-tests-proxy-l5kqk/pods/proxy-service-2k9fx-mgjjs/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-l5kqk/pods/proxy-service-2k9fx-mgjjs/proxy/rewriteme"... (200; 6.484717ms)
+Jul  2 13:05:09.652: INFO: (14) /api/v1/namespaces/e2e-tests-proxy-l5kqk/pods/https:proxy-service-2k9fx-mgjjs:443/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-l5kqk/pods/https:proxy-service-2k9fx-mgjjs:443/proxy/... (200; 6.334215ms)
+Jul  2 13:05:09.652: INFO: (14) /api/v1/namespaces/e2e-tests-proxy-l5kqk/pods/http:proxy-service-2k9fx-mgjjs:160/proxy/: foo (200; 7.001962ms)
+Jul  2 13:05:09.652: INFO: (14) /api/v1/namespaces/e2e-tests-proxy-l5kqk/pods/https:proxy-service-2k9fx-mgjjs:460/proxy/: tls baz (200; 6.841983ms)
+Jul  2 13:05:09.652: INFO: (14) /api/v1/namespaces/e2e-tests-proxy-l5kqk/pods/proxy-service-2k9fx-mgjjs:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-l5kqk/pods/proxy-service-2k9fx-mgjjs:1080/proxy/rewri... (200; 6.794526ms)
+Jul  2 13:05:09.652: INFO: (14) /api/v1/namespaces/e2e-tests-proxy-l5kqk/services/https:proxy-service-2k9fx:tlsportname1/proxy/: tls baz (200; 6.777764ms)
+Jul  2 13:05:09.653: INFO: (14) /api/v1/namespaces/e2e-tests-proxy-l5kqk/pods/proxy-service-2k9fx-mgjjs:162/proxy/: bar (200; 7.185052ms)
+Jul  2 13:05:09.653: INFO: (14) /api/v1/namespaces/e2e-tests-proxy-l5kqk/pods/proxy-service-2k9fx-mgjjs:160/proxy/: foo (200; 7.317826ms)
+Jul  2 13:05:09.691: INFO: (14) /api/v1/namespaces/e2e-tests-proxy-l5kqk/services/http:proxy-service-2k9fx:portname2/proxy/: bar (200; 45.921765ms)
+Jul  2 13:05:09.692: INFO: (14) /api/v1/namespaces/e2e-tests-proxy-l5kqk/services/https:proxy-service-2k9fx:tlsportname2/proxy/: tls qux (200; 46.339034ms)
+Jul  2 13:05:09.692: INFO: (14) /api/v1/namespaces/e2e-tests-proxy-l5kqk/services/proxy-service-2k9fx:portname2/proxy/: bar (200; 45.939343ms)
+Jul  2 13:05:09.692: INFO: (14) /api/v1/namespaces/e2e-tests-proxy-l5kqk/services/http:proxy-service-2k9fx:portname1/proxy/: foo (200; 46.592444ms)
+Jul  2 13:05:09.692: INFO: (14) /api/v1/namespaces/e2e-tests-proxy-l5kqk/services/proxy-service-2k9fx:portname1/proxy/: foo (200; 46.448994ms)
+Jul  2 13:05:09.697: INFO: (15) /api/v1/namespaces/e2e-tests-proxy-l5kqk/pods/https:proxy-service-2k9fx-mgjjs:443/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-l5kqk/pods/https:proxy-service-2k9fx-mgjjs:443/proxy/... (200; 5.48738ms)
+Jul  2 13:05:09.698: INFO: (15) /api/v1/namespaces/e2e-tests-proxy-l5kqk/pods/http:proxy-service-2k9fx-mgjjs:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-l5kqk/pods/http:proxy-service-2k9fx-mgjjs:1080/proxy/... (200; 5.75649ms)
+Jul  2 13:05:09.699: INFO: (15) /api/v1/namespaces/e2e-tests-proxy-l5kqk/services/https:proxy-service-2k9fx:tlsportname1/proxy/: tls baz (200; 7.090074ms)
+Jul  2 13:05:09.699: INFO: (15) /api/v1/namespaces/e2e-tests-proxy-l5kqk/pods/proxy-service-2k9fx-mgjjs/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-l5kqk/pods/proxy-service-2k9fx-mgjjs/proxy/rewriteme"... (200; 6.899165ms)
+Jul  2 13:05:09.699: INFO: (15) /api/v1/namespaces/e2e-tests-proxy-l5kqk/pods/https:proxy-service-2k9fx-mgjjs:460/proxy/: tls baz (200; 7.093666ms)
+Jul  2 13:05:09.699: INFO: (15) /api/v1/namespaces/e2e-tests-proxy-l5kqk/pods/http:proxy-service-2k9fx-mgjjs:160/proxy/: foo (200; 6.796593ms)
+Jul  2 13:05:09.699: INFO: (15) /api/v1/namespaces/e2e-tests-proxy-l5kqk/pods/https:proxy-service-2k9fx-mgjjs:462/proxy/: tls qux (200; 7.08088ms)
+Jul  2 13:05:09.699: INFO: (15) /api/v1/namespaces/e2e-tests-proxy-l5kqk/pods/proxy-service-2k9fx-mgjjs:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-l5kqk/pods/proxy-service-2k9fx-mgjjs:1080/proxy/rewri... (200; 7.171195ms)
+Jul  2 13:05:09.699: INFO: (15) /api/v1/namespaces/e2e-tests-proxy-l5kqk/pods/proxy-service-2k9fx-mgjjs:160/proxy/: foo (200; 6.949025ms)
+Jul  2 13:05:09.699: INFO: (15) /api/v1/namespaces/e2e-tests-proxy-l5kqk/pods/proxy-service-2k9fx-mgjjs:162/proxy/: bar (200; 6.984039ms)
+Jul  2 13:05:09.699: INFO: (15) /api/v1/namespaces/e2e-tests-proxy-l5kqk/services/https:proxy-service-2k9fx:tlsportname2/proxy/: tls qux (200; 7.312002ms)
+Jul  2 13:05:09.699: INFO: (15) /api/v1/namespaces/e2e-tests-proxy-l5kqk/pods/http:proxy-service-2k9fx-mgjjs:162/proxy/: bar (200; 7.223645ms)
+Jul  2 13:05:09.700: INFO: (15) /api/v1/namespaces/e2e-tests-proxy-l5kqk/services/http:proxy-service-2k9fx:portname1/proxy/: foo (200; 8.019819ms)
+Jul  2 13:05:09.700: INFO: (15) /api/v1/namespaces/e2e-tests-proxy-l5kqk/services/proxy-service-2k9fx:portname1/proxy/: foo (200; 8.039331ms)
+Jul  2 13:05:09.700: INFO: (15) /api/v1/namespaces/e2e-tests-proxy-l5kqk/services/http:proxy-service-2k9fx:portname2/proxy/: bar (200; 8.2527ms)
+Jul  2 13:05:09.701: INFO: (15) /api/v1/namespaces/e2e-tests-proxy-l5kqk/services/proxy-service-2k9fx:portname2/proxy/: bar (200; 9.087063ms)
+Jul  2 13:05:09.709: INFO: (16) /api/v1/namespaces/e2e-tests-proxy-l5kqk/pods/proxy-service-2k9fx-mgjjs:160/proxy/: foo (200; 7.626609ms)
+Jul  2 13:05:09.709: INFO: (16) /api/v1/namespaces/e2e-tests-proxy-l5kqk/pods/https:proxy-service-2k9fx-mgjjs:462/proxy/: tls qux (200; 8.038217ms)
+Jul  2 13:05:09.709: INFO: (16) /api/v1/namespaces/e2e-tests-proxy-l5kqk/pods/http:proxy-service-2k9fx-mgjjs:162/proxy/: bar (200; 8.153989ms)
+Jul  2 13:05:09.709: INFO: (16) /api/v1/namespaces/e2e-tests-proxy-l5kqk/pods/proxy-service-2k9fx-mgjjs:162/proxy/: bar (200; 7.838164ms)
+Jul  2 13:05:09.709: INFO: (16) /api/v1/namespaces/e2e-tests-proxy-l5kqk/pods/https:proxy-service-2k9fx-mgjjs:443/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-l5kqk/pods/https:proxy-service-2k9fx-mgjjs:443/proxy/... (200; 7.729927ms)
+Jul  2 13:05:09.709: INFO: (16) /api/v1/namespaces/e2e-tests-proxy-l5kqk/pods/proxy-service-2k9fx-mgjjs:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-l5kqk/pods/proxy-service-2k9fx-mgjjs:1080/proxy/rewri... (200; 7.921395ms)
+Jul  2 13:05:09.709: INFO: (16) /api/v1/namespaces/e2e-tests-proxy-l5kqk/pods/proxy-service-2k9fx-mgjjs/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-l5kqk/pods/proxy-service-2k9fx-mgjjs/proxy/rewriteme"... (200; 7.469861ms)
+Jul  2 13:05:09.714: INFO: (16) /api/v1/namespaces/e2e-tests-proxy-l5kqk/pods/https:proxy-service-2k9fx-mgjjs:460/proxy/: tls baz (200; 12.163903ms)
+Jul  2 13:05:09.714: INFO: (16) /api/v1/namespaces/e2e-tests-proxy-l5kqk/services/https:proxy-service-2k9fx:tlsportname2/proxy/: tls qux (200; 12.426633ms)
+Jul  2 13:05:09.714: INFO: (16) /api/v1/namespaces/e2e-tests-proxy-l5kqk/pods/http:proxy-service-2k9fx-mgjjs:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-l5kqk/pods/http:proxy-service-2k9fx-mgjjs:1080/proxy/... (200; 12.54463ms)
+Jul  2 13:05:09.714: INFO: (16) /api/v1/namespaces/e2e-tests-proxy-l5kqk/services/https:proxy-service-2k9fx:tlsportname1/proxy/: tls baz (200; 12.862452ms)
+Jul  2 13:05:09.715: INFO: (16) /api/v1/namespaces/e2e-tests-proxy-l5kqk/services/proxy-service-2k9fx:portname2/proxy/: bar (200; 13.541777ms)
+Jul  2 13:05:09.714: INFO: (16) /api/v1/namespaces/e2e-tests-proxy-l5kqk/services/proxy-service-2k9fx:portname1/proxy/: foo (200; 12.917189ms)
+Jul  2 13:05:09.715: INFO: (16) /api/v1/namespaces/e2e-tests-proxy-l5kqk/services/http:proxy-service-2k9fx:portname1/proxy/: foo (200; 13.36599ms)
+Jul  2 13:05:09.715: INFO: (16) /api/v1/namespaces/e2e-tests-proxy-l5kqk/services/http:proxy-service-2k9fx:portname2/proxy/: bar (200; 13.691634ms)
+Jul  2 13:05:09.715: INFO: (16) /api/v1/namespaces/e2e-tests-proxy-l5kqk/pods/http:proxy-service-2k9fx-mgjjs:160/proxy/: foo (200; 13.328254ms)
+Jul  2 13:05:09.720: INFO: (17) /api/v1/namespaces/e2e-tests-proxy-l5kqk/pods/proxy-service-2k9fx-mgjjs:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-l5kqk/pods/proxy-service-2k9fx-mgjjs:1080/proxy/rewri... (200; 4.963985ms)
+Jul  2 13:05:09.721: INFO: (17) /api/v1/namespaces/e2e-tests-proxy-l5kqk/pods/proxy-service-2k9fx-mgjjs:162/proxy/: bar (200; 5.511955ms)
+Jul  2 13:05:09.721: INFO: (17) /api/v1/namespaces/e2e-tests-proxy-l5kqk/pods/https:proxy-service-2k9fx-mgjjs:460/proxy/: tls baz (200; 5.737055ms)
+Jul  2 13:05:09.721: INFO: (17) /api/v1/namespaces/e2e-tests-proxy-l5kqk/pods/http:proxy-service-2k9fx-mgjjs:160/proxy/: foo (200; 6.090204ms)
+Jul  2 13:05:09.721: INFO: (17) /api/v1/namespaces/e2e-tests-proxy-l5kqk/pods/http:proxy-service-2k9fx-mgjjs:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-l5kqk/pods/http:proxy-service-2k9fx-mgjjs:1080/proxy/... (200; 5.494262ms)
+Jul  2 13:05:09.722: INFO: (17) /api/v1/namespaces/e2e-tests-proxy-l5kqk/services/proxy-service-2k9fx:portname2/proxy/: bar (200; 7.000289ms)
+Jul  2 13:05:09.722: INFO: (17) /api/v1/namespaces/e2e-tests-proxy-l5kqk/pods/proxy-service-2k9fx-mgjjs/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-l5kqk/pods/proxy-service-2k9fx-mgjjs/proxy/rewriteme"... (200; 6.400888ms)
+Jul  2 13:05:09.722: INFO: (17) /api/v1/namespaces/e2e-tests-proxy-l5kqk/pods/http:proxy-service-2k9fx-mgjjs:162/proxy/: bar (200; 6.444368ms)
+Jul  2 13:05:09.722: INFO: (17) /api/v1/namespaces/e2e-tests-proxy-l5kqk/pods/https:proxy-service-2k9fx-mgjjs:462/proxy/: tls qux (200; 6.700791ms)
+Jul  2 13:05:09.722: INFO: (17) /api/v1/namespaces/e2e-tests-proxy-l5kqk/pods/https:proxy-service-2k9fx-mgjjs:443/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-l5kqk/pods/https:proxy-service-2k9fx-mgjjs:443/proxy/... (200; 6.787924ms)
+Jul  2 13:05:09.722: INFO: (17) /api/v1/namespaces/e2e-tests-proxy-l5kqk/services/http:proxy-service-2k9fx:portname1/proxy/: foo (200; 6.944128ms)
+Jul  2 13:05:09.723: INFO: (17) /api/v1/namespaces/e2e-tests-proxy-l5kqk/services/http:proxy-service-2k9fx:portname2/proxy/: bar (200; 7.583875ms)
+Jul  2 13:05:09.723: INFO: (17) /api/v1/namespaces/e2e-tests-proxy-l5kqk/services/https:proxy-service-2k9fx:tlsportname2/proxy/: tls qux (200; 7.57485ms)
+Jul  2 13:05:09.723: INFO: (17) /api/v1/namespaces/e2e-tests-proxy-l5kqk/services/https:proxy-service-2k9fx:tlsportname1/proxy/: tls baz (200; 7.43658ms)
+Jul  2 13:05:09.723: INFO: (17) /api/v1/namespaces/e2e-tests-proxy-l5kqk/pods/proxy-service-2k9fx-mgjjs:160/proxy/: foo (200; 7.8116ms)
+Jul  2 13:05:09.723: INFO: (17) /api/v1/namespaces/e2e-tests-proxy-l5kqk/services/proxy-service-2k9fx:portname1/proxy/: foo (200; 7.528805ms)
+Jul  2 13:05:09.735: INFO: (18) /api/v1/namespaces/e2e-tests-proxy-l5kqk/pods/proxy-service-2k9fx-mgjjs/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-l5kqk/pods/proxy-service-2k9fx-mgjjs/proxy/rewriteme"... (200; 11.079257ms)
+Jul  2 13:05:09.735: INFO: (18) /api/v1/namespaces/e2e-tests-proxy-l5kqk/pods/proxy-service-2k9fx-mgjjs:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-l5kqk/pods/proxy-service-2k9fx-mgjjs:1080/proxy/rewri... (200; 11.261463ms)
+Jul  2 13:05:09.735: INFO: (18) /api/v1/namespaces/e2e-tests-proxy-l5kqk/pods/https:proxy-service-2k9fx-mgjjs:460/proxy/: tls baz (200; 11.994117ms)
+Jul  2 13:05:09.735: INFO: (18) /api/v1/namespaces/e2e-tests-proxy-l5kqk/services/proxy-service-2k9fx:portname1/proxy/: foo (200; 11.231064ms)
+Jul  2 13:05:09.735: INFO: (18) /api/v1/namespaces/e2e-tests-proxy-l5kqk/pods/proxy-service-2k9fx-mgjjs:160/proxy/: foo (200; 11.608186ms)
+Jul  2 13:05:09.735: INFO: (18) /api/v1/namespaces/e2e-tests-proxy-l5kqk/pods/https:proxy-service-2k9fx-mgjjs:462/proxy/: tls qux (200; 11.412892ms)
+Jul  2 13:05:09.735: INFO: (18) /api/v1/namespaces/e2e-tests-proxy-l5kqk/pods/https:proxy-service-2k9fx-mgjjs:443/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-l5kqk/pods/https:proxy-service-2k9fx-mgjjs:443/proxy/... (200; 11.521208ms)
+Jul  2 13:05:09.736: INFO: (18) /api/v1/namespaces/e2e-tests-proxy-l5kqk/pods/http:proxy-service-2k9fx-mgjjs:160/proxy/: foo (200; 11.428778ms)
+Jul  2 13:05:09.736: INFO: (18) /api/v1/namespaces/e2e-tests-proxy-l5kqk/pods/proxy-service-2k9fx-mgjjs:162/proxy/: bar (200; 11.729018ms)
+Jul  2 13:05:09.736: INFO: (18) /api/v1/namespaces/e2e-tests-proxy-l5kqk/services/http:proxy-service-2k9fx:portname2/proxy/: bar (200; 12.050172ms)
+Jul  2 13:05:09.736: INFO: (18) /api/v1/namespaces/e2e-tests-proxy-l5kqk/pods/http:proxy-service-2k9fx-mgjjs:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-l5kqk/pods/http:proxy-service-2k9fx-mgjjs:1080/proxy/... (200; 11.948933ms)
+Jul  2 13:05:09.736: INFO: (18) /api/v1/namespaces/e2e-tests-proxy-l5kqk/services/https:proxy-service-2k9fx:tlsportname1/proxy/: tls baz (200; 11.686348ms)
+Jul  2 13:05:09.771: INFO: (18) /api/v1/namespaces/e2e-tests-proxy-l5kqk/services/https:proxy-service-2k9fx:tlsportname2/proxy/: tls qux (200; 47.522148ms)
+Jul  2 13:05:09.771: INFO: (18) /api/v1/namespaces/e2e-tests-proxy-l5kqk/services/proxy-service-2k9fx:portname2/proxy/: bar (200; 47.241574ms)
+Jul  2 13:05:09.771: INFO: (18) /api/v1/namespaces/e2e-tests-proxy-l5kqk/services/http:proxy-service-2k9fx:portname1/proxy/: foo (200; 47.273268ms)
+Jul  2 13:05:09.771: INFO: (18) /api/v1/namespaces/e2e-tests-proxy-l5kqk/pods/http:proxy-service-2k9fx-mgjjs:162/proxy/: bar (200; 47.06662ms)
+Jul  2 13:05:09.780: INFO: (19) /api/v1/namespaces/e2e-tests-proxy-l5kqk/pods/proxy-service-2k9fx-mgjjs/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-l5kqk/pods/proxy-service-2k9fx-mgjjs/proxy/rewriteme"... (200; 8.215864ms)
+Jul  2 13:05:09.781: INFO: (19) /api/v1/namespaces/e2e-tests-proxy-l5kqk/services/proxy-service-2k9fx:portname1/proxy/: foo (200; 8.680423ms)
+Jul  2 13:05:09.781: INFO: (19) /api/v1/namespaces/e2e-tests-proxy-l5kqk/pods/https:proxy-service-2k9fx-mgjjs:460/proxy/: tls baz (200; 8.798471ms)
+Jul  2 13:05:09.781: INFO: (19) /api/v1/namespaces/e2e-tests-proxy-l5kqk/services/proxy-service-2k9fx:portname2/proxy/: bar (200; 8.324002ms)
+Jul  2 13:05:09.781: INFO: (19) /api/v1/namespaces/e2e-tests-proxy-l5kqk/services/https:proxy-service-2k9fx:tlsportname2/proxy/: tls qux (200; 8.490067ms)
+Jul  2 13:05:09.781: INFO: (19) /api/v1/namespaces/e2e-tests-proxy-l5kqk/pods/proxy-service-2k9fx-mgjjs:160/proxy/: foo (200; 8.689309ms)
+Jul  2 13:05:09.781: INFO: (19) /api/v1/namespaces/e2e-tests-proxy-l5kqk/pods/http:proxy-service-2k9fx-mgjjs:162/proxy/: bar (200; 8.823075ms)
+Jul  2 13:05:09.781: INFO: (19) /api/v1/namespaces/e2e-tests-proxy-l5kqk/pods/https:proxy-service-2k9fx-mgjjs:443/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-l5kqk/pods/https:proxy-service-2k9fx-mgjjs:443/proxy/... (200; 8.8046ms)
+Jul  2 13:05:09.781: INFO: (19) /api/v1/namespaces/e2e-tests-proxy-l5kqk/pods/http:proxy-service-2k9fx-mgjjs:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-l5kqk/pods/http:proxy-service-2k9fx-mgjjs:1080/proxy/... (200; 8.866337ms)
+Jul  2 13:05:09.781: INFO: (19) /api/v1/namespaces/e2e-tests-proxy-l5kqk/pods/proxy-service-2k9fx-mgjjs:162/proxy/: bar (200; 9.041319ms)
+Jul  2 13:05:09.781: INFO: (19) /api/v1/namespaces/e2e-tests-proxy-l5kqk/pods/proxy-service-2k9fx-mgjjs:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-l5kqk/pods/proxy-service-2k9fx-mgjjs:1080/proxy/rewri... (200; 8.822424ms)
+Jul  2 13:05:09.781: INFO: (19) /api/v1/namespaces/e2e-tests-proxy-l5kqk/services/https:proxy-service-2k9fx:tlsportname1/proxy/: tls baz (200; 9.432104ms)
+Jul  2 13:05:09.781: INFO: (19) /api/v1/namespaces/e2e-tests-proxy-l5kqk/services/http:proxy-service-2k9fx:portname2/proxy/: bar (200; 9.362108ms)
+Jul  2 13:05:09.781: INFO: (19) /api/v1/namespaces/e2e-tests-proxy-l5kqk/pods/http:proxy-service-2k9fx-mgjjs:160/proxy/: foo (200; 9.525077ms)
+Jul  2 13:05:09.782: INFO: (19) /api/v1/namespaces/e2e-tests-proxy-l5kqk/services/http:proxy-service-2k9fx:portname1/proxy/: foo (200; 9.349104ms)
+Jul  2 13:05:09.782: INFO: (19) /api/v1/namespaces/e2e-tests-proxy-l5kqk/pods/https:proxy-service-2k9fx-mgjjs:462/proxy/: tls qux (200; 9.599541ms)
+STEP: deleting { ReplicationController} proxy-service-2k9fx in namespace e2e-tests-proxy-l5kqk, will wait for the garbage collector to delete the pods
+Jul  2 13:05:09.841: INFO: Deleting { ReplicationController} proxy-service-2k9fx took: 6.155629ms
+Jul  2 13:05:09.943: INFO: Terminating { ReplicationController} proxy-service-2k9fx pods took: 101.573266ms
+[AfterEach] version v1
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:05:18.043: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-proxy-l5kqk" for this suite.
+Jul  2 13:05:24.058: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:05:24.146: INFO: namespace: e2e-tests-proxy-l5kqk, resource: bindings, ignored listing per whitelist
+Jul  2 13:05:24.155: INFO: namespace e2e-tests-proxy-l5kqk deletion completed in 6.106909755s
+
+• [SLOW TEST:27.108 seconds]
+[sig-network] Proxy
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/network/framework.go:22
+  version v1
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/network/proxy.go:56
+    should proxy through a service and a pod  [Conformance]
+    /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+[sig-storage] Projected 
+  should provide container's memory request [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:05:24.155: INFO: >>> kubeConfig: /tmp/kubeconfig-575984058
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:858
+[It] should provide container's memory request [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating a pod to test downward API volume plugin
+Jul  2 13:05:24.249: INFO: Waiting up to 5m0s for pod "downwardapi-volume-95258a4a-7df8-11e8-b7a8-22e3071d17c7" in namespace "e2e-tests-projected-fwvrh" to be "success or failure"
+Jul  2 13:05:24.252: INFO: Pod "downwardapi-volume-95258a4a-7df8-11e8-b7a8-22e3071d17c7": Phase="Pending", Reason="", readiness=false. Elapsed: 2.939611ms
+Jul  2 13:05:26.258: INFO: Pod "downwardapi-volume-95258a4a-7df8-11e8-b7a8-22e3071d17c7": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.008579133s
+STEP: Saw pod success
+Jul  2 13:05:26.258: INFO: Pod "downwardapi-volume-95258a4a-7df8-11e8-b7a8-22e3071d17c7" satisfied condition "success or failure"
+Jul  2 13:05:26.261: INFO: Trying to get logs from node shoot--core--confos-worker-w6oh6-z1-59946c4f6c-2w6kp pod downwardapi-volume-95258a4a-7df8-11e8-b7a8-22e3071d17c7 container client-container: <nil>
+STEP: delete the pod
+Jul  2 13:05:26.292: INFO: Waiting for pod downwardapi-volume-95258a4a-7df8-11e8-b7a8-22e3071d17c7 to disappear
+Jul  2 13:05:26.296: INFO: Pod downwardapi-volume-95258a4a-7df8-11e8-b7a8-22e3071d17c7 no longer exists
+[AfterEach] [sig-storage] Projected
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:05:26.297: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-fwvrh" for this suite.
+Jul  2 13:05:32.312: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:05:32.392: INFO: namespace: e2e-tests-projected-fwvrh, resource: bindings, ignored listing per whitelist
+Jul  2 13:05:32.418: INFO: namespace e2e-tests-projected-fwvrh deletion completed in 6.117300066s
+
+• [SLOW TEST:8.263 seconds]
+[sig-storage] Projected
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:34
+  should provide container's memory request [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSSSSSSSSSSSSSSSSSSSSSSS
+------------------------------
+[k8s.io] Probing container 
+  should be restarted with a exec "cat /tmp/health" liveness probe [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [k8s.io] Probing container
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:05:32.420: INFO: >>> kubeConfig: /tmp/kubeconfig-575984058
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [k8s.io] Probing container
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/container_probe.go:48
+[It] should be restarted with a exec "cat /tmp/health" liveness probe [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating pod liveness-exec in namespace e2e-tests-container-probe-5xvwh
+Jul  2 13:05:36.578: INFO: Started pod liveness-exec in namespace e2e-tests-container-probe-5xvwh
+STEP: checking the pod's current state and verifying that restartCount is present
+Jul  2 13:05:36.581: INFO: Initial restart count of pod liveness-exec is 0
+Jul  2 13:06:28.883: INFO: Restart count of pod e2e-tests-container-probe-5xvwh/liveness-exec is now 1 (52.301778131s elapsed)
+STEP: deleting the pod
+[AfterEach] [k8s.io] Probing container
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:06:28.984: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-container-probe-5xvwh" for this suite.
+Jul  2 13:06:34.999: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:06:35.082: INFO: namespace: e2e-tests-container-probe-5xvwh, resource: bindings, ignored listing per whitelist
+Jul  2 13:06:35.266: INFO: namespace e2e-tests-container-probe-5xvwh deletion completed in 6.276842741s
+
+• [SLOW TEST:62.846 seconds]
+[k8s.io] Probing container
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:679
+  should be restarted with a exec "cat /tmp/health" liveness probe [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+S
+------------------------------
+[sig-storage] ConfigMap 
+  should be consumable from pods in volume [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-storage] ConfigMap
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:06:35.266: INFO: >>> kubeConfig: /tmp/kubeconfig-575984058
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should be consumable from pods in volume [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating configMap with name configmap-test-volume-bf8a0eb8-7df8-11e8-b7a8-22e3071d17c7
+STEP: Creating a pod to test consume configMaps
+Jul  2 13:06:35.379: INFO: Waiting up to 5m0s for pod "pod-configmaps-bf8a8ee5-7df8-11e8-b7a8-22e3071d17c7" in namespace "e2e-tests-configmap-8xkcl" to be "success or failure"
+Jul  2 13:06:35.390: INFO: Pod "pod-configmaps-bf8a8ee5-7df8-11e8-b7a8-22e3071d17c7": Phase="Pending", Reason="", readiness=false. Elapsed: 11.082446ms
+Jul  2 13:06:37.395: INFO: Pod "pod-configmaps-bf8a8ee5-7df8-11e8-b7a8-22e3071d17c7": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.015281798s
+STEP: Saw pod success
+Jul  2 13:06:37.395: INFO: Pod "pod-configmaps-bf8a8ee5-7df8-11e8-b7a8-22e3071d17c7" satisfied condition "success or failure"
+Jul  2 13:06:37.398: INFO: Trying to get logs from node shoot--core--confos-worker-w6oh6-z1-59946c4f6c-2w6kp pod pod-configmaps-bf8a8ee5-7df8-11e8-b7a8-22e3071d17c7 container configmap-volume-test: <nil>
+STEP: delete the pod
+Jul  2 13:06:37.482: INFO: Waiting for pod pod-configmaps-bf8a8ee5-7df8-11e8-b7a8-22e3071d17c7 to disappear
+Jul  2 13:06:37.485: INFO: Pod pod-configmaps-bf8a8ee5-7df8-11e8-b7a8-22e3071d17c7 no longer exists
+[AfterEach] [sig-storage] ConfigMap
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:06:37.485: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-configmap-8xkcl" for this suite.
+Jul  2 13:06:43.498: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:06:43.621: INFO: namespace: e2e-tests-configmap-8xkcl, resource: bindings, ignored listing per whitelist
+Jul  2 13:06:43.624: INFO: namespace e2e-tests-configmap-8xkcl deletion completed in 6.135490477s
+
+• [SLOW TEST:8.358 seconds]
+[sig-storage] ConfigMap
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/configmap_volume.go:32
+  should be consumable from pods in volume [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+S
+------------------------------
+[sig-api-machinery] Downward API 
+  should provide pod UID as env vars [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-api-machinery] Downward API
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:06:43.624: INFO: >>> kubeConfig: /tmp/kubeconfig-575984058
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should provide pod UID as env vars [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating a pod to test downward api env vars
+Jul  2 13:06:43.713: INFO: Waiting up to 5m0s for pod "downward-api-c483031d-7df8-11e8-b7a8-22e3071d17c7" in namespace "e2e-tests-downward-api-dthqj" to be "success or failure"
+Jul  2 13:06:43.716: INFO: Pod "downward-api-c483031d-7df8-11e8-b7a8-22e3071d17c7": Phase="Pending", Reason="", readiness=false. Elapsed: 2.486962ms
+Jul  2 13:06:45.720: INFO: Pod "downward-api-c483031d-7df8-11e8-b7a8-22e3071d17c7": Phase="Pending", Reason="", readiness=false. Elapsed: 2.006641963s
+Jul  2 13:06:47.724: INFO: Pod "downward-api-c483031d-7df8-11e8-b7a8-22e3071d17c7": Phase="Pending", Reason="", readiness=false. Elapsed: 4.010570591s
+Jul  2 13:06:49.728: INFO: Pod "downward-api-c483031d-7df8-11e8-b7a8-22e3071d17c7": Phase="Succeeded", Reason="", readiness=false. Elapsed: 6.014488865s
+STEP: Saw pod success
+Jul  2 13:06:49.728: INFO: Pod "downward-api-c483031d-7df8-11e8-b7a8-22e3071d17c7" satisfied condition "success or failure"
+Jul  2 13:06:49.731: INFO: Trying to get logs from node shoot--core--confos-worker-w6oh6-z1-59946c4f6c-2w6kp pod downward-api-c483031d-7df8-11e8-b7a8-22e3071d17c7 container dapi-container: <nil>
+STEP: delete the pod
+Jul  2 13:06:49.748: INFO: Waiting for pod downward-api-c483031d-7df8-11e8-b7a8-22e3071d17c7 to disappear
+Jul  2 13:06:49.752: INFO: Pod downward-api-c483031d-7df8-11e8-b7a8-22e3071d17c7 no longer exists
+[AfterEach] [sig-api-machinery] Downward API
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:06:49.752: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-downward-api-dthqj" for this suite.
+Jul  2 13:06:55.769: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:06:55.789: INFO: namespace: e2e-tests-downward-api-dthqj, resource: bindings, ignored listing per whitelist
+Jul  2 13:06:55.882: INFO: namespace e2e-tests-downward-api-dthqj deletion completed in 6.126840548s
+
+• [SLOW TEST:12.258 seconds]
+[sig-api-machinery] Downward API
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downward_api.go:37
+  should provide pod UID as env vars [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSSSS
+------------------------------
+[sig-storage] Projected 
+  should update annotations on modification [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:06:55.883: INFO: >>> kubeConfig: /tmp/kubeconfig-575984058
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:858
+[It] should update annotations on modification [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating the pod
+Jul  2 13:06:58.592: INFO: Successfully updated pod "annotationupdatecbd1be96-7df8-11e8-b7a8-22e3071d17c7"
+[AfterEach] [sig-storage] Projected
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:07:02.692: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-jn4p2" for this suite.
+Jul  2 13:07:24.712: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:07:24.856: INFO: namespace: e2e-tests-projected-jn4p2, resource: bindings, ignored listing per whitelist
+Jul  2 13:07:24.876: INFO: namespace e2e-tests-projected-jn4p2 deletion completed in 22.180519146s
+
+• [SLOW TEST:28.994 seconds]
+[sig-storage] Projected
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:34
+  should update annotations on modification [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSSSSSSSSSSSSSSSSSSSSS
+------------------------------
+[sig-storage] Projected 
+  should be consumable from pods in volume with defaultMode set [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:07:24.878: INFO: >>> kubeConfig: /tmp/kubeconfig-575984058
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:858
+[It] should be consumable from pods in volume with defaultMode set [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating projection with secret that has name projected-secret-test-dd1a4fff-7df8-11e8-b7a8-22e3071d17c7
+STEP: Creating a pod to test consume secrets
+Jul  2 13:07:24.976: INFO: Waiting up to 5m0s for pod "pod-projected-secrets-dd1b039e-7df8-11e8-b7a8-22e3071d17c7" in namespace "e2e-tests-projected-xl9fq" to be "success or failure"
+Jul  2 13:07:24.978: INFO: Pod "pod-projected-secrets-dd1b039e-7df8-11e8-b7a8-22e3071d17c7": Phase="Pending", Reason="", readiness=false. Elapsed: 2.58628ms
+Jul  2 13:07:26.983: INFO: Pod "pod-projected-secrets-dd1b039e-7df8-11e8-b7a8-22e3071d17c7": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.007037583s
+STEP: Saw pod success
+Jul  2 13:07:26.983: INFO: Pod "pod-projected-secrets-dd1b039e-7df8-11e8-b7a8-22e3071d17c7" satisfied condition "success or failure"
+Jul  2 13:07:26.985: INFO: Trying to get logs from node shoot--core--confos-worker-w6oh6-z1-59946c4f6c-2w6kp pod pod-projected-secrets-dd1b039e-7df8-11e8-b7a8-22e3071d17c7 container projected-secret-volume-test: <nil>
+STEP: delete the pod
+Jul  2 13:07:27.001: INFO: Waiting for pod pod-projected-secrets-dd1b039e-7df8-11e8-b7a8-22e3071d17c7 to disappear
+Jul  2 13:07:27.004: INFO: Pod pod-projected-secrets-dd1b039e-7df8-11e8-b7a8-22e3071d17c7 no longer exists
+[AfterEach] [sig-storage] Projected
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:07:27.004: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-xl9fq" for this suite.
+Jul  2 13:07:33.065: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:07:33.084: INFO: namespace: e2e-tests-projected-xl9fq, resource: bindings, ignored listing per whitelist
+Jul  2 13:07:33.168: INFO: namespace e2e-tests-projected-xl9fq deletion completed in 6.160403538s
+
+• [SLOW TEST:8.291 seconds]
+[sig-storage] Projected
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:34
+  should be consumable from pods in volume with defaultMode set [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSSSSSSSSSSSSSSSSS
+------------------------------
+[sig-api-machinery] CustomResourceDefinition resources Simple CustomResourceDefinition 
+  creating/deleting custom resource definition objects works  [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-api-machinery] CustomResourceDefinition resources
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:07:33.169: INFO: >>> kubeConfig: /tmp/kubeconfig-575984058
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] creating/deleting custom resource definition objects works  [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+Jul  2 13:07:33.248: INFO: >>> kubeConfig: /tmp/kubeconfig-575984058
+[AfterEach] [sig-api-machinery] CustomResourceDefinition resources
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:07:34.389: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-custom-resource-definition-gtmvh" for this suite.
+Jul  2 13:07:40.565: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:07:40.637: INFO: namespace: e2e-tests-custom-resource-definition-gtmvh, resource: bindings, ignored listing per whitelist
+Jul  2 13:07:40.669: INFO: namespace e2e-tests-custom-resource-definition-gtmvh deletion completed in 6.20369848s
+
+• [SLOW TEST:7.501 seconds]
+[sig-api-machinery] CustomResourceDefinition resources
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apimachinery/framework.go:22
+  Simple CustomResourceDefinition
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apimachinery/custom_resource_definition.go:35
+    creating/deleting custom resource definition objects works  [Conformance]
+    /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSSSSSSS
+------------------------------
+[k8s.io] [sig-node] Pods Extended [k8s.io] Pods Set QOS Class 
+  should be submitted and removed  [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [k8s.io] [sig-node] Pods Extended
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:07:40.670: INFO: >>> kubeConfig: /tmp/kubeconfig-575984058
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [k8s.io] Pods Set QOS Class
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/node/pods.go:199
+[It] should be submitted and removed  [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: creating the pod
+STEP: submitting the pod to kubernetes
+STEP: verifying QOS class is set on the pod
+[AfterEach] [k8s.io] [sig-node] Pods Extended
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:07:40.766: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-pods-nljr6" for this suite.
+Jul  2 13:08:02.780: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:08:02.805: INFO: namespace: e2e-tests-pods-nljr6, resource: bindings, ignored listing per whitelist
+Jul  2 13:08:02.881: INFO: namespace e2e-tests-pods-nljr6 deletion completed in 22.111035756s
+
+• [SLOW TEST:22.211 seconds]
+[k8s.io] [sig-node] Pods Extended
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:679
+  [k8s.io] Pods Set QOS Class
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:679
+    should be submitted and removed  [Conformance]
+    /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+S
+------------------------------
+[sig-network] Proxy version v1 
+  should proxy logs on node using proxy subresource  [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] version v1
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:08:02.881: INFO: >>> kubeConfig: /tmp/kubeconfig-575984058
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should proxy logs on node using proxy subresource  [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+Jul  2 13:08:02.986: INFO: (0) /api/v1/nodes/shoot--core--confos-worker-w6oh6-z1-59946c4f6c-2w6kp/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 6.579269ms)
+Jul  2 13:08:03.024: INFO: (1) /api/v1/nodes/shoot--core--confos-worker-w6oh6-z1-59946c4f6c-2w6kp/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 38.238595ms)
+Jul  2 13:08:03.029: INFO: (2) /api/v1/nodes/shoot--core--confos-worker-w6oh6-z1-59946c4f6c-2w6kp/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 4.475526ms)
+Jul  2 13:08:03.033: INFO: (3) /api/v1/nodes/shoot--core--confos-worker-w6oh6-z1-59946c4f6c-2w6kp/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 4.052649ms)
+Jul  2 13:08:03.037: INFO: (4) /api/v1/nodes/shoot--core--confos-worker-w6oh6-z1-59946c4f6c-2w6kp/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 4.042122ms)
+Jul  2 13:08:03.041: INFO: (5) /api/v1/nodes/shoot--core--confos-worker-w6oh6-z1-59946c4f6c-2w6kp/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 4.233802ms)
+Jul  2 13:08:03.046: INFO: (6) /api/v1/nodes/shoot--core--confos-worker-w6oh6-z1-59946c4f6c-2w6kp/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 4.515383ms)
+Jul  2 13:08:03.050: INFO: (7) /api/v1/nodes/shoot--core--confos-worker-w6oh6-z1-59946c4f6c-2w6kp/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 4.264851ms)
+Jul  2 13:08:03.054: INFO: (8) /api/v1/nodes/shoot--core--confos-worker-w6oh6-z1-59946c4f6c-2w6kp/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 4.171689ms)
+Jul  2 13:08:03.079: INFO: (9) /api/v1/nodes/shoot--core--confos-worker-w6oh6-z1-59946c4f6c-2w6kp/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 24.192669ms)
+Jul  2 13:08:03.083: INFO: (10) /api/v1/nodes/shoot--core--confos-worker-w6oh6-z1-59946c4f6c-2w6kp/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 4.710414ms)
+Jul  2 13:08:03.087: INFO: (11) /api/v1/nodes/shoot--core--confos-worker-w6oh6-z1-59946c4f6c-2w6kp/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 4.010043ms)
+Jul  2 13:08:03.092: INFO: (12) /api/v1/nodes/shoot--core--confos-worker-w6oh6-z1-59946c4f6c-2w6kp/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 4.466991ms)
+Jul  2 13:08:03.097: INFO: (13) /api/v1/nodes/shoot--core--confos-worker-w6oh6-z1-59946c4f6c-2w6kp/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 4.67802ms)
+Jul  2 13:08:03.101: INFO: (14) /api/v1/nodes/shoot--core--confos-worker-w6oh6-z1-59946c4f6c-2w6kp/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 4.332747ms)
+Jul  2 13:08:03.105: INFO: (15) /api/v1/nodes/shoot--core--confos-worker-w6oh6-z1-59946c4f6c-2w6kp/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 4.297916ms)
+Jul  2 13:08:03.110: INFO: (16) /api/v1/nodes/shoot--core--confos-worker-w6oh6-z1-59946c4f6c-2w6kp/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 4.366751ms)
+Jul  2 13:08:03.114: INFO: (17) /api/v1/nodes/shoot--core--confos-worker-w6oh6-z1-59946c4f6c-2w6kp/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 4.330506ms)
+Jul  2 13:08:03.119: INFO: (18) /api/v1/nodes/shoot--core--confos-worker-w6oh6-z1-59946c4f6c-2w6kp/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 4.054869ms)
+Jul  2 13:08:03.188: INFO: (19) /api/v1/nodes/shoot--core--confos-worker-w6oh6-z1-59946c4f6c-2w6kp/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 69.417804ms)
+[AfterEach] version v1
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:08:03.188: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-proxy-24kvk" for this suite.
+Jul  2 13:08:09.202: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:08:09.261: INFO: namespace: e2e-tests-proxy-24kvk, resource: bindings, ignored listing per whitelist
+Jul  2 13:08:09.296: INFO: namespace e2e-tests-proxy-24kvk deletion completed in 6.103963196s
+
+• [SLOW TEST:6.415 seconds]
+[sig-network] Proxy
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/network/framework.go:22
+  version v1
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/network/proxy.go:56
+    should proxy logs on node using proxy subresource  [Conformance]
+    /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSS
+------------------------------
+[sig-storage] EmptyDir volumes 
+  volume on default medium should have the correct mode [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-storage] EmptyDir volumes
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:08:09.296: INFO: >>> kubeConfig: /tmp/kubeconfig-575984058
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] volume on default medium should have the correct mode [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating a pod to test emptydir volume type on node default medium
+Jul  2 13:08:09.392: INFO: Waiting up to 5m0s for pod "pod-f794a779-7df8-11e8-b7a8-22e3071d17c7" in namespace "e2e-tests-emptydir-fpdk9" to be "success or failure"
+Jul  2 13:08:09.395: INFO: Pod "pod-f794a779-7df8-11e8-b7a8-22e3071d17c7": Phase="Pending", Reason="", readiness=false. Elapsed: 2.681128ms
+Jul  2 13:08:11.399: INFO: Pod "pod-f794a779-7df8-11e8-b7a8-22e3071d17c7": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.006666832s
+STEP: Saw pod success
+Jul  2 13:08:11.399: INFO: Pod "pod-f794a779-7df8-11e8-b7a8-22e3071d17c7" satisfied condition "success or failure"
+Jul  2 13:08:11.478: INFO: Trying to get logs from node shoot--core--confos-worker-w6oh6-z1-59946c4f6c-2w6kp pod pod-f794a779-7df8-11e8-b7a8-22e3071d17c7 container test-container: <nil>
+STEP: delete the pod
+Jul  2 13:08:11.496: INFO: Waiting for pod pod-f794a779-7df8-11e8-b7a8-22e3071d17c7 to disappear
+Jul  2 13:08:11.498: INFO: Pod pod-f794a779-7df8-11e8-b7a8-22e3071d17c7 no longer exists
+[AfterEach] [sig-storage] EmptyDir volumes
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:08:11.498: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-emptydir-fpdk9" for this suite.
+Jul  2 13:08:17.511: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:08:17.552: INFO: namespace: e2e-tests-emptydir-fpdk9, resource: bindings, ignored listing per whitelist
+Jul  2 13:08:17.614: INFO: namespace e2e-tests-emptydir-fpdk9 deletion completed in 6.112760254s
+
+• [SLOW TEST:8.318 seconds]
+[sig-storage] EmptyDir volumes
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/empty_dir.go:40
+  volume on default medium should have the correct mode [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSSS
+------------------------------
+[sig-storage] EmptyDir volumes 
+  should support (non-root,0666,tmpfs) [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-storage] EmptyDir volumes
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:08:17.614: INFO: >>> kubeConfig: /tmp/kubeconfig-575984058
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should support (non-root,0666,tmpfs) [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating a pod to test emptydir 0666 on tmpfs
+Jul  2 13:08:17.711: INFO: Waiting up to 5m0s for pod "pod-fc89ffd5-7df8-11e8-b7a8-22e3071d17c7" in namespace "e2e-tests-emptydir-p7zhx" to be "success or failure"
+Jul  2 13:08:17.713: INFO: Pod "pod-fc89ffd5-7df8-11e8-b7a8-22e3071d17c7": Phase="Pending", Reason="", readiness=false. Elapsed: 2.364091ms
+Jul  2 13:08:19.718: INFO: Pod "pod-fc89ffd5-7df8-11e8-b7a8-22e3071d17c7": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.007045385s
+STEP: Saw pod success
+Jul  2 13:08:19.718: INFO: Pod "pod-fc89ffd5-7df8-11e8-b7a8-22e3071d17c7" satisfied condition "success or failure"
+Jul  2 13:08:19.765: INFO: Trying to get logs from node shoot--core--confos-worker-w6oh6-z1-59946c4f6c-2w6kp pod pod-fc89ffd5-7df8-11e8-b7a8-22e3071d17c7 container test-container: <nil>
+STEP: delete the pod
+Jul  2 13:08:19.791: INFO: Waiting for pod pod-fc89ffd5-7df8-11e8-b7a8-22e3071d17c7 to disappear
+Jul  2 13:08:19.804: INFO: Pod pod-fc89ffd5-7df8-11e8-b7a8-22e3071d17c7 no longer exists
+[AfterEach] [sig-storage] EmptyDir volumes
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:08:19.804: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-emptydir-p7zhx" for this suite.
+Jul  2 13:08:25.819: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:08:25.901: INFO: namespace: e2e-tests-emptydir-p7zhx, resource: bindings, ignored listing per whitelist
+Jul  2 13:08:25.912: INFO: namespace e2e-tests-emptydir-p7zhx deletion completed in 6.104339521s
+
+• [SLOW TEST:8.298 seconds]
+[sig-storage] EmptyDir volumes
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/empty_dir.go:40
+  should support (non-root,0666,tmpfs) [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSSSS
+------------------------------
+[sig-scheduling] SchedulerPredicates [Serial] 
+  validates resource limits of pods that are allowed to run  [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-scheduling] SchedulerPredicates [Serial]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:08:25.912: INFO: >>> kubeConfig: /tmp/kubeconfig-575984058
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-scheduling] SchedulerPredicates [Serial]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/scheduling/predicates.go:79
+Jul  2 13:08:25.991: INFO: Waiting up to 1m0s for all nodes to be ready
+Jul  2 13:09:26.012: INFO: Waiting for terminating namespaces to be deleted...
+Jul  2 13:09:26.017: INFO: Waiting up to 5m0s for all pods (need at least 0) in namespace 'kube-system' to be running and ready
+Jul  2 13:09:26.030: INFO: 14 / 14 pods in namespace 'kube-system' are running and ready (0 seconds elapsed)
+Jul  2 13:09:26.030: INFO: expected 8 pod replicas in namespace 'kube-system', 8 are Running and Ready.
+Jul  2 13:09:26.034: INFO: Waiting for pods to enter Success, but no pods in "kube-system" match label map[name:e2e-image-puller]
+Jul  2 13:09:26.034: INFO: 
+Logging pods the kubelet thinks is on node shoot--core--confos-worker-w6oh6-z1-59946c4f6c-2w6kp before test
+Jul  2 13:09:26.043: INFO: kube-proxy-qhrt7 from kube-system started at 2018-07-02 12:48:29 +0000 UTC (1 container statuses recorded)
+Jul  2 13:09:26.043: INFO: 	Container kube-proxy ready: true, restart count 0
+Jul  2 13:09:26.043: INFO: calico-node-s9p8b from kube-system started at 2018-07-02 12:48:29 +0000 UTC (2 container statuses recorded)
+Jul  2 13:09:26.043: INFO: 	Container calico-node ready: true, restart count 0
+Jul  2 13:09:26.043: INFO: 	Container install-cni ready: true, restart count 0
+Jul  2 13:09:26.043: INFO: node-exporter-xvs9p from kube-system started at 2018-07-02 12:48:29 +0000 UTC (1 container statuses recorded)
+Jul  2 13:09:26.043: INFO: 	Container node-exporter ready: true, restart count 0
+Jul  2 13:09:26.043: INFO: kube-dns-9c4dfc4fb-t986t from kube-system started at 2018-07-02 12:48:51 +0000 UTC (3 container statuses recorded)
+Jul  2 13:09:26.043: INFO: 	Container dnsmasq ready: true, restart count 0
+Jul  2 13:09:26.043: INFO: 	Container kubedns ready: true, restart count 0
+Jul  2 13:09:26.043: INFO: 	Container sidecar ready: true, restart count 0
+Jul  2 13:09:26.043: INFO: sonobuoy from sonobuoy started at 2018-07-02 12:53:36 +0000 UTC (1 container statuses recorded)
+Jul  2 13:09:26.044: INFO: 	Container kube-sonobuoy ready: true, restart count 0
+Jul  2 13:09:26.044: INFO: sonobuoy-e2e-job-bf7785bfa7874841 from sonobuoy started at 2018-07-02 12:53:52 +0000 UTC (2 container statuses recorded)
+Jul  2 13:09:26.044: INFO: 	Container e2e ready: true, restart count 0
+Jul  2 13:09:26.044: INFO: 	Container sonobuoy-worker ready: true, restart count 0
+Jul  2 13:09:26.044: INFO: 
+Logging pods the kubelet thinks is on node shoot--core--confos-worker-w6oh6-z1-59946c4f6c-znspz before test
+Jul  2 13:09:26.190: INFO: addons-kubernetes-dashboard-5486b968b7-cd62s from kube-system started at 2018-07-02 12:48:44 +0000 UTC (1 container statuses recorded)
+Jul  2 13:09:26.190: INFO: 	Container main ready: true, restart count 0
+Jul  2 13:09:26.190: INFO: kube-dns-9c4dfc4fb-b2hj2 from kube-system started at 2018-07-02 12:48:44 +0000 UTC (3 container statuses recorded)
+Jul  2 13:09:26.190: INFO: 	Container dnsmasq ready: true, restart count 0
+Jul  2 13:09:26.190: INFO: 	Container kubedns ready: true, restart count 0
+Jul  2 13:09:26.190: INFO: 	Container sidecar ready: true, restart count 0
+Jul  2 13:09:26.190: INFO: calico-node-smddt from kube-system started at 2018-07-02 12:48:23 +0000 UTC (2 container statuses recorded)
+Jul  2 13:09:26.190: INFO: 	Container calico-node ready: true, restart count 0
+Jul  2 13:09:26.190: INFO: 	Container install-cni ready: true, restart count 0
+Jul  2 13:09:26.190: INFO: kube-proxy-d4jrv from kube-system started at 2018-07-02 12:48:23 +0000 UTC (1 container statuses recorded)
+Jul  2 13:09:26.190: INFO: 	Container kube-proxy ready: true, restart count 0
+Jul  2 13:09:26.190: INFO: kube-dns-autoscaler-6dd4765967-wsgbv from kube-system started at 2018-07-02 12:48:44 +0000 UTC (1 container statuses recorded)
+Jul  2 13:09:26.190: INFO: 	Container autoscaler ready: true, restart count 0
+Jul  2 13:09:26.190: INFO: addons-heapster-e3b0c-64455ddddb-f7qqp from kube-system started at 2018-07-02 12:48:44 +0000 UTC (2 container statuses recorded)
+Jul  2 13:09:26.190: INFO: 	Container heapster ready: true, restart count 0
+Jul  2 13:09:26.190: INFO: 	Container heapster-nanny ready: true, restart count 0
+Jul  2 13:09:26.190: INFO: addons-nginx-ingress-nginx-ingress-k8s-backend-7b5569797f-7kzfj from kube-system started at 2018-07-02 12:48:44 +0000 UTC (1 container statuses recorded)
+Jul  2 13:09:26.190: INFO: 	Container nginx-ingress-nginx-ingress-k8s-backend ready: true, restart count 0
+Jul  2 13:09:26.190: INFO: node-exporter-f55cq from kube-system started at 2018-07-02 12:48:23 +0000 UTC (1 container statuses recorded)
+Jul  2 13:09:26.190: INFO: 	Container node-exporter ready: true, restart count 0
+Jul  2 13:09:26.190: INFO: vpn-shoot-b8c466986-fq5pc from kube-system started at 2018-07-02 12:48:44 +0000 UTC (1 container statuses recorded)
+Jul  2 13:09:26.190: INFO: 	Container vpn-shoot ready: true, restart count 0
+Jul  2 13:09:26.190: INFO: addons-nginx-ingress-controller-79bfb57974-kmxqj from kube-system started at 2018-07-02 12:48:44 +0000 UTC (1 container statuses recorded)
+Jul  2 13:09:26.190: INFO: 	Container nginx-ingress-controller ready: true, restart count 0
+[It] validates resource limits of pods that are allowed to run  [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: verifying the node has the label node shoot--core--confos-worker-w6oh6-z1-59946c4f6c-2w6kp
+STEP: verifying the node has the label node shoot--core--confos-worker-w6oh6-z1-59946c4f6c-znspz
+Jul  2 13:09:26.222: INFO: Pod addons-heapster-e3b0c-64455ddddb-f7qqp requesting resource cpu=50m on Node shoot--core--confos-worker-w6oh6-z1-59946c4f6c-znspz
+Jul  2 13:09:26.222: INFO: Pod addons-kubernetes-dashboard-5486b968b7-cd62s requesting resource cpu=50m on Node shoot--core--confos-worker-w6oh6-z1-59946c4f6c-znspz
+Jul  2 13:09:26.222: INFO: Pod addons-nginx-ingress-controller-79bfb57974-kmxqj requesting resource cpu=100m on Node shoot--core--confos-worker-w6oh6-z1-59946c4f6c-znspz
+Jul  2 13:09:26.222: INFO: Pod addons-nginx-ingress-nginx-ingress-k8s-backend-7b5569797f-7kzfj requesting resource cpu=0m on Node shoot--core--confos-worker-w6oh6-z1-59946c4f6c-znspz
+Jul  2 13:09:26.222: INFO: Pod calico-node-s9p8b requesting resource cpu=250m on Node shoot--core--confos-worker-w6oh6-z1-59946c4f6c-2w6kp
+Jul  2 13:09:26.222: INFO: Pod calico-node-smddt requesting resource cpu=250m on Node shoot--core--confos-worker-w6oh6-z1-59946c4f6c-znspz
+Jul  2 13:09:26.223: INFO: Pod kube-dns-9c4dfc4fb-b2hj2 requesting resource cpu=260m on Node shoot--core--confos-worker-w6oh6-z1-59946c4f6c-znspz
+Jul  2 13:09:26.223: INFO: Pod kube-dns-9c4dfc4fb-t986t requesting resource cpu=260m on Node shoot--core--confos-worker-w6oh6-z1-59946c4f6c-2w6kp
+Jul  2 13:09:26.223: INFO: Pod kube-dns-autoscaler-6dd4765967-wsgbv requesting resource cpu=20m on Node shoot--core--confos-worker-w6oh6-z1-59946c4f6c-znspz
+Jul  2 13:09:26.223: INFO: Pod kube-proxy-d4jrv requesting resource cpu=50m on Node shoot--core--confos-worker-w6oh6-z1-59946c4f6c-znspz
+Jul  2 13:09:26.223: INFO: Pod kube-proxy-qhrt7 requesting resource cpu=50m on Node shoot--core--confos-worker-w6oh6-z1-59946c4f6c-2w6kp
+Jul  2 13:09:26.223: INFO: Pod node-exporter-f55cq requesting resource cpu=10m on Node shoot--core--confos-worker-w6oh6-z1-59946c4f6c-znspz
+Jul  2 13:09:26.223: INFO: Pod node-exporter-xvs9p requesting resource cpu=10m on Node shoot--core--confos-worker-w6oh6-z1-59946c4f6c-2w6kp
+Jul  2 13:09:26.223: INFO: Pod vpn-shoot-b8c466986-fq5pc requesting resource cpu=100m on Node shoot--core--confos-worker-w6oh6-z1-59946c4f6c-znspz
+Jul  2 13:09:26.223: INFO: Pod sonobuoy requesting resource cpu=0m on Node shoot--core--confos-worker-w6oh6-z1-59946c4f6c-2w6kp
+Jul  2 13:09:26.223: INFO: Pod sonobuoy-e2e-job-bf7785bfa7874841 requesting resource cpu=0m on Node shoot--core--confos-worker-w6oh6-z1-59946c4f6c-2w6kp
+STEP: Starting Pods to consume most of the cluster CPU.
+STEP: Creating another pod that requires unavailable amount of CPU.
+STEP: Considering event: 
+Type = [Normal], Name = [filler-pod-2560f02d-7df9-11e8-b7a8-22e3071d17c7.153d8f42fddbe446], Reason = [Scheduled], Message = [Successfully assigned e2e-tests-sched-pred-vq9hp/filler-pod-2560f02d-7df9-11e8-b7a8-22e3071d17c7 to shoot--core--confos-worker-w6oh6-z1-59946c4f6c-2w6kp]
+STEP: Considering event: 
+Type = [Normal], Name = [filler-pod-2560f02d-7df9-11e8-b7a8-22e3071d17c7.153d8f432ad9f682], Reason = [Pulled], Message = [Container image "k8s.gcr.io/pause:3.1" already present on machine]
+STEP: Considering event: 
+Type = [Normal], Name = [filler-pod-2560f02d-7df9-11e8-b7a8-22e3071d17c7.153d8f432c5e12ae], Reason = [Created], Message = [Created container]
+STEP: Considering event: 
+Type = [Normal], Name = [filler-pod-2560f02d-7df9-11e8-b7a8-22e3071d17c7.153d8f4333cc69e3], Reason = [Started], Message = [Started container]
+STEP: Considering event: 
+Type = [Normal], Name = [filler-pod-256235c4-7df9-11e8-b7a8-22e3071d17c7.153d8f42fe17c7f9], Reason = [Scheduled], Message = [Successfully assigned e2e-tests-sched-pred-vq9hp/filler-pod-256235c4-7df9-11e8-b7a8-22e3071d17c7 to shoot--core--confos-worker-w6oh6-z1-59946c4f6c-znspz]
+STEP: Considering event: 
+Type = [Normal], Name = [filler-pod-256235c4-7df9-11e8-b7a8-22e3071d17c7.153d8f432d9a43cd], Reason = [Pulled], Message = [Container image "k8s.gcr.io/pause:3.1" already present on machine]
+STEP: Considering event: 
+Type = [Normal], Name = [filler-pod-256235c4-7df9-11e8-b7a8-22e3071d17c7.153d8f43301f1ea2], Reason = [Created], Message = [Created container]
+STEP: Considering event: 
+Type = [Normal], Name = [filler-pod-256235c4-7df9-11e8-b7a8-22e3071d17c7.153d8f43397a542d], Reason = [Started], Message = [Started container]
+STEP: Considering event: 
+Type = [Warning], Name = [additional-pod.153d8f43766543c8], Reason = [FailedScheduling], Message = [0/2 nodes are available: 2 Insufficient cpu.]
+STEP: removing the label node off the node shoot--core--confos-worker-w6oh6-z1-59946c4f6c-2w6kp
+STEP: verifying the node doesn't have the label node
+STEP: removing the label node off the node shoot--core--confos-worker-w6oh6-z1-59946c4f6c-znspz
+STEP: verifying the node doesn't have the label node
+[AfterEach] [sig-scheduling] SchedulerPredicates [Serial]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:09:29.288: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-sched-pred-vq9hp" for this suite.
+Jul  2 13:09:51.308: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:09:51.457: INFO: namespace: e2e-tests-sched-pred-vq9hp, resource: bindings, ignored listing per whitelist
+Jul  2 13:09:51.459: INFO: namespace e2e-tests-sched-pred-vq9hp deletion completed in 22.167143827s
+[AfterEach] [sig-scheduling] SchedulerPredicates [Serial]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/scheduling/predicates.go:70
+
+• [SLOW TEST:85.547 seconds]
+[sig-scheduling] SchedulerPredicates [Serial]
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/scheduling/framework.go:22
+  validates resource limits of pods that are allowed to run  [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSSSSSSSSSSSSSSSSSSSS
+------------------------------
+[sig-api-machinery] Garbage collector 
+  should orphan pods created by rc if delete options say so [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-api-machinery] Garbage collector
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:09:51.462: INFO: >>> kubeConfig: /tmp/kubeconfig-575984058
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should orphan pods created by rc if delete options say so [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: create the rc
+STEP: delete the rc
+STEP: wait for the rc to be deleted
+STEP: wait for 30 seconds to see if the garbage collector mistakenly deletes the pods
+STEP: Gathering metrics
+W0702 13:10:31.582243      16 metrics_grabber.go:81] Master node is not registered. Grabbing metrics from Scheduler, ControllerManager and ClusterAutoscaler is disabled.
+Jul  2 13:10:31.582: INFO: For apiserver_request_count:
+For apiserver_request_latencies_summary:
+For etcd_helper_cache_entry_count:
+For etcd_helper_cache_hit_count:
+For etcd_helper_cache_miss_count:
+For etcd_request_cache_add_latencies_summary:
+For etcd_request_cache_get_latencies_summary:
+For etcd_request_latencies_summary:
+For garbage_collector_attempt_to_delete_queue_latency:
+For garbage_collector_attempt_to_delete_work_duration:
+For garbage_collector_attempt_to_orphan_queue_latency:
+For garbage_collector_attempt_to_orphan_work_duration:
+For garbage_collector_dirty_processing_latency_microseconds:
+For garbage_collector_event_processing_latency_microseconds:
+For garbage_collector_graph_changes_queue_latency:
+For garbage_collector_graph_changes_work_duration:
+For garbage_collector_orphan_processing_latency_microseconds:
+For namespace_queue_latency:
+For namespace_queue_latency_sum:
+For namespace_queue_latency_count:
+For namespace_retries:
+For namespace_work_duration:
+For namespace_work_duration_sum:
+For namespace_work_duration_count:
+For function_duration_seconds:
+For errors_total:
+For evicted_pods_total:
+
+[AfterEach] [sig-api-machinery] Garbage collector
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:10:31.582: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-gc-br7k9" for this suite.
+Jul  2 13:10:37.599: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:10:37.665: INFO: namespace: e2e-tests-gc-br7k9, resource: bindings, ignored listing per whitelist
+Jul  2 13:10:37.699: INFO: namespace e2e-tests-gc-br7k9 deletion completed in 6.113761312s
+
+• [SLOW TEST:46.237 seconds]
+[sig-api-machinery] Garbage collector
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apimachinery/framework.go:22
+  should orphan pods created by rc if delete options say so [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SS
+------------------------------
+[sig-storage] Projected 
+  updates should be reflected in volume [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:10:37.699: INFO: >>> kubeConfig: /tmp/kubeconfig-575984058
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:858
+[It] updates should be reflected in volume [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating projection with configMap that has name projected-configmap-test-upd-50095afb-7df9-11e8-b7a8-22e3071d17c7
+STEP: Creating the pod
+STEP: Updating configmap projected-configmap-test-upd-50095afb-7df9-11e8-b7a8-22e3071d17c7
+STEP: waiting to observe update in volume
+[AfterEach] [sig-storage] Projected
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:10:43.971: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-zjx22" for this suite.
+Jul  2 13:11:05.989: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:11:06.033: INFO: namespace: e2e-tests-projected-zjx22, resource: bindings, ignored listing per whitelist
+Jul  2 13:11:06.085: INFO: namespace e2e-tests-projected-zjx22 deletion completed in 22.10933679s
+
+• [SLOW TEST:28.386 seconds]
+[sig-storage] Projected
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:34
+  updates should be reflected in volume [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+[sig-apps] Daemon set [Serial] 
+  should update pod when spec was updated and update strategy is RollingUpdate [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-apps] Daemon set [Serial]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:11:06.085: INFO: >>> kubeConfig: /tmp/kubeconfig-575984058
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-apps] Daemon set [Serial]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/daemon_set.go:99
+[It] should update pod when spec was updated and update strategy is RollingUpdate [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+Jul  2 13:11:06.182: INFO: Creating simple daemon set daemon-set
+STEP: Check that daemon pods launch on every node of the cluster.
+Jul  2 13:11:06.193: INFO: Number of nodes with available pods: 0
+Jul  2 13:11:06.193: INFO: Node shoot--core--confos-worker-w6oh6-z1-59946c4f6c-2w6kp is running more than one daemon pod
+Jul  2 13:11:07.278: INFO: Number of nodes with available pods: 0
+Jul  2 13:11:07.278: INFO: Node shoot--core--confos-worker-w6oh6-z1-59946c4f6c-2w6kp is running more than one daemon pod
+Jul  2 13:11:08.202: INFO: Number of nodes with available pods: 1
+Jul  2 13:11:08.202: INFO: Node shoot--core--confos-worker-w6oh6-z1-59946c4f6c-znspz is running more than one daemon pod
+Jul  2 13:11:09.201: INFO: Number of nodes with available pods: 2
+Jul  2 13:11:09.201: INFO: Number of running nodes: 2, number of available pods: 2
+STEP: Update daemon pods image.
+STEP: Check that daemon pods images are updated.
+Jul  2 13:11:09.222: INFO: Wrong image for pod: daemon-set-4tnrs. Expected: gcr.io/kubernetes-e2e-test-images/redis-amd64:1.0, got: gcr.io/kubernetes-e2e-test-images/serve-hostname-amd64:1.0.
+Jul  2 13:11:09.222: INFO: Wrong image for pod: daemon-set-gw4lx. Expected: gcr.io/kubernetes-e2e-test-images/redis-amd64:1.0, got: gcr.io/kubernetes-e2e-test-images/serve-hostname-amd64:1.0.
+Jul  2 13:11:10.234: INFO: Wrong image for pod: daemon-set-4tnrs. Expected: gcr.io/kubernetes-e2e-test-images/redis-amd64:1.0, got: gcr.io/kubernetes-e2e-test-images/serve-hostname-amd64:1.0.
+Jul  2 13:11:10.234: INFO: Wrong image for pod: daemon-set-gw4lx. Expected: gcr.io/kubernetes-e2e-test-images/redis-amd64:1.0, got: gcr.io/kubernetes-e2e-test-images/serve-hostname-amd64:1.0.
+Jul  2 13:11:11.234: INFO: Wrong image for pod: daemon-set-4tnrs. Expected: gcr.io/kubernetes-e2e-test-images/redis-amd64:1.0, got: gcr.io/kubernetes-e2e-test-images/serve-hostname-amd64:1.0.
+Jul  2 13:11:11.234: INFO: Wrong image for pod: daemon-set-gw4lx. Expected: gcr.io/kubernetes-e2e-test-images/redis-amd64:1.0, got: gcr.io/kubernetes-e2e-test-images/serve-hostname-amd64:1.0.
+Jul  2 13:11:11.234: INFO: Pod daemon-set-gw4lx is not available
+Jul  2 13:11:12.234: INFO: Wrong image for pod: daemon-set-4tnrs. Expected: gcr.io/kubernetes-e2e-test-images/redis-amd64:1.0, got: gcr.io/kubernetes-e2e-test-images/serve-hostname-amd64:1.0.
+Jul  2 13:11:12.234: INFO: Wrong image for pod: daemon-set-gw4lx. Expected: gcr.io/kubernetes-e2e-test-images/redis-amd64:1.0, got: gcr.io/kubernetes-e2e-test-images/serve-hostname-amd64:1.0.
+Jul  2 13:11:12.234: INFO: Pod daemon-set-gw4lx is not available
+Jul  2 13:11:13.235: INFO: Wrong image for pod: daemon-set-4tnrs. Expected: gcr.io/kubernetes-e2e-test-images/redis-amd64:1.0, got: gcr.io/kubernetes-e2e-test-images/serve-hostname-amd64:1.0.
+Jul  2 13:11:13.235: INFO: Wrong image for pod: daemon-set-gw4lx. Expected: gcr.io/kubernetes-e2e-test-images/redis-amd64:1.0, got: gcr.io/kubernetes-e2e-test-images/serve-hostname-amd64:1.0.
+Jul  2 13:11:13.235: INFO: Pod daemon-set-gw4lx is not available
+Jul  2 13:11:14.235: INFO: Wrong image for pod: daemon-set-4tnrs. Expected: gcr.io/kubernetes-e2e-test-images/redis-amd64:1.0, got: gcr.io/kubernetes-e2e-test-images/serve-hostname-amd64:1.0.
+Jul  2 13:11:14.235: INFO: Wrong image for pod: daemon-set-gw4lx. Expected: gcr.io/kubernetes-e2e-test-images/redis-amd64:1.0, got: gcr.io/kubernetes-e2e-test-images/serve-hostname-amd64:1.0.
+Jul  2 13:11:14.235: INFO: Pod daemon-set-gw4lx is not available
+Jul  2 13:11:15.234: INFO: Wrong image for pod: daemon-set-4tnrs. Expected: gcr.io/kubernetes-e2e-test-images/redis-amd64:1.0, got: gcr.io/kubernetes-e2e-test-images/serve-hostname-amd64:1.0.
+Jul  2 13:11:15.234: INFO: Wrong image for pod: daemon-set-gw4lx. Expected: gcr.io/kubernetes-e2e-test-images/redis-amd64:1.0, got: gcr.io/kubernetes-e2e-test-images/serve-hostname-amd64:1.0.
+Jul  2 13:11:15.234: INFO: Pod daemon-set-gw4lx is not available
+Jul  2 13:11:16.235: INFO: Wrong image for pod: daemon-set-4tnrs. Expected: gcr.io/kubernetes-e2e-test-images/redis-amd64:1.0, got: gcr.io/kubernetes-e2e-test-images/serve-hostname-amd64:1.0.
+Jul  2 13:11:16.235: INFO: Wrong image for pod: daemon-set-gw4lx. Expected: gcr.io/kubernetes-e2e-test-images/redis-amd64:1.0, got: gcr.io/kubernetes-e2e-test-images/serve-hostname-amd64:1.0.
+Jul  2 13:11:16.235: INFO: Pod daemon-set-gw4lx is not available
+Jul  2 13:11:17.234: INFO: Wrong image for pod: daemon-set-4tnrs. Expected: gcr.io/kubernetes-e2e-test-images/redis-amd64:1.0, got: gcr.io/kubernetes-e2e-test-images/serve-hostname-amd64:1.0.
+Jul  2 13:11:17.235: INFO: Wrong image for pod: daemon-set-gw4lx. Expected: gcr.io/kubernetes-e2e-test-images/redis-amd64:1.0, got: gcr.io/kubernetes-e2e-test-images/serve-hostname-amd64:1.0.
+Jul  2 13:11:17.235: INFO: Pod daemon-set-gw4lx is not available
+Jul  2 13:11:18.235: INFO: Wrong image for pod: daemon-set-4tnrs. Expected: gcr.io/kubernetes-e2e-test-images/redis-amd64:1.0, got: gcr.io/kubernetes-e2e-test-images/serve-hostname-amd64:1.0.
+Jul  2 13:11:18.235: INFO: Pod daemon-set-s5xtl is not available
+Jul  2 13:11:19.234: INFO: Wrong image for pod: daemon-set-4tnrs. Expected: gcr.io/kubernetes-e2e-test-images/redis-amd64:1.0, got: gcr.io/kubernetes-e2e-test-images/serve-hostname-amd64:1.0.
+Jul  2 13:11:19.234: INFO: Pod daemon-set-s5xtl is not available
+Jul  2 13:11:20.234: INFO: Wrong image for pod: daemon-set-4tnrs. Expected: gcr.io/kubernetes-e2e-test-images/redis-amd64:1.0, got: gcr.io/kubernetes-e2e-test-images/serve-hostname-amd64:1.0.
+Jul  2 13:11:21.235: INFO: Wrong image for pod: daemon-set-4tnrs. Expected: gcr.io/kubernetes-e2e-test-images/redis-amd64:1.0, got: gcr.io/kubernetes-e2e-test-images/serve-hostname-amd64:1.0.
+Jul  2 13:11:22.265: INFO: Wrong image for pod: daemon-set-4tnrs. Expected: gcr.io/kubernetes-e2e-test-images/redis-amd64:1.0, got: gcr.io/kubernetes-e2e-test-images/serve-hostname-amd64:1.0.
+Jul  2 13:11:22.265: INFO: Pod daemon-set-4tnrs is not available
+Jul  2 13:11:23.234: INFO: Wrong image for pod: daemon-set-4tnrs. Expected: gcr.io/kubernetes-e2e-test-images/redis-amd64:1.0, got: gcr.io/kubernetes-e2e-test-images/serve-hostname-amd64:1.0.
+Jul  2 13:11:23.234: INFO: Pod daemon-set-4tnrs is not available
+Jul  2 13:11:24.234: INFO: Wrong image for pod: daemon-set-4tnrs. Expected: gcr.io/kubernetes-e2e-test-images/redis-amd64:1.0, got: gcr.io/kubernetes-e2e-test-images/serve-hostname-amd64:1.0.
+Jul  2 13:11:24.234: INFO: Pod daemon-set-4tnrs is not available
+Jul  2 13:11:25.234: INFO: Wrong image for pod: daemon-set-4tnrs. Expected: gcr.io/kubernetes-e2e-test-images/redis-amd64:1.0, got: gcr.io/kubernetes-e2e-test-images/serve-hostname-amd64:1.0.
+Jul  2 13:11:25.234: INFO: Pod daemon-set-4tnrs is not available
+Jul  2 13:11:26.234: INFO: Wrong image for pod: daemon-set-4tnrs. Expected: gcr.io/kubernetes-e2e-test-images/redis-amd64:1.0, got: gcr.io/kubernetes-e2e-test-images/serve-hostname-amd64:1.0.
+Jul  2 13:11:26.234: INFO: Pod daemon-set-4tnrs is not available
+Jul  2 13:11:27.234: INFO: Wrong image for pod: daemon-set-4tnrs. Expected: gcr.io/kubernetes-e2e-test-images/redis-amd64:1.0, got: gcr.io/kubernetes-e2e-test-images/serve-hostname-amd64:1.0.
+Jul  2 13:11:27.235: INFO: Pod daemon-set-4tnrs is not available
+Jul  2 13:11:28.234: INFO: Wrong image for pod: daemon-set-4tnrs. Expected: gcr.io/kubernetes-e2e-test-images/redis-amd64:1.0, got: gcr.io/kubernetes-e2e-test-images/serve-hostname-amd64:1.0.
+Jul  2 13:11:28.235: INFO: Pod daemon-set-4tnrs is not available
+Jul  2 13:11:29.234: INFO: Wrong image for pod: daemon-set-4tnrs. Expected: gcr.io/kubernetes-e2e-test-images/redis-amd64:1.0, got: gcr.io/kubernetes-e2e-test-images/serve-hostname-amd64:1.0.
+Jul  2 13:11:29.234: INFO: Pod daemon-set-4tnrs is not available
+Jul  2 13:11:30.234: INFO: Wrong image for pod: daemon-set-4tnrs. Expected: gcr.io/kubernetes-e2e-test-images/redis-amd64:1.0, got: gcr.io/kubernetes-e2e-test-images/serve-hostname-amd64:1.0.
+Jul  2 13:11:30.234: INFO: Pod daemon-set-4tnrs is not available
+Jul  2 13:11:31.235: INFO: Wrong image for pod: daemon-set-4tnrs. Expected: gcr.io/kubernetes-e2e-test-images/redis-amd64:1.0, got: gcr.io/kubernetes-e2e-test-images/serve-hostname-amd64:1.0.
+Jul  2 13:11:31.235: INFO: Pod daemon-set-4tnrs is not available
+Jul  2 13:11:32.265: INFO: Wrong image for pod: daemon-set-4tnrs. Expected: gcr.io/kubernetes-e2e-test-images/redis-amd64:1.0, got: gcr.io/kubernetes-e2e-test-images/serve-hostname-amd64:1.0.
+Jul  2 13:11:32.265: INFO: Pod daemon-set-4tnrs is not available
+Jul  2 13:11:33.233: INFO: Pod daemon-set-w9gjg is not available
+STEP: Check that daemon pods are still running on every node of the cluster.
+Jul  2 13:11:33.243: INFO: Number of nodes with available pods: 1
+Jul  2 13:11:33.243: INFO: Node shoot--core--confos-worker-w6oh6-z1-59946c4f6c-znspz is running more than one daemon pod
+Jul  2 13:11:34.250: INFO: Number of nodes with available pods: 1
+Jul  2 13:11:34.250: INFO: Node shoot--core--confos-worker-w6oh6-z1-59946c4f6c-znspz is running more than one daemon pod
+Jul  2 13:11:35.251: INFO: Number of nodes with available pods: 2
+Jul  2 13:11:35.251: INFO: Number of running nodes: 2, number of available pods: 2
+[AfterEach] [sig-apps] Daemon set [Serial]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/daemon_set.go:65
+STEP: Deleting DaemonSet "daemon-set"
+STEP: deleting {extensions DaemonSet} daemon-set in namespace e2e-tests-daemonsets-t7rh9, will wait for the garbage collector to delete the pods
+Jul  2 13:11:35.334: INFO: Deleting {extensions DaemonSet} daemon-set took: 5.743681ms
+Jul  2 13:11:35.435: INFO: Terminating {extensions DaemonSet} daemon-set pods took: 100.174683ms
+Jul  2 13:11:48.039: INFO: Number of nodes with available pods: 0
+Jul  2 13:11:48.039: INFO: Number of running nodes: 0, number of available pods: 0
+Jul  2 13:11:48.042: INFO: daemonset: {"kind":"DaemonSetList","apiVersion":"apps/v1","metadata":{"selfLink":"/apis/apps/v1/namespaces/e2e-tests-daemonsets-t7rh9/daemonsets","resourceVersion":"4473"},"items":null}
+
+Jul  2 13:11:48.045: INFO: pods: {"kind":"PodList","apiVersion":"v1","metadata":{"selfLink":"/api/v1/namespaces/e2e-tests-daemonsets-t7rh9/pods","resourceVersion":"4473"},"items":null}
+
+[AfterEach] [sig-apps] Daemon set [Serial]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:11:48.053: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-daemonsets-t7rh9" for this suite.
+Jul  2 13:11:54.067: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:11:54.165: INFO: namespace: e2e-tests-daemonsets-t7rh9, resource: bindings, ignored listing per whitelist
+Jul  2 13:11:54.319: INFO: namespace e2e-tests-daemonsets-t7rh9 deletion completed in 6.262487056s
+
+• [SLOW TEST:48.234 seconds]
+[sig-apps] Daemon set [Serial]
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/framework.go:22
+  should update pod when spec was updated and update strategy is RollingUpdate [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+S
+------------------------------
+[sig-storage] Projected 
+  should provide node allocatable (memory) as default memory limit if the limit is not set [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:11:54.319: INFO: >>> kubeConfig: /tmp/kubeconfig-575984058
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:858
+[It] should provide node allocatable (memory) as default memory limit if the limit is not set [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating a pod to test downward API volume plugin
+Jul  2 13:11:54.406: INFO: Waiting up to 5m0s for pod "downwardapi-volume-7db30121-7df9-11e8-b7a8-22e3071d17c7" in namespace "e2e-tests-projected-49kkf" to be "success or failure"
+Jul  2 13:11:54.409: INFO: Pod "downwardapi-volume-7db30121-7df9-11e8-b7a8-22e3071d17c7": Phase="Pending", Reason="", readiness=false. Elapsed: 2.946859ms
+Jul  2 13:11:56.413: INFO: Pod "downwardapi-volume-7db30121-7df9-11e8-b7a8-22e3071d17c7": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.007584608s
+STEP: Saw pod success
+Jul  2 13:11:56.413: INFO: Pod "downwardapi-volume-7db30121-7df9-11e8-b7a8-22e3071d17c7" satisfied condition "success or failure"
+Jul  2 13:11:56.465: INFO: Trying to get logs from node shoot--core--confos-worker-w6oh6-z1-59946c4f6c-2w6kp pod downwardapi-volume-7db30121-7df9-11e8-b7a8-22e3071d17c7 container client-container: <nil>
+STEP: delete the pod
+Jul  2 13:11:56.481: INFO: Waiting for pod downwardapi-volume-7db30121-7df9-11e8-b7a8-22e3071d17c7 to disappear
+Jul  2 13:11:56.492: INFO: Pod downwardapi-volume-7db30121-7df9-11e8-b7a8-22e3071d17c7 no longer exists
+[AfterEach] [sig-storage] Projected
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:11:56.492: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-49kkf" for this suite.
+Jul  2 13:12:02.565: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:12:02.612: INFO: namespace: e2e-tests-projected-49kkf, resource: bindings, ignored listing per whitelist
+Jul  2 13:12:02.737: INFO: namespace e2e-tests-projected-49kkf deletion completed in 6.238705751s
+
+• [SLOW TEST:8.418 seconds]
+[sig-storage] Projected
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:34
+  should provide node allocatable (memory) as default memory limit if the limit is not set [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSS
+------------------------------
+[sig-apps] Daemon set [Serial] 
+  should retry creating failed daemon pods [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-apps] Daemon set [Serial]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:12:02.737: INFO: >>> kubeConfig: /tmp/kubeconfig-575984058
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-apps] Daemon set [Serial]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/daemon_set.go:99
+[It] should retry creating failed daemon pods [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating a simple DaemonSet "daemon-set"
+STEP: Check that daemon pods launch on every node of the cluster.
+Jul  2 13:12:02.832: INFO: Number of nodes with available pods: 0
+Jul  2 13:12:02.832: INFO: Node shoot--core--confos-worker-w6oh6-z1-59946c4f6c-2w6kp is running more than one daemon pod
+Jul  2 13:12:03.840: INFO: Number of nodes with available pods: 0
+Jul  2 13:12:03.840: INFO: Node shoot--core--confos-worker-w6oh6-z1-59946c4f6c-2w6kp is running more than one daemon pod
+Jul  2 13:12:04.841: INFO: Number of nodes with available pods: 2
+Jul  2 13:12:04.841: INFO: Number of running nodes: 2, number of available pods: 2
+STEP: Set a daemon pod's phase to 'Failed', check that the daemon pod is revived.
+Jul  2 13:12:04.858: INFO: Number of nodes with available pods: 1
+Jul  2 13:12:04.858: INFO: Node shoot--core--confos-worker-w6oh6-z1-59946c4f6c-2w6kp is running more than one daemon pod
+Jul  2 13:12:05.867: INFO: Number of nodes with available pods: 1
+Jul  2 13:12:05.867: INFO: Node shoot--core--confos-worker-w6oh6-z1-59946c4f6c-2w6kp is running more than one daemon pod
+Jul  2 13:12:06.867: INFO: Number of nodes with available pods: 2
+Jul  2 13:12:06.867: INFO: Number of running nodes: 2, number of available pods: 2
+STEP: Wait for the failed daemon pod to be completely deleted.
+[AfterEach] [sig-apps] Daemon set [Serial]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/daemon_set.go:65
+STEP: Deleting DaemonSet "daemon-set"
+STEP: deleting {extensions DaemonSet} daemon-set in namespace e2e-tests-daemonsets-g6dtt, will wait for the garbage collector to delete the pods
+Jul  2 13:12:06.931: INFO: Deleting {extensions DaemonSet} daemon-set took: 6.737852ms
+Jul  2 13:12:07.032: INFO: Terminating {extensions DaemonSet} daemon-set pods took: 100.223442ms
+Jul  2 13:12:10.636: INFO: Number of nodes with available pods: 0
+Jul  2 13:12:10.636: INFO: Number of running nodes: 0, number of available pods: 0
+Jul  2 13:12:10.639: INFO: daemonset: {"kind":"DaemonSetList","apiVersion":"apps/v1","metadata":{"selfLink":"/apis/apps/v1/namespaces/e2e-tests-daemonsets-g6dtt/daemonsets","resourceVersion":"4574"},"items":null}
+
+Jul  2 13:12:10.642: INFO: pods: {"kind":"PodList","apiVersion":"v1","metadata":{"selfLink":"/api/v1/namespaces/e2e-tests-daemonsets-g6dtt/pods","resourceVersion":"4574"},"items":null}
+
+[AfterEach] [sig-apps] Daemon set [Serial]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:12:10.651: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-daemonsets-g6dtt" for this suite.
+Jul  2 13:12:16.665: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:12:16.748: INFO: namespace: e2e-tests-daemonsets-g6dtt, resource: bindings, ignored listing per whitelist
+Jul  2 13:12:16.853: INFO: namespace e2e-tests-daemonsets-g6dtt deletion completed in 6.198161588s
+
+• [SLOW TEST:14.116 seconds]
+[sig-apps] Daemon set [Serial]
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/framework.go:22
+  should retry creating failed daemon pods [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSS
+------------------------------
+[sig-apps] StatefulSet [k8s.io] Basic StatefulSet functionality [StatefulSetBasic] 
+  should perform canary updates and phased rolling updates of template modifications [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-apps] StatefulSet
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:12:16.853: INFO: >>> kubeConfig: /tmp/kubeconfig-575984058
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-apps] StatefulSet
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/statefulset.go:57
+[BeforeEach] [k8s.io] Basic StatefulSet functionality [StatefulSetBasic]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/statefulset.go:72
+STEP: Creating service test in namespace e2e-tests-statefulset-pkxwh
+[It] should perform canary updates and phased rolling updates of template modifications [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating a new StaefulSet
+Jul  2 13:12:16.947: INFO: Found 0 stateful pods, waiting for 3
+Jul  2 13:12:26.981: INFO: Waiting for pod ss2-0 to enter Running - Ready=true, currently Running - Ready=true
+Jul  2 13:12:26.981: INFO: Waiting for pod ss2-1 to enter Running - Ready=true, currently Running - Ready=true
+Jul  2 13:12:26.981: INFO: Waiting for pod ss2-2 to enter Running - Ready=true, currently Running - Ready=true
+STEP: Updating stateful set template: update image from k8s.gcr.io/nginx-slim-amd64:0.20 to k8s.gcr.io/nginx-slim-amd64:0.21
+Jul  2 13:12:27.008: INFO: Updating stateful set ss2
+STEP: Creating a new revision
+STEP: Not applying an update when the partition is greater than the number of replicas
+STEP: Performing a canary update
+Jul  2 13:12:37.039: INFO: Updating stateful set ss2
+Jul  2 13:12:37.045: INFO: Waiting for Pod e2e-tests-statefulset-pkxwh/ss2-2 to have revision ss2-56dd5fb9c4 update revision ss2-76cb68b6ff
+Jul  2 13:12:47.070: INFO: Waiting for Pod e2e-tests-statefulset-pkxwh/ss2-2 to have revision ss2-56dd5fb9c4 update revision ss2-76cb68b6ff
+STEP: Restoring Pods to the correct revision when they are deleted
+Jul  2 13:12:57.130: INFO: Found 2 stateful pods, waiting for 3
+Jul  2 13:13:07.165: INFO: Waiting for pod ss2-0 to enter Running - Ready=true, currently Running - Ready=true
+Jul  2 13:13:07.165: INFO: Waiting for pod ss2-1 to enter Running - Ready=true, currently Running - Ready=true
+Jul  2 13:13:07.165: INFO: Waiting for pod ss2-2 to enter Running - Ready=true, currently Running - Ready=true
+STEP: Performing a phased rolling update
+Jul  2 13:13:07.190: INFO: Updating stateful set ss2
+Jul  2 13:13:07.198: INFO: Waiting for Pod e2e-tests-statefulset-pkxwh/ss2-1 to have revision ss2-56dd5fb9c4 update revision ss2-76cb68b6ff
+Jul  2 13:13:17.222: INFO: Updating stateful set ss2
+Jul  2 13:13:17.228: INFO: Waiting for StatefulSet e2e-tests-statefulset-pkxwh/ss2 to complete update
+Jul  2 13:13:17.229: INFO: Waiting for Pod e2e-tests-statefulset-pkxwh/ss2-0 to have revision ss2-56dd5fb9c4 update revision ss2-76cb68b6ff
+Jul  2 13:13:27.238: INFO: Waiting for StatefulSet e2e-tests-statefulset-pkxwh/ss2 to complete update
+Jul  2 13:13:27.238: INFO: Waiting for Pod e2e-tests-statefulset-pkxwh/ss2-0 to have revision ss2-56dd5fb9c4 update revision ss2-76cb68b6ff
+[AfterEach] [k8s.io] Basic StatefulSet functionality [StatefulSetBasic]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/statefulset.go:83
+Jul  2 13:13:37.279: INFO: Deleting all statefulset in ns e2e-tests-statefulset-pkxwh
+Jul  2 13:13:37.282: INFO: Scaling statefulset ss2 to 0
+Jul  2 13:13:57.296: INFO: Waiting for statefulset status.replicas updated to 0
+Jul  2 13:13:57.299: INFO: Deleting statefulset ss2
+[AfterEach] [sig-apps] StatefulSet
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:13:57.377: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-statefulset-pkxwh" for this suite.
+Jul  2 13:14:03.391: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:14:03.405: INFO: namespace: e2e-tests-statefulset-pkxwh, resource: bindings, ignored listing per whitelist
+Jul  2 13:14:03.485: INFO: namespace e2e-tests-statefulset-pkxwh deletion completed in 6.103854775s
+
+• [SLOW TEST:106.632 seconds]
+[sig-apps] StatefulSet
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/framework.go:22
+  [k8s.io] Basic StatefulSet functionality [StatefulSetBasic]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:679
+    should perform canary updates and phased rolling updates of template modifications [Conformance]
+    /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SS
+------------------------------
+[k8s.io] Pods 
+  should get a host IP [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [k8s.io] Pods
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:14:03.485: INFO: >>> kubeConfig: /tmp/kubeconfig-575984058
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [k8s.io] Pods
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/pods.go:127
+[It] should get a host IP [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: creating pod
+Jul  2 13:14:05.590: INFO: Pod pod-hostip-cab0dc39-7df9-11e8-b7a8-22e3071d17c7 has hostIP: 10.250.0.17
+[AfterEach] [k8s.io] Pods
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:14:05.590: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-pods-wsjld" for this suite.
+Jul  2 13:14:27.605: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:14:27.671: INFO: namespace: e2e-tests-pods-wsjld, resource: bindings, ignored listing per whitelist
+Jul  2 13:14:27.717: INFO: namespace e2e-tests-pods-wsjld deletion completed in 22.123415202s
+
+• [SLOW TEST:24.233 seconds]
+[k8s.io] Pods
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:679
+  should get a host IP [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSSS
+------------------------------
+[sig-storage] EmptyDir volumes 
+  should support (root,0777,tmpfs) [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-storage] EmptyDir volumes
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:14:27.718: INFO: >>> kubeConfig: /tmp/kubeconfig-575984058
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should support (root,0777,tmpfs) [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating a pod to test emptydir 0777 on tmpfs
+Jul  2 13:14:27.817: INFO: Waiting up to 5m0s for pod "pod-d923a570-7df9-11e8-b7a8-22e3071d17c7" in namespace "e2e-tests-emptydir-sgqkr" to be "success or failure"
+Jul  2 13:14:27.821: INFO: Pod "pod-d923a570-7df9-11e8-b7a8-22e3071d17c7": Phase="Pending", Reason="", readiness=false. Elapsed: 4.719771ms
+Jul  2 13:14:29.864: INFO: Pod "pod-d923a570-7df9-11e8-b7a8-22e3071d17c7": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.047658524s
+STEP: Saw pod success
+Jul  2 13:14:29.865: INFO: Pod "pod-d923a570-7df9-11e8-b7a8-22e3071d17c7" satisfied condition "success or failure"
+Jul  2 13:14:29.868: INFO: Trying to get logs from node shoot--core--confos-worker-w6oh6-z1-59946c4f6c-2w6kp pod pod-d923a570-7df9-11e8-b7a8-22e3071d17c7 container test-container: <nil>
+STEP: delete the pod
+Jul  2 13:14:29.885: INFO: Waiting for pod pod-d923a570-7df9-11e8-b7a8-22e3071d17c7 to disappear
+Jul  2 13:14:29.893: INFO: Pod pod-d923a570-7df9-11e8-b7a8-22e3071d17c7 no longer exists
+[AfterEach] [sig-storage] EmptyDir volumes
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:14:29.893: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-emptydir-sgqkr" for this suite.
+Jul  2 13:14:35.916: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:14:35.935: INFO: namespace: e2e-tests-emptydir-sgqkr, resource: bindings, ignored listing per whitelist
+Jul  2 13:14:36.014: INFO: namespace e2e-tests-emptydir-sgqkr deletion completed in 6.110185502s
+
+• [SLOW TEST:8.296 seconds]
+[sig-storage] EmptyDir volumes
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/empty_dir.go:40
+  should support (root,0777,tmpfs) [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSSS
+------------------------------
+[sig-apps] Daemon set [Serial] 
+  should run and stop complex daemon [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-apps] Daemon set [Serial]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:14:36.014: INFO: >>> kubeConfig: /tmp/kubeconfig-575984058
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-apps] Daemon set [Serial]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/daemon_set.go:99
+[It] should run and stop complex daemon [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+Jul  2 13:14:36.103: INFO: Creating daemon "daemon-set" with a node selector
+STEP: Initially, daemon pods should not be running on any nodes.
+Jul  2 13:14:36.109: INFO: Number of nodes with available pods: 0
+Jul  2 13:14:36.109: INFO: Number of running nodes: 0, number of available pods: 0
+STEP: Change node label to blue, check that daemon pod is launched.
+Jul  2 13:14:36.129: INFO: Number of nodes with available pods: 0
+Jul  2 13:14:36.129: INFO: Node shoot--core--confos-worker-w6oh6-z1-59946c4f6c-2w6kp is running more than one daemon pod
+Jul  2 13:14:37.133: INFO: Number of nodes with available pods: 0
+Jul  2 13:14:37.133: INFO: Node shoot--core--confos-worker-w6oh6-z1-59946c4f6c-2w6kp is running more than one daemon pod
+Jul  2 13:14:38.133: INFO: Number of nodes with available pods: 1
+Jul  2 13:14:38.133: INFO: Number of running nodes: 1, number of available pods: 1
+STEP: Update the node label to green, and wait for daemons to be unscheduled
+Jul  2 13:14:38.148: INFO: Number of nodes with available pods: 1
+Jul  2 13:14:38.148: INFO: Number of running nodes: 0, number of available pods: 1
+Jul  2 13:14:39.171: INFO: Number of nodes with available pods: 0
+Jul  2 13:14:39.171: INFO: Number of running nodes: 0, number of available pods: 0
+STEP: Update DaemonSet node selector to green, and change its update strategy to RollingUpdate
+Jul  2 13:14:39.179: INFO: Number of nodes with available pods: 0
+Jul  2 13:14:39.179: INFO: Node shoot--core--confos-worker-w6oh6-z1-59946c4f6c-2w6kp is running more than one daemon pod
+Jul  2 13:14:40.183: INFO: Number of nodes with available pods: 0
+Jul  2 13:14:40.183: INFO: Node shoot--core--confos-worker-w6oh6-z1-59946c4f6c-2w6kp is running more than one daemon pod
+Jul  2 13:14:41.183: INFO: Number of nodes with available pods: 0
+Jul  2 13:14:41.183: INFO: Node shoot--core--confos-worker-w6oh6-z1-59946c4f6c-2w6kp is running more than one daemon pod
+Jul  2 13:14:42.183: INFO: Number of nodes with available pods: 0
+Jul  2 13:14:42.183: INFO: Node shoot--core--confos-worker-w6oh6-z1-59946c4f6c-2w6kp is running more than one daemon pod
+Jul  2 13:14:43.183: INFO: Number of nodes with available pods: 0
+Jul  2 13:14:43.183: INFO: Node shoot--core--confos-worker-w6oh6-z1-59946c4f6c-2w6kp is running more than one daemon pod
+Jul  2 13:14:44.182: INFO: Number of nodes with available pods: 0
+Jul  2 13:14:44.182: INFO: Node shoot--core--confos-worker-w6oh6-z1-59946c4f6c-2w6kp is running more than one daemon pod
+Jul  2 13:14:45.183: INFO: Number of nodes with available pods: 0
+Jul  2 13:14:45.183: INFO: Node shoot--core--confos-worker-w6oh6-z1-59946c4f6c-2w6kp is running more than one daemon pod
+Jul  2 13:14:46.183: INFO: Number of nodes with available pods: 0
+Jul  2 13:14:46.183: INFO: Node shoot--core--confos-worker-w6oh6-z1-59946c4f6c-2w6kp is running more than one daemon pod
+Jul  2 13:14:47.184: INFO: Number of nodes with available pods: 0
+Jul  2 13:14:47.184: INFO: Node shoot--core--confos-worker-w6oh6-z1-59946c4f6c-2w6kp is running more than one daemon pod
+Jul  2 13:14:48.182: INFO: Number of nodes with available pods: 0
+Jul  2 13:14:48.182: INFO: Node shoot--core--confos-worker-w6oh6-z1-59946c4f6c-2w6kp is running more than one daemon pod
+Jul  2 13:14:49.182: INFO: Number of nodes with available pods: 1
+Jul  2 13:14:49.183: INFO: Number of running nodes: 1, number of available pods: 1
+[AfterEach] [sig-apps] Daemon set [Serial]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/daemon_set.go:65
+STEP: Deleting DaemonSet "daemon-set"
+STEP: deleting {extensions DaemonSet} daemon-set in namespace e2e-tests-daemonsets-7vng4, will wait for the garbage collector to delete the pods
+Jul  2 13:14:49.246: INFO: Deleting {extensions DaemonSet} daemon-set took: 5.599804ms
+Jul  2 13:14:49.346: INFO: Terminating {extensions DaemonSet} daemon-set pods took: 100.196277ms
+Jul  2 13:14:52.151: INFO: Number of nodes with available pods: 0
+Jul  2 13:14:52.151: INFO: Number of running nodes: 0, number of available pods: 0
+Jul  2 13:14:52.154: INFO: daemonset: {"kind":"DaemonSetList","apiVersion":"apps/v1","metadata":{"selfLink":"/apis/apps/v1/namespaces/e2e-tests-daemonsets-7vng4/daemonsets","resourceVersion":"5137"},"items":null}
+
+Jul  2 13:14:52.157: INFO: pods: {"kind":"PodList","apiVersion":"v1","metadata":{"selfLink":"/api/v1/namespaces/e2e-tests-daemonsets-7vng4/pods","resourceVersion":"5137"},"items":null}
+
+[AfterEach] [sig-apps] Daemon set [Serial]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:14:52.174: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-daemonsets-7vng4" for this suite.
+Jul  2 13:14:58.200: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:14:58.400: INFO: namespace: e2e-tests-daemonsets-7vng4, resource: bindings, ignored listing per whitelist
+Jul  2 13:14:58.414: INFO: namespace e2e-tests-daemonsets-7vng4 deletion completed in 6.236093635s
+
+• [SLOW TEST:22.400 seconds]
+[sig-apps] Daemon set [Serial]
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/framework.go:22
+  should run and stop complex daemon [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSSSSSSS
+------------------------------
+[sig-apps] ReplicaSet 
+  should serve a basic image on each replica with a public image  [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-apps] ReplicaSet
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:14:58.416: INFO: >>> kubeConfig: /tmp/kubeconfig-575984058
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should serve a basic image on each replica with a public image  [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+Jul  2 13:14:58.497: INFO: Creating ReplicaSet my-hostname-basic-eb6dee92-7df9-11e8-b7a8-22e3071d17c7
+Jul  2 13:14:58.504: INFO: Pod name my-hostname-basic-eb6dee92-7df9-11e8-b7a8-22e3071d17c7: Found 0 pods out of 1
+Jul  2 13:15:03.509: INFO: Pod name my-hostname-basic-eb6dee92-7df9-11e8-b7a8-22e3071d17c7: Found 1 pods out of 1
+Jul  2 13:15:03.509: INFO: Ensuring a pod for ReplicaSet "my-hostname-basic-eb6dee92-7df9-11e8-b7a8-22e3071d17c7" is running
+Jul  2 13:15:03.513: INFO: Pod "my-hostname-basic-eb6dee92-7df9-11e8-b7a8-22e3071d17c7-m4777" is running (conditions: [{Type:Initialized Status:True LastProbeTime:0001-01-01 00:00:00 +0000 UTC LastTransitionTime:2018-07-02 13:14:58 +0000 UTC Reason: Message:} {Type:Ready Status:True LastProbeTime:0001-01-01 00:00:00 +0000 UTC LastTransitionTime:2018-07-02 13:15:00 +0000 UTC Reason: Message:} {Type:ContainersReady Status:True LastProbeTime:0001-01-01 00:00:00 +0000 UTC LastTransitionTime:0001-01-01 00:00:00 +0000 UTC Reason: Message:} {Type:PodScheduled Status:True LastProbeTime:0001-01-01 00:00:00 +0000 UTC LastTransitionTime:2018-07-02 13:14:58 +0000 UTC Reason: Message:}])
+Jul  2 13:15:03.513: INFO: Trying to dial the pod
+Jul  2 13:15:08.644: INFO: Controller my-hostname-basic-eb6dee92-7df9-11e8-b7a8-22e3071d17c7: Got expected result from replica 1 [my-hostname-basic-eb6dee92-7df9-11e8-b7a8-22e3071d17c7-m4777]: "my-hostname-basic-eb6dee92-7df9-11e8-b7a8-22e3071d17c7-m4777", 1 of 1 required successes so far
+[AfterEach] [sig-apps] ReplicaSet
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:15:08.644: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-replicaset-dz6hs" for this suite.
+Jul  2 13:15:14.662: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:15:14.718: INFO: namespace: e2e-tests-replicaset-dz6hs, resource: bindings, ignored listing per whitelist
+Jul  2 13:15:14.753: INFO: namespace e2e-tests-replicaset-dz6hs deletion completed in 6.104641473s
+
+• [SLOW TEST:16.338 seconds]
+[sig-apps] ReplicaSet
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/framework.go:22
+  should serve a basic image on each replica with a public image  [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSSSS
+------------------------------
+[sig-storage] Secrets 
+  should be consumable from pods in volume with defaultMode set [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-storage] Secrets
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:15:14.753: INFO: >>> kubeConfig: /tmp/kubeconfig-575984058
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should be consumable from pods in volume with defaultMode set [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating secret with name secret-test-f52bb88c-7df9-11e8-b7a8-22e3071d17c7
+STEP: Creating a pod to test consume secrets
+Jul  2 13:15:14.850: INFO: Waiting up to 5m0s for pod "pod-secrets-f52c3292-7df9-11e8-b7a8-22e3071d17c7" in namespace "e2e-tests-secrets-zsjgq" to be "success or failure"
+Jul  2 13:15:14.853: INFO: Pod "pod-secrets-f52c3292-7df9-11e8-b7a8-22e3071d17c7": Phase="Pending", Reason="", readiness=false. Elapsed: 2.945271ms
+Jul  2 13:15:16.903: INFO: Pod "pod-secrets-f52c3292-7df9-11e8-b7a8-22e3071d17c7": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.053272006s
+STEP: Saw pod success
+Jul  2 13:15:16.903: INFO: Pod "pod-secrets-f52c3292-7df9-11e8-b7a8-22e3071d17c7" satisfied condition "success or failure"
+Jul  2 13:15:16.908: INFO: Trying to get logs from node shoot--core--confos-worker-w6oh6-z1-59946c4f6c-2w6kp pod pod-secrets-f52c3292-7df9-11e8-b7a8-22e3071d17c7 container secret-volume-test: <nil>
+STEP: delete the pod
+Jul  2 13:15:16.929: INFO: Waiting for pod pod-secrets-f52c3292-7df9-11e8-b7a8-22e3071d17c7 to disappear
+Jul  2 13:15:16.933: INFO: Pod pod-secrets-f52c3292-7df9-11e8-b7a8-22e3071d17c7 no longer exists
+[AfterEach] [sig-storage] Secrets
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:15:16.933: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-secrets-zsjgq" for this suite.
+Jul  2 13:15:22.980: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:15:23.070: INFO: namespace: e2e-tests-secrets-zsjgq, resource: bindings, ignored listing per whitelist
+Jul  2 13:15:23.072: INFO: namespace e2e-tests-secrets-zsjgq deletion completed in 6.135845462s
+
+• [SLOW TEST:8.320 seconds]
+[sig-storage] Secrets
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/secrets_volume.go:33
+  should be consumable from pods in volume with defaultMode set [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSS
+------------------------------
+[sig-api-machinery] Downward API 
+  should provide pod name, namespace and IP address as env vars [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-api-machinery] Downward API
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:15:23.074: INFO: >>> kubeConfig: /tmp/kubeconfig-575984058
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should provide pod name, namespace and IP address as env vars [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating a pod to test downward api env vars
+Jul  2 13:15:23.152: INFO: Waiting up to 5m0s for pod "downward-api-fa1f31a5-7df9-11e8-b7a8-22e3071d17c7" in namespace "e2e-tests-downward-api-k6s4m" to be "success or failure"
+Jul  2 13:15:23.155: INFO: Pod "downward-api-fa1f31a5-7df9-11e8-b7a8-22e3071d17c7": Phase="Pending", Reason="", readiness=false. Elapsed: 2.72643ms
+Jul  2 13:15:25.159: INFO: Pod "downward-api-fa1f31a5-7df9-11e8-b7a8-22e3071d17c7": Phase="Pending", Reason="", readiness=false. Elapsed: 2.006965419s
+Jul  2 13:15:27.164: INFO: Pod "downward-api-fa1f31a5-7df9-11e8-b7a8-22e3071d17c7": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.011744617s
+STEP: Saw pod success
+Jul  2 13:15:27.164: INFO: Pod "downward-api-fa1f31a5-7df9-11e8-b7a8-22e3071d17c7" satisfied condition "success or failure"
+Jul  2 13:15:27.167: INFO: Trying to get logs from node shoot--core--confos-worker-w6oh6-z1-59946c4f6c-2w6kp pod downward-api-fa1f31a5-7df9-11e8-b7a8-22e3071d17c7 container dapi-container: <nil>
+STEP: delete the pod
+Jul  2 13:15:27.281: INFO: Waiting for pod downward-api-fa1f31a5-7df9-11e8-b7a8-22e3071d17c7 to disappear
+Jul  2 13:15:27.285: INFO: Pod downward-api-fa1f31a5-7df9-11e8-b7a8-22e3071d17c7 no longer exists
+[AfterEach] [sig-api-machinery] Downward API
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:15:27.287: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-downward-api-k6s4m" for this suite.
+Jul  2 13:15:33.311: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:15:33.337: INFO: namespace: e2e-tests-downward-api-k6s4m, resource: bindings, ignored listing per whitelist
+Jul  2 13:15:33.412: INFO: namespace e2e-tests-downward-api-k6s4m deletion completed in 6.118178668s
+
+• [SLOW TEST:10.338 seconds]
+[sig-api-machinery] Downward API
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downward_api.go:37
+  should provide pod name, namespace and IP address as env vars [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSSSSSSSSS
+------------------------------
+[sig-storage] Projected 
+  should be consumable from pods in volume [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:15:33.414: INFO: >>> kubeConfig: /tmp/kubeconfig-575984058
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:858
+[It] should be consumable from pods in volume [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating configMap with name projected-configmap-test-volume-004bd689-7dfa-11e8-b7a8-22e3071d17c7
+STEP: Creating a pod to test consume configMaps
+Jul  2 13:15:33.517: INFO: Waiting up to 5m0s for pod "pod-projected-configmaps-004cc1ac-7dfa-11e8-b7a8-22e3071d17c7" in namespace "e2e-tests-projected-2l4g5" to be "success or failure"
+Jul  2 13:15:33.521: INFO: Pod "pod-projected-configmaps-004cc1ac-7dfa-11e8-b7a8-22e3071d17c7": Phase="Pending", Reason="", readiness=false. Elapsed: 4.095336ms
+Jul  2 13:15:35.537: INFO: Pod "pod-projected-configmaps-004cc1ac-7dfa-11e8-b7a8-22e3071d17c7": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.019445132s
+STEP: Saw pod success
+Jul  2 13:15:35.537: INFO: Pod "pod-projected-configmaps-004cc1ac-7dfa-11e8-b7a8-22e3071d17c7" satisfied condition "success or failure"
+Jul  2 13:15:35.540: INFO: Trying to get logs from node shoot--core--confos-worker-w6oh6-z1-59946c4f6c-2w6kp pod pod-projected-configmaps-004cc1ac-7dfa-11e8-b7a8-22e3071d17c7 container projected-configmap-volume-test: <nil>
+STEP: delete the pod
+Jul  2 13:15:35.583: INFO: Waiting for pod pod-projected-configmaps-004cc1ac-7dfa-11e8-b7a8-22e3071d17c7 to disappear
+Jul  2 13:15:35.593: INFO: Pod pod-projected-configmaps-004cc1ac-7dfa-11e8-b7a8-22e3071d17c7 no longer exists
+[AfterEach] [sig-storage] Projected
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:15:35.593: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-2l4g5" for this suite.
+Jul  2 13:15:41.608: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:15:41.717: INFO: namespace: e2e-tests-projected-2l4g5, resource: bindings, ignored listing per whitelist
+Jul  2 13:15:41.774: INFO: namespace e2e-tests-projected-2l4g5 deletion completed in 6.176941832s
+
+• [SLOW TEST:8.361 seconds]
+[sig-storage] Projected
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:34
+  should be consumable from pods in volume [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+[sig-storage] Secrets 
+  should be consumable from pods in volume with mappings [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-storage] Secrets
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:15:41.775: INFO: >>> kubeConfig: /tmp/kubeconfig-575984058
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should be consumable from pods in volume with mappings [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating secret with name secret-test-map-0545eed4-7dfa-11e8-b7a8-22e3071d17c7
+STEP: Creating a pod to test consume secrets
+Jul  2 13:15:41.866: INFO: Waiting up to 5m0s for pod "pod-secrets-0546789a-7dfa-11e8-b7a8-22e3071d17c7" in namespace "e2e-tests-secrets-r7wg2" to be "success or failure"
+Jul  2 13:15:41.870: INFO: Pod "pod-secrets-0546789a-7dfa-11e8-b7a8-22e3071d17c7": Phase="Pending", Reason="", readiness=false. Elapsed: 4.032311ms
+Jul  2 13:15:43.875: INFO: Pod "pod-secrets-0546789a-7dfa-11e8-b7a8-22e3071d17c7": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.009208865s
+STEP: Saw pod success
+Jul  2 13:15:43.875: INFO: Pod "pod-secrets-0546789a-7dfa-11e8-b7a8-22e3071d17c7" satisfied condition "success or failure"
+Jul  2 13:15:43.878: INFO: Trying to get logs from node shoot--core--confos-worker-w6oh6-z1-59946c4f6c-2w6kp pod pod-secrets-0546789a-7dfa-11e8-b7a8-22e3071d17c7 container secret-volume-test: <nil>
+STEP: delete the pod
+Jul  2 13:15:43.900: INFO: Waiting for pod pod-secrets-0546789a-7dfa-11e8-b7a8-22e3071d17c7 to disappear
+Jul  2 13:15:43.917: INFO: Pod pod-secrets-0546789a-7dfa-11e8-b7a8-22e3071d17c7 no longer exists
+[AfterEach] [sig-storage] Secrets
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:15:43.917: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-secrets-r7wg2" for this suite.
+Jul  2 13:15:49.933: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:15:50.049: INFO: namespace: e2e-tests-secrets-r7wg2, resource: bindings, ignored listing per whitelist
+Jul  2 13:15:50.123: INFO: namespace e2e-tests-secrets-r7wg2 deletion completed in 6.200656838s
+
+• [SLOW TEST:8.349 seconds]
+[sig-storage] Secrets
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/secrets_volume.go:33
+  should be consumable from pods in volume with mappings [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SS
+------------------------------
+[sig-storage] Secrets 
+  should be consumable from pods in volume with mappings and Item Mode set [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-storage] Secrets
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:15:50.124: INFO: >>> kubeConfig: /tmp/kubeconfig-575984058
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should be consumable from pods in volume with mappings and Item Mode set [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating secret with name secret-test-map-0a409181-7dfa-11e8-b7a8-22e3071d17c7
+STEP: Creating a pod to test consume secrets
+Jul  2 13:15:50.218: INFO: Waiting up to 5m0s for pod "pod-secrets-0a411dd1-7dfa-11e8-b7a8-22e3071d17c7" in namespace "e2e-tests-secrets-6pdm8" to be "success or failure"
+Jul  2 13:15:50.223: INFO: Pod "pod-secrets-0a411dd1-7dfa-11e8-b7a8-22e3071d17c7": Phase="Pending", Reason="", readiness=false. Elapsed: 5.458363ms
+Jul  2 13:15:52.265: INFO: Pod "pod-secrets-0a411dd1-7dfa-11e8-b7a8-22e3071d17c7": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.046962116s
+STEP: Saw pod success
+Jul  2 13:15:52.265: INFO: Pod "pod-secrets-0a411dd1-7dfa-11e8-b7a8-22e3071d17c7" satisfied condition "success or failure"
+Jul  2 13:15:52.268: INFO: Trying to get logs from node shoot--core--confos-worker-w6oh6-z1-59946c4f6c-2w6kp pod pod-secrets-0a411dd1-7dfa-11e8-b7a8-22e3071d17c7 container secret-volume-test: <nil>
+STEP: delete the pod
+Jul  2 13:15:52.287: INFO: Waiting for pod pod-secrets-0a411dd1-7dfa-11e8-b7a8-22e3071d17c7 to disappear
+Jul  2 13:15:52.289: INFO: Pod pod-secrets-0a411dd1-7dfa-11e8-b7a8-22e3071d17c7 no longer exists
+[AfterEach] [sig-storage] Secrets
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:15:52.289: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-secrets-6pdm8" for this suite.
+Jul  2 13:15:58.303: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:15:58.330: INFO: namespace: e2e-tests-secrets-6pdm8, resource: bindings, ignored listing per whitelist
+Jul  2 13:15:58.485: INFO: namespace e2e-tests-secrets-6pdm8 deletion completed in 6.191279697s
+
+• [SLOW TEST:8.361 seconds]
+[sig-storage] Secrets
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/secrets_volume.go:33
+  should be consumable from pods in volume with mappings and Item Mode set [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SS
+------------------------------
+[sig-storage] Downward API volume 
+  should set mode on item file [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:15:58.485: INFO: >>> kubeConfig: /tmp/kubeconfig-575984058
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downwardapi_volume.go:38
+[It] should set mode on item file [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating a pod to test downward API volume plugin
+Jul  2 13:15:58.572: INFO: Waiting up to 5m0s for pod "downwardapi-volume-0f3bc8bf-7dfa-11e8-b7a8-22e3071d17c7" in namespace "e2e-tests-downward-api-lkcnv" to be "success or failure"
+Jul  2 13:15:58.575: INFO: Pod "downwardapi-volume-0f3bc8bf-7dfa-11e8-b7a8-22e3071d17c7": Phase="Pending", Reason="", readiness=false. Elapsed: 2.756382ms
+Jul  2 13:16:00.587: INFO: Pod "downwardapi-volume-0f3bc8bf-7dfa-11e8-b7a8-22e3071d17c7": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.014953145s
+STEP: Saw pod success
+Jul  2 13:16:00.587: INFO: Pod "downwardapi-volume-0f3bc8bf-7dfa-11e8-b7a8-22e3071d17c7" satisfied condition "success or failure"
+Jul  2 13:16:00.590: INFO: Trying to get logs from node shoot--core--confos-worker-w6oh6-z1-59946c4f6c-2w6kp pod downwardapi-volume-0f3bc8bf-7dfa-11e8-b7a8-22e3071d17c7 container client-container: <nil>
+STEP: delete the pod
+Jul  2 13:16:00.607: INFO: Waiting for pod downwardapi-volume-0f3bc8bf-7dfa-11e8-b7a8-22e3071d17c7 to disappear
+Jul  2 13:16:00.615: INFO: Pod downwardapi-volume-0f3bc8bf-7dfa-11e8-b7a8-22e3071d17c7 no longer exists
+[AfterEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:16:00.615: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-downward-api-lkcnv" for this suite.
+Jul  2 13:16:06.640: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:16:06.779: INFO: namespace: e2e-tests-downward-api-lkcnv, resource: bindings, ignored listing per whitelist
+Jul  2 13:16:06.802: INFO: namespace e2e-tests-downward-api-lkcnv deletion completed in 6.180884287s
+
+• [SLOW TEST:8.317 seconds]
+[sig-storage] Downward API volume
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downwardapi_volume.go:33
+  should set mode on item file [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+[sig-storage] Projected 
+  should be consumable from pods in volume with mappings [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:16:06.802: INFO: >>> kubeConfig: /tmp/kubeconfig-575984058
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:858
+[It] should be consumable from pods in volume with mappings [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating configMap with name projected-configmap-test-volume-map-14314a5b-7dfa-11e8-b7a8-22e3071d17c7
+STEP: Creating a pod to test consume configMaps
+Jul  2 13:16:06.895: INFO: Waiting up to 5m0s for pod "pod-projected-configmaps-1431ce4d-7dfa-11e8-b7a8-22e3071d17c7" in namespace "e2e-tests-projected-lg9zv" to be "success or failure"
+Jul  2 13:16:06.899: INFO: Pod "pod-projected-configmaps-1431ce4d-7dfa-11e8-b7a8-22e3071d17c7": Phase="Pending", Reason="", readiness=false. Elapsed: 4.003174ms
+Jul  2 13:16:08.979: INFO: Pod "pod-projected-configmaps-1431ce4d-7dfa-11e8-b7a8-22e3071d17c7": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.083292863s
+STEP: Saw pod success
+Jul  2 13:16:08.979: INFO: Pod "pod-projected-configmaps-1431ce4d-7dfa-11e8-b7a8-22e3071d17c7" satisfied condition "success or failure"
+Jul  2 13:16:08.982: INFO: Trying to get logs from node shoot--core--confos-worker-w6oh6-z1-59946c4f6c-2w6kp pod pod-projected-configmaps-1431ce4d-7dfa-11e8-b7a8-22e3071d17c7 container projected-configmap-volume-test: <nil>
+STEP: delete the pod
+Jul  2 13:16:09.006: INFO: Waiting for pod pod-projected-configmaps-1431ce4d-7dfa-11e8-b7a8-22e3071d17c7 to disappear
+Jul  2 13:16:09.008: INFO: Pod pod-projected-configmaps-1431ce4d-7dfa-11e8-b7a8-22e3071d17c7 no longer exists
+[AfterEach] [sig-storage] Projected
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:16:09.009: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-lg9zv" for this suite.
+Jul  2 13:16:15.065: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:16:15.242: INFO: namespace: e2e-tests-projected-lg9zv, resource: bindings, ignored listing per whitelist
+Jul  2 13:16:15.317: INFO: namespace e2e-tests-projected-lg9zv deletion completed in 6.293099527s
+
+• [SLOW TEST:8.515 seconds]
+[sig-storage] Projected
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:34
+  should be consumable from pods in volume with mappings [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SS
+------------------------------
+[sig-api-machinery] Garbage collector 
+  should delete pods created by rc when not orphaning [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-api-machinery] Garbage collector
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:16:15.317: INFO: >>> kubeConfig: /tmp/kubeconfig-575984058
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should delete pods created by rc when not orphaning [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: create the rc
+STEP: delete the rc
+STEP: wait for all pods to be garbage collected
+STEP: Gathering metrics
+W0702 13:16:25.577593      16 metrics_grabber.go:81] Master node is not registered. Grabbing metrics from Scheduler, ControllerManager and ClusterAutoscaler is disabled.
+Jul  2 13:16:25.578: INFO: For apiserver_request_count:
+For apiserver_request_latencies_summary:
+For etcd_helper_cache_entry_count:
+For etcd_helper_cache_hit_count:
+For etcd_helper_cache_miss_count:
+For etcd_request_cache_add_latencies_summary:
+For etcd_request_cache_get_latencies_summary:
+For etcd_request_latencies_summary:
+For garbage_collector_attempt_to_delete_queue_latency:
+For garbage_collector_attempt_to_delete_work_duration:
+For garbage_collector_attempt_to_orphan_queue_latency:
+For garbage_collector_attempt_to_orphan_work_duration:
+For garbage_collector_dirty_processing_latency_microseconds:
+For garbage_collector_event_processing_latency_microseconds:
+For garbage_collector_graph_changes_queue_latency:
+For garbage_collector_graph_changes_work_duration:
+For garbage_collector_orphan_processing_latency_microseconds:
+For namespace_queue_latency:
+For namespace_queue_latency_sum:
+For namespace_queue_latency_count:
+For namespace_retries:
+For namespace_work_duration:
+For namespace_work_duration_sum:
+For namespace_work_duration_count:
+For function_duration_seconds:
+For errors_total:
+For evicted_pods_total:
+
+[AfterEach] [sig-api-machinery] Garbage collector
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:16:25.578: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-gc-sqdtl" for this suite.
+Jul  2 13:16:31.680: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:16:31.747: INFO: namespace: e2e-tests-gc-sqdtl, resource: bindings, ignored listing per whitelist
+Jul  2 13:16:31.780: INFO: namespace e2e-tests-gc-sqdtl deletion completed in 6.114169523s
+
+• [SLOW TEST:16.463 seconds]
+[sig-api-machinery] Garbage collector
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apimachinery/framework.go:22
+  should delete pods created by rc when not orphaning [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSS
+------------------------------
+[sig-network] Networking Granular Checks: Pods 
+  should function for intra-pod communication: udp [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-network] Networking
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:16:31.782: INFO: >>> kubeConfig: /tmp/kubeconfig-575984058
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should function for intra-pod communication: udp [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Performing setup for networking test in namespace e2e-tests-pod-network-test-rjpfk
+STEP: creating a selector
+STEP: Creating the service pods in kubernetes
+Jul  2 13:16:31.868: INFO: Waiting up to 10m0s for all (but 0) nodes to be schedulable
+STEP: Creating test pods
+Jul  2 13:16:53.987: INFO: ExecWithOptions {Command:[/bin/sh -c curl -g -q -s 'http://100.96.1.75:8080/dial?request=hostName&protocol=udp&host=100.96.0.23&port=8081&tries=1'] Namespace:e2e-tests-pod-network-test-rjpfk PodName:host-test-container-pod ContainerName:hostexec Stdin:<nil> CaptureStdout:true CaptureStderr:true PreserveWhitespace:false}
+Jul  2 13:16:53.987: INFO: >>> kubeConfig: /tmp/kubeconfig-575984058
+Jul  2 13:16:54.404: INFO: Waiting for endpoints: map[]
+Jul  2 13:16:54.408: INFO: ExecWithOptions {Command:[/bin/sh -c curl -g -q -s 'http://100.96.1.75:8080/dial?request=hostName&protocol=udp&host=100.96.1.74&port=8081&tries=1'] Namespace:e2e-tests-pod-network-test-rjpfk PodName:host-test-container-pod ContainerName:hostexec Stdin:<nil> CaptureStdout:true CaptureStderr:true PreserveWhitespace:false}
+Jul  2 13:16:54.408: INFO: >>> kubeConfig: /tmp/kubeconfig-575984058
+Jul  2 13:16:54.896: INFO: Waiting for endpoints: map[]
+[AfterEach] [sig-network] Networking
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:16:54.903: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-pod-network-test-rjpfk" for this suite.
+Jul  2 13:17:16.920: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:17:17.061: INFO: namespace: e2e-tests-pod-network-test-rjpfk, resource: bindings, ignored listing per whitelist
+Jul  2 13:17:17.072: INFO: namespace e2e-tests-pod-network-test-rjpfk deletion completed in 22.162571323s
+
+• [SLOW TEST:45.291 seconds]
+[sig-network] Networking
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/networking.go:25
+  Granular Checks: Pods
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/networking.go:28
+    should function for intra-pod communication: udp [NodeConformance] [Conformance]
+    /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSS
+------------------------------
+[sig-storage] Projected 
+  should be consumable in multiple volumes in a pod [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:17:17.072: INFO: >>> kubeConfig: /tmp/kubeconfig-575984058
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:858
+[It] should be consumable in multiple volumes in a pod [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating secret with name projected-secret-test-3e13b6b2-7dfa-11e8-b7a8-22e3071d17c7
+STEP: Creating a pod to test consume secrets
+Jul  2 13:17:17.165: INFO: Waiting up to 5m0s for pod "pod-projected-secrets-3e142b49-7dfa-11e8-b7a8-22e3071d17c7" in namespace "e2e-tests-projected-964lp" to be "success or failure"
+Jul  2 13:17:17.168: INFO: Pod "pod-projected-secrets-3e142b49-7dfa-11e8-b7a8-22e3071d17c7": Phase="Pending", Reason="", readiness=false. Elapsed: 2.93409ms
+Jul  2 13:17:19.172: INFO: Pod "pod-projected-secrets-3e142b49-7dfa-11e8-b7a8-22e3071d17c7": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.007034293s
+STEP: Saw pod success
+Jul  2 13:17:19.172: INFO: Pod "pod-projected-secrets-3e142b49-7dfa-11e8-b7a8-22e3071d17c7" satisfied condition "success or failure"
+Jul  2 13:17:19.175: INFO: Trying to get logs from node shoot--core--confos-worker-w6oh6-z1-59946c4f6c-2w6kp pod pod-projected-secrets-3e142b49-7dfa-11e8-b7a8-22e3071d17c7 container secret-volume-test: <nil>
+STEP: delete the pod
+Jul  2 13:17:19.281: INFO: Waiting for pod pod-projected-secrets-3e142b49-7dfa-11e8-b7a8-22e3071d17c7 to disappear
+Jul  2 13:17:19.288: INFO: Pod pod-projected-secrets-3e142b49-7dfa-11e8-b7a8-22e3071d17c7 no longer exists
+[AfterEach] [sig-storage] Projected
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:17:19.288: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-964lp" for this suite.
+Jul  2 13:17:25.301: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:17:25.309: INFO: namespace: e2e-tests-projected-964lp, resource: bindings, ignored listing per whitelist
+Jul  2 13:17:25.546: INFO: namespace e2e-tests-projected-964lp deletion completed in 6.254587415s
+
+• [SLOW TEST:8.474 seconds]
+[sig-storage] Projected
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:34
+  should be consumable in multiple volumes in a pod [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSSSSSSSSSSSSSS
+------------------------------
+[sig-api-machinery] Secrets 
+  should be consumable from pods in env vars [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-api-machinery] Secrets
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:17:25.549: INFO: >>> kubeConfig: /tmp/kubeconfig-575984058
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should be consumable from pods in env vars [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating secret with name secret-test-432aba23-7dfa-11e8-b7a8-22e3071d17c7
+STEP: Creating a pod to test consume secrets
+Jul  2 13:17:25.704: INFO: Waiting up to 5m0s for pod "pod-secrets-432b302c-7dfa-11e8-b7a8-22e3071d17c7" in namespace "e2e-tests-secrets-fm9s6" to be "success or failure"
+Jul  2 13:17:25.707: INFO: Pod "pod-secrets-432b302c-7dfa-11e8-b7a8-22e3071d17c7": Phase="Pending", Reason="", readiness=false. Elapsed: 2.569533ms
+Jul  2 13:17:27.778: INFO: Pod "pod-secrets-432b302c-7dfa-11e8-b7a8-22e3071d17c7": Phase="Pending", Reason="", readiness=false. Elapsed: 2.073976488s
+Jul  2 13:17:29.783: INFO: Pod "pod-secrets-432b302c-7dfa-11e8-b7a8-22e3071d17c7": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.078574394s
+STEP: Saw pod success
+Jul  2 13:17:29.783: INFO: Pod "pod-secrets-432b302c-7dfa-11e8-b7a8-22e3071d17c7" satisfied condition "success or failure"
+Jul  2 13:17:29.879: INFO: Trying to get logs from node shoot--core--confos-worker-w6oh6-z1-59946c4f6c-2w6kp pod pod-secrets-432b302c-7dfa-11e8-b7a8-22e3071d17c7 container secret-env-test: <nil>
+STEP: delete the pod
+Jul  2 13:17:29.910: INFO: Waiting for pod pod-secrets-432b302c-7dfa-11e8-b7a8-22e3071d17c7 to disappear
+Jul  2 13:17:29.914: INFO: Pod pod-secrets-432b302c-7dfa-11e8-b7a8-22e3071d17c7 no longer exists
+[AfterEach] [sig-api-machinery] Secrets
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:17:29.914: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-secrets-fm9s6" for this suite.
+Jul  2 13:17:35.980: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:17:36.050: INFO: namespace: e2e-tests-secrets-fm9s6, resource: bindings, ignored listing per whitelist
+Jul  2 13:17:36.082: INFO: namespace e2e-tests-secrets-fm9s6 deletion completed in 6.164093968s
+
+• [SLOW TEST:10.533 seconds]
+[sig-api-machinery] Secrets
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/secrets.go:30
+  should be consumable from pods in env vars [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSSSS
+------------------------------
+[sig-api-machinery] Downward API 
+  should provide container's limits.cpu/memory and requests.cpu/memory as env vars [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-api-machinery] Downward API
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:17:36.082: INFO: >>> kubeConfig: /tmp/kubeconfig-575984058
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should provide container's limits.cpu/memory and requests.cpu/memory as env vars [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating a pod to test downward api env vars
+Jul  2 13:17:36.176: INFO: Waiting up to 5m0s for pod "downward-api-49690715-7dfa-11e8-b7a8-22e3071d17c7" in namespace "e2e-tests-downward-api-2vt8p" to be "success or failure"
+Jul  2 13:17:36.181: INFO: Pod "downward-api-49690715-7dfa-11e8-b7a8-22e3071d17c7": Phase="Pending", Reason="", readiness=false. Elapsed: 4.151467ms
+Jul  2 13:17:38.185: INFO: Pod "downward-api-49690715-7dfa-11e8-b7a8-22e3071d17c7": Phase="Pending", Reason="", readiness=false. Elapsed: 2.008662061s
+Jul  2 13:17:40.265: INFO: Pod "downward-api-49690715-7dfa-11e8-b7a8-22e3071d17c7": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.088933752s
+STEP: Saw pod success
+Jul  2 13:17:40.265: INFO: Pod "downward-api-49690715-7dfa-11e8-b7a8-22e3071d17c7" satisfied condition "success or failure"
+Jul  2 13:17:40.268: INFO: Trying to get logs from node shoot--core--confos-worker-w6oh6-z1-59946c4f6c-2w6kp pod downward-api-49690715-7dfa-11e8-b7a8-22e3071d17c7 container dapi-container: <nil>
+STEP: delete the pod
+Jul  2 13:17:40.287: INFO: Waiting for pod downward-api-49690715-7dfa-11e8-b7a8-22e3071d17c7 to disappear
+Jul  2 13:17:40.290: INFO: Pod downward-api-49690715-7dfa-11e8-b7a8-22e3071d17c7 no longer exists
+[AfterEach] [sig-api-machinery] Downward API
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:17:40.290: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-downward-api-2vt8p" for this suite.
+Jul  2 13:17:46.306: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:17:46.438: INFO: namespace: e2e-tests-downward-api-2vt8p, resource: bindings, ignored listing per whitelist
+Jul  2 13:17:46.470: INFO: namespace e2e-tests-downward-api-2vt8p deletion completed in 6.176713507s
+
+• [SLOW TEST:10.388 seconds]
+[sig-api-machinery] Downward API
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downward_api.go:37
+  should provide container's limits.cpu/memory and requests.cpu/memory as env vars [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+[sig-storage] Projected 
+  should project all components that make up the projection API [Projection][NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:17:46.471: INFO: >>> kubeConfig: /tmp/kubeconfig-575984058
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:858
+[It] should project all components that make up the projection API [Projection][NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating configMap with name configmap-projected-all-test-volume-4f992ad1-7dfa-11e8-b7a8-22e3071d17c7
+STEP: Creating secret with name secret-projected-all-test-volume-4f9929cc-7dfa-11e8-b7a8-22e3071d17c7
+STEP: Creating a pod to test Check all projections for projected volume plugin
+Jul  2 13:17:46.565: INFO: Waiting up to 5m0s for pod "projected-volume-4f992995-7dfa-11e8-b7a8-22e3071d17c7" in namespace "e2e-tests-projected-vx7br" to be "success or failure"
+Jul  2 13:17:46.567: INFO: Pod "projected-volume-4f992995-7dfa-11e8-b7a8-22e3071d17c7": Phase="Pending", Reason="", readiness=false. Elapsed: 2.523667ms
+Jul  2 13:17:48.572: INFO: Pod "projected-volume-4f992995-7dfa-11e8-b7a8-22e3071d17c7": Phase="Pending", Reason="", readiness=false. Elapsed: 2.006818609s
+Jul  2 13:17:50.576: INFO: Pod "projected-volume-4f992995-7dfa-11e8-b7a8-22e3071d17c7": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.011138121s
+STEP: Saw pod success
+Jul  2 13:17:50.576: INFO: Pod "projected-volume-4f992995-7dfa-11e8-b7a8-22e3071d17c7" satisfied condition "success or failure"
+Jul  2 13:17:50.578: INFO: Trying to get logs from node shoot--core--confos-worker-w6oh6-z1-59946c4f6c-2w6kp pod projected-volume-4f992995-7dfa-11e8-b7a8-22e3071d17c7 container projected-all-volume-test: <nil>
+STEP: delete the pod
+Jul  2 13:17:50.690: INFO: Waiting for pod projected-volume-4f992995-7dfa-11e8-b7a8-22e3071d17c7 to disappear
+Jul  2 13:17:50.693: INFO: Pod projected-volume-4f992995-7dfa-11e8-b7a8-22e3071d17c7 no longer exists
+[AfterEach] [sig-storage] Projected
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:17:50.693: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-vx7br" for this suite.
+Jul  2 13:17:56.709: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:17:56.908: INFO: namespace: e2e-tests-projected-vx7br, resource: bindings, ignored listing per whitelist
+Jul  2 13:17:56.917: INFO: namespace e2e-tests-projected-vx7br deletion completed in 6.220094176s
+
+• [SLOW TEST:10.446 seconds]
+[sig-storage] Projected
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:34
+  should project all components that make up the projection API [Projection][NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSS
+------------------------------
+[sig-storage] EmptyDir volumes 
+  should support (non-root,0644,default) [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-storage] EmptyDir volumes
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:17:56.917: INFO: >>> kubeConfig: /tmp/kubeconfig-575984058
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should support (non-root,0644,default) [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating a pod to test emptydir 0644 on node default medium
+Jul  2 13:17:57.009: INFO: Waiting up to 5m0s for pod "pod-55d3a456-7dfa-11e8-b7a8-22e3071d17c7" in namespace "e2e-tests-emptydir-57xht" to be "success or failure"
+Jul  2 13:17:57.015: INFO: Pod "pod-55d3a456-7dfa-11e8-b7a8-22e3071d17c7": Phase="Pending", Reason="", readiness=false. Elapsed: 6.891395ms
+Jul  2 13:17:59.019: INFO: Pod "pod-55d3a456-7dfa-11e8-b7a8-22e3071d17c7": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.010470494s
+STEP: Saw pod success
+Jul  2 13:17:59.019: INFO: Pod "pod-55d3a456-7dfa-11e8-b7a8-22e3071d17c7" satisfied condition "success or failure"
+Jul  2 13:17:59.026: INFO: Trying to get logs from node shoot--core--confos-worker-w6oh6-z1-59946c4f6c-2w6kp pod pod-55d3a456-7dfa-11e8-b7a8-22e3071d17c7 container test-container: <nil>
+STEP: delete the pod
+Jul  2 13:17:59.052: INFO: Waiting for pod pod-55d3a456-7dfa-11e8-b7a8-22e3071d17c7 to disappear
+Jul  2 13:17:59.060: INFO: Pod pod-55d3a456-7dfa-11e8-b7a8-22e3071d17c7 no longer exists
+[AfterEach] [sig-storage] EmptyDir volumes
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:17:59.061: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-emptydir-57xht" for this suite.
+Jul  2 13:18:05.075: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:18:05.180: INFO: namespace: e2e-tests-emptydir-57xht, resource: bindings, ignored listing per whitelist
+Jul  2 13:18:05.253: INFO: namespace e2e-tests-emptydir-57xht deletion completed in 6.187426435s
+
+• [SLOW TEST:8.336 seconds]
+[sig-storage] EmptyDir volumes
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/empty_dir.go:40
+  should support (non-root,0644,default) [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SS
+------------------------------
+[k8s.io] Docker Containers 
+  should be able to override the image's default command and arguments [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [k8s.io] Docker Containers
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:18:05.254: INFO: >>> kubeConfig: /tmp/kubeconfig-575984058
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should be able to override the image's default command and arguments [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating a pod to test override all
+Jul  2 13:18:05.342: INFO: Waiting up to 5m0s for pod "client-containers-5acb3d7e-7dfa-11e8-b7a8-22e3071d17c7" in namespace "e2e-tests-containers-8c2tg" to be "success or failure"
+Jul  2 13:18:05.347: INFO: Pod "client-containers-5acb3d7e-7dfa-11e8-b7a8-22e3071d17c7": Phase="Pending", Reason="", readiness=false. Elapsed: 5.062607ms
+Jul  2 13:18:07.355: INFO: Pod "client-containers-5acb3d7e-7dfa-11e8-b7a8-22e3071d17c7": Phase="Pending", Reason="", readiness=false. Elapsed: 2.013373548s
+Jul  2 13:18:09.359: INFO: Pod "client-containers-5acb3d7e-7dfa-11e8-b7a8-22e3071d17c7": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.017057869s
+STEP: Saw pod success
+Jul  2 13:18:09.359: INFO: Pod "client-containers-5acb3d7e-7dfa-11e8-b7a8-22e3071d17c7" satisfied condition "success or failure"
+Jul  2 13:18:09.362: INFO: Trying to get logs from node shoot--core--confos-worker-w6oh6-z1-59946c4f6c-2w6kp pod client-containers-5acb3d7e-7dfa-11e8-b7a8-22e3071d17c7 container test-container: <nil>
+STEP: delete the pod
+Jul  2 13:18:09.389: INFO: Waiting for pod client-containers-5acb3d7e-7dfa-11e8-b7a8-22e3071d17c7 to disappear
+Jul  2 13:18:09.394: INFO: Pod client-containers-5acb3d7e-7dfa-11e8-b7a8-22e3071d17c7 no longer exists
+[AfterEach] [k8s.io] Docker Containers
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:18:09.394: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-containers-8c2tg" for this suite.
+Jul  2 13:18:15.410: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:18:15.487: INFO: namespace: e2e-tests-containers-8c2tg, resource: bindings, ignored listing per whitelist
+Jul  2 13:18:15.515: INFO: namespace e2e-tests-containers-8c2tg deletion completed in 6.116436398s
+
+• [SLOW TEST:10.261 seconds]
+[k8s.io] Docker Containers
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:679
+  should be able to override the image's default command and arguments [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSS
+------------------------------
+[k8s.io] Variable Expansion 
+  should allow composing env vars into new env vars [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [k8s.io] Variable Expansion
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:18:15.516: INFO: >>> kubeConfig: /tmp/kubeconfig-575984058
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should allow composing env vars into new env vars [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating a pod to test env composition
+Jul  2 13:18:15.607: INFO: Waiting up to 5m0s for pod "var-expansion-60e993e0-7dfa-11e8-b7a8-22e3071d17c7" in namespace "e2e-tests-var-expansion-fwm8h" to be "success or failure"
+Jul  2 13:18:15.609: INFO: Pod "var-expansion-60e993e0-7dfa-11e8-b7a8-22e3071d17c7": Phase="Pending", Reason="", readiness=false. Elapsed: 2.409719ms
+Jul  2 13:18:17.613: INFO: Pod "var-expansion-60e993e0-7dfa-11e8-b7a8-22e3071d17c7": Phase="Pending", Reason="", readiness=false. Elapsed: 2.006373652s
+Jul  2 13:18:19.617: INFO: Pod "var-expansion-60e993e0-7dfa-11e8-b7a8-22e3071d17c7": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.010577458s
+STEP: Saw pod success
+Jul  2 13:18:19.618: INFO: Pod "var-expansion-60e993e0-7dfa-11e8-b7a8-22e3071d17c7" satisfied condition "success or failure"
+Jul  2 13:18:19.620: INFO: Trying to get logs from node shoot--core--confos-worker-w6oh6-z1-59946c4f6c-2w6kp pod var-expansion-60e993e0-7dfa-11e8-b7a8-22e3071d17c7 container dapi-container: <nil>
+STEP: delete the pod
+Jul  2 13:18:19.671: INFO: Waiting for pod var-expansion-60e993e0-7dfa-11e8-b7a8-22e3071d17c7 to disappear
+Jul  2 13:18:19.679: INFO: Pod var-expansion-60e993e0-7dfa-11e8-b7a8-22e3071d17c7 no longer exists
+[AfterEach] [k8s.io] Variable Expansion
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:18:19.679: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-var-expansion-fwm8h" for this suite.
+Jul  2 13:18:25.695: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:18:25.747: INFO: namespace: e2e-tests-var-expansion-fwm8h, resource: bindings, ignored listing per whitelist
+Jul  2 13:18:25.794: INFO: namespace e2e-tests-var-expansion-fwm8h deletion completed in 6.111485027s
+
+• [SLOW TEST:10.279 seconds]
+[k8s.io] Variable Expansion
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:679
+  should allow composing env vars into new env vars [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSS
+------------------------------
+[sig-storage] Projected 
+  should be consumable from pods in volume as non-root with defaultMode and fsGroup set [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:18:25.795: INFO: >>> kubeConfig: /tmp/kubeconfig-575984058
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:858
+[It] should be consumable from pods in volume as non-root with defaultMode and fsGroup set [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating projection with secret that has name projected-secret-test-670b03d2-7dfa-11e8-b7a8-22e3071d17c7
+STEP: Creating a pod to test consume secrets
+Jul  2 13:18:25.895: INFO: Waiting up to 5m0s for pod "pod-projected-secrets-670b77c7-7dfa-11e8-b7a8-22e3071d17c7" in namespace "e2e-tests-projected-lx42c" to be "success or failure"
+Jul  2 13:18:25.901: INFO: Pod "pod-projected-secrets-670b77c7-7dfa-11e8-b7a8-22e3071d17c7": Phase="Pending", Reason="", readiness=false. Elapsed: 5.760689ms
+Jul  2 13:18:27.906: INFO: Pod "pod-projected-secrets-670b77c7-7dfa-11e8-b7a8-22e3071d17c7": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.011501883s
+STEP: Saw pod success
+Jul  2 13:18:27.906: INFO: Pod "pod-projected-secrets-670b77c7-7dfa-11e8-b7a8-22e3071d17c7" satisfied condition "success or failure"
+Jul  2 13:18:27.909: INFO: Trying to get logs from node shoot--core--confos-worker-w6oh6-z1-59946c4f6c-2w6kp pod pod-projected-secrets-670b77c7-7dfa-11e8-b7a8-22e3071d17c7 container projected-secret-volume-test: <nil>
+STEP: delete the pod
+Jul  2 13:18:27.933: INFO: Waiting for pod pod-projected-secrets-670b77c7-7dfa-11e8-b7a8-22e3071d17c7 to disappear
+Jul  2 13:18:27.950: INFO: Pod pod-projected-secrets-670b77c7-7dfa-11e8-b7a8-22e3071d17c7 no longer exists
+[AfterEach] [sig-storage] Projected
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:18:27.950: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-lx42c" for this suite.
+Jul  2 13:18:33.971: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:18:33.990: INFO: namespace: e2e-tests-projected-lx42c, resource: bindings, ignored listing per whitelist
+Jul  2 13:18:34.073: INFO: namespace e2e-tests-projected-lx42c deletion completed in 6.118796533s
+
+• [SLOW TEST:8.278 seconds]
+[sig-storage] Projected
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:34
+  should be consumable from pods in volume as non-root with defaultMode and fsGroup set [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSSSSSSSSS
+------------------------------
+[k8s.io] Pods 
+  should allow activeDeadlineSeconds to be updated [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [k8s.io] Pods
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:18:34.074: INFO: >>> kubeConfig: /tmp/kubeconfig-575984058
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [k8s.io] Pods
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/pods.go:127
+[It] should allow activeDeadlineSeconds to be updated [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: creating the pod
+STEP: submitting the pod to kubernetes
+STEP: verifying the pod is in kubernetes
+STEP: updating the pod
+Jul  2 13:18:36.770: INFO: Successfully updated pod "pod-update-activedeadlineseconds-6bf82d38-7dfa-11e8-b7a8-22e3071d17c7"
+Jul  2 13:18:36.770: INFO: Waiting up to 5m0s for pod "pod-update-activedeadlineseconds-6bf82d38-7dfa-11e8-b7a8-22e3071d17c7" in namespace "e2e-tests-pods-qb2d9" to be "terminated due to deadline exceeded"
+Jul  2 13:18:36.773: INFO: Pod "pod-update-activedeadlineseconds-6bf82d38-7dfa-11e8-b7a8-22e3071d17c7": Phase="Running", Reason="", readiness=true. Elapsed: 3.114441ms
+Jul  2 13:18:38.778: INFO: Pod "pod-update-activedeadlineseconds-6bf82d38-7dfa-11e8-b7a8-22e3071d17c7": Phase="Running", Reason="", readiness=true. Elapsed: 2.008092384s
+Jul  2 13:18:40.783: INFO: Pod "pod-update-activedeadlineseconds-6bf82d38-7dfa-11e8-b7a8-22e3071d17c7": Phase="Failed", Reason="DeadlineExceeded", readiness=false. Elapsed: 4.012486129s
+Jul  2 13:18:40.783: INFO: Pod "pod-update-activedeadlineseconds-6bf82d38-7dfa-11e8-b7a8-22e3071d17c7" satisfied condition "terminated due to deadline exceeded"
+[AfterEach] [k8s.io] Pods
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:18:40.783: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-pods-qb2d9" for this suite.
+Jul  2 13:18:46.873: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:18:46.932: INFO: namespace: e2e-tests-pods-qb2d9, resource: bindings, ignored listing per whitelist
+Jul  2 13:18:46.964: INFO: namespace e2e-tests-pods-qb2d9 deletion completed in 6.178105284s
+
+• [SLOW TEST:12.891 seconds]
+[k8s.io] Pods
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:679
+  should allow activeDeadlineSeconds to be updated [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+[sig-storage] EmptyDir volumes 
+  should support (non-root,0666,default) [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-storage] EmptyDir volumes
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:18:46.965: INFO: >>> kubeConfig: /tmp/kubeconfig-575984058
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should support (non-root,0666,default) [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating a pod to test emptydir 0666 on node default medium
+Jul  2 13:18:47.051: INFO: Waiting up to 5m0s for pod "pod-73a7bfb0-7dfa-11e8-b7a8-22e3071d17c7" in namespace "e2e-tests-emptydir-wc2fk" to be "success or failure"
+Jul  2 13:18:47.054: INFO: Pod "pod-73a7bfb0-7dfa-11e8-b7a8-22e3071d17c7": Phase="Pending", Reason="", readiness=false. Elapsed: 3.048822ms
+Jul  2 13:18:49.058: INFO: Pod "pod-73a7bfb0-7dfa-11e8-b7a8-22e3071d17c7": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.006975651s
+STEP: Saw pod success
+Jul  2 13:18:49.059: INFO: Pod "pod-73a7bfb0-7dfa-11e8-b7a8-22e3071d17c7" satisfied condition "success or failure"
+Jul  2 13:18:49.061: INFO: Trying to get logs from node shoot--core--confos-worker-w6oh6-z1-59946c4f6c-2w6kp pod pod-73a7bfb0-7dfa-11e8-b7a8-22e3071d17c7 container test-container: <nil>
+STEP: delete the pod
+Jul  2 13:18:49.080: INFO: Waiting for pod pod-73a7bfb0-7dfa-11e8-b7a8-22e3071d17c7 to disappear
+Jul  2 13:18:49.086: INFO: Pod pod-73a7bfb0-7dfa-11e8-b7a8-22e3071d17c7 no longer exists
+[AfterEach] [sig-storage] EmptyDir volumes
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:18:49.086: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-emptydir-wc2fk" for this suite.
+Jul  2 13:18:55.107: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:18:55.201: INFO: namespace: e2e-tests-emptydir-wc2fk, resource: bindings, ignored listing per whitelist
+Jul  2 13:18:55.214: INFO: namespace e2e-tests-emptydir-wc2fk deletion completed in 6.122311804s
+
+• [SLOW TEST:8.249 seconds]
+[sig-storage] EmptyDir volumes
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/empty_dir.go:40
+  should support (non-root,0666,default) [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SS
+------------------------------
+[sig-network] Services 
+  should provide secure master service  [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-network] Services
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:18:55.214: INFO: >>> kubeConfig: /tmp/kubeconfig-575984058
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-network] Services
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/network/service.go:83
+[It] should provide secure master service  [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[AfterEach] [sig-network] Services
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:18:55.300: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-services-5cghf" for this suite.
+Jul  2 13:19:01.320: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:19:01.385: INFO: namespace: e2e-tests-services-5cghf, resource: bindings, ignored listing per whitelist
+Jul  2 13:19:01.443: INFO: namespace e2e-tests-services-5cghf deletion completed in 6.139658922s
+[AfterEach] [sig-network] Services
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/network/service.go:88
+
+• [SLOW TEST:6.229 seconds]
+[sig-network] Services
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/network/framework.go:22
+  should provide secure master service  [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSSSSSSSSSSSSSSSSSSSSSS
+------------------------------
+[sig-storage] EmptyDir volumes 
+  should support (root,0644,default) [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-storage] EmptyDir volumes
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:19:01.444: INFO: >>> kubeConfig: /tmp/kubeconfig-575984058
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should support (root,0644,default) [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating a pod to test emptydir 0644 on node default medium
+Jul  2 13:19:01.537: INFO: Waiting up to 5m0s for pod "pod-7c49871a-7dfa-11e8-b7a8-22e3071d17c7" in namespace "e2e-tests-emptydir-657bp" to be "success or failure"
+Jul  2 13:19:01.541: INFO: Pod "pod-7c49871a-7dfa-11e8-b7a8-22e3071d17c7": Phase="Pending", Reason="", readiness=false. Elapsed: 3.928309ms
+Jul  2 13:19:03.545: INFO: Pod "pod-7c49871a-7dfa-11e8-b7a8-22e3071d17c7": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.008004761s
+STEP: Saw pod success
+Jul  2 13:19:03.545: INFO: Pod "pod-7c49871a-7dfa-11e8-b7a8-22e3071d17c7" satisfied condition "success or failure"
+Jul  2 13:19:03.547: INFO: Trying to get logs from node shoot--core--confos-worker-w6oh6-z1-59946c4f6c-2w6kp pod pod-7c49871a-7dfa-11e8-b7a8-22e3071d17c7 container test-container: <nil>
+STEP: delete the pod
+Jul  2 13:19:03.565: INFO: Waiting for pod pod-7c49871a-7dfa-11e8-b7a8-22e3071d17c7 to disappear
+Jul  2 13:19:03.573: INFO: Pod pod-7c49871a-7dfa-11e8-b7a8-22e3071d17c7 no longer exists
+[AfterEach] [sig-storage] EmptyDir volumes
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:19:03.573: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-emptydir-657bp" for this suite.
+Jul  2 13:19:09.590: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:19:09.610: INFO: namespace: e2e-tests-emptydir-657bp, resource: bindings, ignored listing per whitelist
+Jul  2 13:19:09.743: INFO: namespace e2e-tests-emptydir-657bp deletion completed in 6.163408579s
+
+• [SLOW TEST:8.299 seconds]
+[sig-storage] EmptyDir volumes
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/empty_dir.go:40
+  should support (root,0644,default) [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSSS
+------------------------------
+[k8s.io] [sig-node] Events 
+  should be sent by kubelets and the scheduler about pods scheduling and running  [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [k8s.io] [sig-node] Events
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:19:09.744: INFO: >>> kubeConfig: /tmp/kubeconfig-575984058
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should be sent by kubelets and the scheduler about pods scheduling and running  [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: creating the pod
+STEP: submitting the pod to kubernetes
+STEP: verifying the pod is in kubernetes
+STEP: retrieving the pod
+&Pod{ObjectMeta:k8s_io_apimachinery_pkg_apis_meta_v1.ObjectMeta{Name:send-events-813b3f8d-7dfa-11e8-b7a8-22e3071d17c7,GenerateName:,Namespace:e2e-tests-events-7rg4v,SelfLink:/api/v1/namespaces/e2e-tests-events-7rg4v/pods/send-events-813b3f8d-7dfa-11e8-b7a8-22e3071d17c7,UID:813fcde7-7dfa-11e8-a560-160e0404a9f8,ResourceVersion:6086,Generation:0,CreationTimestamp:2018-07-02 13:19:09 +0000 UTC,DeletionTimestamp:<nil>,DeletionGracePeriodSeconds:nil,Labels:map[string]string{name: foo,time: 823993803,},Annotations:map[string]string{cni.projectcalico.org/podIP: 100.96.1.88/32,},OwnerReferences:[],Finalizers:[],ClusterName:,Initializers:nil,},Spec:PodSpec{Volumes:[{default-token-6t95f {nil nil nil nil nil SecretVolumeSource{SecretName:default-token-6t95f,Items:[],DefaultMode:*420,Optional:nil,} nil nil nil nil nil nil nil nil nil nil nil nil nil nil nil nil nil nil nil nil nil}}],Containers:[{p gcr.io/kubernetes-e2e-test-images/serve-hostname-amd64:1.0 [] []  [{ 0 80 TCP }] [] [] {map[] map[]} [{default-token-6t95f true /var/run/secrets/kubernetes.io/serviceaccount  <nil>}] [] nil nil nil /dev/termination-log File IfNotPresent nil false false false}],RestartPolicy:Always,TerminationGracePeriodSeconds:*30,ActiveDeadlineSeconds:nil,DNSPolicy:ClusterFirst,NodeSelector:map[string]string{},ServiceAccountName:default,DeprecatedServiceAccount:default,NodeName:shoot--core--confos-worker-w6oh6-z1-59946c4f6c-2w6kp,HostNetwork:false,HostPID:false,HostIPC:false,SecurityContext:&PodSecurityContext{SELinuxOptions:nil,RunAsUser:nil,RunAsNonRoot:nil,SupplementalGroups:[],FSGroup:nil,RunAsGroup:nil,Sysctls:[],},ImagePullSecrets:[],Hostname:,Subdomain:,Affinity:nil,SchedulerName:default-scheduler,InitContainers:[],AutomountServiceAccountToken:nil,Tolerations:[{node.kubernetes.io/not-ready Exists  NoExecute 0xc421d4ff50} {node.kubernetes.io/unreachable Exists  NoExecute 0xc421d4ff70}],HostAliases:[],PriorityClassName:,Priority:nil,DNSConfig:nil,ShareProcessNamespace:nil,ReadinessGates:[],},Status:PodStatus{Phase:Running,Conditions:[{Initialized True 0001-01-01 00:00:00 +0000 UTC 2018-07-02 13:19:09 +0000 UTC  } {Ready True 0001-01-01 00:00:00 +0000 UTC 2018-07-02 13:19:11 +0000 UTC  } {ContainersReady True 0001-01-01 00:00:00 +0000 UTC 0001-01-01 00:00:00 +0000 UTC  } {PodScheduled True 0001-01-01 00:00:00 +0000 UTC 2018-07-02 13:19:09 +0000 UTC  }],Message:,Reason:,HostIP:10.250.0.17,PodIP:100.96.1.88,StartTime:2018-07-02 13:19:09 +0000 UTC,ContainerStatuses:[{p {nil ContainerStateRunning{StartedAt:2018-07-02 13:19:10 +0000 UTC,} nil} {nil nil nil} true 0 gcr.io/kubernetes-e2e-test-images/serve-hostname-amd64:1.0 docker-pullable://gcr.io/kubernetes-e2e-test-images/serve-hostname-amd64@sha256:2dd4032e98a0450d95a0ac71a5e465f542a900812d8c41bc6ca635aed1a5fc91 docker://631ad5eb54a814398ebee4412c0423723e45565bedab7b7cc552711634953713}],QOSClass:BestEffort,InitContainerStatuses:[],NominatedNodeName:,},}
+STEP: checking for scheduler event about the pod
+Saw scheduler event for our pod.
+STEP: checking for kubelet event about the pod
+Saw kubelet event for our pod.
+STEP: deleting the pod
+[AfterEach] [k8s.io] [sig-node] Events
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:19:15.890: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-events-7rg4v" for this suite.
+Jul  2 13:19:37.909: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:19:38.085: INFO: namespace: e2e-tests-events-7rg4v, resource: bindings, ignored listing per whitelist
+Jul  2 13:19:38.132: INFO: namespace e2e-tests-events-7rg4v deletion completed in 22.23496774s
+
+• [SLOW TEST:28.388 seconds]
+[k8s.io] [sig-node] Events
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:679
+  should be sent by kubelets and the scheduler about pods scheduling and running  [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SS
+------------------------------
+[k8s.io] Docker Containers 
+  should use the image defaults if command and args are blank [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [k8s.io] Docker Containers
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:19:38.132: INFO: >>> kubeConfig: /tmp/kubeconfig-575984058
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should use the image defaults if command and args are blank [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating a pod to test use defaults
+Jul  2 13:19:38.226: INFO: Waiting up to 5m0s for pod "client-containers-9228768f-7dfa-11e8-b7a8-22e3071d17c7" in namespace "e2e-tests-containers-c892b" to be "success or failure"
+Jul  2 13:19:38.230: INFO: Pod "client-containers-9228768f-7dfa-11e8-b7a8-22e3071d17c7": Phase="Pending", Reason="", readiness=false. Elapsed: 3.379457ms
+Jul  2 13:19:40.234: INFO: Pod "client-containers-9228768f-7dfa-11e8-b7a8-22e3071d17c7": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.007109389s
+STEP: Saw pod success
+Jul  2 13:19:40.234: INFO: Pod "client-containers-9228768f-7dfa-11e8-b7a8-22e3071d17c7" satisfied condition "success or failure"
+Jul  2 13:19:40.236: INFO: Trying to get logs from node shoot--core--confos-worker-w6oh6-z1-59946c4f6c-2w6kp pod client-containers-9228768f-7dfa-11e8-b7a8-22e3071d17c7 container test-container: <nil>
+STEP: delete the pod
+Jul  2 13:19:40.297: INFO: Waiting for pod client-containers-9228768f-7dfa-11e8-b7a8-22e3071d17c7 to disappear
+Jul  2 13:19:40.300: INFO: Pod client-containers-9228768f-7dfa-11e8-b7a8-22e3071d17c7 no longer exists
+[AfterEach] [k8s.io] Docker Containers
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:19:40.300: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-containers-c892b" for this suite.
+Jul  2 13:19:46.316: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:19:46.324: INFO: namespace: e2e-tests-containers-c892b, resource: bindings, ignored listing per whitelist
+Jul  2 13:19:46.450: INFO: namespace e2e-tests-containers-c892b deletion completed in 6.144760792s
+
+• [SLOW TEST:8.318 seconds]
+[k8s.io] Docker Containers
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:679
+  should use the image defaults if command and args are blank [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSSS
+------------------------------
+[sig-storage] Projected 
+  should be consumable from pods in volume with mappings and Item mode set [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:19:46.450: INFO: >>> kubeConfig: /tmp/kubeconfig-575984058
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:858
+[It] should be consumable from pods in volume with mappings and Item mode set [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating configMap with name projected-configmap-test-volume-map-971c1f7d-7dfa-11e8-b7a8-22e3071d17c7
+STEP: Creating a pod to test consume configMaps
+Jul  2 13:19:46.539: INFO: Waiting up to 5m0s for pod "pod-projected-configmaps-971cb61e-7dfa-11e8-b7a8-22e3071d17c7" in namespace "e2e-tests-projected-5znd7" to be "success or failure"
+Jul  2 13:19:46.541: INFO: Pod "pod-projected-configmaps-971cb61e-7dfa-11e8-b7a8-22e3071d17c7": Phase="Pending", Reason="", readiness=false. Elapsed: 2.553583ms
+Jul  2 13:19:48.565: INFO: Pod "pod-projected-configmaps-971cb61e-7dfa-11e8-b7a8-22e3071d17c7": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.026706076s
+STEP: Saw pod success
+Jul  2 13:19:48.565: INFO: Pod "pod-projected-configmaps-971cb61e-7dfa-11e8-b7a8-22e3071d17c7" satisfied condition "success or failure"
+Jul  2 13:19:48.569: INFO: Trying to get logs from node shoot--core--confos-worker-w6oh6-z1-59946c4f6c-2w6kp pod pod-projected-configmaps-971cb61e-7dfa-11e8-b7a8-22e3071d17c7 container projected-configmap-volume-test: <nil>
+STEP: delete the pod
+Jul  2 13:19:48.607: INFO: Waiting for pod pod-projected-configmaps-971cb61e-7dfa-11e8-b7a8-22e3071d17c7 to disappear
+Jul  2 13:19:48.625: INFO: Pod pod-projected-configmaps-971cb61e-7dfa-11e8-b7a8-22e3071d17c7 no longer exists
+[AfterEach] [sig-storage] Projected
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:19:48.625: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-5znd7" for this suite.
+Jul  2 13:19:54.644: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:19:54.651: INFO: namespace: e2e-tests-projected-5znd7, resource: bindings, ignored listing per whitelist
+Jul  2 13:19:54.737: INFO: namespace e2e-tests-projected-5znd7 deletion completed in 6.103385s
+
+• [SLOW TEST:8.287 seconds]
+[sig-storage] Projected
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:34
+  should be consumable from pods in volume with mappings and Item mode set [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSSSS
+------------------------------
+[sig-storage] Projected 
+  should be consumable from pods in volume [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:19:54.737: INFO: >>> kubeConfig: /tmp/kubeconfig-575984058
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:858
+[It] should be consumable from pods in volume [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating projection with secret that has name projected-secret-test-9c0d566d-7dfa-11e8-b7a8-22e3071d17c7
+STEP: Creating a pod to test consume secrets
+Jul  2 13:19:54.831: INFO: Waiting up to 5m0s for pod "pod-projected-secrets-9c0dec09-7dfa-11e8-b7a8-22e3071d17c7" in namespace "e2e-tests-projected-p9ctf" to be "success or failure"
+Jul  2 13:19:54.835: INFO: Pod "pod-projected-secrets-9c0dec09-7dfa-11e8-b7a8-22e3071d17c7": Phase="Pending", Reason="", readiness=false. Elapsed: 3.638058ms
+Jul  2 13:19:56.840: INFO: Pod "pod-projected-secrets-9c0dec09-7dfa-11e8-b7a8-22e3071d17c7": Phase="Pending", Reason="", readiness=false. Elapsed: 2.008759174s
+Jul  2 13:19:58.844: INFO: Pod "pod-projected-secrets-9c0dec09-7dfa-11e8-b7a8-22e3071d17c7": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.013213047s
+STEP: Saw pod success
+Jul  2 13:19:58.844: INFO: Pod "pod-projected-secrets-9c0dec09-7dfa-11e8-b7a8-22e3071d17c7" satisfied condition "success or failure"
+Jul  2 13:19:58.847: INFO: Trying to get logs from node shoot--core--confos-worker-w6oh6-z1-59946c4f6c-2w6kp pod pod-projected-secrets-9c0dec09-7dfa-11e8-b7a8-22e3071d17c7 container projected-secret-volume-test: <nil>
+STEP: delete the pod
+Jul  2 13:19:58.871: INFO: Waiting for pod pod-projected-secrets-9c0dec09-7dfa-11e8-b7a8-22e3071d17c7 to disappear
+Jul  2 13:19:58.882: INFO: Pod pod-projected-secrets-9c0dec09-7dfa-11e8-b7a8-22e3071d17c7 no longer exists
+[AfterEach] [sig-storage] Projected
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:19:58.882: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-p9ctf" for this suite.
+Jul  2 13:20:04.896: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:20:05.174: INFO: namespace: e2e-tests-projected-p9ctf, resource: bindings, ignored listing per whitelist
+Jul  2 13:20:05.220: INFO: namespace e2e-tests-projected-p9ctf deletion completed in 6.334348821s
+
+• [SLOW TEST:10.484 seconds]
+[sig-storage] Projected
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:34
+  should be consumable from pods in volume [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSSSSS
+------------------------------
+[sig-api-machinery] Secrets 
+  should be consumable via the environment [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-api-machinery] Secrets
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:20:05.223: INFO: >>> kubeConfig: /tmp/kubeconfig-575984058
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should be consumable via the environment [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: creating secret e2e-tests-secrets-96fqf/secret-test-a24dd9d4-7dfa-11e8-b7a8-22e3071d17c7
+STEP: Creating a pod to test consume secrets
+Jul  2 13:20:05.319: INFO: Waiting up to 5m0s for pod "pod-configmaps-a24e7543-7dfa-11e8-b7a8-22e3071d17c7" in namespace "e2e-tests-secrets-96fqf" to be "success or failure"
+Jul  2 13:20:05.325: INFO: Pod "pod-configmaps-a24e7543-7dfa-11e8-b7a8-22e3071d17c7": Phase="Pending", Reason="", readiness=false. Elapsed: 5.62004ms
+Jul  2 13:20:07.329: INFO: Pod "pod-configmaps-a24e7543-7dfa-11e8-b7a8-22e3071d17c7": Phase="Pending", Reason="", readiness=false. Elapsed: 2.009468942s
+Jul  2 13:20:09.379: INFO: Pod "pod-configmaps-a24e7543-7dfa-11e8-b7a8-22e3071d17c7": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.059773139s
+STEP: Saw pod success
+Jul  2 13:20:09.379: INFO: Pod "pod-configmaps-a24e7543-7dfa-11e8-b7a8-22e3071d17c7" satisfied condition "success or failure"
+Jul  2 13:20:09.382: INFO: Trying to get logs from node shoot--core--confos-worker-w6oh6-z1-59946c4f6c-2w6kp pod pod-configmaps-a24e7543-7dfa-11e8-b7a8-22e3071d17c7 container env-test: <nil>
+STEP: delete the pod
+Jul  2 13:20:09.402: INFO: Waiting for pod pod-configmaps-a24e7543-7dfa-11e8-b7a8-22e3071d17c7 to disappear
+Jul  2 13:20:09.407: INFO: Pod pod-configmaps-a24e7543-7dfa-11e8-b7a8-22e3071d17c7 no longer exists
+[AfterEach] [sig-api-machinery] Secrets
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:20:09.408: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-secrets-96fqf" for this suite.
+Jul  2 13:20:15.465: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:20:15.487: INFO: namespace: e2e-tests-secrets-96fqf, resource: bindings, ignored listing per whitelist
+Jul  2 13:20:15.563: INFO: namespace e2e-tests-secrets-96fqf deletion completed in 6.146387148s
+
+• [SLOW TEST:10.340 seconds]
+[sig-api-machinery] Secrets
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/secrets.go:30
+  should be consumable via the environment [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+[sig-storage] Projected 
+  should provide container's cpu request [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:20:15.563: INFO: >>> kubeConfig: /tmp/kubeconfig-575984058
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:858
+[It] should provide container's cpu request [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating a pod to test downward API volume plugin
+Jul  2 13:20:15.655: INFO: Waiting up to 5m0s for pod "downwardapi-volume-a87751a3-7dfa-11e8-b7a8-22e3071d17c7" in namespace "e2e-tests-projected-wrq2t" to be "success or failure"
+Jul  2 13:20:15.658: INFO: Pod "downwardapi-volume-a87751a3-7dfa-11e8-b7a8-22e3071d17c7": Phase="Pending", Reason="", readiness=false. Elapsed: 2.765502ms
+Jul  2 13:20:17.662: INFO: Pod "downwardapi-volume-a87751a3-7dfa-11e8-b7a8-22e3071d17c7": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.006662238s
+STEP: Saw pod success
+Jul  2 13:20:17.662: INFO: Pod "downwardapi-volume-a87751a3-7dfa-11e8-b7a8-22e3071d17c7" satisfied condition "success or failure"
+Jul  2 13:20:17.665: INFO: Trying to get logs from node shoot--core--confos-worker-w6oh6-z1-59946c4f6c-2w6kp pod downwardapi-volume-a87751a3-7dfa-11e8-b7a8-22e3071d17c7 container client-container: <nil>
+STEP: delete the pod
+Jul  2 13:20:17.680: INFO: Waiting for pod downwardapi-volume-a87751a3-7dfa-11e8-b7a8-22e3071d17c7 to disappear
+Jul  2 13:20:17.685: INFO: Pod downwardapi-volume-a87751a3-7dfa-11e8-b7a8-22e3071d17c7 no longer exists
+[AfterEach] [sig-storage] Projected
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:20:17.685: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-wrq2t" for this suite.
+Jul  2 13:20:23.765: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:20:23.774: INFO: namespace: e2e-tests-projected-wrq2t, resource: bindings, ignored listing per whitelist
+Jul  2 13:20:23.862: INFO: namespace e2e-tests-projected-wrq2t deletion completed in 6.174230125s
+
+• [SLOW TEST:8.300 seconds]
+[sig-storage] Projected
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:34
+  should provide container's cpu request [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+S
+------------------------------
+[sig-storage] Downward API volume 
+  should provide podname only [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:20:23.863: INFO: >>> kubeConfig: /tmp/kubeconfig-575984058
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downwardapi_volume.go:38
+[It] should provide podname only [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating a pod to test downward API volume plugin
+Jul  2 13:20:23.958: INFO: Waiting up to 5m0s for pod "downwardapi-volume-ad6a7345-7dfa-11e8-b7a8-22e3071d17c7" in namespace "e2e-tests-downward-api-b9nv9" to be "success or failure"
+Jul  2 13:20:23.960: INFO: Pod "downwardapi-volume-ad6a7345-7dfa-11e8-b7a8-22e3071d17c7": Phase="Pending", Reason="", readiness=false. Elapsed: 2.771071ms
+Jul  2 13:20:25.965: INFO: Pod "downwardapi-volume-ad6a7345-7dfa-11e8-b7a8-22e3071d17c7": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.007558552s
+STEP: Saw pod success
+Jul  2 13:20:25.965: INFO: Pod "downwardapi-volume-ad6a7345-7dfa-11e8-b7a8-22e3071d17c7" satisfied condition "success or failure"
+Jul  2 13:20:25.968: INFO: Trying to get logs from node shoot--core--confos-worker-w6oh6-z1-59946c4f6c-2w6kp pod downwardapi-volume-ad6a7345-7dfa-11e8-b7a8-22e3071d17c7 container client-container: <nil>
+STEP: delete the pod
+Jul  2 13:20:26.080: INFO: Waiting for pod downwardapi-volume-ad6a7345-7dfa-11e8-b7a8-22e3071d17c7 to disappear
+Jul  2 13:20:26.088: INFO: Pod downwardapi-volume-ad6a7345-7dfa-11e8-b7a8-22e3071d17c7 no longer exists
+[AfterEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:20:26.089: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-downward-api-b9nv9" for this suite.
+Jul  2 13:20:32.106: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:20:32.149: INFO: namespace: e2e-tests-downward-api-b9nv9, resource: bindings, ignored listing per whitelist
+Jul  2 13:20:32.222: INFO: namespace e2e-tests-downward-api-b9nv9 deletion completed in 6.129360483s
+
+• [SLOW TEST:8.360 seconds]
+[sig-storage] Downward API volume
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downwardapi_volume.go:33
+  should provide podname only [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSSSSSSSSS
+------------------------------
+[k8s.io] Pods 
+  should be submitted and removed [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [k8s.io] Pods
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:20:32.223: INFO: >>> kubeConfig: /tmp/kubeconfig-575984058
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [k8s.io] Pods
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/pods.go:127
+[It] should be submitted and removed [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: creating the pod
+STEP: setting up watch
+STEP: submitting the pod to kubernetes
+STEP: verifying the pod is in kubernetes
+STEP: verifying pod creation was observed
+Jul  2 13:20:34.332: INFO: running pod: &v1.Pod{TypeMeta:v1.TypeMeta{Kind:"", APIVersion:""}, ObjectMeta:v1.ObjectMeta{Name:"pod-submit-remove-b2652647-7dfa-11e8-b7a8-22e3071d17c7", GenerateName:"", Namespace:"e2e-tests-pods-tr52n", SelfLink:"/api/v1/namespaces/e2e-tests-pods-tr52n/pods/pod-submit-remove-b2652647-7dfa-11e8-b7a8-22e3071d17c7", UID:"b26aad2a-7dfa-11e8-a560-160e0404a9f8", ResourceVersion:"6376", Generation:0, CreationTimestamp:v1.Time{Time:time.Time{wall:0x0, ext:63666134432, loc:(*time.Location)(0x642c9a0)}}, DeletionTimestamp:(*v1.Time)(nil), DeletionGracePeriodSeconds:(*int64)(nil), Labels:map[string]string{"time":"306955420", "name":"foo"}, Annotations:map[string]string{"cni.projectcalico.org/podIP":"100.96.1.96/32"}, OwnerReferences:[]v1.OwnerReference(nil), Initializers:(*v1.Initializers)(nil), Finalizers:[]string(nil), ClusterName:""}, Spec:v1.PodSpec{Volumes:[]v1.Volume{v1.Volume{Name:"default-token-4fddl", VolumeSource:v1.VolumeSource{HostPath:(*v1.HostPathVolumeSource)(nil), EmptyDir:(*v1.EmptyDirVolumeSource)(nil), GCEPersistentDisk:(*v1.GCEPersistentDiskVolumeSource)(nil), AWSElasticBlockStore:(*v1.AWSElasticBlockStoreVolumeSource)(nil), GitRepo:(*v1.GitRepoVolumeSource)(nil), Secret:(*v1.SecretVolumeSource)(0xc42063b340), NFS:(*v1.NFSVolumeSource)(nil), ISCSI:(*v1.ISCSIVolumeSource)(nil), Glusterfs:(*v1.GlusterfsVolumeSource)(nil), PersistentVolumeClaim:(*v1.PersistentVolumeClaimVolumeSource)(nil), RBD:(*v1.RBDVolumeSource)(nil), FlexVolume:(*v1.FlexVolumeSource)(nil), Cinder:(*v1.CinderVolumeSource)(nil), CephFS:(*v1.CephFSVolumeSource)(nil), Flocker:(*v1.FlockerVolumeSource)(nil), DownwardAPI:(*v1.DownwardAPIVolumeSource)(nil), FC:(*v1.FCVolumeSource)(nil), AzureFile:(*v1.AzureFileVolumeSource)(nil), ConfigMap:(*v1.ConfigMapVolumeSource)(nil), VsphereVolume:(*v1.VsphereVirtualDiskVolumeSource)(nil), Quobyte:(*v1.QuobyteVolumeSource)(nil), AzureDisk:(*v1.AzureDiskVolumeSource)(nil), PhotonPersistentDisk:(*v1.PhotonPersistentDiskVolumeSource)(nil), Projected:(*v1.ProjectedVolumeSource)(nil), PortworxVolume:(*v1.PortworxVolumeSource)(nil), ScaleIO:(*v1.ScaleIOVolumeSource)(nil), StorageOS:(*v1.StorageOSVolumeSource)(nil)}}}, InitContainers:[]v1.Container(nil), Containers:[]v1.Container{v1.Container{Name:"nginx", Image:"k8s.gcr.io/nginx-slim-amd64:0.20", Command:[]string(nil), Args:[]string(nil), WorkingDir:"", Ports:[]v1.ContainerPort(nil), EnvFrom:[]v1.EnvFromSource(nil), Env:[]v1.EnvVar(nil), Resources:v1.ResourceRequirements{Limits:v1.ResourceList(nil), Requests:v1.ResourceList(nil)}, VolumeMounts:[]v1.VolumeMount{v1.VolumeMount{Name:"default-token-4fddl", ReadOnly:true, MountPath:"/var/run/secrets/kubernetes.io/serviceaccount", SubPath:"", MountPropagation:(*v1.MountPropagationMode)(nil)}}, VolumeDevices:[]v1.VolumeDevice(nil), LivenessProbe:(*v1.Probe)(nil), ReadinessProbe:(*v1.Probe)(nil), Lifecycle:(*v1.Lifecycle)(nil), TerminationMessagePath:"/dev/termination-log", TerminationMessagePolicy:"File", ImagePullPolicy:"IfNotPresent", SecurityContext:(*v1.SecurityContext)(nil), Stdin:false, StdinOnce:false, TTY:false}}, RestartPolicy:"Always", TerminationGracePeriodSeconds:(*int64)(0xc4200c66b8), ActiveDeadlineSeconds:(*int64)(nil), DNSPolicy:"ClusterFirst", NodeSelector:map[string]string(nil), ServiceAccountName:"default", DeprecatedServiceAccount:"default", AutomountServiceAccountToken:(*bool)(nil), NodeName:"shoot--core--confos-worker-w6oh6-z1-59946c4f6c-2w6kp", HostNetwork:false, HostPID:false, HostIPC:false, ShareProcessNamespace:(*bool)(nil), SecurityContext:(*v1.PodSecurityContext)(0xc4210afc20), ImagePullSecrets:[]v1.LocalObjectReference(nil), Hostname:"", Subdomain:"", Affinity:(*v1.Affinity)(nil), SchedulerName:"default-scheduler", Tolerations:[]v1.Toleration{v1.Toleration{Key:"node.kubernetes.io/not-ready", Operator:"Exists", Value:"", Effect:"NoExecute", TolerationSeconds:(*int64)(0xc4200c69f0)}, v1.Toleration{Key:"node.kubernetes.io/unreachable", Operator:"Exists", Value:"", Effect:"NoExecute", TolerationSeconds:(*int64)(0xc4200c6c50)}}, HostAliases:[]v1.HostAlias(nil), PriorityClassName:"", Priority:(*int32)(nil), DNSConfig:(*v1.PodDNSConfig)(nil), ReadinessGates:[]v1.PodReadinessGate(nil)}, Status:v1.PodStatus{Phase:"Running", Conditions:[]v1.PodCondition{v1.PodCondition{Type:"Initialized", Status:"True", LastProbeTime:v1.Time{Time:time.Time{wall:0x0, ext:0, loc:(*time.Location)(nil)}}, LastTransitionTime:v1.Time{Time:time.Time{wall:0x0, ext:63666134432, loc:(*time.Location)(0x642c9a0)}}, Reason:"", Message:""}, v1.PodCondition{Type:"Ready", Status:"True", LastProbeTime:v1.Time{Time:time.Time{wall:0x0, ext:0, loc:(*time.Location)(nil)}}, LastTransitionTime:v1.Time{Time:time.Time{wall:0x0, ext:63666134433, loc:(*time.Location)(0x642c9a0)}}, Reason:"", Message:""}, v1.PodCondition{Type:"ContainersReady", Status:"True", LastProbeTime:v1.Time{Time:time.Time{wall:0x0, ext:0, loc:(*time.Location)(nil)}}, LastTransitionTime:v1.Time{Time:time.Time{wall:0x0, ext:0, loc:(*time.Location)(nil)}}, Reason:"", Message:""}, v1.PodCondition{Type:"PodScheduled", Status:"True", LastProbeTime:v1.Time{Time:time.Time{wall:0x0, ext:0, loc:(*time.Location)(nil)}}, LastTransitionTime:v1.Time{Time:time.Time{wall:0x0, ext:63666134432, loc:(*time.Location)(0x642c9a0)}}, Reason:"", Message:""}}, Message:"", Reason:"", NominatedNodeName:"", HostIP:"10.250.0.17", PodIP:"100.96.1.96", StartTime:(*v1.Time)(0xc420916920), InitContainerStatuses:[]v1.ContainerStatus(nil), ContainerStatuses:[]v1.ContainerStatus{v1.ContainerStatus{Name:"nginx", State:v1.ContainerState{Waiting:(*v1.ContainerStateWaiting)(nil), Running:(*v1.ContainerStateRunning)(0xc420916940), Terminated:(*v1.ContainerStateTerminated)(nil)}, LastTerminationState:v1.ContainerState{Waiting:(*v1.ContainerStateWaiting)(nil), Running:(*v1.ContainerStateRunning)(nil), Terminated:(*v1.ContainerStateTerminated)(nil)}, Ready:true, RestartCount:0, Image:"k8s.gcr.io/nginx-slim-amd64:0.20", ImageID:"docker-pullable://k8s.gcr.io/nginx-slim-amd64@sha256:6654db6d4028756062edac466454ee5c9cf9b20ef79e35a81e3c840031eb1e2b", ContainerID:"docker://7f0ef7638c6d7af69c33b2ebb4748ae3f4ddaf33b6892818618ef578c9baf1fb"}}, QOSClass:"BestEffort"}}
+STEP: deleting the pod gracefully
+STEP: verifying the kubelet observed the termination notice
+STEP: verifying pod deletion was observed
+[AfterEach] [k8s.io] Pods
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:20:47.936: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-pods-tr52n" for this suite.
+Jul  2 13:20:53.954: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:20:53.964: INFO: namespace: e2e-tests-pods-tr52n, resource: bindings, ignored listing per whitelist
+Jul  2 13:20:54.053: INFO: namespace e2e-tests-pods-tr52n deletion completed in 6.112208472s
+
+• [SLOW TEST:21.831 seconds]
+[k8s.io] Pods
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:679
+  should be submitted and removed [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSSSSSSSSS
+------------------------------
+[k8s.io] KubeletManagedEtcHosts 
+  should test kubelet managed /etc/hosts file [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [k8s.io] KubeletManagedEtcHosts
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:20:54.055: INFO: >>> kubeConfig: /tmp/kubeconfig-575984058
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should test kubelet managed /etc/hosts file [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Setting up the test
+STEP: Creating hostNetwork=false pod
+STEP: Creating hostNetwork=true pod
+STEP: Running the test
+STEP: Verifying /etc/hosts of container is kubelet-managed for pod with hostNetwork=false
+Jul  2 13:20:58.377: INFO: ExecWithOptions {Command:[cat /etc/hosts] Namespace:e2e-tests-e2e-kubelet-etc-hosts-vk9h2 PodName:test-pod ContainerName:busybox-1 Stdin:<nil> CaptureStdout:true CaptureStderr:true PreserveWhitespace:false}
+Jul  2 13:20:58.377: INFO: >>> kubeConfig: /tmp/kubeconfig-575984058
+Jul  2 13:20:58.733: INFO: Exec stderr: ""
+Jul  2 13:20:58.733: INFO: ExecWithOptions {Command:[cat /etc/hosts-original] Namespace:e2e-tests-e2e-kubelet-etc-hosts-vk9h2 PodName:test-pod ContainerName:busybox-1 Stdin:<nil> CaptureStdout:true CaptureStderr:true PreserveWhitespace:false}
+Jul  2 13:20:58.733: INFO: >>> kubeConfig: /tmp/kubeconfig-575984058
+Jul  2 13:20:59.110: INFO: Exec stderr: ""
+Jul  2 13:20:59.110: INFO: ExecWithOptions {Command:[cat /etc/hosts] Namespace:e2e-tests-e2e-kubelet-etc-hosts-vk9h2 PodName:test-pod ContainerName:busybox-2 Stdin:<nil> CaptureStdout:true CaptureStderr:true PreserveWhitespace:false}
+Jul  2 13:20:59.110: INFO: >>> kubeConfig: /tmp/kubeconfig-575984058
+Jul  2 13:20:59.485: INFO: Exec stderr: ""
+Jul  2 13:20:59.485: INFO: ExecWithOptions {Command:[cat /etc/hosts-original] Namespace:e2e-tests-e2e-kubelet-etc-hosts-vk9h2 PodName:test-pod ContainerName:busybox-2 Stdin:<nil> CaptureStdout:true CaptureStderr:true PreserveWhitespace:false}
+Jul  2 13:20:59.485: INFO: >>> kubeConfig: /tmp/kubeconfig-575984058
+Jul  2 13:20:59.913: INFO: Exec stderr: ""
+STEP: Verifying /etc/hosts of container is not kubelet-managed since container specifies /etc/hosts mount
+Jul  2 13:20:59.913: INFO: ExecWithOptions {Command:[cat /etc/hosts] Namespace:e2e-tests-e2e-kubelet-etc-hosts-vk9h2 PodName:test-pod ContainerName:busybox-3 Stdin:<nil> CaptureStdout:true CaptureStderr:true PreserveWhitespace:false}
+Jul  2 13:20:59.913: INFO: >>> kubeConfig: /tmp/kubeconfig-575984058
+Jul  2 13:21:00.365: INFO: Exec stderr: ""
+Jul  2 13:21:00.365: INFO: ExecWithOptions {Command:[cat /etc/hosts-original] Namespace:e2e-tests-e2e-kubelet-etc-hosts-vk9h2 PodName:test-pod ContainerName:busybox-3 Stdin:<nil> CaptureStdout:true CaptureStderr:true PreserveWhitespace:false}
+Jul  2 13:21:00.365: INFO: >>> kubeConfig: /tmp/kubeconfig-575984058
+Jul  2 13:21:00.825: INFO: Exec stderr: ""
+STEP: Verifying /etc/hosts content of container is not kubelet-managed for pod with hostNetwork=true
+Jul  2 13:21:00.825: INFO: ExecWithOptions {Command:[cat /etc/hosts] Namespace:e2e-tests-e2e-kubelet-etc-hosts-vk9h2 PodName:test-host-network-pod ContainerName:busybox-1 Stdin:<nil> CaptureStdout:true CaptureStderr:true PreserveWhitespace:false}
+Jul  2 13:21:00.825: INFO: >>> kubeConfig: /tmp/kubeconfig-575984058
+Jul  2 13:21:01.175: INFO: Exec stderr: ""
+Jul  2 13:21:01.175: INFO: ExecWithOptions {Command:[cat /etc/hosts-original] Namespace:e2e-tests-e2e-kubelet-etc-hosts-vk9h2 PodName:test-host-network-pod ContainerName:busybox-1 Stdin:<nil> CaptureStdout:true CaptureStderr:true PreserveWhitespace:false}
+Jul  2 13:21:01.175: INFO: >>> kubeConfig: /tmp/kubeconfig-575984058
+Jul  2 13:21:01.509: INFO: Exec stderr: ""
+Jul  2 13:21:01.509: INFO: ExecWithOptions {Command:[cat /etc/hosts] Namespace:e2e-tests-e2e-kubelet-etc-hosts-vk9h2 PodName:test-host-network-pod ContainerName:busybox-2 Stdin:<nil> CaptureStdout:true CaptureStderr:true PreserveWhitespace:false}
+Jul  2 13:21:01.509: INFO: >>> kubeConfig: /tmp/kubeconfig-575984058
+Jul  2 13:21:01.932: INFO: Exec stderr: ""
+Jul  2 13:21:01.932: INFO: ExecWithOptions {Command:[cat /etc/hosts-original] Namespace:e2e-tests-e2e-kubelet-etc-hosts-vk9h2 PodName:test-host-network-pod ContainerName:busybox-2 Stdin:<nil> CaptureStdout:true CaptureStderr:true PreserveWhitespace:false}
+Jul  2 13:21:01.932: INFO: >>> kubeConfig: /tmp/kubeconfig-575984058
+Jul  2 13:21:02.341: INFO: Exec stderr: ""
+[AfterEach] [k8s.io] KubeletManagedEtcHosts
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:21:02.341: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-e2e-kubelet-etc-hosts-vk9h2" for this suite.
+Jul  2 13:21:52.355: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:21:52.383: INFO: namespace: e2e-tests-e2e-kubelet-etc-hosts-vk9h2, resource: bindings, ignored listing per whitelist
+Jul  2 13:21:52.546: INFO: namespace e2e-tests-e2e-kubelet-etc-hosts-vk9h2 deletion completed in 50.20142566s
+
+• [SLOW TEST:58.491 seconds]
+[k8s.io] KubeletManagedEtcHosts
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:679
+  should test kubelet managed /etc/hosts file [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+[sig-api-machinery] Watchers 
+  should observe add, update, and delete watch notifications on configmaps [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-api-machinery] Watchers
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:21:52.546: INFO: >>> kubeConfig: /tmp/kubeconfig-575984058
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should observe add, update, and delete watch notifications on configmaps [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: creating a watch on configmaps with label A
+STEP: creating a watch on configmaps with label B
+STEP: creating a watch on configmaps with label A or B
+STEP: creating a configmap with label A and ensuring the correct watchers observe the notification
+Jul  2 13:21:52.650: INFO: Got : ADDED &ConfigMap{ObjectMeta:k8s_io_apimachinery_pkg_apis_meta_v1.ObjectMeta{Name:e2e-watch-test-configmap-a,GenerateName:,Namespace:e2e-tests-watch-hqxlw,SelfLink:/api/v1/namespaces/e2e-tests-watch-hqxlw/configmaps/e2e-watch-test-configmap-a,UID:e24c48fb-7dfa-11e8-a560-160e0404a9f8,ResourceVersion:6572,Generation:0,CreationTimestamp:2018-07-02 13:21:52 +0000 UTC,DeletionTimestamp:<nil>,DeletionGracePeriodSeconds:nil,Labels:map[string]string{watch-this-configmap: multiple-watchers-A,},Annotations:map[string]string{},OwnerReferences:[],Finalizers:[],ClusterName:,Initializers:nil,},Data:map[string]string{},BinaryData:map[string][]byte{},}
+Jul  2 13:21:52.650: INFO: Got : ADDED &ConfigMap{ObjectMeta:k8s_io_apimachinery_pkg_apis_meta_v1.ObjectMeta{Name:e2e-watch-test-configmap-a,GenerateName:,Namespace:e2e-tests-watch-hqxlw,SelfLink:/api/v1/namespaces/e2e-tests-watch-hqxlw/configmaps/e2e-watch-test-configmap-a,UID:e24c48fb-7dfa-11e8-a560-160e0404a9f8,ResourceVersion:6572,Generation:0,CreationTimestamp:2018-07-02 13:21:52 +0000 UTC,DeletionTimestamp:<nil>,DeletionGracePeriodSeconds:nil,Labels:map[string]string{watch-this-configmap: multiple-watchers-A,},Annotations:map[string]string{},OwnerReferences:[],Finalizers:[],ClusterName:,Initializers:nil,},Data:map[string]string{},BinaryData:map[string][]byte{},}
+STEP: modifying configmap A and ensuring the correct watchers observe the notification
+Jul  2 13:22:02.766: INFO: Got : MODIFIED &ConfigMap{ObjectMeta:k8s_io_apimachinery_pkg_apis_meta_v1.ObjectMeta{Name:e2e-watch-test-configmap-a,GenerateName:,Namespace:e2e-tests-watch-hqxlw,SelfLink:/api/v1/namespaces/e2e-tests-watch-hqxlw/configmaps/e2e-watch-test-configmap-a,UID:e24c48fb-7dfa-11e8-a560-160e0404a9f8,ResourceVersion:6592,Generation:0,CreationTimestamp:2018-07-02 13:21:52 +0000 UTC,DeletionTimestamp:<nil>,DeletionGracePeriodSeconds:nil,Labels:map[string]string{watch-this-configmap: multiple-watchers-A,},Annotations:map[string]string{},OwnerReferences:[],Finalizers:[],ClusterName:,Initializers:nil,},Data:map[string]string{mutation: 1,},BinaryData:map[string][]byte{},}
+Jul  2 13:22:02.766: INFO: Got : MODIFIED &ConfigMap{ObjectMeta:k8s_io_apimachinery_pkg_apis_meta_v1.ObjectMeta{Name:e2e-watch-test-configmap-a,GenerateName:,Namespace:e2e-tests-watch-hqxlw,SelfLink:/api/v1/namespaces/e2e-tests-watch-hqxlw/configmaps/e2e-watch-test-configmap-a,UID:e24c48fb-7dfa-11e8-a560-160e0404a9f8,ResourceVersion:6592,Generation:0,CreationTimestamp:2018-07-02 13:21:52 +0000 UTC,DeletionTimestamp:<nil>,DeletionGracePeriodSeconds:nil,Labels:map[string]string{watch-this-configmap: multiple-watchers-A,},Annotations:map[string]string{},OwnerReferences:[],Finalizers:[],ClusterName:,Initializers:nil,},Data:map[string]string{mutation: 1,},BinaryData:map[string][]byte{},}
+STEP: modifying configmap A again and ensuring the correct watchers observe the notification
+Jul  2 13:22:12.866: INFO: Got : MODIFIED &ConfigMap{ObjectMeta:k8s_io_apimachinery_pkg_apis_meta_v1.ObjectMeta{Name:e2e-watch-test-configmap-a,GenerateName:,Namespace:e2e-tests-watch-hqxlw,SelfLink:/api/v1/namespaces/e2e-tests-watch-hqxlw/configmaps/e2e-watch-test-configmap-a,UID:e24c48fb-7dfa-11e8-a560-160e0404a9f8,ResourceVersion:6614,Generation:0,CreationTimestamp:2018-07-02 13:21:52 +0000 UTC,DeletionTimestamp:<nil>,DeletionGracePeriodSeconds:nil,Labels:map[string]string{watch-this-configmap: multiple-watchers-A,},Annotations:map[string]string{},OwnerReferences:[],Finalizers:[],ClusterName:,Initializers:nil,},Data:map[string]string{mutation: 2,},BinaryData:map[string][]byte{},}
+Jul  2 13:22:12.866: INFO: Got : MODIFIED &ConfigMap{ObjectMeta:k8s_io_apimachinery_pkg_apis_meta_v1.ObjectMeta{Name:e2e-watch-test-configmap-a,GenerateName:,Namespace:e2e-tests-watch-hqxlw,SelfLink:/api/v1/namespaces/e2e-tests-watch-hqxlw/configmaps/e2e-watch-test-configmap-a,UID:e24c48fb-7dfa-11e8-a560-160e0404a9f8,ResourceVersion:6614,Generation:0,CreationTimestamp:2018-07-02 13:21:52 +0000 UTC,DeletionTimestamp:<nil>,DeletionGracePeriodSeconds:nil,Labels:map[string]string{watch-this-configmap: multiple-watchers-A,},Annotations:map[string]string{},OwnerReferences:[],Finalizers:[],ClusterName:,Initializers:nil,},Data:map[string]string{mutation: 2,},BinaryData:map[string][]byte{},}
+STEP: deleting configmap A and ensuring the correct watchers observe the notification
+Jul  2 13:22:22.872: INFO: Got : DELETED &ConfigMap{ObjectMeta:k8s_io_apimachinery_pkg_apis_meta_v1.ObjectMeta{Name:e2e-watch-test-configmap-a,GenerateName:,Namespace:e2e-tests-watch-hqxlw,SelfLink:/api/v1/namespaces/e2e-tests-watch-hqxlw/configmaps/e2e-watch-test-configmap-a,UID:e24c48fb-7dfa-11e8-a560-160e0404a9f8,ResourceVersion:6635,Generation:0,CreationTimestamp:2018-07-02 13:21:52 +0000 UTC,DeletionTimestamp:<nil>,DeletionGracePeriodSeconds:nil,Labels:map[string]string{watch-this-configmap: multiple-watchers-A,},Annotations:map[string]string{},OwnerReferences:[],Finalizers:[],ClusterName:,Initializers:nil,},Data:map[string]string{mutation: 2,},BinaryData:map[string][]byte{},}
+Jul  2 13:22:22.872: INFO: Got : DELETED &ConfigMap{ObjectMeta:k8s_io_apimachinery_pkg_apis_meta_v1.ObjectMeta{Name:e2e-watch-test-configmap-a,GenerateName:,Namespace:e2e-tests-watch-hqxlw,SelfLink:/api/v1/namespaces/e2e-tests-watch-hqxlw/configmaps/e2e-watch-test-configmap-a,UID:e24c48fb-7dfa-11e8-a560-160e0404a9f8,ResourceVersion:6635,Generation:0,CreationTimestamp:2018-07-02 13:21:52 +0000 UTC,DeletionTimestamp:<nil>,DeletionGracePeriodSeconds:nil,Labels:map[string]string{watch-this-configmap: multiple-watchers-A,},Annotations:map[string]string{},OwnerReferences:[],Finalizers:[],ClusterName:,Initializers:nil,},Data:map[string]string{mutation: 2,},BinaryData:map[string][]byte{},}
+STEP: creating a configmap with label B and ensuring the correct watchers observe the notification
+Jul  2 13:22:32.966: INFO: Got : ADDED &ConfigMap{ObjectMeta:k8s_io_apimachinery_pkg_apis_meta_v1.ObjectMeta{Name:e2e-watch-test-configmap-b,GenerateName:,Namespace:e2e-tests-watch-hqxlw,SelfLink:/api/v1/namespaces/e2e-tests-watch-hqxlw/configmaps/e2e-watch-test-configmap-b,UID:fa467b14-7dfa-11e8-a560-160e0404a9f8,ResourceVersion:6655,Generation:0,CreationTimestamp:2018-07-02 13:22:32 +0000 UTC,DeletionTimestamp:<nil>,DeletionGracePeriodSeconds:nil,Labels:map[string]string{watch-this-configmap: multiple-watchers-B,},Annotations:map[string]string{},OwnerReferences:[],Finalizers:[],ClusterName:,Initializers:nil,},Data:map[string]string{},BinaryData:map[string][]byte{},}
+Jul  2 13:22:32.966: INFO: Got : ADDED &ConfigMap{ObjectMeta:k8s_io_apimachinery_pkg_apis_meta_v1.ObjectMeta{Name:e2e-watch-test-configmap-b,GenerateName:,Namespace:e2e-tests-watch-hqxlw,SelfLink:/api/v1/namespaces/e2e-tests-watch-hqxlw/configmaps/e2e-watch-test-configmap-b,UID:fa467b14-7dfa-11e8-a560-160e0404a9f8,ResourceVersion:6655,Generation:0,CreationTimestamp:2018-07-02 13:22:32 +0000 UTC,DeletionTimestamp:<nil>,DeletionGracePeriodSeconds:nil,Labels:map[string]string{watch-this-configmap: multiple-watchers-B,},Annotations:map[string]string{},OwnerReferences:[],Finalizers:[],ClusterName:,Initializers:nil,},Data:map[string]string{},BinaryData:map[string][]byte{},}
+STEP: deleting configmap B and ensuring the correct watchers observe the notification
+Jul  2 13:22:43.067: INFO: Got : DELETED &ConfigMap{ObjectMeta:k8s_io_apimachinery_pkg_apis_meta_v1.ObjectMeta{Name:e2e-watch-test-configmap-b,GenerateName:,Namespace:e2e-tests-watch-hqxlw,SelfLink:/api/v1/namespaces/e2e-tests-watch-hqxlw/configmaps/e2e-watch-test-configmap-b,UID:fa467b14-7dfa-11e8-a560-160e0404a9f8,ResourceVersion:6677,Generation:0,CreationTimestamp:2018-07-02 13:22:32 +0000 UTC,DeletionTimestamp:<nil>,DeletionGracePeriodSeconds:nil,Labels:map[string]string{watch-this-configmap: multiple-watchers-B,},Annotations:map[string]string{},OwnerReferences:[],Finalizers:[],ClusterName:,Initializers:nil,},Data:map[string]string{},BinaryData:map[string][]byte{},}
+Jul  2 13:22:43.068: INFO: Got : DELETED &ConfigMap{ObjectMeta:k8s_io_apimachinery_pkg_apis_meta_v1.ObjectMeta{Name:e2e-watch-test-configmap-b,GenerateName:,Namespace:e2e-tests-watch-hqxlw,SelfLink:/api/v1/namespaces/e2e-tests-watch-hqxlw/configmaps/e2e-watch-test-configmap-b,UID:fa467b14-7dfa-11e8-a560-160e0404a9f8,ResourceVersion:6677,Generation:0,CreationTimestamp:2018-07-02 13:22:32 +0000 UTC,DeletionTimestamp:<nil>,DeletionGracePeriodSeconds:nil,Labels:map[string]string{watch-this-configmap: multiple-watchers-B,},Annotations:map[string]string{},OwnerReferences:[],Finalizers:[],ClusterName:,Initializers:nil,},Data:map[string]string{},BinaryData:map[string][]byte{},}
+[AfterEach] [sig-api-machinery] Watchers
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:22:53.068: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-watch-hqxlw" for this suite.
+Jul  2 13:22:59.084: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:22:59.091: INFO: namespace: e2e-tests-watch-hqxlw, resource: bindings, ignored listing per whitelist
+Jul  2 13:22:59.341: INFO: namespace e2e-tests-watch-hqxlw deletion completed in 6.268408128s
+
+• [SLOW TEST:66.795 seconds]
+[sig-api-machinery] Watchers
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apimachinery/framework.go:22
+  should observe add, update, and delete watch notifications on configmaps [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSSSSSS
+------------------------------
+[sig-storage] Projected 
+  should update labels on modification [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:22:59.341: INFO: >>> kubeConfig: /tmp/kubeconfig-575984058
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:858
+[It] should update labels on modification [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating the pod
+Jul  2 13:23:01.962: INFO: Successfully updated pod "labelsupdate0a160b92-7dfb-11e8-b7a8-22e3071d17c7"
+[AfterEach] [sig-storage] Projected
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:23:03.981: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-5pct4" for this suite.
+Jul  2 13:23:25.994: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:23:26.065: INFO: namespace: e2e-tests-projected-5pct4, resource: bindings, ignored listing per whitelist
+Jul  2 13:23:26.091: INFO: namespace e2e-tests-projected-5pct4 deletion completed in 22.107076876s
+
+• [SLOW TEST:26.750 seconds]
+[sig-storage] Projected
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:34
+  should update labels on modification [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+S
+------------------------------
+[sig-apps] StatefulSet [k8s.io] Basic StatefulSet functionality [StatefulSetBasic] 
+  should perform rolling updates and roll backs of template modifications [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-apps] StatefulSet
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:23:26.091: INFO: >>> kubeConfig: /tmp/kubeconfig-575984058
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-apps] StatefulSet
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/statefulset.go:57
+[BeforeEach] [k8s.io] Basic StatefulSet functionality [StatefulSetBasic]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/statefulset.go:72
+STEP: Creating service test in namespace e2e-tests-statefulset-h5mj7
+[It] should perform rolling updates and roll backs of template modifications [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating a new StatefulSet
+Jul  2 13:23:26.192: INFO: Found 0 stateful pods, waiting for 3
+Jul  2 13:23:36.197: INFO: Waiting for pod ss2-0 to enter Running - Ready=true, currently Running - Ready=true
+Jul  2 13:23:36.197: INFO: Waiting for pod ss2-1 to enter Running - Ready=true, currently Running - Ready=true
+Jul  2 13:23:36.197: INFO: Waiting for pod ss2-2 to enter Running - Ready=true, currently Running - Ready=true
+Jul  2 13:23:36.206: INFO: Running '/usr/local/bin/kubectl --kubeconfig=/tmp/kubeconfig-575984058 exec --namespace=e2e-tests-statefulset-h5mj7 ss2-1 -- /bin/sh -c mv -v /usr/share/nginx/html/index.html /tmp/ || true'
+Jul  2 13:23:36.698: INFO: stderr: ""
+Jul  2 13:23:36.698: INFO: stdout: "'/usr/share/nginx/html/index.html' -> '/tmp/index.html'\n"
+Jul  2 13:23:36.698: INFO: stdout of mv -v /usr/share/nginx/html/index.html /tmp/ || true on ss2-1: '/usr/share/nginx/html/index.html' -> '/tmp/index.html'
+
+STEP: Updating StatefulSet template: update image from k8s.gcr.io/nginx-slim-amd64:0.20 to k8s.gcr.io/nginx-slim-amd64:0.21
+Jul  2 13:23:36.722: INFO: Updating stateful set ss2
+STEP: Creating a new revision
+STEP: Updating Pods in reverse ordinal order
+Jul  2 13:23:46.786: INFO: Running '/usr/local/bin/kubectl --kubeconfig=/tmp/kubeconfig-575984058 exec --namespace=e2e-tests-statefulset-h5mj7 ss2-1 -- /bin/sh -c mv -v /tmp/index.html /usr/share/nginx/html/ || true'
+Jul  2 13:23:47.230: INFO: stderr: ""
+Jul  2 13:23:47.230: INFO: stdout: "'/tmp/index.html' -> '/usr/share/nginx/html/index.html'\n"
+Jul  2 13:23:47.230: INFO: stdout of mv -v /tmp/index.html /usr/share/nginx/html/ || true on ss2-1: '/tmp/index.html' -> '/usr/share/nginx/html/index.html'
+
+Jul  2 13:23:57.268: INFO: Waiting for StatefulSet e2e-tests-statefulset-h5mj7/ss2 to complete update
+Jul  2 13:23:57.268: INFO: Waiting for Pod e2e-tests-statefulset-h5mj7/ss2-0 to have revision ss2-56dd5fb9c4 update revision ss2-76cb68b6ff
+Jul  2 13:23:57.268: INFO: Waiting for Pod e2e-tests-statefulset-h5mj7/ss2-1 to have revision ss2-56dd5fb9c4 update revision ss2-76cb68b6ff
+Jul  2 13:23:57.268: INFO: Waiting for Pod e2e-tests-statefulset-h5mj7/ss2-2 to have revision ss2-56dd5fb9c4 update revision ss2-76cb68b6ff
+Jul  2 13:24:07.276: INFO: Waiting for StatefulSet e2e-tests-statefulset-h5mj7/ss2 to complete update
+Jul  2 13:24:07.276: INFO: Waiting for Pod e2e-tests-statefulset-h5mj7/ss2-0 to have revision ss2-56dd5fb9c4 update revision ss2-76cb68b6ff
+Jul  2 13:24:07.276: INFO: Waiting for Pod e2e-tests-statefulset-h5mj7/ss2-1 to have revision ss2-56dd5fb9c4 update revision ss2-76cb68b6ff
+Jul  2 13:24:17.465: INFO: Waiting for StatefulSet e2e-tests-statefulset-h5mj7/ss2 to complete update
+Jul  2 13:24:17.465: INFO: Waiting for Pod e2e-tests-statefulset-h5mj7/ss2-0 to have revision ss2-56dd5fb9c4 update revision ss2-76cb68b6ff
+STEP: Rolling back to a previous revision
+Jul  2 13:24:27.276: INFO: Running '/usr/local/bin/kubectl --kubeconfig=/tmp/kubeconfig-575984058 exec --namespace=e2e-tests-statefulset-h5mj7 ss2-1 -- /bin/sh -c mv -v /usr/share/nginx/html/index.html /tmp/ || true'
+Jul  2 13:24:27.804: INFO: stderr: ""
+Jul  2 13:24:27.804: INFO: stdout: "'/usr/share/nginx/html/index.html' -> '/tmp/index.html'\n"
+Jul  2 13:24:27.804: INFO: stdout of mv -v /usr/share/nginx/html/index.html /tmp/ || true on ss2-1: '/usr/share/nginx/html/index.html' -> '/tmp/index.html'
+
+Jul  2 13:24:37.890: INFO: Updating stateful set ss2
+STEP: Rolling back update in reverse ordinal order
+Jul  2 13:24:47.983: INFO: Running '/usr/local/bin/kubectl --kubeconfig=/tmp/kubeconfig-575984058 exec --namespace=e2e-tests-statefulset-h5mj7 ss2-1 -- /bin/sh -c mv -v /tmp/index.html /usr/share/nginx/html/ || true'
+Jul  2 13:24:48.465: INFO: stderr: ""
+Jul  2 13:24:48.465: INFO: stdout: "'/tmp/index.html' -> '/usr/share/nginx/html/index.html'\n"
+Jul  2 13:24:48.465: INFO: stdout of mv -v /tmp/index.html /usr/share/nginx/html/ || true on ss2-1: '/tmp/index.html' -> '/usr/share/nginx/html/index.html'
+
+Jul  2 13:24:58.578: INFO: Waiting for StatefulSet e2e-tests-statefulset-h5mj7/ss2 to complete update
+Jul  2 13:24:58.578: INFO: Waiting for Pod e2e-tests-statefulset-h5mj7/ss2-0 to have revision ss2-76cb68b6ff update revision ss2-56dd5fb9c4
+Jul  2 13:24:58.578: INFO: Waiting for Pod e2e-tests-statefulset-h5mj7/ss2-1 to have revision ss2-76cb68b6ff update revision ss2-56dd5fb9c4
+Jul  2 13:25:08.586: INFO: Waiting for StatefulSet e2e-tests-statefulset-h5mj7/ss2 to complete update
+Jul  2 13:25:08.586: INFO: Waiting for Pod e2e-tests-statefulset-h5mj7/ss2-0 to have revision ss2-76cb68b6ff update revision ss2-56dd5fb9c4
+Jul  2 13:25:08.586: INFO: Waiting for Pod e2e-tests-statefulset-h5mj7/ss2-1 to have revision ss2-76cb68b6ff update revision ss2-56dd5fb9c4
+Jul  2 13:25:18.669: INFO: Waiting for StatefulSet e2e-tests-statefulset-h5mj7/ss2 to complete update
+[AfterEach] [k8s.io] Basic StatefulSet functionality [StatefulSetBasic]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/statefulset.go:83
+Jul  2 13:25:28.680: INFO: Deleting all statefulset in ns e2e-tests-statefulset-h5mj7
+Jul  2 13:25:28.683: INFO: Scaling statefulset ss2 to 0
+Jul  2 13:25:48.698: INFO: Waiting for statefulset status.replicas updated to 0
+Jul  2 13:25:48.701: INFO: Deleting statefulset ss2
+[AfterEach] [sig-apps] StatefulSet
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:25:48.769: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-statefulset-h5mj7" for this suite.
+Jul  2 13:25:54.787: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:25:54.883: INFO: namespace: e2e-tests-statefulset-h5mj7, resource: bindings, ignored listing per whitelist
+Jul  2 13:25:54.898: INFO: namespace e2e-tests-statefulset-h5mj7 deletion completed in 6.12551672s
+
+• [SLOW TEST:148.807 seconds]
+[sig-apps] StatefulSet
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/framework.go:22
+  [k8s.io] Basic StatefulSet functionality [StatefulSetBasic]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:679
+    should perform rolling updates and roll backs of template modifications [Conformance]
+    /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+S
+------------------------------
+[sig-apps] Daemon set [Serial] 
+  should run and stop simple daemon [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-apps] Daemon set [Serial]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:25:54.899: INFO: >>> kubeConfig: /tmp/kubeconfig-575984058
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-apps] Daemon set [Serial]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/daemon_set.go:99
+[It] should run and stop simple daemon [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating simple DaemonSet "daemon-set"
+STEP: Check that daemon pods launch on every node of the cluster.
+Jul  2 13:25:55.001: INFO: Number of nodes with available pods: 0
+Jul  2 13:25:55.001: INFO: Node shoot--core--confos-worker-w6oh6-z1-59946c4f6c-2w6kp is running more than one daemon pod
+Jul  2 13:25:56.010: INFO: Number of nodes with available pods: 0
+Jul  2 13:25:56.010: INFO: Node shoot--core--confos-worker-w6oh6-z1-59946c4f6c-2w6kp is running more than one daemon pod
+Jul  2 13:25:57.013: INFO: Number of nodes with available pods: 1
+Jul  2 13:25:57.013: INFO: Node shoot--core--confos-worker-w6oh6-z1-59946c4f6c-2w6kp is running more than one daemon pod
+Jul  2 13:25:58.008: INFO: Number of nodes with available pods: 2
+Jul  2 13:25:58.009: INFO: Number of running nodes: 2, number of available pods: 2
+STEP: Stop a daemon pod, check that the daemon pod is revived.
+Jul  2 13:25:58.027: INFO: Number of nodes with available pods: 1
+Jul  2 13:25:58.027: INFO: Node shoot--core--confos-worker-w6oh6-z1-59946c4f6c-znspz is running more than one daemon pod
+Jul  2 13:25:59.035: INFO: Number of nodes with available pods: 1
+Jul  2 13:25:59.035: INFO: Node shoot--core--confos-worker-w6oh6-z1-59946c4f6c-znspz is running more than one daemon pod
+Jul  2 13:26:00.035: INFO: Number of nodes with available pods: 1
+Jul  2 13:26:00.035: INFO: Node shoot--core--confos-worker-w6oh6-z1-59946c4f6c-znspz is running more than one daemon pod
+Jul  2 13:26:01.036: INFO: Number of nodes with available pods: 1
+Jul  2 13:26:01.036: INFO: Node shoot--core--confos-worker-w6oh6-z1-59946c4f6c-znspz is running more than one daemon pod
+Jul  2 13:26:02.035: INFO: Number of nodes with available pods: 1
+Jul  2 13:26:02.036: INFO: Node shoot--core--confos-worker-w6oh6-z1-59946c4f6c-znspz is running more than one daemon pod
+Jul  2 13:26:03.070: INFO: Number of nodes with available pods: 2
+Jul  2 13:26:03.070: INFO: Number of running nodes: 2, number of available pods: 2
+[AfterEach] [sig-apps] Daemon set [Serial]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/daemon_set.go:65
+STEP: Deleting DaemonSet "daemon-set"
+STEP: deleting {extensions DaemonSet} daemon-set in namespace e2e-tests-daemonsets-kvrlv, will wait for the garbage collector to delete the pods
+Jul  2 13:26:03.133: INFO: Deleting {extensions DaemonSet} daemon-set took: 6.191514ms
+Jul  2 13:26:03.233: INFO: Terminating {extensions DaemonSet} daemon-set pods took: 100.402439ms
+Jul  2 13:26:12.537: INFO: Number of nodes with available pods: 0
+Jul  2 13:26:12.537: INFO: Number of running nodes: 0, number of available pods: 0
+Jul  2 13:26:12.540: INFO: daemonset: {"kind":"DaemonSetList","apiVersion":"apps/v1","metadata":{"selfLink":"/apis/apps/v1/namespaces/e2e-tests-daemonsets-kvrlv/daemonsets","resourceVersion":"7358"},"items":null}
+
+Jul  2 13:26:12.542: INFO: pods: {"kind":"PodList","apiVersion":"v1","metadata":{"selfLink":"/api/v1/namespaces/e2e-tests-daemonsets-kvrlv/pods","resourceVersion":"7358"},"items":null}
+
+[AfterEach] [sig-apps] Daemon set [Serial]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:26:12.551: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-daemonsets-kvrlv" for this suite.
+Jul  2 13:26:18.566: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:26:18.760: INFO: namespace: e2e-tests-daemonsets-kvrlv, resource: bindings, ignored listing per whitelist
+Jul  2 13:26:18.814: INFO: namespace e2e-tests-daemonsets-kvrlv deletion completed in 6.259993793s
+
+• [SLOW TEST:23.916 seconds]
+[sig-apps] Daemon set [Serial]
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/framework.go:22
+  should run and stop simple daemon [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSS
+------------------------------
+[sig-storage] EmptyDir volumes 
+  should support (root,0666,default) [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-storage] EmptyDir volumes
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:26:18.816: INFO: >>> kubeConfig: /tmp/kubeconfig-575984058
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should support (root,0666,default) [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating a pod to test emptydir 0666 on node default medium
+Jul  2 13:26:18.910: INFO: Waiting up to 5m0s for pod "pod-80fbcb59-7dfb-11e8-b7a8-22e3071d17c7" in namespace "e2e-tests-emptydir-qlxz8" to be "success or failure"
+Jul  2 13:26:18.915: INFO: Pod "pod-80fbcb59-7dfb-11e8-b7a8-22e3071d17c7": Phase="Pending", Reason="", readiness=false. Elapsed: 5.016225ms
+Jul  2 13:26:20.920: INFO: Pod "pod-80fbcb59-7dfb-11e8-b7a8-22e3071d17c7": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.00960877s
+STEP: Saw pod success
+Jul  2 13:26:20.920: INFO: Pod "pod-80fbcb59-7dfb-11e8-b7a8-22e3071d17c7" satisfied condition "success or failure"
+Jul  2 13:26:20.923: INFO: Trying to get logs from node shoot--core--confos-worker-w6oh6-z1-59946c4f6c-2w6kp pod pod-80fbcb59-7dfb-11e8-b7a8-22e3071d17c7 container test-container: <nil>
+STEP: delete the pod
+Jul  2 13:26:20.940: INFO: Waiting for pod pod-80fbcb59-7dfb-11e8-b7a8-22e3071d17c7 to disappear
+Jul  2 13:26:20.944: INFO: Pod pod-80fbcb59-7dfb-11e8-b7a8-22e3071d17c7 no longer exists
+[AfterEach] [sig-storage] EmptyDir volumes
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:26:20.944: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-emptydir-qlxz8" for this suite.
+Jul  2 13:26:26.968: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:26:26.986: INFO: namespace: e2e-tests-emptydir-qlxz8, resource: bindings, ignored listing per whitelist
+Jul  2 13:26:27.070: INFO: namespace e2e-tests-emptydir-qlxz8 deletion completed in 6.115609731s
+
+• [SLOW TEST:8.255 seconds]
+[sig-storage] EmptyDir volumes
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/empty_dir.go:40
+  should support (root,0666,default) [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSSSSSSSSSSSSSSSSSSSSSSSS
+------------------------------
+[sig-apps] StatefulSet [k8s.io] Basic StatefulSet functionality [StatefulSetBasic] 
+  Should recreate evicted statefulset [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-apps] StatefulSet
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:26:27.071: INFO: >>> kubeConfig: /tmp/kubeconfig-575984058
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-apps] StatefulSet
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/statefulset.go:57
+[BeforeEach] [k8s.io] Basic StatefulSet functionality [StatefulSetBasic]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/statefulset.go:72
+STEP: Creating service test in namespace e2e-tests-statefulset-65zfj
+[It] Should recreate evicted statefulset [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Looking for a node to schedule stateful set and pod
+STEP: Creating pod with conflicting port in namespace e2e-tests-statefulset-65zfj
+STEP: Creating statefulset with conflicting port in namespace e2e-tests-statefulset-65zfj
+STEP: Waiting until pod test-pod will start running in namespace e2e-tests-statefulset-65zfj
+STEP: Waiting until stateful pod ss-0 will be recreated and deleted at least once in namespace e2e-tests-statefulset-65zfj
+Jul  2 13:26:31.170: INFO: Observed stateful pod in namespace: e2e-tests-statefulset-65zfj, name: ss-0, uid: 87f4997a-7dfb-11e8-a560-160e0404a9f8, status phase: Pending. Waiting for statefulset controller to delete.
+Jul  2 13:26:31.365: INFO: Observed stateful pod in namespace: e2e-tests-statefulset-65zfj, name: ss-0, uid: 87f4997a-7dfb-11e8-a560-160e0404a9f8, status phase: Failed. Waiting for statefulset controller to delete.
+Jul  2 13:26:31.369: INFO: Observed stateful pod in namespace: e2e-tests-statefulset-65zfj, name: ss-0, uid: 87f4997a-7dfb-11e8-a560-160e0404a9f8, status phase: Failed. Waiting for statefulset controller to delete.
+Jul  2 13:26:31.467: INFO: Observed delete event for stateful pod ss-0 in namespace e2e-tests-statefulset-65zfj
+STEP: Removing pod with conflicting port in namespace e2e-tests-statefulset-65zfj
+STEP: Waiting when stateful pod ss-0 will be recreated in namespace e2e-tests-statefulset-65zfj and will be in running state
+[AfterEach] [k8s.io] Basic StatefulSet functionality [StatefulSetBasic]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/statefulset.go:83
+Jul  2 13:26:33.496: INFO: Deleting all statefulset in ns e2e-tests-statefulset-65zfj
+Jul  2 13:26:33.499: INFO: Scaling statefulset ss to 0
+Jul  2 13:26:43.512: INFO: Waiting for statefulset status.replicas updated to 0
+Jul  2 13:26:43.580: INFO: Deleting statefulset ss
+[AfterEach] [sig-apps] StatefulSet
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:26:43.594: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-statefulset-65zfj" for this suite.
+Jul  2 13:26:49.607: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:26:49.686: INFO: namespace: e2e-tests-statefulset-65zfj, resource: bindings, ignored listing per whitelist
+Jul  2 13:26:49.745: INFO: namespace e2e-tests-statefulset-65zfj deletion completed in 6.147427627s
+
+• [SLOW TEST:22.674 seconds]
+[sig-apps] StatefulSet
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/framework.go:22
+  [k8s.io] Basic StatefulSet functionality [StatefulSetBasic]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:679
+    Should recreate evicted statefulset [Conformance]
+    /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSSSSSS
+------------------------------
+[sig-network] Networking Granular Checks: Pods 
+  should function for node-pod communication: udp [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-network] Networking
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:26:49.747: INFO: >>> kubeConfig: /tmp/kubeconfig-575984058
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should function for node-pod communication: udp [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Performing setup for networking test in namespace e2e-tests-pod-network-test-mhdb6
+STEP: creating a selector
+STEP: Creating the service pods in kubernetes
+Jul  2 13:26:49.834: INFO: Waiting up to 10m0s for all (but 0) nodes to be schedulable
+STEP: Creating test pods
+Jul  2 13:27:09.987: INFO: ExecWithOptions {Command:[/bin/sh -c echo 'hostName' | timeout -t 2 nc -w 1 -u 100.96.0.29 8081 | grep -v '^\s*$'] Namespace:e2e-tests-pod-network-test-mhdb6 PodName:host-test-container-pod ContainerName:hostexec Stdin:<nil> CaptureStdout:true CaptureStderr:true PreserveWhitespace:false}
+Jul  2 13:27:09.987: INFO: >>> kubeConfig: /tmp/kubeconfig-575984058
+Jul  2 13:27:11.341: INFO: Found all expected endpoints: [netserver-0]
+Jul  2 13:27:11.344: INFO: ExecWithOptions {Command:[/bin/sh -c echo 'hostName' | timeout -t 2 nc -w 1 -u 100.96.1.109 8081 | grep -v '^\s*$'] Namespace:e2e-tests-pod-network-test-mhdb6 PodName:host-test-container-pod ContainerName:hostexec Stdin:<nil> CaptureStdout:true CaptureStderr:true PreserveWhitespace:false}
+Jul  2 13:27:11.344: INFO: >>> kubeConfig: /tmp/kubeconfig-575984058
+Jul  2 13:27:12.722: INFO: Found all expected endpoints: [netserver-1]
+[AfterEach] [sig-network] Networking
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:27:12.722: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-pod-network-test-mhdb6" for this suite.
+Jul  2 13:27:34.738: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:27:34.783: INFO: namespace: e2e-tests-pod-network-test-mhdb6, resource: bindings, ignored listing per whitelist
+Jul  2 13:27:34.902: INFO: namespace e2e-tests-pod-network-test-mhdb6 deletion completed in 22.175175143s
+
+• [SLOW TEST:45.155 seconds]
+[sig-network] Networking
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/networking.go:25
+  Granular Checks: Pods
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/networking.go:28
+    should function for node-pod communication: udp [NodeConformance] [Conformance]
+    /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+[k8s.io] Probing container 
+  should have monotonically increasing restart count [Slow][NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [k8s.io] Probing container
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:27:34.902: INFO: >>> kubeConfig: /tmp/kubeconfig-575984058
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [k8s.io] Probing container
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/container_probe.go:48
+[It] should have monotonically increasing restart count [Slow][NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating pod liveness-http in namespace e2e-tests-container-probe-rtzht
+Jul  2 13:27:39.000: INFO: Started pod liveness-http in namespace e2e-tests-container-probe-rtzht
+STEP: checking the pod's current state and verifying that restartCount is present
+Jul  2 13:27:39.002: INFO: Initial restart count of pod liveness-http is 0
+Jul  2 13:27:51.085: INFO: Restart count of pod e2e-tests-container-probe-rtzht/liveness-http is now 1 (12.082864697s elapsed)
+Jul  2 13:28:11.178: INFO: Restart count of pod e2e-tests-container-probe-rtzht/liveness-http is now 2 (32.175400384s elapsed)
+Jul  2 13:28:31.300: INFO: Restart count of pod e2e-tests-container-probe-rtzht/liveness-http is now 3 (52.297230825s elapsed)
+Jul  2 13:28:49.569: INFO: Restart count of pod e2e-tests-container-probe-rtzht/liveness-http is now 4 (1m10.566398329s elapsed)
+Jul  2 13:30:02.068: INFO: Restart count of pod e2e-tests-container-probe-rtzht/liveness-http is now 5 (2m23.06594689s elapsed)
+STEP: deleting the pod
+[AfterEach] [k8s.io] Probing container
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:30:02.091: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-container-probe-rtzht" for this suite.
+Jul  2 13:30:08.109: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:30:08.179: INFO: namespace: e2e-tests-container-probe-rtzht, resource: bindings, ignored listing per whitelist
+Jul  2 13:30:08.207: INFO: namespace e2e-tests-container-probe-rtzht deletion completed in 6.109357701s
+
+• [SLOW TEST:153.305 seconds]
+[k8s.io] Probing container
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:679
+  should have monotonically increasing restart count [Slow][NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSS
+------------------------------
+[sig-storage] Downward API volume 
+  should provide container's cpu request [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:30:08.208: INFO: >>> kubeConfig: /tmp/kubeconfig-575984058
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downwardapi_volume.go:38
+[It] should provide container's cpu request [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating a pod to test downward API volume plugin
+Jul  2 13:30:08.299: INFO: Waiting up to 5m0s for pod "downwardapi-volume-09b5e2f8-7dfc-11e8-b7a8-22e3071d17c7" in namespace "e2e-tests-downward-api-bkz8s" to be "success or failure"
+Jul  2 13:30:08.302: INFO: Pod "downwardapi-volume-09b5e2f8-7dfc-11e8-b7a8-22e3071d17c7": Phase="Pending", Reason="", readiness=false. Elapsed: 2.949236ms
+Jul  2 13:30:10.306: INFO: Pod "downwardapi-volume-09b5e2f8-7dfc-11e8-b7a8-22e3071d17c7": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.006602494s
+STEP: Saw pod success
+Jul  2 13:30:10.306: INFO: Pod "downwardapi-volume-09b5e2f8-7dfc-11e8-b7a8-22e3071d17c7" satisfied condition "success or failure"
+Jul  2 13:30:10.309: INFO: Trying to get logs from node shoot--core--confos-worker-w6oh6-z1-59946c4f6c-2w6kp pod downwardapi-volume-09b5e2f8-7dfc-11e8-b7a8-22e3071d17c7 container client-container: <nil>
+STEP: delete the pod
+Jul  2 13:30:10.346: INFO: Waiting for pod downwardapi-volume-09b5e2f8-7dfc-11e8-b7a8-22e3071d17c7 to disappear
+Jul  2 13:30:10.352: INFO: Pod downwardapi-volume-09b5e2f8-7dfc-11e8-b7a8-22e3071d17c7 no longer exists
+[AfterEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:30:10.352: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-downward-api-bkz8s" for this suite.
+Jul  2 13:30:16.370: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:30:16.544: INFO: namespace: e2e-tests-downward-api-bkz8s, resource: bindings, ignored listing per whitelist
+Jul  2 13:30:16.553: INFO: namespace e2e-tests-downward-api-bkz8s deletion completed in 6.196879014s
+
+• [SLOW TEST:8.345 seconds]
+[sig-storage] Downward API volume
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downwardapi_volume.go:33
+  should provide container's cpu request [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSS
+------------------------------
+[sig-api-machinery] Watchers 
+  should observe an object deletion if it stops meeting the requirements of the selector [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-api-machinery] Watchers
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:30:16.553: INFO: >>> kubeConfig: /tmp/kubeconfig-575984058
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should observe an object deletion if it stops meeting the requirements of the selector [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: creating a watch on configmaps with a certain label
+STEP: creating a new configmap
+STEP: modifying the configmap once
+STEP: changing the label value of the configmap
+STEP: Expecting to observe a delete notification for the watched object
+Jul  2 13:30:16.659: INFO: Got : ADDED &ConfigMap{ObjectMeta:k8s_io_apimachinery_pkg_apis_meta_v1.ObjectMeta{Name:e2e-watch-test-label-changed,GenerateName:,Namespace:e2e-tests-watch-8k25d,SelfLink:/api/v1/namespaces/e2e-tests-watch-8k25d/configmaps/e2e-watch-test-label-changed,UID:0eb45d96-7dfc-11e8-a560-160e0404a9f8,ResourceVersion:8027,Generation:0,CreationTimestamp:2018-07-02 13:30:16 +0000 UTC,DeletionTimestamp:<nil>,DeletionGracePeriodSeconds:nil,Labels:map[string]string{watch-this-configmap: label-changed-and-restored,},Annotations:map[string]string{},OwnerReferences:[],Finalizers:[],ClusterName:,Initializers:nil,},Data:map[string]string{},BinaryData:map[string][]byte{},}
+Jul  2 13:30:16.659: INFO: Got : MODIFIED &ConfigMap{ObjectMeta:k8s_io_apimachinery_pkg_apis_meta_v1.ObjectMeta{Name:e2e-watch-test-label-changed,GenerateName:,Namespace:e2e-tests-watch-8k25d,SelfLink:/api/v1/namespaces/e2e-tests-watch-8k25d/configmaps/e2e-watch-test-label-changed,UID:0eb45d96-7dfc-11e8-a560-160e0404a9f8,ResourceVersion:8028,Generation:0,CreationTimestamp:2018-07-02 13:30:16 +0000 UTC,DeletionTimestamp:<nil>,DeletionGracePeriodSeconds:nil,Labels:map[string]string{watch-this-configmap: label-changed-and-restored,},Annotations:map[string]string{},OwnerReferences:[],Finalizers:[],ClusterName:,Initializers:nil,},Data:map[string]string{mutation: 1,},BinaryData:map[string][]byte{},}
+Jul  2 13:30:16.659: INFO: Got : DELETED &ConfigMap{ObjectMeta:k8s_io_apimachinery_pkg_apis_meta_v1.ObjectMeta{Name:e2e-watch-test-label-changed,GenerateName:,Namespace:e2e-tests-watch-8k25d,SelfLink:/api/v1/namespaces/e2e-tests-watch-8k25d/configmaps/e2e-watch-test-label-changed,UID:0eb45d96-7dfc-11e8-a560-160e0404a9f8,ResourceVersion:8029,Generation:0,CreationTimestamp:2018-07-02 13:30:16 +0000 UTC,DeletionTimestamp:<nil>,DeletionGracePeriodSeconds:nil,Labels:map[string]string{watch-this-configmap: label-changed-and-restored,},Annotations:map[string]string{},OwnerReferences:[],Finalizers:[],ClusterName:,Initializers:nil,},Data:map[string]string{mutation: 1,},BinaryData:map[string][]byte{},}
+STEP: modifying the configmap a second time
+STEP: Expecting not to observe a notification because the object no longer meets the selector's requirements
+STEP: changing the label value of the configmap back
+STEP: modifying the configmap a third time
+STEP: deleting the configmap
+STEP: Expecting to observe an add notification for the watched object when the label value was restored
+Jul  2 13:30:26.773: INFO: Got : ADDED &ConfigMap{ObjectMeta:k8s_io_apimachinery_pkg_apis_meta_v1.ObjectMeta{Name:e2e-watch-test-label-changed,GenerateName:,Namespace:e2e-tests-watch-8k25d,SelfLink:/api/v1/namespaces/e2e-tests-watch-8k25d/configmaps/e2e-watch-test-label-changed,UID:0eb45d96-7dfc-11e8-a560-160e0404a9f8,ResourceVersion:8049,Generation:0,CreationTimestamp:2018-07-02 13:30:16 +0000 UTC,DeletionTimestamp:<nil>,DeletionGracePeriodSeconds:nil,Labels:map[string]string{watch-this-configmap: label-changed-and-restored,},Annotations:map[string]string{},OwnerReferences:[],Finalizers:[],ClusterName:,Initializers:nil,},Data:map[string]string{mutation: 2,},BinaryData:map[string][]byte{},}
+Jul  2 13:30:26.773: INFO: Got : MODIFIED &ConfigMap{ObjectMeta:k8s_io_apimachinery_pkg_apis_meta_v1.ObjectMeta{Name:e2e-watch-test-label-changed,GenerateName:,Namespace:e2e-tests-watch-8k25d,SelfLink:/api/v1/namespaces/e2e-tests-watch-8k25d/configmaps/e2e-watch-test-label-changed,UID:0eb45d96-7dfc-11e8-a560-160e0404a9f8,ResourceVersion:8052,Generation:0,CreationTimestamp:2018-07-02 13:30:16 +0000 UTC,DeletionTimestamp:<nil>,DeletionGracePeriodSeconds:nil,Labels:map[string]string{watch-this-configmap: label-changed-and-restored,},Annotations:map[string]string{},OwnerReferences:[],Finalizers:[],ClusterName:,Initializers:nil,},Data:map[string]string{mutation: 3,},BinaryData:map[string][]byte{},}
+Jul  2 13:30:26.774: INFO: Got : DELETED &ConfigMap{ObjectMeta:k8s_io_apimachinery_pkg_apis_meta_v1.ObjectMeta{Name:e2e-watch-test-label-changed,GenerateName:,Namespace:e2e-tests-watch-8k25d,SelfLink:/api/v1/namespaces/e2e-tests-watch-8k25d/configmaps/e2e-watch-test-label-changed,UID:0eb45d96-7dfc-11e8-a560-160e0404a9f8,ResourceVersion:8053,Generation:0,CreationTimestamp:2018-07-02 13:30:16 +0000 UTC,DeletionTimestamp:<nil>,DeletionGracePeriodSeconds:nil,Labels:map[string]string{watch-this-configmap: label-changed-and-restored,},Annotations:map[string]string{},OwnerReferences:[],Finalizers:[],ClusterName:,Initializers:nil,},Data:map[string]string{mutation: 3,},BinaryData:map[string][]byte{},}
+[AfterEach] [sig-api-machinery] Watchers
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:30:26.774: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-watch-8k25d" for this suite.
+Jul  2 13:30:32.787: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:30:32.958: INFO: namespace: e2e-tests-watch-8k25d, resource: bindings, ignored listing per whitelist
+Jul  2 13:30:32.977: INFO: namespace e2e-tests-watch-8k25d deletion completed in 6.200104606s
+
+• [SLOW TEST:16.425 seconds]
+[sig-api-machinery] Watchers
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apimachinery/framework.go:22
+  should observe an object deletion if it stops meeting the requirements of the selector [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSS
+------------------------------
+[sig-api-machinery] ConfigMap 
+  should be consumable via the environment [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-api-machinery] ConfigMap
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:30:32.979: INFO: >>> kubeConfig: /tmp/kubeconfig-575984058
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should be consumable via the environment [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating configMap e2e-tests-configmap-sjptv/configmap-test-18798271-7dfc-11e8-b7a8-22e3071d17c7
+STEP: Creating a pod to test consume configMaps
+Jul  2 13:30:33.073: INFO: Waiting up to 5m0s for pod "pod-configmaps-1879f8e9-7dfc-11e8-b7a8-22e3071d17c7" in namespace "e2e-tests-configmap-sjptv" to be "success or failure"
+Jul  2 13:30:33.081: INFO: Pod "pod-configmaps-1879f8e9-7dfc-11e8-b7a8-22e3071d17c7": Phase="Pending", Reason="", readiness=false. Elapsed: 7.697459ms
+Jul  2 13:30:35.084: INFO: Pod "pod-configmaps-1879f8e9-7dfc-11e8-b7a8-22e3071d17c7": Phase="Pending", Reason="", readiness=false. Elapsed: 2.011579425s
+Jul  2 13:30:37.088: INFO: Pod "pod-configmaps-1879f8e9-7dfc-11e8-b7a8-22e3071d17c7": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.015525549s
+STEP: Saw pod success
+Jul  2 13:30:37.088: INFO: Pod "pod-configmaps-1879f8e9-7dfc-11e8-b7a8-22e3071d17c7" satisfied condition "success or failure"
+Jul  2 13:30:37.095: INFO: Trying to get logs from node shoot--core--confos-worker-w6oh6-z1-59946c4f6c-2w6kp pod pod-configmaps-1879f8e9-7dfc-11e8-b7a8-22e3071d17c7 container env-test: <nil>
+STEP: delete the pod
+Jul  2 13:30:37.114: INFO: Waiting for pod pod-configmaps-1879f8e9-7dfc-11e8-b7a8-22e3071d17c7 to disappear
+Jul  2 13:30:37.121: INFO: Pod pod-configmaps-1879f8e9-7dfc-11e8-b7a8-22e3071d17c7 no longer exists
+[AfterEach] [sig-api-machinery] ConfigMap
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:30:37.121: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-configmap-sjptv" for this suite.
+Jul  2 13:30:43.181: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:30:43.203: INFO: namespace: e2e-tests-configmap-sjptv, resource: bindings, ignored listing per whitelist
+Jul  2 13:30:43.277: INFO: namespace e2e-tests-configmap-sjptv deletion completed in 6.152451795s
+
+• [SLOW TEST:10.298 seconds]
+[sig-api-machinery] ConfigMap
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/configmap.go:29
+  should be consumable via the environment [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+S
+------------------------------
+[sig-scheduling] SchedulerPredicates [Serial] 
+  validates that NodeSelector is respected if matching  [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-scheduling] SchedulerPredicates [Serial]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:30:43.277: INFO: >>> kubeConfig: /tmp/kubeconfig-575984058
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-scheduling] SchedulerPredicates [Serial]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/scheduling/predicates.go:79
+Jul  2 13:30:43.399: INFO: Waiting up to 1m0s for all nodes to be ready
+Jul  2 13:31:43.419: INFO: Waiting for terminating namespaces to be deleted...
+Jul  2 13:31:43.464: INFO: Waiting up to 5m0s for all pods (need at least 0) in namespace 'kube-system' to be running and ready
+Jul  2 13:31:43.476: INFO: 14 / 14 pods in namespace 'kube-system' are running and ready (0 seconds elapsed)
+Jul  2 13:31:43.477: INFO: expected 8 pod replicas in namespace 'kube-system', 8 are Running and Ready.
+Jul  2 13:31:43.480: INFO: Waiting for pods to enter Success, but no pods in "kube-system" match label map[name:e2e-image-puller]
+Jul  2 13:31:43.480: INFO: 
+Logging pods the kubelet thinks is on node shoot--core--confos-worker-w6oh6-z1-59946c4f6c-2w6kp before test
+Jul  2 13:31:43.581: INFO: sonobuoy from sonobuoy started at 2018-07-02 12:53:36 +0000 UTC (1 container statuses recorded)
+Jul  2 13:31:43.581: INFO: 	Container kube-sonobuoy ready: true, restart count 0
+Jul  2 13:31:43.581: INFO: kube-dns-9c4dfc4fb-t986t from kube-system started at 2018-07-02 12:48:51 +0000 UTC (3 container statuses recorded)
+Jul  2 13:31:43.581: INFO: 	Container dnsmasq ready: true, restart count 0
+Jul  2 13:31:43.581: INFO: 	Container kubedns ready: true, restart count 0
+Jul  2 13:31:43.581: INFO: 	Container sidecar ready: true, restart count 0
+Jul  2 13:31:43.581: INFO: calico-node-s9p8b from kube-system started at 2018-07-02 12:48:29 +0000 UTC (2 container statuses recorded)
+Jul  2 13:31:43.581: INFO: 	Container calico-node ready: true, restart count 0
+Jul  2 13:31:43.581: INFO: 	Container install-cni ready: true, restart count 0
+Jul  2 13:31:43.581: INFO: node-exporter-xvs9p from kube-system started at 2018-07-02 12:48:29 +0000 UTC (1 container statuses recorded)
+Jul  2 13:31:43.581: INFO: 	Container node-exporter ready: true, restart count 0
+Jul  2 13:31:43.581: INFO: sonobuoy-e2e-job-bf7785bfa7874841 from sonobuoy started at 2018-07-02 12:53:52 +0000 UTC (2 container statuses recorded)
+Jul  2 13:31:43.581: INFO: 	Container e2e ready: true, restart count 0
+Jul  2 13:31:43.581: INFO: 	Container sonobuoy-worker ready: true, restart count 0
+Jul  2 13:31:43.581: INFO: kube-proxy-qhrt7 from kube-system started at 2018-07-02 12:48:29 +0000 UTC (1 container statuses recorded)
+Jul  2 13:31:43.581: INFO: 	Container kube-proxy ready: true, restart count 0
+Jul  2 13:31:43.581: INFO: 
+Logging pods the kubelet thinks is on node shoot--core--confos-worker-w6oh6-z1-59946c4f6c-znspz before test
+Jul  2 13:31:43.631: INFO: node-exporter-f55cq from kube-system started at 2018-07-02 12:48:23 +0000 UTC (1 container statuses recorded)
+Jul  2 13:31:43.631: INFO: 	Container node-exporter ready: true, restart count 0
+Jul  2 13:31:43.631: INFO: vpn-shoot-b8c466986-fq5pc from kube-system started at 2018-07-02 12:48:44 +0000 UTC (1 container statuses recorded)
+Jul  2 13:31:43.631: INFO: 	Container vpn-shoot ready: true, restart count 0
+Jul  2 13:31:43.631: INFO: addons-nginx-ingress-controller-79bfb57974-kmxqj from kube-system started at 2018-07-02 12:48:44 +0000 UTC (1 container statuses recorded)
+Jul  2 13:31:43.631: INFO: 	Container nginx-ingress-controller ready: true, restart count 0
+Jul  2 13:31:43.631: INFO: addons-heapster-e3b0c-64455ddddb-f7qqp from kube-system started at 2018-07-02 12:48:44 +0000 UTC (2 container statuses recorded)
+Jul  2 13:31:43.631: INFO: 	Container heapster ready: true, restart count 0
+Jul  2 13:31:43.631: INFO: 	Container heapster-nanny ready: true, restart count 0
+Jul  2 13:31:43.631: INFO: kube-proxy-d4jrv from kube-system started at 2018-07-02 12:48:23 +0000 UTC (1 container statuses recorded)
+Jul  2 13:31:43.631: INFO: 	Container kube-proxy ready: true, restart count 0
+Jul  2 13:31:43.631: INFO: addons-nginx-ingress-nginx-ingress-k8s-backend-7b5569797f-7kzfj from kube-system started at 2018-07-02 12:48:44 +0000 UTC (1 container statuses recorded)
+Jul  2 13:31:43.631: INFO: 	Container nginx-ingress-nginx-ingress-k8s-backend ready: true, restart count 0
+Jul  2 13:31:43.631: INFO: calico-node-smddt from kube-system started at 2018-07-02 12:48:23 +0000 UTC (2 container statuses recorded)
+Jul  2 13:31:43.631: INFO: 	Container calico-node ready: true, restart count 0
+Jul  2 13:31:43.631: INFO: 	Container install-cni ready: true, restart count 0
+Jul  2 13:31:43.631: INFO: kube-dns-autoscaler-6dd4765967-wsgbv from kube-system started at 2018-07-02 12:48:44 +0000 UTC (1 container statuses recorded)
+Jul  2 13:31:43.631: INFO: 	Container autoscaler ready: true, restart count 0
+Jul  2 13:31:43.631: INFO: addons-kubernetes-dashboard-5486b968b7-cd62s from kube-system started at 2018-07-02 12:48:44 +0000 UTC (1 container statuses recorded)
+Jul  2 13:31:43.631: INFO: 	Container main ready: true, restart count 0
+Jul  2 13:31:43.631: INFO: kube-dns-9c4dfc4fb-b2hj2 from kube-system started at 2018-07-02 12:48:44 +0000 UTC (3 container statuses recorded)
+Jul  2 13:31:43.631: INFO: 	Container dnsmasq ready: true, restart count 0
+Jul  2 13:31:43.631: INFO: 	Container kubedns ready: true, restart count 0
+Jul  2 13:31:43.631: INFO: 	Container sidecar ready: true, restart count 0
+[It] validates that NodeSelector is respected if matching  [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Trying to launch a pod without a label to get a node which can launch it.
+STEP: Explicitly delete pod here to free the resource it takes.
+STEP: Trying to apply a random label on the found node.
+STEP: verifying the node has the label kubernetes.io/e2e-43c025da-7dfc-11e8-b7a8-22e3071d17c7 42
+STEP: Trying to relaunch the pod, now with labels.
+STEP: removing the label kubernetes.io/e2e-43c025da-7dfc-11e8-b7a8-22e3071d17c7 off the node shoot--core--confos-worker-w6oh6-z1-59946c4f6c-2w6kp
+STEP: verifying the node doesn't have the label kubernetes.io/e2e-43c025da-7dfc-11e8-b7a8-22e3071d17c7
+[AfterEach] [sig-scheduling] SchedulerPredicates [Serial]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:31:47.776: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-sched-pred-cmf9d" for this suite.
+Jul  2 13:32:09.789: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:32:09.831: INFO: namespace: e2e-tests-sched-pred-cmf9d, resource: bindings, ignored listing per whitelist
+Jul  2 13:32:09.883: INFO: namespace e2e-tests-sched-pred-cmf9d deletion completed in 22.104133164s
+[AfterEach] [sig-scheduling] SchedulerPredicates [Serial]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/scheduling/predicates.go:70
+
+• [SLOW TEST:86.606 seconds]
+[sig-scheduling] SchedulerPredicates [Serial]
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/scheduling/framework.go:22
+  validates that NodeSelector is respected if matching  [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSS
+------------------------------
+[sig-api-machinery] Garbage collector 
+  should orphan RS created by deployment when deleteOptions.PropagationPolicy is Orphan [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-api-machinery] Garbage collector
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:32:09.883: INFO: >>> kubeConfig: /tmp/kubeconfig-575984058
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should orphan RS created by deployment when deleteOptions.PropagationPolicy is Orphan [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: create the deployment
+STEP: Wait for the Deployment to create new ReplicaSet
+STEP: delete the deployment
+STEP: wait for 30 seconds to see if the garbage collector mistakenly deletes the rs
+STEP: Gathering metrics
+W0702 13:32:40.666204      16 metrics_grabber.go:81] Master node is not registered. Grabbing metrics from Scheduler, ControllerManager and ClusterAutoscaler is disabled.
+Jul  2 13:32:40.666: INFO: For apiserver_request_count:
+For apiserver_request_latencies_summary:
+For etcd_helper_cache_entry_count:
+For etcd_helper_cache_hit_count:
+For etcd_helper_cache_miss_count:
+For etcd_request_cache_add_latencies_summary:
+For etcd_request_cache_get_latencies_summary:
+For etcd_request_latencies_summary:
+For garbage_collector_attempt_to_delete_queue_latency:
+For garbage_collector_attempt_to_delete_work_duration:
+For garbage_collector_attempt_to_orphan_queue_latency:
+For garbage_collector_attempt_to_orphan_work_duration:
+For garbage_collector_dirty_processing_latency_microseconds:
+For garbage_collector_event_processing_latency_microseconds:
+For garbage_collector_graph_changes_queue_latency:
+For garbage_collector_graph_changes_work_duration:
+For garbage_collector_orphan_processing_latency_microseconds:
+For namespace_queue_latency:
+For namespace_queue_latency_sum:
+For namespace_queue_latency_count:
+For namespace_retries:
+For namespace_work_duration:
+For namespace_work_duration_sum:
+For namespace_work_duration_count:
+For function_duration_seconds:
+For errors_total:
+For evicted_pods_total:
+
+[AfterEach] [sig-api-machinery] Garbage collector
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:32:40.666: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-gc-94r7d" for this suite.
+Jul  2 13:32:46.685: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:32:46.856: INFO: namespace: e2e-tests-gc-94r7d, resource: bindings, ignored listing per whitelist
+Jul  2 13:32:46.885: INFO: namespace e2e-tests-gc-94r7d deletion completed in 6.215283587s
+
+• [SLOW TEST:37.002 seconds]
+[sig-api-machinery] Garbage collector
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apimachinery/framework.go:22
+  should orphan RS created by deployment when deleteOptions.PropagationPolicy is Orphan [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSS
+------------------------------
+[sig-storage] Projected 
+  optional updates should be reflected in volume [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:32:46.886: INFO: >>> kubeConfig: /tmp/kubeconfig-575984058
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:858
+[It] optional updates should be reflected in volume [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating secret with name s-test-opt-del-684c3daf-7dfc-11e8-b7a8-22e3071d17c7
+STEP: Creating secret with name s-test-opt-upd-684c3dee-7dfc-11e8-b7a8-22e3071d17c7
+STEP: Creating the pod
+STEP: Deleting secret s-test-opt-del-684c3daf-7dfc-11e8-b7a8-22e3071d17c7
+STEP: Updating secret s-test-opt-upd-684c3dee-7dfc-11e8-b7a8-22e3071d17c7
+STEP: Creating secret with name s-test-opt-create-684c3e0c-7dfc-11e8-b7a8-22e3071d17c7
+STEP: waiting to observe update in volume
+[AfterEach] [sig-storage] Projected
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:33:59.002: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-kd7p6" for this suite.
+Jul  2 13:34:21.069: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:34:21.087: INFO: namespace: e2e-tests-projected-kd7p6, resource: bindings, ignored listing per whitelist
+Jul  2 13:34:21.168: INFO: namespace e2e-tests-projected-kd7p6 deletion completed in 22.161659929s
+
+• [SLOW TEST:94.283 seconds]
+[sig-storage] Projected
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:34
+  optional updates should be reflected in volume [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSSSSSSSSSSSSSS
+------------------------------
+[sig-storage] Projected 
+  should be consumable from pods in volume with mappings [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:34:21.169: INFO: >>> kubeConfig: /tmp/kubeconfig-575984058
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:858
+[It] should be consumable from pods in volume with mappings [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating projection with secret that has name projected-secret-test-map-a07be493-7dfc-11e8-b7a8-22e3071d17c7
+STEP: Creating a pod to test consume secrets
+Jul  2 13:34:21.258: INFO: Waiting up to 5m0s for pod "pod-projected-secrets-a07c5c93-7dfc-11e8-b7a8-22e3071d17c7" in namespace "e2e-tests-projected-8j95d" to be "success or failure"
+Jul  2 13:34:21.260: INFO: Pod "pod-projected-secrets-a07c5c93-7dfc-11e8-b7a8-22e3071d17c7": Phase="Pending", Reason="", readiness=false. Elapsed: 2.560587ms
+Jul  2 13:34:23.267: INFO: Pod "pod-projected-secrets-a07c5c93-7dfc-11e8-b7a8-22e3071d17c7": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.009371716s
+STEP: Saw pod success
+Jul  2 13:34:23.267: INFO: Pod "pod-projected-secrets-a07c5c93-7dfc-11e8-b7a8-22e3071d17c7" satisfied condition "success or failure"
+Jul  2 13:34:23.270: INFO: Trying to get logs from node shoot--core--confos-worker-w6oh6-z1-59946c4f6c-2w6kp pod pod-projected-secrets-a07c5c93-7dfc-11e8-b7a8-22e3071d17c7 container projected-secret-volume-test: <nil>
+STEP: delete the pod
+Jul  2 13:34:23.380: INFO: Waiting for pod pod-projected-secrets-a07c5c93-7dfc-11e8-b7a8-22e3071d17c7 to disappear
+Jul  2 13:34:23.385: INFO: Pod pod-projected-secrets-a07c5c93-7dfc-11e8-b7a8-22e3071d17c7 no longer exists
+[AfterEach] [sig-storage] Projected
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:34:23.385: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-8j95d" for this suite.
+Jul  2 13:34:29.399: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:34:29.414: INFO: namespace: e2e-tests-projected-8j95d, resource: bindings, ignored listing per whitelist
+Jul  2 13:34:29.516: INFO: namespace e2e-tests-projected-8j95d deletion completed in 6.127165749s
+
+• [SLOW TEST:8.347 seconds]
+[sig-storage] Projected
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:34
+  should be consumable from pods in volume with mappings [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSSS
+------------------------------
+[sig-storage] ConfigMap 
+  optional updates should be reflected in volume [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-storage] ConfigMap
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:34:29.516: INFO: >>> kubeConfig: /tmp/kubeconfig-575984058
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] optional updates should be reflected in volume [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating configMap with name cm-test-opt-del-a5764809-7dfc-11e8-b7a8-22e3071d17c7
+STEP: Creating configMap with name cm-test-opt-upd-a5764848-7dfc-11e8-b7a8-22e3071d17c7
+STEP: Creating the pod
+STEP: Deleting configmap cm-test-opt-del-a5764809-7dfc-11e8-b7a8-22e3071d17c7
+STEP: Updating configmap cm-test-opt-upd-a5764848-7dfc-11e8-b7a8-22e3071d17c7
+STEP: Creating configMap with name cm-test-opt-create-a576485a-7dfc-11e8-b7a8-22e3071d17c7
+STEP: waiting to observe update in volume
+[AfterEach] [sig-storage] ConfigMap
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:34:34.045: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-configmap-lg4lz" for this suite.
+Jul  2 13:34:56.063: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:34:56.236: INFO: namespace: e2e-tests-configmap-lg4lz, resource: bindings, ignored listing per whitelist
+Jul  2 13:34:56.251: INFO: namespace e2e-tests-configmap-lg4lz deletion completed in 22.202489009s
+
+• [SLOW TEST:26.735 seconds]
+[sig-storage] ConfigMap
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/configmap_volume.go:32
+  optional updates should be reflected in volume [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSSSS
+------------------------------
+[sig-network] Networking Granular Checks: Pods 
+  should function for node-pod communication: http [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-network] Networking
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:34:56.253: INFO: >>> kubeConfig: /tmp/kubeconfig-575984058
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should function for node-pod communication: http [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Performing setup for networking test in namespace e2e-tests-pod-network-test-kpp7x
+STEP: creating a selector
+STEP: Creating the service pods in kubernetes
+Jul  2 13:34:56.343: INFO: Waiting up to 10m0s for all (but 0) nodes to be schedulable
+STEP: Creating test pods
+Jul  2 13:35:12.494: INFO: ExecWithOptions {Command:[/bin/sh -c timeout -t 15 curl -g -q -s --connect-timeout 1 http://100.96.1.120:8080/hostName | grep -v '^\s*$'] Namespace:e2e-tests-pod-network-test-kpp7x PodName:host-test-container-pod ContainerName:hostexec Stdin:<nil> CaptureStdout:true CaptureStderr:true PreserveWhitespace:false}
+Jul  2 13:35:12.494: INFO: >>> kubeConfig: /tmp/kubeconfig-575984058
+Jul  2 13:35:12.862: INFO: Found all expected endpoints: [netserver-0]
+Jul  2 13:35:12.866: INFO: ExecWithOptions {Command:[/bin/sh -c timeout -t 15 curl -g -q -s --connect-timeout 1 http://100.96.0.31:8080/hostName | grep -v '^\s*$'] Namespace:e2e-tests-pod-network-test-kpp7x PodName:host-test-container-pod ContainerName:hostexec Stdin:<nil> CaptureStdout:true CaptureStderr:true PreserveWhitespace:false}
+Jul  2 13:35:12.866: INFO: >>> kubeConfig: /tmp/kubeconfig-575984058
+Jul  2 13:35:13.337: INFO: Found all expected endpoints: [netserver-1]
+[AfterEach] [sig-network] Networking
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:35:13.337: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-pod-network-test-kpp7x" for this suite.
+Jul  2 13:35:35.356: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:35:35.364: INFO: namespace: e2e-tests-pod-network-test-kpp7x, resource: bindings, ignored listing per whitelist
+Jul  2 13:35:35.465: INFO: namespace e2e-tests-pod-network-test-kpp7x deletion completed in 22.123070672s
+
+• [SLOW TEST:39.212 seconds]
+[sig-network] Networking
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/networking.go:25
+  Granular Checks: Pods
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/networking.go:28
+    should function for node-pod communication: http [NodeConformance] [Conformance]
+    /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSS
+------------------------------
+[sig-storage] EmptyDir volumes 
+  should support (root,0777,default) [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-storage] EmptyDir volumes
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:35:35.466: INFO: >>> kubeConfig: /tmp/kubeconfig-575984058
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should support (root,0777,default) [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating a pod to test emptydir 0777 on node default medium
+Jul  2 13:35:35.555: INFO: Waiting up to 5m0s for pod "pod-ccc51270-7dfc-11e8-b7a8-22e3071d17c7" in namespace "e2e-tests-emptydir-n6vz4" to be "success or failure"
+Jul  2 13:35:35.558: INFO: Pod "pod-ccc51270-7dfc-11e8-b7a8-22e3071d17c7": Phase="Pending", Reason="", readiness=false. Elapsed: 2.961783ms
+Jul  2 13:35:37.564: INFO: Pod "pod-ccc51270-7dfc-11e8-b7a8-22e3071d17c7": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.009412152s
+STEP: Saw pod success
+Jul  2 13:35:37.564: INFO: Pod "pod-ccc51270-7dfc-11e8-b7a8-22e3071d17c7" satisfied condition "success or failure"
+Jul  2 13:35:37.567: INFO: Trying to get logs from node shoot--core--confos-worker-w6oh6-z1-59946c4f6c-2w6kp pod pod-ccc51270-7dfc-11e8-b7a8-22e3071d17c7 container test-container: <nil>
+STEP: delete the pod
+Jul  2 13:35:37.595: INFO: Waiting for pod pod-ccc51270-7dfc-11e8-b7a8-22e3071d17c7 to disappear
+Jul  2 13:35:37.598: INFO: Pod pod-ccc51270-7dfc-11e8-b7a8-22e3071d17c7 no longer exists
+[AfterEach] [sig-storage] EmptyDir volumes
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:35:37.598: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-emptydir-n6vz4" for this suite.
+Jul  2 13:35:43.619: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:35:43.674: INFO: namespace: e2e-tests-emptydir-n6vz4, resource: bindings, ignored listing per whitelist
+Jul  2 13:35:43.752: INFO: namespace e2e-tests-emptydir-n6vz4 deletion completed in 6.144979358s
+
+• [SLOW TEST:8.286 seconds]
+[sig-storage] EmptyDir volumes
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/empty_dir.go:40
+  should support (root,0777,default) [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSSS
+------------------------------
+[sig-storage] Downward API volume 
+  should provide node allocatable (cpu) as default cpu limit if the limit is not set [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:35:43.753: INFO: >>> kubeConfig: /tmp/kubeconfig-575984058
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downwardapi_volume.go:38
+[It] should provide node allocatable (cpu) as default cpu limit if the limit is not set [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating a pod to test downward API volume plugin
+Jul  2 13:35:43.835: INFO: Waiting up to 5m0s for pod "downwardapi-volume-d1b4a674-7dfc-11e8-b7a8-22e3071d17c7" in namespace "e2e-tests-downward-api-zgzpk" to be "success or failure"
+Jul  2 13:35:43.838: INFO: Pod "downwardapi-volume-d1b4a674-7dfc-11e8-b7a8-22e3071d17c7": Phase="Pending", Reason="", readiness=false. Elapsed: 2.298859ms
+Jul  2 13:35:45.842: INFO: Pod "downwardapi-volume-d1b4a674-7dfc-11e8-b7a8-22e3071d17c7": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.006412877s
+STEP: Saw pod success
+Jul  2 13:35:45.842: INFO: Pod "downwardapi-volume-d1b4a674-7dfc-11e8-b7a8-22e3071d17c7" satisfied condition "success or failure"
+Jul  2 13:35:45.845: INFO: Trying to get logs from node shoot--core--confos-worker-w6oh6-z1-59946c4f6c-2w6kp pod downwardapi-volume-d1b4a674-7dfc-11e8-b7a8-22e3071d17c7 container client-container: <nil>
+STEP: delete the pod
+Jul  2 13:35:45.862: INFO: Waiting for pod downwardapi-volume-d1b4a674-7dfc-11e8-b7a8-22e3071d17c7 to disappear
+Jul  2 13:35:45.882: INFO: Pod downwardapi-volume-d1b4a674-7dfc-11e8-b7a8-22e3071d17c7 no longer exists
+[AfterEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:35:45.882: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-downward-api-zgzpk" for this suite.
+Jul  2 13:35:51.966: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:35:52.070: INFO: namespace: e2e-tests-downward-api-zgzpk, resource: bindings, ignored listing per whitelist
+Jul  2 13:35:52.078: INFO: namespace e2e-tests-downward-api-zgzpk deletion completed in 6.192170165s
+
+• [SLOW TEST:8.326 seconds]
+[sig-storage] Downward API volume
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downwardapi_volume.go:33
+  should provide node allocatable (cpu) as default cpu limit if the limit is not set [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSSSSSSSS
+------------------------------
+[sig-auth] ServiceAccounts 
+  should allow opting out of API token automount  [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-auth] ServiceAccounts
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:35:52.078: INFO: >>> kubeConfig: /tmp/kubeconfig-575984058
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should allow opting out of API token automount  [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: getting the auto-created API token
+Jul  2 13:35:52.682: INFO: created pod pod-service-account-defaultsa
+Jul  2 13:35:52.682: INFO: pod pod-service-account-defaultsa service account token volume mount: true
+Jul  2 13:35:52.686: INFO: created pod pod-service-account-mountsa
+Jul  2 13:35:52.686: INFO: pod pod-service-account-mountsa service account token volume mount: true
+Jul  2 13:35:52.692: INFO: created pod pod-service-account-nomountsa
+Jul  2 13:35:52.692: INFO: pod pod-service-account-nomountsa service account token volume mount: false
+Jul  2 13:35:52.696: INFO: created pod pod-service-account-defaultsa-mountspec
+Jul  2 13:35:52.696: INFO: pod pod-service-account-defaultsa-mountspec service account token volume mount: true
+Jul  2 13:35:52.701: INFO: created pod pod-service-account-mountsa-mountspec
+Jul  2 13:35:52.701: INFO: pod pod-service-account-mountsa-mountspec service account token volume mount: true
+Jul  2 13:35:52.704: INFO: created pod pod-service-account-nomountsa-mountspec
+Jul  2 13:35:52.705: INFO: pod pod-service-account-nomountsa-mountspec service account token volume mount: true
+Jul  2 13:35:52.710: INFO: created pod pod-service-account-defaultsa-nomountspec
+Jul  2 13:35:52.710: INFO: pod pod-service-account-defaultsa-nomountspec service account token volume mount: false
+Jul  2 13:35:52.714: INFO: created pod pod-service-account-mountsa-nomountspec
+Jul  2 13:35:52.714: INFO: pod pod-service-account-mountsa-nomountspec service account token volume mount: false
+Jul  2 13:35:52.717: INFO: created pod pod-service-account-nomountsa-nomountspec
+Jul  2 13:35:52.717: INFO: pod pod-service-account-nomountsa-nomountspec service account token volume mount: false
+[AfterEach] [sig-auth] ServiceAccounts
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:35:52.717: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-svcaccounts-4tjkm" for this suite.
+Jul  2 13:35:58.781: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:35:58.939: INFO: namespace: e2e-tests-svcaccounts-4tjkm, resource: bindings, ignored listing per whitelist
+Jul  2 13:35:58.948: INFO: namespace e2e-tests-svcaccounts-4tjkm deletion completed in 6.216383403s
+
+• [SLOW TEST:6.869 seconds]
+[sig-auth] ServiceAccounts
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/auth/framework.go:22
+  should allow opting out of API token automount  [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS
+------------------------------
+[sig-api-machinery] ConfigMap 
+  should be consumable via environment variable [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-api-machinery] ConfigMap
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:35:58.949: INFO: >>> kubeConfig: /tmp/kubeconfig-575984058
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should be consumable via environment variable [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating configMap e2e-tests-configmap-ttvdm/configmap-test-dac3e427-7dfc-11e8-b7a8-22e3071d17c7
+STEP: Creating a pod to test consume configMaps
+Jul  2 13:35:59.038: INFO: Waiting up to 5m0s for pod "pod-configmaps-dac457d6-7dfc-11e8-b7a8-22e3071d17c7" in namespace "e2e-tests-configmap-ttvdm" to be "success or failure"
+Jul  2 13:35:59.041: INFO: Pod "pod-configmaps-dac457d6-7dfc-11e8-b7a8-22e3071d17c7": Phase="Pending", Reason="", readiness=false. Elapsed: 2.563914ms
+Jul  2 13:36:01.045: INFO: Pod "pod-configmaps-dac457d6-7dfc-11e8-b7a8-22e3071d17c7": Phase="Pending", Reason="", readiness=false. Elapsed: 2.006398148s
+Jul  2 13:36:03.053: INFO: Pod "pod-configmaps-dac457d6-7dfc-11e8-b7a8-22e3071d17c7": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.014908774s
+STEP: Saw pod success
+Jul  2 13:36:03.053: INFO: Pod "pod-configmaps-dac457d6-7dfc-11e8-b7a8-22e3071d17c7" satisfied condition "success or failure"
+Jul  2 13:36:03.056: INFO: Trying to get logs from node shoot--core--confos-worker-w6oh6-z1-59946c4f6c-2w6kp pod pod-configmaps-dac457d6-7dfc-11e8-b7a8-22e3071d17c7 container env-test: <nil>
+STEP: delete the pod
+Jul  2 13:36:03.075: INFO: Waiting for pod pod-configmaps-dac457d6-7dfc-11e8-b7a8-22e3071d17c7 to disappear
+Jul  2 13:36:03.088: INFO: Pod pod-configmaps-dac457d6-7dfc-11e8-b7a8-22e3071d17c7 no longer exists
+[AfterEach] [sig-api-machinery] ConfigMap
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:36:03.088: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-configmap-ttvdm" for this suite.
+Jul  2 13:36:09.109: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:36:09.147: INFO: namespace: e2e-tests-configmap-ttvdm, resource: bindings, ignored listing per whitelist
+Jul  2 13:36:09.212: INFO: namespace e2e-tests-configmap-ttvdm deletion completed in 6.118704785s
+
+• [SLOW TEST:10.263 seconds]
+[sig-api-machinery] ConfigMap
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/configmap.go:29
+  should be consumable via environment variable [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSSSSSSS
+------------------------------
+[sig-scheduling] SchedulerPredicates [Serial] 
+  validates that NodeSelector is respected if not matching  [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-scheduling] SchedulerPredicates [Serial]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:36:09.212: INFO: >>> kubeConfig: /tmp/kubeconfig-575984058
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-scheduling] SchedulerPredicates [Serial]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/scheduling/predicates.go:79
+Jul  2 13:36:09.292: INFO: Waiting up to 1m0s for all nodes to be ready
+Jul  2 13:37:09.315: INFO: Waiting for terminating namespaces to be deleted...
+Jul  2 13:37:09.320: INFO: Waiting up to 5m0s for all pods (need at least 0) in namespace 'kube-system' to be running and ready
+Jul  2 13:37:09.343: INFO: 14 / 14 pods in namespace 'kube-system' are running and ready (0 seconds elapsed)
+Jul  2 13:37:09.343: INFO: expected 8 pod replicas in namespace 'kube-system', 8 are Running and Ready.
+Jul  2 13:37:09.348: INFO: Waiting for pods to enter Success, but no pods in "kube-system" match label map[name:e2e-image-puller]
+Jul  2 13:37:09.348: INFO: 
+Logging pods the kubelet thinks is on node shoot--core--confos-worker-w6oh6-z1-59946c4f6c-2w6kp before test
+Jul  2 13:37:09.355: INFO: kube-dns-9c4dfc4fb-t986t from kube-system started at 2018-07-02 12:48:51 +0000 UTC (3 container statuses recorded)
+Jul  2 13:37:09.355: INFO: 	Container dnsmasq ready: true, restart count 0
+Jul  2 13:37:09.355: INFO: 	Container kubedns ready: true, restart count 0
+Jul  2 13:37:09.355: INFO: 	Container sidecar ready: true, restart count 0
+Jul  2 13:37:09.356: INFO: sonobuoy from sonobuoy started at 2018-07-02 12:53:36 +0000 UTC (1 container statuses recorded)
+Jul  2 13:37:09.356: INFO: 	Container kube-sonobuoy ready: true, restart count 0
+Jul  2 13:37:09.356: INFO: node-exporter-xvs9p from kube-system started at 2018-07-02 12:48:29 +0000 UTC (1 container statuses recorded)
+Jul  2 13:37:09.356: INFO: 	Container node-exporter ready: true, restart count 0
+Jul  2 13:37:09.356: INFO: sonobuoy-e2e-job-bf7785bfa7874841 from sonobuoy started at 2018-07-02 12:53:52 +0000 UTC (2 container statuses recorded)
+Jul  2 13:37:09.356: INFO: 	Container e2e ready: true, restart count 0
+Jul  2 13:37:09.356: INFO: 	Container sonobuoy-worker ready: true, restart count 0
+Jul  2 13:37:09.356: INFO: kube-proxy-qhrt7 from kube-system started at 2018-07-02 12:48:29 +0000 UTC (1 container statuses recorded)
+Jul  2 13:37:09.356: INFO: 	Container kube-proxy ready: true, restart count 0
+Jul  2 13:37:09.356: INFO: calico-node-s9p8b from kube-system started at 2018-07-02 12:48:29 +0000 UTC (2 container statuses recorded)
+Jul  2 13:37:09.356: INFO: 	Container calico-node ready: true, restart count 0
+Jul  2 13:37:09.356: INFO: 	Container install-cni ready: true, restart count 0
+Jul  2 13:37:09.356: INFO: 
+Logging pods the kubelet thinks is on node shoot--core--confos-worker-w6oh6-z1-59946c4f6c-znspz before test
+Jul  2 13:37:09.409: INFO: node-exporter-f55cq from kube-system started at 2018-07-02 12:48:23 +0000 UTC (1 container statuses recorded)
+Jul  2 13:37:09.409: INFO: 	Container node-exporter ready: true, restart count 0
+Jul  2 13:37:09.409: INFO: vpn-shoot-b8c466986-fq5pc from kube-system started at 2018-07-02 12:48:44 +0000 UTC (1 container statuses recorded)
+Jul  2 13:37:09.409: INFO: 	Container vpn-shoot ready: true, restart count 0
+Jul  2 13:37:09.409: INFO: addons-nginx-ingress-controller-79bfb57974-kmxqj from kube-system started at 2018-07-02 12:48:44 +0000 UTC (1 container statuses recorded)
+Jul  2 13:37:09.409: INFO: 	Container nginx-ingress-controller ready: true, restart count 0
+Jul  2 13:37:09.409: INFO: addons-heapster-e3b0c-64455ddddb-f7qqp from kube-system started at 2018-07-02 12:48:44 +0000 UTC (2 container statuses recorded)
+Jul  2 13:37:09.409: INFO: 	Container heapster ready: true, restart count 0
+Jul  2 13:37:09.409: INFO: 	Container heapster-nanny ready: true, restart count 0
+Jul  2 13:37:09.409: INFO: kube-proxy-d4jrv from kube-system started at 2018-07-02 12:48:23 +0000 UTC (1 container statuses recorded)
+Jul  2 13:37:09.409: INFO: 	Container kube-proxy ready: true, restart count 0
+Jul  2 13:37:09.409: INFO: addons-nginx-ingress-nginx-ingress-k8s-backend-7b5569797f-7kzfj from kube-system started at 2018-07-02 12:48:44 +0000 UTC (1 container statuses recorded)
+Jul  2 13:37:09.409: INFO: 	Container nginx-ingress-nginx-ingress-k8s-backend ready: true, restart count 0
+Jul  2 13:37:09.409: INFO: calico-node-smddt from kube-system started at 2018-07-02 12:48:23 +0000 UTC (2 container statuses recorded)
+Jul  2 13:37:09.409: INFO: 	Container calico-node ready: true, restart count 0
+Jul  2 13:37:09.409: INFO: 	Container install-cni ready: true, restart count 0
+Jul  2 13:37:09.409: INFO: kube-dns-autoscaler-6dd4765967-wsgbv from kube-system started at 2018-07-02 12:48:44 +0000 UTC (1 container statuses recorded)
+Jul  2 13:37:09.409: INFO: 	Container autoscaler ready: true, restart count 0
+Jul  2 13:37:09.409: INFO: addons-kubernetes-dashboard-5486b968b7-cd62s from kube-system started at 2018-07-02 12:48:44 +0000 UTC (1 container statuses recorded)
+Jul  2 13:37:09.409: INFO: 	Container main ready: true, restart count 0
+Jul  2 13:37:09.409: INFO: kube-dns-9c4dfc4fb-b2hj2 from kube-system started at 2018-07-02 12:48:44 +0000 UTC (3 container statuses recorded)
+Jul  2 13:37:09.409: INFO: 	Container dnsmasq ready: true, restart count 0
+Jul  2 13:37:09.409: INFO: 	Container kubedns ready: true, restart count 0
+Jul  2 13:37:09.409: INFO: 	Container sidecar ready: true, restart count 0
+[It] validates that NodeSelector is respected if not matching  [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Trying to schedule Pod with nonempty NodeSelector.
+STEP: Considering event: 
+Type = [Warning], Name = [restricted-pod.153d90c63bde20ca], Reason = [FailedScheduling], Message = [0/2 nodes are available: 2 node(s) didn't match node selector.]
+[AfterEach] [sig-scheduling] SchedulerPredicates [Serial]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:37:10.567: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-sched-pred-q7pvs" for this suite.
+Jul  2 13:37:32.582: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:37:32.712: INFO: namespace: e2e-tests-sched-pred-q7pvs, resource: bindings, ignored listing per whitelist
+Jul  2 13:37:32.751: INFO: namespace e2e-tests-sched-pred-q7pvs deletion completed in 22.180384518s
+[AfterEach] [sig-scheduling] SchedulerPredicates [Serial]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/scheduling/predicates.go:70
+
+• [SLOW TEST:83.540 seconds]
+[sig-scheduling] SchedulerPredicates [Serial]
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/scheduling/framework.go:22
+  validates that NodeSelector is respected if not matching  [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSSSS
+------------------------------
+[sig-storage] Projected 
+  should be consumable in multiple volumes in the same pod [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:37:32.752: INFO: >>> kubeConfig: /tmp/kubeconfig-575984058
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:858
+[It] should be consumable in multiple volumes in the same pod [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating configMap with name projected-configmap-test-volume-12aeadab-7dfd-11e8-b7a8-22e3071d17c7
+STEP: Creating a pod to test consume configMaps
+Jul  2 13:37:32.852: INFO: Waiting up to 5m0s for pod "pod-projected-configmaps-12af354d-7dfd-11e8-b7a8-22e3071d17c7" in namespace "e2e-tests-projected-4qbqr" to be "success or failure"
+Jul  2 13:37:32.855: INFO: Pod "pod-projected-configmaps-12af354d-7dfd-11e8-b7a8-22e3071d17c7": Phase="Pending", Reason="", readiness=false. Elapsed: 3.209907ms
+Jul  2 13:37:34.859: INFO: Pod "pod-projected-configmaps-12af354d-7dfd-11e8-b7a8-22e3071d17c7": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.00735296s
+STEP: Saw pod success
+Jul  2 13:37:34.859: INFO: Pod "pod-projected-configmaps-12af354d-7dfd-11e8-b7a8-22e3071d17c7" satisfied condition "success or failure"
+Jul  2 13:37:34.881: INFO: Trying to get logs from node shoot--core--confos-worker-w6oh6-z1-59946c4f6c-2w6kp pod pod-projected-configmaps-12af354d-7dfd-11e8-b7a8-22e3071d17c7 container projected-configmap-volume-test: <nil>
+STEP: delete the pod
+Jul  2 13:37:34.909: INFO: Waiting for pod pod-projected-configmaps-12af354d-7dfd-11e8-b7a8-22e3071d17c7 to disappear
+Jul  2 13:37:34.921: INFO: Pod pod-projected-configmaps-12af354d-7dfd-11e8-b7a8-22e3071d17c7 no longer exists
+[AfterEach] [sig-storage] Projected
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:37:34.921: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-4qbqr" for this suite.
+Jul  2 13:37:40.937: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:37:41.035: INFO: namespace: e2e-tests-projected-4qbqr, resource: bindings, ignored listing per whitelist
+Jul  2 13:37:41.046: INFO: namespace e2e-tests-projected-4qbqr deletion completed in 6.119513452s
+
+• [SLOW TEST:8.295 seconds]
+[sig-storage] Projected
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:34
+  should be consumable in multiple volumes in the same pod [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SS
+------------------------------
+[sig-storage] Projected 
+  optional updates should be reflected in volume [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:37:41.046: INFO: >>> kubeConfig: /tmp/kubeconfig-575984058
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:858
+[It] optional updates should be reflected in volume [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating configMap with name cm-test-opt-del-179ed84f-7dfd-11e8-b7a8-22e3071d17c7
+STEP: Creating configMap with name cm-test-opt-upd-179ed88b-7dfd-11e8-b7a8-22e3071d17c7
+STEP: Creating the pod
+STEP: Deleting configmap cm-test-opt-del-179ed84f-7dfd-11e8-b7a8-22e3071d17c7
+STEP: Updating configmap cm-test-opt-upd-179ed88b-7dfd-11e8-b7a8-22e3071d17c7
+STEP: Creating configMap with name cm-test-opt-create-179ed89f-7dfd-11e8-b7a8-22e3071d17c7
+STEP: waiting to observe update in volume
+[AfterEach] [sig-storage] Projected
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:37:47.618: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-dmzxz" for this suite.
+Jul  2 13:38:09.682: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:38:09.793: INFO: namespace: e2e-tests-projected-dmzxz, resource: bindings, ignored listing per whitelist
+Jul  2 13:38:09.852: INFO: namespace e2e-tests-projected-dmzxz deletion completed in 22.229811525s
+
+• [SLOW TEST:28.805 seconds]
+[sig-storage] Projected
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:34
+  optional updates should be reflected in volume [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+S
+------------------------------
+[k8s.io] Docker Containers 
+  should be able to override the image's default arguments (docker cmd) [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [k8s.io] Docker Containers
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:38:09.853: INFO: >>> kubeConfig: /tmp/kubeconfig-575984058
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should be able to override the image's default arguments (docker cmd) [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating a pod to test override arguments
+Jul  2 13:38:09.944: INFO: Waiting up to 5m0s for pod "client-containers-28cb1327-7dfd-11e8-b7a8-22e3071d17c7" in namespace "e2e-tests-containers-j5jr4" to be "success or failure"
+Jul  2 13:38:09.951: INFO: Pod "client-containers-28cb1327-7dfd-11e8-b7a8-22e3071d17c7": Phase="Pending", Reason="", readiness=false. Elapsed: 6.268832ms
+Jul  2 13:38:11.982: INFO: Pod "client-containers-28cb1327-7dfd-11e8-b7a8-22e3071d17c7": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.037864667s
+STEP: Saw pod success
+Jul  2 13:38:11.982: INFO: Pod "client-containers-28cb1327-7dfd-11e8-b7a8-22e3071d17c7" satisfied condition "success or failure"
+Jul  2 13:38:11.986: INFO: Trying to get logs from node shoot--core--confos-worker-w6oh6-z1-59946c4f6c-2w6kp pod client-containers-28cb1327-7dfd-11e8-b7a8-22e3071d17c7 container test-container: <nil>
+STEP: delete the pod
+Jul  2 13:38:12.047: INFO: Waiting for pod client-containers-28cb1327-7dfd-11e8-b7a8-22e3071d17c7 to disappear
+Jul  2 13:38:12.052: INFO: Pod client-containers-28cb1327-7dfd-11e8-b7a8-22e3071d17c7 no longer exists
+[AfterEach] [k8s.io] Docker Containers
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:38:12.053: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-containers-j5jr4" for this suite.
+Jul  2 13:38:18.068: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:38:18.096: INFO: namespace: e2e-tests-containers-j5jr4, resource: bindings, ignored listing per whitelist
+Jul  2 13:38:18.167: INFO: namespace e2e-tests-containers-j5jr4 deletion completed in 6.10863814s
+
+• [SLOW TEST:8.314 seconds]
+[k8s.io] Docker Containers
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:679
+  should be able to override the image's default arguments (docker cmd) [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSSSSSSSSSS
+------------------------------
+[sig-network] Service endpoints latency 
+  should not be very high  [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-network] Service endpoints latency
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:38:18.167: INFO: >>> kubeConfig: /tmp/kubeconfig-575984058
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should not be very high  [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: creating replication controller svc-latency-rc in namespace e2e-tests-svc-latency-77hr6
+I0702 13:38:18.250953      16 runners.go:177] Created replication controller with name: svc-latency-rc, namespace: e2e-tests-svc-latency-77hr6, replica count: 1
+I0702 13:38:19.301522      16 runners.go:177] svc-latency-rc Pods: 1 out of 1 created, 0 running, 1 pending, 0 waiting, 0 inactive, 0 terminating, 0 unknown, 0 runningButNotReady 
+I0702 13:38:20.301754      16 runners.go:177] svc-latency-rc Pods: 1 out of 1 created, 1 running, 0 pending, 0 waiting, 0 inactive, 0 terminating, 0 unknown, 0 runningButNotReady 
+Jul  2 13:38:20.417: INFO: Created: latency-svc-dbp9c
+Jul  2 13:38:20.422: INFO: Got endpoints: latency-svc-dbp9c [20.487108ms]
+Jul  2 13:38:20.433: INFO: Created: latency-svc-vpsf2
+Jul  2 13:38:20.435: INFO: Got endpoints: latency-svc-vpsf2 [13.148711ms]
+Jul  2 13:38:20.439: INFO: Created: latency-svc-jr9bw
+Jul  2 13:38:20.442: INFO: Got endpoints: latency-svc-jr9bw [19.110233ms]
+Jul  2 13:38:20.445: INFO: Created: latency-svc-qkc8h
+Jul  2 13:38:20.447: INFO: Got endpoints: latency-svc-qkc8h [24.427392ms]
+Jul  2 13:38:20.451: INFO: Created: latency-svc-c2xnq
+Jul  2 13:38:20.454: INFO: Got endpoints: latency-svc-c2xnq [30.441515ms]
+Jul  2 13:38:20.457: INFO: Created: latency-svc-l8rrd
+Jul  2 13:38:20.459: INFO: Got endpoints: latency-svc-l8rrd [36.139846ms]
+Jul  2 13:38:20.462: INFO: Created: latency-svc-fx2tm
+Jul  2 13:38:20.464: INFO: Got endpoints: latency-svc-fx2tm [40.338251ms]
+Jul  2 13:38:20.476: INFO: Created: latency-svc-7ccm6
+Jul  2 13:38:20.484: INFO: Got endpoints: latency-svc-7ccm6 [60.169893ms]
+Jul  2 13:38:20.485: INFO: Created: latency-svc-cv9tx
+Jul  2 13:38:20.489: INFO: Got endpoints: latency-svc-cv9tx [65.210122ms]
+Jul  2 13:38:20.493: INFO: Created: latency-svc-b7knp
+Jul  2 13:38:20.495: INFO: Got endpoints: latency-svc-b7knp [71.571259ms]
+Jul  2 13:38:20.498: INFO: Created: latency-svc-n6j4h
+Jul  2 13:38:20.501: INFO: Got endpoints: latency-svc-n6j4h [76.785852ms]
+Jul  2 13:38:20.505: INFO: Created: latency-svc-v5sxj
+Jul  2 13:38:20.511: INFO: Got endpoints: latency-svc-v5sxj [86.829425ms]
+Jul  2 13:38:20.521: INFO: Created: latency-svc-j22cr
+Jul  2 13:38:20.524: INFO: Got endpoints: latency-svc-j22cr [101.678188ms]
+Jul  2 13:38:20.531: INFO: Created: latency-svc-n2bt8
+Jul  2 13:38:20.533: INFO: Got endpoints: latency-svc-n2bt8 [109.243444ms]
+Jul  2 13:38:20.541: INFO: Created: latency-svc-v2hzt
+Jul  2 13:38:20.544: INFO: Got endpoints: latency-svc-v2hzt [120.49828ms]
+Jul  2 13:38:20.581: INFO: Created: latency-svc-dptf9
+Jul  2 13:38:20.586: INFO: Got endpoints: latency-svc-dptf9 [161.896993ms]
+Jul  2 13:38:20.588: INFO: Created: latency-svc-5kgpk
+Jul  2 13:38:20.592: INFO: Got endpoints: latency-svc-5kgpk [156.647487ms]
+Jul  2 13:38:20.595: INFO: Created: latency-svc-r69v8
+Jul  2 13:38:20.599: INFO: Got endpoints: latency-svc-r69v8 [157.280567ms]
+Jul  2 13:38:20.603: INFO: Created: latency-svc-77s4f
+Jul  2 13:38:20.607: INFO: Got endpoints: latency-svc-77s4f [159.489368ms]
+Jul  2 13:38:20.616: INFO: Created: latency-svc-mk5pl
+Jul  2 13:38:20.616: INFO: Got endpoints: latency-svc-mk5pl [161.957694ms]
+Jul  2 13:38:20.626: INFO: Created: latency-svc-nw2tz
+Jul  2 13:38:20.632: INFO: Got endpoints: latency-svc-nw2tz [172.575376ms]
+Jul  2 13:38:20.638: INFO: Created: latency-svc-w2g9s
+Jul  2 13:38:20.639: INFO: Got endpoints: latency-svc-w2g9s [175.011699ms]
+Jul  2 13:38:20.643: INFO: Created: latency-svc-l88wg
+Jul  2 13:38:20.651: INFO: Created: latency-svc-2ntvp
+Jul  2 13:38:20.653: INFO: Got endpoints: latency-svc-2ntvp [164.818511ms]
+Jul  2 13:38:20.656: INFO: Got endpoints: latency-svc-l88wg [171.805019ms]
+Jul  2 13:38:20.657: INFO: Created: latency-svc-p86cg
+Jul  2 13:38:20.660: INFO: Got endpoints: latency-svc-p86cg [164.743757ms]
+Jul  2 13:38:20.663: INFO: Created: latency-svc-hhh6q
+Jul  2 13:38:20.666: INFO: Got endpoints: latency-svc-hhh6q [165.399636ms]
+Jul  2 13:38:20.670: INFO: Created: latency-svc-mjjfh
+Jul  2 13:38:20.675: INFO: Got endpoints: latency-svc-mjjfh [164.334135ms]
+Jul  2 13:38:20.678: INFO: Created: latency-svc-hdtlb
+Jul  2 13:38:20.682: INFO: Got endpoints: latency-svc-hdtlb [15.912226ms]
+Jul  2 13:38:20.686: INFO: Created: latency-svc-46fjg
+Jul  2 13:38:20.693: INFO: Got endpoints: latency-svc-46fjg [168.787933ms]
+Jul  2 13:38:20.695: INFO: Created: latency-svc-rmk2c
+Jul  2 13:38:20.700: INFO: Got endpoints: latency-svc-rmk2c [166.696163ms]
+Jul  2 13:38:20.705: INFO: Created: latency-svc-khxmj
+Jul  2 13:38:20.705: INFO: Got endpoints: latency-svc-khxmj [160.297281ms]
+Jul  2 13:38:20.709: INFO: Created: latency-svc-cns9h
+Jul  2 13:38:20.714: INFO: Got endpoints: latency-svc-cns9h [127.709498ms]
+Jul  2 13:38:20.718: INFO: Created: latency-svc-25tfs
+Jul  2 13:38:20.719: INFO: Got endpoints: latency-svc-25tfs [126.460222ms]
+Jul  2 13:38:20.723: INFO: Created: latency-svc-wd7dm
+Jul  2 13:38:20.724: INFO: Got endpoints: latency-svc-wd7dm [125.092972ms]
+Jul  2 13:38:20.727: INFO: Created: latency-svc-l7v95
+Jul  2 13:38:20.730: INFO: Got endpoints: latency-svc-l7v95 [122.678809ms]
+Jul  2 13:38:20.732: INFO: Created: latency-svc-4ckfj
+Jul  2 13:38:20.735: INFO: Got endpoints: latency-svc-4ckfj [119.862906ms]
+Jul  2 13:38:20.740: INFO: Created: latency-svc-7sbjd
+Jul  2 13:38:20.747: INFO: Created: latency-svc-h8x69
+Jul  2 13:38:20.753: INFO: Created: latency-svc-hzcdp
+Jul  2 13:38:20.759: INFO: Created: latency-svc-fmgwm
+Jul  2 13:38:20.765: INFO: Created: latency-svc-6qtrp
+Jul  2 13:38:20.773: INFO: Got endpoints: latency-svc-7sbjd [141.057596ms]
+Jul  2 13:38:20.775: INFO: Created: latency-svc-74xc6
+Jul  2 13:38:20.781: INFO: Created: latency-svc-w2dwk
+Jul  2 13:38:20.788: INFO: Created: latency-svc-87xn2
+Jul  2 13:38:20.799: INFO: Created: latency-svc-m72c4
+Jul  2 13:38:20.806: INFO: Created: latency-svc-wtw5g
+Jul  2 13:38:20.814: INFO: Created: latency-svc-lbdbg
+Jul  2 13:38:20.819: INFO: Got endpoints: latency-svc-h8x69 [180.479202ms]
+Jul  2 13:38:20.821: INFO: Created: latency-svc-944t2
+Jul  2 13:38:20.828: INFO: Created: latency-svc-5t2j5
+Jul  2 13:38:20.835: INFO: Created: latency-svc-w4gbc
+Jul  2 13:38:20.841: INFO: Created: latency-svc-6v86w
+Jul  2 13:38:20.847: INFO: Created: latency-svc-v6dq5
+Jul  2 13:38:20.856: INFO: Created: latency-svc-q4bt5
+Jul  2 13:38:20.869: INFO: Got endpoints: latency-svc-hzcdp [215.32589ms]
+Jul  2 13:38:20.879: INFO: Created: latency-svc-9f9lv
+Jul  2 13:38:20.920: INFO: Got endpoints: latency-svc-fmgwm [263.907039ms]
+Jul  2 13:38:20.930: INFO: Created: latency-svc-26jq8
+Jul  2 13:38:20.969: INFO: Got endpoints: latency-svc-6qtrp [308.769568ms]
+Jul  2 13:38:20.983: INFO: Created: latency-svc-6l2dp
+Jul  2 13:38:21.020: INFO: Got endpoints: latency-svc-74xc6 [344.991902ms]
+Jul  2 13:38:21.029: INFO: Created: latency-svc-qgdj5
+Jul  2 13:38:21.070: INFO: Got endpoints: latency-svc-w2dwk [386.367431ms]
+Jul  2 13:38:21.079: INFO: Created: latency-svc-zzmkj
+Jul  2 13:38:21.121: INFO: Got endpoints: latency-svc-87xn2 [427.149181ms]
+Jul  2 13:38:21.131: INFO: Created: latency-svc-6x5z5
+Jul  2 13:38:21.170: INFO: Got endpoints: latency-svc-m72c4 [469.84859ms]
+Jul  2 13:38:21.180: INFO: Created: latency-svc-w5lch
+Jul  2 13:38:21.220: INFO: Got endpoints: latency-svc-wtw5g [515.013508ms]
+Jul  2 13:38:21.234: INFO: Created: latency-svc-phxdw
+Jul  2 13:38:21.270: INFO: Got endpoints: latency-svc-lbdbg [556.053562ms]
+Jul  2 13:38:21.283: INFO: Created: latency-svc-9nz2t
+Jul  2 13:38:21.320: INFO: Got endpoints: latency-svc-944t2 [601.563316ms]
+Jul  2 13:38:21.331: INFO: Created: latency-svc-vghk4
+Jul  2 13:38:21.370: INFO: Got endpoints: latency-svc-5t2j5 [645.366714ms]
+Jul  2 13:38:21.381: INFO: Created: latency-svc-v7jbh
+Jul  2 13:38:21.421: INFO: Got endpoints: latency-svc-w4gbc [690.802771ms]
+Jul  2 13:38:21.431: INFO: Created: latency-svc-jb2x4
+Jul  2 13:38:21.471: INFO: Got endpoints: latency-svc-6v86w [735.357089ms]
+Jul  2 13:38:21.483: INFO: Created: latency-svc-4dlfq
+Jul  2 13:38:21.520: INFO: Got endpoints: latency-svc-v6dq5 [746.564439ms]
+Jul  2 13:38:21.531: INFO: Created: latency-svc-sqpxp
+Jul  2 13:38:21.570: INFO: Got endpoints: latency-svc-q4bt5 [750.295196ms]
+Jul  2 13:38:21.580: INFO: Created: latency-svc-cdtzm
+Jul  2 13:38:21.619: INFO: Got endpoints: latency-svc-9f9lv [750.069043ms]
+Jul  2 13:38:21.634: INFO: Created: latency-svc-dt24s
+Jul  2 13:38:21.669: INFO: Got endpoints: latency-svc-26jq8 [749.649395ms]
+Jul  2 13:38:21.682: INFO: Created: latency-svc-jrp5q
+Jul  2 13:38:21.720: INFO: Got endpoints: latency-svc-6l2dp [751.017284ms]
+Jul  2 13:38:21.733: INFO: Created: latency-svc-8l7v8
+Jul  2 13:38:21.770: INFO: Got endpoints: latency-svc-qgdj5 [749.70547ms]
+Jul  2 13:38:21.780: INFO: Created: latency-svc-7xpmn
+Jul  2 13:38:21.820: INFO: Got endpoints: latency-svc-zzmkj [750.162894ms]
+Jul  2 13:38:21.830: INFO: Created: latency-svc-6rm6x
+Jul  2 13:38:21.869: INFO: Got endpoints: latency-svc-6x5z5 [748.596308ms]
+Jul  2 13:38:21.878: INFO: Created: latency-svc-2849m
+Jul  2 13:38:21.920: INFO: Got endpoints: latency-svc-w5lch [749.922421ms]
+Jul  2 13:38:21.933: INFO: Created: latency-svc-hhpgx
+Jul  2 13:38:21.969: INFO: Got endpoints: latency-svc-phxdw [748.859942ms]
+Jul  2 13:38:21.978: INFO: Created: latency-svc-s9v4t
+Jul  2 13:38:22.019: INFO: Got endpoints: latency-svc-9nz2t [749.486272ms]
+Jul  2 13:38:22.030: INFO: Created: latency-svc-bftdr
+Jul  2 13:38:22.069: INFO: Got endpoints: latency-svc-vghk4 [748.586608ms]
+Jul  2 13:38:22.079: INFO: Created: latency-svc-8n8nz
+Jul  2 13:38:22.119: INFO: Got endpoints: latency-svc-v7jbh [749.739955ms]
+Jul  2 13:38:22.129: INFO: Created: latency-svc-6rxng
+Jul  2 13:38:22.169: INFO: Got endpoints: latency-svc-jb2x4 [747.969657ms]
+Jul  2 13:38:22.180: INFO: Created: latency-svc-5s69b
+Jul  2 13:38:22.219: INFO: Got endpoints: latency-svc-4dlfq [748.513711ms]
+Jul  2 13:38:22.232: INFO: Created: latency-svc-6w6x7
+Jul  2 13:38:22.269: INFO: Got endpoints: latency-svc-sqpxp [749.28846ms]
+Jul  2 13:38:22.279: INFO: Created: latency-svc-lptjj
+Jul  2 13:38:22.320: INFO: Got endpoints: latency-svc-cdtzm [750.122371ms]
+Jul  2 13:38:22.329: INFO: Created: latency-svc-l8g88
+Jul  2 13:38:22.369: INFO: Got endpoints: latency-svc-dt24s [749.701017ms]
+Jul  2 13:38:22.380: INFO: Created: latency-svc-pl7dh
+Jul  2 13:38:22.419: INFO: Got endpoints: latency-svc-jrp5q [749.893781ms]
+Jul  2 13:38:22.429: INFO: Created: latency-svc-xc5fk
+Jul  2 13:38:22.469: INFO: Got endpoints: latency-svc-8l7v8 [748.857432ms]
+Jul  2 13:38:22.479: INFO: Created: latency-svc-dbppk
+Jul  2 13:38:22.519: INFO: Got endpoints: latency-svc-7xpmn [749.118557ms]
+Jul  2 13:38:22.530: INFO: Created: latency-svc-bvtgw
+Jul  2 13:38:22.570: INFO: Got endpoints: latency-svc-6rm6x [749.723895ms]
+Jul  2 13:38:22.580: INFO: Created: latency-svc-lz9db
+Jul  2 13:38:22.619: INFO: Got endpoints: latency-svc-2849m [749.731425ms]
+Jul  2 13:38:22.630: INFO: Created: latency-svc-kn7vf
+Jul  2 13:38:22.670: INFO: Got endpoints: latency-svc-hhpgx [749.897161ms]
+Jul  2 13:38:22.680: INFO: Created: latency-svc-578pk
+Jul  2 13:38:22.720: INFO: Got endpoints: latency-svc-s9v4t [750.576127ms]
+Jul  2 13:38:22.731: INFO: Created: latency-svc-fnwmt
+Jul  2 13:38:22.770: INFO: Got endpoints: latency-svc-bftdr [750.030338ms]
+Jul  2 13:38:22.780: INFO: Created: latency-svc-6rrjg
+Jul  2 13:38:22.819: INFO: Got endpoints: latency-svc-8n8nz [750.223931ms]
+Jul  2 13:38:22.829: INFO: Created: latency-svc-fb8xh
+Jul  2 13:38:22.870: INFO: Got endpoints: latency-svc-6rxng [750.158025ms]
+Jul  2 13:38:22.880: INFO: Created: latency-svc-gp6dt
+Jul  2 13:38:22.919: INFO: Got endpoints: latency-svc-5s69b [749.751243ms]
+Jul  2 13:38:22.929: INFO: Created: latency-svc-7h7s4
+Jul  2 13:38:22.971: INFO: Got endpoints: latency-svc-6w6x7 [751.094296ms]
+Jul  2 13:38:22.981: INFO: Created: latency-svc-pztf4
+Jul  2 13:38:23.020: INFO: Got endpoints: latency-svc-lptjj [750.782303ms]
+Jul  2 13:38:23.029: INFO: Created: latency-svc-ntck8
+Jul  2 13:38:23.070: INFO: Got endpoints: latency-svc-l8g88 [749.867553ms]
+Jul  2 13:38:23.081: INFO: Created: latency-svc-vncq7
+Jul  2 13:38:23.119: INFO: Got endpoints: latency-svc-pl7dh [749.637402ms]
+Jul  2 13:38:23.130: INFO: Created: latency-svc-x9qdk
+Jul  2 13:38:23.169: INFO: Got endpoints: latency-svc-xc5fk [749.542036ms]
+Jul  2 13:38:23.180: INFO: Created: latency-svc-9cn4m
+Jul  2 13:38:23.219: INFO: Got endpoints: latency-svc-dbppk [749.993678ms]
+Jul  2 13:38:23.230: INFO: Created: latency-svc-9v8vw
+Jul  2 13:38:23.269: INFO: Got endpoints: latency-svc-bvtgw [749.536942ms]
+Jul  2 13:38:23.282: INFO: Created: latency-svc-sk7zj
+Jul  2 13:38:23.319: INFO: Got endpoints: latency-svc-lz9db [748.902085ms]
+Jul  2 13:38:23.328: INFO: Created: latency-svc-sjskq
+Jul  2 13:38:23.369: INFO: Got endpoints: latency-svc-kn7vf [749.225054ms]
+Jul  2 13:38:23.378: INFO: Created: latency-svc-tq2s2
+Jul  2 13:38:23.419: INFO: Got endpoints: latency-svc-578pk [748.73296ms]
+Jul  2 13:38:23.429: INFO: Created: latency-svc-52b87
+Jul  2 13:38:23.469: INFO: Got endpoints: latency-svc-fnwmt [749.408385ms]
+Jul  2 13:38:23.479: INFO: Created: latency-svc-w966b
+Jul  2 13:38:23.520: INFO: Got endpoints: latency-svc-6rrjg [750.439302ms]
+Jul  2 13:38:23.530: INFO: Created: latency-svc-7l8sr
+Jul  2 13:38:23.569: INFO: Got endpoints: latency-svc-fb8xh [749.804954ms]
+Jul  2 13:38:23.585: INFO: Created: latency-svc-h5vdb
+Jul  2 13:38:23.620: INFO: Got endpoints: latency-svc-gp6dt [750.072959ms]
+Jul  2 13:38:23.631: INFO: Created: latency-svc-sfrfl
+Jul  2 13:38:23.669: INFO: Got endpoints: latency-svc-7h7s4 [750.297088ms]
+Jul  2 13:38:23.683: INFO: Created: latency-svc-clghb
+Jul  2 13:38:23.719: INFO: Got endpoints: latency-svc-pztf4 [748.484809ms]
+Jul  2 13:38:23.731: INFO: Created: latency-svc-nnqx8
+Jul  2 13:38:23.772: INFO: Got endpoints: latency-svc-ntck8 [752.174524ms]
+Jul  2 13:38:23.783: INFO: Created: latency-svc-zwzld
+Jul  2 13:38:23.820: INFO: Got endpoints: latency-svc-vncq7 [750.083383ms]
+Jul  2 13:38:23.833: INFO: Created: latency-svc-944rl
+Jul  2 13:38:23.869: INFO: Got endpoints: latency-svc-x9qdk [750.149271ms]
+Jul  2 13:38:23.879: INFO: Created: latency-svc-mrnhq
+Jul  2 13:38:23.922: INFO: Got endpoints: latency-svc-9cn4m [752.306989ms]
+Jul  2 13:38:23.933: INFO: Created: latency-svc-gmn27
+Jul  2 13:38:23.969: INFO: Got endpoints: latency-svc-9v8vw [750.010546ms]
+Jul  2 13:38:23.980: INFO: Created: latency-svc-4ppvs
+Jul  2 13:38:24.020: INFO: Got endpoints: latency-svc-sk7zj [751.065542ms]
+Jul  2 13:38:24.030: INFO: Created: latency-svc-zfpkk
+Jul  2 13:38:24.070: INFO: Got endpoints: latency-svc-sjskq [750.7294ms]
+Jul  2 13:38:24.080: INFO: Created: latency-svc-z8vf6
+Jul  2 13:38:24.120: INFO: Got endpoints: latency-svc-tq2s2 [750.939588ms]
+Jul  2 13:38:24.131: INFO: Created: latency-svc-ljz6j
+Jul  2 13:38:24.169: INFO: Got endpoints: latency-svc-52b87 [750.355044ms]
+Jul  2 13:38:24.180: INFO: Created: latency-svc-z6mrr
+Jul  2 13:38:24.219: INFO: Got endpoints: latency-svc-w966b [749.80379ms]
+Jul  2 13:38:24.230: INFO: Created: latency-svc-2vkjt
+Jul  2 13:38:24.269: INFO: Got endpoints: latency-svc-7l8sr [748.493594ms]
+Jul  2 13:38:24.278: INFO: Created: latency-svc-n9rl2
+Jul  2 13:38:24.319: INFO: Got endpoints: latency-svc-h5vdb [750.027094ms]
+Jul  2 13:38:24.329: INFO: Created: latency-svc-bdnwt
+Jul  2 13:38:24.369: INFO: Got endpoints: latency-svc-sfrfl [749.280729ms]
+Jul  2 13:38:24.379: INFO: Created: latency-svc-cj9md
+Jul  2 13:38:24.419: INFO: Got endpoints: latency-svc-clghb [749.762352ms]
+Jul  2 13:38:24.431: INFO: Created: latency-svc-frkww
+Jul  2 13:38:24.469: INFO: Got endpoints: latency-svc-nnqx8 [749.701861ms]
+Jul  2 13:38:24.480: INFO: Created: latency-svc-smgwf
+Jul  2 13:38:24.519: INFO: Got endpoints: latency-svc-zwzld [746.875355ms]
+Jul  2 13:38:24.533: INFO: Created: latency-svc-gdcts
+Jul  2 13:38:24.569: INFO: Got endpoints: latency-svc-944rl [748.93557ms]
+Jul  2 13:38:24.579: INFO: Created: latency-svc-96trx
+Jul  2 13:38:24.619: INFO: Got endpoints: latency-svc-mrnhq [749.587129ms]
+Jul  2 13:38:24.631: INFO: Created: latency-svc-hfxg5
+Jul  2 13:38:24.669: INFO: Got endpoints: latency-svc-gmn27 [747.512847ms]
+Jul  2 13:38:24.680: INFO: Created: latency-svc-nl2zq
+Jul  2 13:38:24.720: INFO: Got endpoints: latency-svc-4ppvs [750.062703ms]
+Jul  2 13:38:24.731: INFO: Created: latency-svc-7lhld
+Jul  2 13:38:24.770: INFO: Got endpoints: latency-svc-zfpkk [749.519524ms]
+Jul  2 13:38:24.781: INFO: Created: latency-svc-g2klt
+Jul  2 13:38:24.820: INFO: Got endpoints: latency-svc-z8vf6 [750.355895ms]
+Jul  2 13:38:24.831: INFO: Created: latency-svc-96cjb
+Jul  2 13:38:24.870: INFO: Got endpoints: latency-svc-ljz6j [750.260056ms]
+Jul  2 13:38:24.882: INFO: Created: latency-svc-szj65
+Jul  2 13:38:24.919: INFO: Got endpoints: latency-svc-z6mrr [750.227979ms]
+Jul  2 13:38:24.930: INFO: Created: latency-svc-bgvh9
+Jul  2 13:38:24.969: INFO: Got endpoints: latency-svc-2vkjt [750.233091ms]
+Jul  2 13:38:24.982: INFO: Created: latency-svc-vlbrq
+Jul  2 13:38:25.019: INFO: Got endpoints: latency-svc-n9rl2 [750.267249ms]
+Jul  2 13:38:25.028: INFO: Created: latency-svc-zswmh
+Jul  2 13:38:25.069: INFO: Got endpoints: latency-svc-bdnwt [749.837593ms]
+Jul  2 13:38:25.080: INFO: Created: latency-svc-pvnfj
+Jul  2 13:38:25.119: INFO: Got endpoints: latency-svc-cj9md [750.060637ms]
+Jul  2 13:38:25.131: INFO: Created: latency-svc-85q9q
+Jul  2 13:38:25.169: INFO: Got endpoints: latency-svc-frkww [749.853174ms]
+Jul  2 13:38:25.180: INFO: Created: latency-svc-hsr9r
+Jul  2 13:38:25.219: INFO: Got endpoints: latency-svc-smgwf [749.98368ms]
+Jul  2 13:38:25.232: INFO: Created: latency-svc-qsg8q
+Jul  2 13:38:25.271: INFO: Got endpoints: latency-svc-gdcts [751.874949ms]
+Jul  2 13:38:25.283: INFO: Created: latency-svc-x4rq9
+Jul  2 13:38:25.319: INFO: Got endpoints: latency-svc-96trx [749.963598ms]
+Jul  2 13:38:25.332: INFO: Created: latency-svc-fqhdv
+Jul  2 13:38:25.370: INFO: Got endpoints: latency-svc-hfxg5 [750.814847ms]
+Jul  2 13:38:25.383: INFO: Created: latency-svc-4rc4z
+Jul  2 13:38:25.420: INFO: Got endpoints: latency-svc-nl2zq [750.33684ms]
+Jul  2 13:38:25.430: INFO: Created: latency-svc-mnc4j
+Jul  2 13:38:25.469: INFO: Got endpoints: latency-svc-7lhld [749.528692ms]
+Jul  2 13:38:25.482: INFO: Created: latency-svc-vrc6q
+Jul  2 13:38:25.519: INFO: Got endpoints: latency-svc-g2klt [749.607307ms]
+Jul  2 13:38:25.530: INFO: Created: latency-svc-t8h8z
+Jul  2 13:38:25.570: INFO: Got endpoints: latency-svc-96cjb [749.256038ms]
+Jul  2 13:38:25.581: INFO: Created: latency-svc-hbpg4
+Jul  2 13:38:25.619: INFO: Got endpoints: latency-svc-szj65 [748.895715ms]
+Jul  2 13:38:25.631: INFO: Created: latency-svc-qpqmm
+Jul  2 13:38:25.669: INFO: Got endpoints: latency-svc-bgvh9 [749.290488ms]
+Jul  2 13:38:25.682: INFO: Created: latency-svc-q5z2g
+Jul  2 13:38:25.720: INFO: Got endpoints: latency-svc-vlbrq [750.781186ms]
+Jul  2 13:38:25.732: INFO: Created: latency-svc-hbhmj
+Jul  2 13:38:25.769: INFO: Got endpoints: latency-svc-zswmh [749.96909ms]
+Jul  2 13:38:25.786: INFO: Created: latency-svc-n25nx
+Jul  2 13:38:25.819: INFO: Got endpoints: latency-svc-pvnfj [749.927178ms]
+Jul  2 13:38:25.832: INFO: Created: latency-svc-nbqtt
+Jul  2 13:38:25.870: INFO: Got endpoints: latency-svc-85q9q [749.92722ms]
+Jul  2 13:38:25.880: INFO: Created: latency-svc-btjb6
+Jul  2 13:38:25.920: INFO: Got endpoints: latency-svc-hsr9r [751.079463ms]
+Jul  2 13:38:25.932: INFO: Created: latency-svc-6rkpg
+Jul  2 13:38:25.969: INFO: Got endpoints: latency-svc-qsg8q [749.786512ms]
+Jul  2 13:38:25.980: INFO: Created: latency-svc-cbv5b
+Jul  2 13:38:26.019: INFO: Got endpoints: latency-svc-x4rq9 [747.866084ms]
+Jul  2 13:38:26.030: INFO: Created: latency-svc-w7cpw
+Jul  2 13:38:26.069: INFO: Got endpoints: latency-svc-fqhdv [750.125648ms]
+Jul  2 13:38:26.092: INFO: Created: latency-svc-6s9tf
+Jul  2 13:38:26.120: INFO: Got endpoints: latency-svc-4rc4z [749.825623ms]
+Jul  2 13:38:26.131: INFO: Created: latency-svc-lxkgl
+Jul  2 13:38:26.169: INFO: Got endpoints: latency-svc-mnc4j [749.708836ms]
+Jul  2 13:38:26.181: INFO: Created: latency-svc-shqxx
+Jul  2 13:38:26.219: INFO: Got endpoints: latency-svc-vrc6q [749.916797ms]
+Jul  2 13:38:26.229: INFO: Created: latency-svc-2wrx6
+Jul  2 13:38:26.269: INFO: Got endpoints: latency-svc-t8h8z [749.205124ms]
+Jul  2 13:38:26.279: INFO: Created: latency-svc-9tzvj
+Jul  2 13:38:26.322: INFO: Got endpoints: latency-svc-hbpg4 [751.942887ms]
+Jul  2 13:38:26.332: INFO: Created: latency-svc-lnpkw
+Jul  2 13:38:26.373: INFO: Got endpoints: latency-svc-qpqmm [754.087581ms]
+Jul  2 13:38:26.385: INFO: Created: latency-svc-lpsjr
+Jul  2 13:38:26.420: INFO: Got endpoints: latency-svc-q5z2g [751.38539ms]
+Jul  2 13:38:26.436: INFO: Created: latency-svc-znq6p
+Jul  2 13:38:26.469: INFO: Got endpoints: latency-svc-hbhmj [749.080952ms]
+Jul  2 13:38:26.480: INFO: Created: latency-svc-qkpsj
+Jul  2 13:38:26.520: INFO: Got endpoints: latency-svc-n25nx [750.832453ms]
+Jul  2 13:38:26.531: INFO: Created: latency-svc-8vtzt
+Jul  2 13:38:26.569: INFO: Got endpoints: latency-svc-nbqtt [749.620686ms]
+Jul  2 13:38:26.580: INFO: Created: latency-svc-kpgrx
+Jul  2 13:38:26.619: INFO: Got endpoints: latency-svc-btjb6 [748.965307ms]
+Jul  2 13:38:26.630: INFO: Created: latency-svc-rvgxp
+Jul  2 13:38:26.669: INFO: Got endpoints: latency-svc-6rkpg [749.12955ms]
+Jul  2 13:38:26.680: INFO: Created: latency-svc-7l26t
+Jul  2 13:38:26.719: INFO: Got endpoints: latency-svc-cbv5b [750.156651ms]
+Jul  2 13:38:26.731: INFO: Created: latency-svc-hx8fl
+Jul  2 13:38:26.769: INFO: Got endpoints: latency-svc-w7cpw [750.507216ms]
+Jul  2 13:38:26.781: INFO: Created: latency-svc-74qn7
+Jul  2 13:38:26.820: INFO: Got endpoints: latency-svc-6s9tf [750.566166ms]
+Jul  2 13:38:26.831: INFO: Created: latency-svc-52ftr
+Jul  2 13:38:26.869: INFO: Got endpoints: latency-svc-lxkgl [749.49008ms]
+Jul  2 13:38:26.883: INFO: Created: latency-svc-8pzls
+Jul  2 13:38:26.921: INFO: Got endpoints: latency-svc-shqxx [751.792188ms]
+Jul  2 13:38:26.934: INFO: Created: latency-svc-64mbm
+Jul  2 13:38:26.969: INFO: Got endpoints: latency-svc-2wrx6 [749.816931ms]
+Jul  2 13:38:26.985: INFO: Created: latency-svc-l7l9k
+Jul  2 13:38:27.019: INFO: Got endpoints: latency-svc-9tzvj [750.19309ms]
+Jul  2 13:38:27.031: INFO: Created: latency-svc-cf9tc
+Jul  2 13:38:27.069: INFO: Got endpoints: latency-svc-lnpkw [747.543177ms]
+Jul  2 13:38:27.081: INFO: Created: latency-svc-826wg
+Jul  2 13:38:27.120: INFO: Got endpoints: latency-svc-lpsjr [746.556954ms]
+Jul  2 13:38:27.130: INFO: Created: latency-svc-2w9ws
+Jul  2 13:38:27.169: INFO: Got endpoints: latency-svc-znq6p [748.981982ms]
+Jul  2 13:38:27.180: INFO: Created: latency-svc-m67mr
+Jul  2 13:38:27.219: INFO: Got endpoints: latency-svc-qkpsj [750.032516ms]
+Jul  2 13:38:27.230: INFO: Created: latency-svc-qrk86
+Jul  2 13:38:27.269: INFO: Got endpoints: latency-svc-8vtzt [749.35775ms]
+Jul  2 13:38:27.280: INFO: Created: latency-svc-f48dx
+Jul  2 13:38:27.320: INFO: Got endpoints: latency-svc-kpgrx [750.436592ms]
+Jul  2 13:38:27.329: INFO: Created: latency-svc-9xp2q
+Jul  2 13:38:27.370: INFO: Got endpoints: latency-svc-rvgxp [750.71921ms]
+Jul  2 13:38:27.379: INFO: Created: latency-svc-mll7q
+Jul  2 13:38:27.420: INFO: Got endpoints: latency-svc-7l26t [750.502031ms]
+Jul  2 13:38:27.430: INFO: Created: latency-svc-rcll9
+Jul  2 13:38:27.470: INFO: Got endpoints: latency-svc-hx8fl [750.864427ms]
+Jul  2 13:38:27.479: INFO: Created: latency-svc-w4gql
+Jul  2 13:38:27.519: INFO: Got endpoints: latency-svc-74qn7 [749.647757ms]
+Jul  2 13:38:27.530: INFO: Created: latency-svc-tx2f5
+Jul  2 13:38:27.569: INFO: Got endpoints: latency-svc-52ftr [749.023059ms]
+Jul  2 13:38:27.579: INFO: Created: latency-svc-jdf5z
+Jul  2 13:38:27.619: INFO: Got endpoints: latency-svc-8pzls [749.703386ms]
+Jul  2 13:38:27.629: INFO: Created: latency-svc-d6hgm
+Jul  2 13:38:27.669: INFO: Got endpoints: latency-svc-64mbm [747.434441ms]
+Jul  2 13:38:27.679: INFO: Created: latency-svc-cn7h4
+Jul  2 13:38:27.719: INFO: Got endpoints: latency-svc-l7l9k [749.425001ms]
+Jul  2 13:38:27.729: INFO: Created: latency-svc-mxh4g
+Jul  2 13:38:27.769: INFO: Got endpoints: latency-svc-cf9tc [750.163011ms]
+Jul  2 13:38:27.781: INFO: Created: latency-svc-fjs8s
+Jul  2 13:38:27.820: INFO: Got endpoints: latency-svc-826wg [750.863164ms]
+Jul  2 13:38:27.831: INFO: Created: latency-svc-2bq55
+Jul  2 13:38:27.869: INFO: Got endpoints: latency-svc-2w9ws [749.407579ms]
+Jul  2 13:38:27.879: INFO: Created: latency-svc-k5952
+Jul  2 13:38:27.920: INFO: Got endpoints: latency-svc-m67mr [750.258365ms]
+Jul  2 13:38:27.930: INFO: Created: latency-svc-wdk27
+Jul  2 13:38:27.969: INFO: Got endpoints: latency-svc-qrk86 [749.760433ms]
+Jul  2 13:38:27.978: INFO: Created: latency-svc-dqjjk
+Jul  2 13:38:28.019: INFO: Got endpoints: latency-svc-f48dx [749.926813ms]
+Jul  2 13:38:28.033: INFO: Created: latency-svc-nh5pt
+Jul  2 13:38:28.069: INFO: Got endpoints: latency-svc-9xp2q [749.568273ms]
+Jul  2 13:38:28.079: INFO: Created: latency-svc-zdtbr
+Jul  2 13:38:28.119: INFO: Got endpoints: latency-svc-mll7q [749.079513ms]
+Jul  2 13:38:28.129: INFO: Created: latency-svc-k6n7v
+Jul  2 13:38:28.170: INFO: Got endpoints: latency-svc-rcll9 [749.802821ms]
+Jul  2 13:38:28.180: INFO: Created: latency-svc-tgz6n
+Jul  2 13:38:28.219: INFO: Got endpoints: latency-svc-w4gql [748.782384ms]
+Jul  2 13:38:28.229: INFO: Created: latency-svc-82pkf
+Jul  2 13:38:28.269: INFO: Got endpoints: latency-svc-tx2f5 [749.397835ms]
+Jul  2 13:38:28.320: INFO: Got endpoints: latency-svc-jdf5z [750.601885ms]
+Jul  2 13:38:28.369: INFO: Got endpoints: latency-svc-d6hgm [749.957421ms]
+Jul  2 13:38:28.419: INFO: Got endpoints: latency-svc-cn7h4 [750.311617ms]
+Jul  2 13:38:28.469: INFO: Got endpoints: latency-svc-mxh4g [750.093268ms]
+Jul  2 13:38:28.520: INFO: Got endpoints: latency-svc-fjs8s [750.524454ms]
+Jul  2 13:38:28.569: INFO: Got endpoints: latency-svc-2bq55 [749.087993ms]
+Jul  2 13:38:28.620: INFO: Got endpoints: latency-svc-k5952 [750.921536ms]
+Jul  2 13:38:28.670: INFO: Got endpoints: latency-svc-wdk27 [749.939572ms]
+Jul  2 13:38:28.720: INFO: Got endpoints: latency-svc-dqjjk [750.53392ms]
+Jul  2 13:38:28.770: INFO: Got endpoints: latency-svc-nh5pt [750.094987ms]
+Jul  2 13:38:28.820: INFO: Got endpoints: latency-svc-zdtbr [750.742681ms]
+Jul  2 13:38:28.870: INFO: Got endpoints: latency-svc-k6n7v [750.402847ms]
+Jul  2 13:38:28.920: INFO: Got endpoints: latency-svc-tgz6n [749.53584ms]
+Jul  2 13:38:28.970: INFO: Got endpoints: latency-svc-82pkf [750.801555ms]
+Jul  2 13:38:28.970: INFO: Latencies: [13.148711ms 15.912226ms 19.110233ms 24.427392ms 30.441515ms 36.139846ms 40.338251ms 60.169893ms 65.210122ms 71.571259ms 76.785852ms 86.829425ms 101.678188ms 109.243444ms 119.862906ms 120.49828ms 122.678809ms 125.092972ms 126.460222ms 127.709498ms 141.057596ms 156.647487ms 157.280567ms 159.489368ms 160.297281ms 161.896993ms 161.957694ms 164.334135ms 164.743757ms 164.818511ms 165.399636ms 166.696163ms 168.787933ms 171.805019ms 172.575376ms 175.011699ms 180.479202ms 215.32589ms 263.907039ms 308.769568ms 344.991902ms 386.367431ms 427.149181ms 469.84859ms 515.013508ms 556.053562ms 601.563316ms 645.366714ms 690.802771ms 735.357089ms 746.556954ms 746.564439ms 746.875355ms 747.434441ms 747.512847ms 747.543177ms 747.866084ms 747.969657ms 748.484809ms 748.493594ms 748.513711ms 748.586608ms 748.596308ms 748.73296ms 748.782384ms 748.857432ms 748.859942ms 748.895715ms 748.902085ms 748.93557ms 748.965307ms 748.981982ms 749.023059ms 749.079513ms 749.080952ms 749.087993ms 749.118557ms 749.12955ms 749.205124ms 749.225054ms 749.256038ms 749.280729ms 749.28846ms 749.290488ms 749.35775ms 749.397835ms 749.407579ms 749.408385ms 749.425001ms 749.486272ms 749.49008ms 749.519524ms 749.528692ms 749.53584ms 749.536942ms 749.542036ms 749.568273ms 749.587129ms 749.607307ms 749.620686ms 749.637402ms 749.647757ms 749.649395ms 749.701017ms 749.701861ms 749.703386ms 749.70547ms 749.708836ms 749.723895ms 749.731425ms 749.739955ms 749.751243ms 749.760433ms 749.762352ms 749.786512ms 749.802821ms 749.80379ms 749.804954ms 749.816931ms 749.825623ms 749.837593ms 749.853174ms 749.867553ms 749.893781ms 749.897161ms 749.916797ms 749.922421ms 749.926813ms 749.927178ms 749.92722ms 749.939572ms 749.957421ms 749.963598ms 749.96909ms 749.98368ms 749.993678ms 750.010546ms 750.027094ms 750.030338ms 750.032516ms 750.060637ms 750.062703ms 750.069043ms 750.072959ms 750.083383ms 750.093268ms 750.094987ms 750.122371ms 750.125648ms 750.149271ms 750.156651ms 750.158025ms 750.162894ms 750.163011ms 750.19309ms 750.223931ms 750.227979ms 750.233091ms 750.258365ms 750.260056ms 750.267249ms 750.295196ms 750.297088ms 750.311617ms 750.33684ms 750.355044ms 750.355895ms 750.402847ms 750.436592ms 750.439302ms 750.502031ms 750.507216ms 750.524454ms 750.53392ms 750.566166ms 750.576127ms 750.601885ms 750.71921ms 750.7294ms 750.742681ms 750.781186ms 750.782303ms 750.801555ms 750.814847ms 750.832453ms 750.863164ms 750.864427ms 750.921536ms 750.939588ms 751.017284ms 751.065542ms 751.079463ms 751.094296ms 751.38539ms 751.792188ms 751.874949ms 751.942887ms 752.174524ms 752.306989ms 754.087581ms]
+Jul  2 13:38:28.970: INFO: 50 %ile: 749.637402ms
+Jul  2 13:38:28.970: INFO: 90 %ile: 750.781186ms
+Jul  2 13:38:28.970: INFO: 99 %ile: 752.306989ms
+Jul  2 13:38:28.970: INFO: Total sample count: 200
+[AfterEach] [sig-network] Service endpoints latency
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:38:28.970: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-svc-latency-77hr6" for this suite.
+Jul  2 13:38:50.990: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:38:51.066: INFO: namespace: e2e-tests-svc-latency-77hr6, resource: bindings, ignored listing per whitelist
+Jul  2 13:38:51.243: INFO: namespace e2e-tests-svc-latency-77hr6 deletion completed in 22.268755455s
+
+• [SLOW TEST:33.076 seconds]
+[sig-network] Service endpoints latency
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/network/framework.go:22
+  should not be very high  [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSSSSSSSS
+------------------------------
+[k8s.io] Probing container 
+  with readiness probe that fails should never be ready and never restart [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [k8s.io] Probing container
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:38:51.244: INFO: >>> kubeConfig: /tmp/kubeconfig-575984058
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [k8s.io] Probing container
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/container_probe.go:48
+[It] with readiness probe that fails should never be ready and never restart [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[AfterEach] [k8s.io] Probing container
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:39:51.334: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-container-probe-5rt4z" for this suite.
+Jul  2 13:40:13.382: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:40:13.496: INFO: namespace: e2e-tests-container-probe-5rt4z, resource: bindings, ignored listing per whitelist
+Jul  2 13:40:13.513: INFO: namespace e2e-tests-container-probe-5rt4z deletion completed in 22.175125246s
+
+• [SLOW TEST:82.270 seconds]
+[k8s.io] Probing container
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:679
+  with readiness probe that fails should never be ready and never restart [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+[sig-network] Services 
+  should serve multiport endpoints from pods  [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-network] Services
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:40:13.514: INFO: >>> kubeConfig: /tmp/kubeconfig-575984058
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-network] Services
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/network/service.go:83
+[It] should serve multiport endpoints from pods  [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: creating service multi-endpoint-test in namespace e2e-tests-services-hkhhg
+STEP: waiting up to 3m0s for service multi-endpoint-test in namespace e2e-tests-services-hkhhg to expose endpoints map[]
+Jul  2 13:40:13.634: INFO: successfully validated that service multi-endpoint-test in namespace e2e-tests-services-hkhhg exposes endpoints map[] (4.351844ms elapsed)
+STEP: Creating pod pod1 in namespace e2e-tests-services-hkhhg
+STEP: waiting up to 3m0s for service multi-endpoint-test in namespace e2e-tests-services-hkhhg to expose endpoints map[pod1:[100]]
+Jul  2 13:40:16.682: INFO: successfully validated that service multi-endpoint-test in namespace e2e-tests-services-hkhhg exposes endpoints map[pod1:[100]] (3.042044696s elapsed)
+STEP: Creating pod pod2 in namespace e2e-tests-services-hkhhg
+STEP: waiting up to 3m0s for service multi-endpoint-test in namespace e2e-tests-services-hkhhg to expose endpoints map[pod1:[100] pod2:[101]]
+Jul  2 13:40:18.986: INFO: successfully validated that service multi-endpoint-test in namespace e2e-tests-services-hkhhg exposes endpoints map[pod1:[100] pod2:[101]] (2.220108406s elapsed)
+STEP: Deleting pod pod1 in namespace e2e-tests-services-hkhhg
+STEP: waiting up to 3m0s for service multi-endpoint-test in namespace e2e-tests-services-hkhhg to expose endpoints map[pod2:[101]]
+Jul  2 13:40:18.998: INFO: successfully validated that service multi-endpoint-test in namespace e2e-tests-services-hkhhg exposes endpoints map[pod2:[101]] (5.883598ms elapsed)
+STEP: Deleting pod pod2 in namespace e2e-tests-services-hkhhg
+STEP: waiting up to 3m0s for service multi-endpoint-test in namespace e2e-tests-services-hkhhg to expose endpoints map[]
+Jul  2 13:40:19.005: INFO: successfully validated that service multi-endpoint-test in namespace e2e-tests-services-hkhhg exposes endpoints map[] (2.652115ms elapsed)
+[AfterEach] [sig-network] Services
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:40:19.018: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-services-hkhhg" for this suite.
+Jul  2 13:40:41.039: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:40:41.140: INFO: namespace: e2e-tests-services-hkhhg, resource: bindings, ignored listing per whitelist
+Jul  2 13:40:41.157: INFO: namespace e2e-tests-services-hkhhg deletion completed in 22.132333976s
+[AfterEach] [sig-network] Services
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/network/service.go:88
+
+• [SLOW TEST:27.643 seconds]
+[sig-network] Services
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/network/framework.go:22
+  should serve multiport endpoints from pods  [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSSSSSSSSSS
+------------------------------
+[sig-api-machinery] Downward API 
+  should provide default limits.cpu/memory from node allocatable [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-api-machinery] Downward API
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:40:41.158: INFO: >>> kubeConfig: /tmp/kubeconfig-575984058
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should provide default limits.cpu/memory from node allocatable [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating a pod to test downward api env vars
+Jul  2 13:40:41.262: INFO: Waiting up to 5m0s for pod "downward-api-82fc28b1-7dfd-11e8-b7a8-22e3071d17c7" in namespace "e2e-tests-downward-api-vnlwq" to be "success or failure"
+Jul  2 13:40:41.265: INFO: Pod "downward-api-82fc28b1-7dfd-11e8-b7a8-22e3071d17c7": Phase="Pending", Reason="", readiness=false. Elapsed: 3.583047ms
+Jul  2 13:40:43.269: INFO: Pod "downward-api-82fc28b1-7dfd-11e8-b7a8-22e3071d17c7": Phase="Pending", Reason="", readiness=false. Elapsed: 2.007538671s
+Jul  2 13:40:45.281: INFO: Pod "downward-api-82fc28b1-7dfd-11e8-b7a8-22e3071d17c7": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.018975053s
+STEP: Saw pod success
+Jul  2 13:40:45.281: INFO: Pod "downward-api-82fc28b1-7dfd-11e8-b7a8-22e3071d17c7" satisfied condition "success or failure"
+Jul  2 13:40:45.366: INFO: Trying to get logs from node shoot--core--confos-worker-w6oh6-z1-59946c4f6c-2w6kp pod downward-api-82fc28b1-7dfd-11e8-b7a8-22e3071d17c7 container dapi-container: <nil>
+STEP: delete the pod
+Jul  2 13:40:45.399: INFO: Waiting for pod downward-api-82fc28b1-7dfd-11e8-b7a8-22e3071d17c7 to disappear
+Jul  2 13:40:45.416: INFO: Pod downward-api-82fc28b1-7dfd-11e8-b7a8-22e3071d17c7 no longer exists
+[AfterEach] [sig-api-machinery] Downward API
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:40:45.416: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-downward-api-vnlwq" for this suite.
+Jul  2 13:40:51.431: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:40:51.487: INFO: namespace: e2e-tests-downward-api-vnlwq, resource: bindings, ignored listing per whitelist
+Jul  2 13:40:51.529: INFO: namespace e2e-tests-downward-api-vnlwq deletion completed in 6.109001915s
+
+• [SLOW TEST:10.371 seconds]
+[sig-api-machinery] Downward API
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downward_api.go:37
+  should provide default limits.cpu/memory from node allocatable [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSSSSSSSSS
+------------------------------
+[sig-storage] Projected 
+  should be consumable from pods in volume with mappings and Item Mode set [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:40:51.530: INFO: >>> kubeConfig: /tmp/kubeconfig-575984058
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:858
+[It] should be consumable from pods in volume with mappings and Item Mode set [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating projection with secret that has name projected-secret-test-map-89281527-7dfd-11e8-b7a8-22e3071d17c7
+STEP: Creating a pod to test consume secrets
+Jul  2 13:40:51.619: INFO: Waiting up to 5m0s for pod "pod-projected-secrets-892896ce-7dfd-11e8-b7a8-22e3071d17c7" in namespace "e2e-tests-projected-lwj65" to be "success or failure"
+Jul  2 13:40:51.623: INFO: Pod "pod-projected-secrets-892896ce-7dfd-11e8-b7a8-22e3071d17c7": Phase="Pending", Reason="", readiness=false. Elapsed: 4.40238ms
+Jul  2 13:40:53.632: INFO: Pod "pod-projected-secrets-892896ce-7dfd-11e8-b7a8-22e3071d17c7": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.013233648s
+STEP: Saw pod success
+Jul  2 13:40:53.632: INFO: Pod "pod-projected-secrets-892896ce-7dfd-11e8-b7a8-22e3071d17c7" satisfied condition "success or failure"
+Jul  2 13:40:53.635: INFO: Trying to get logs from node shoot--core--confos-worker-w6oh6-z1-59946c4f6c-2w6kp pod pod-projected-secrets-892896ce-7dfd-11e8-b7a8-22e3071d17c7 container projected-secret-volume-test: <nil>
+STEP: delete the pod
+Jul  2 13:40:53.656: INFO: Waiting for pod pod-projected-secrets-892896ce-7dfd-11e8-b7a8-22e3071d17c7 to disappear
+Jul  2 13:40:53.665: INFO: Pod pod-projected-secrets-892896ce-7dfd-11e8-b7a8-22e3071d17c7 no longer exists
+[AfterEach] [sig-storage] Projected
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:40:53.665: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-lwj65" for this suite.
+Jul  2 13:40:59.682: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:40:59.811: INFO: namespace: e2e-tests-projected-lwj65, resource: bindings, ignored listing per whitelist
+Jul  2 13:40:59.874: INFO: namespace e2e-tests-projected-lwj65 deletion completed in 6.205768077s
+
+• [SLOW TEST:8.345 seconds]
+[sig-storage] Projected
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:34
+  should be consumable from pods in volume with mappings and Item Mode set [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+[sig-network] DNS 
+  should provide DNS for the cluster  [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-network] DNS
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:40:59.876: INFO: >>> kubeConfig: /tmp/kubeconfig-575984058
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should provide DNS for the cluster  [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Running these commands on wheezy: for i in `seq 1 600`; do test -n "$$(dig +notcp +noall +answer +search kubernetes.default A)" && echo OK > /results/wheezy_udp@kubernetes.default;test -n "$$(dig +tcp +noall +answer +search kubernetes.default A)" && echo OK > /results/wheezy_tcp@kubernetes.default;test -n "$$(dig +notcp +noall +answer +search kubernetes.default.svc A)" && echo OK > /results/wheezy_udp@kubernetes.default.svc;test -n "$$(dig +tcp +noall +answer +search kubernetes.default.svc A)" && echo OK > /results/wheezy_tcp@kubernetes.default.svc;test -n "$$(dig +notcp +noall +answer +search kubernetes.default.svc.cluster.local A)" && echo OK > /results/wheezy_udp@kubernetes.default.svc.cluster.local;test -n "$$(dig +tcp +noall +answer +search kubernetes.default.svc.cluster.local A)" && echo OK > /results/wheezy_tcp@kubernetes.default.svc.cluster.local;test -n "$$(getent hosts dns-querier-1.dns-test-service.e2e-tests-dns-jnmsp.svc.cluster.local)" && echo OK > /results/wheezy_hosts@dns-querier-1.dns-test-service.e2e-tests-dns-jnmsp.svc.cluster.local;test -n "$$(getent hosts dns-querier-1)" && echo OK > /results/wheezy_hosts@dns-querier-1;podARec=$$(hostname -i| awk -F. '{print $$1"-"$$2"-"$$3"-"$$4".e2e-tests-dns-jnmsp.pod.cluster.local"}');test -n "$$(dig +notcp +noall +answer +search $${podARec} A)" && echo OK > /results/wheezy_udp@PodARecord;test -n "$$(dig +tcp +noall +answer +search $${podARec} A)" && echo OK > /results/wheezy_tcp@PodARecord;sleep 1; done
+
+STEP: Running these commands on jessie: for i in `seq 1 600`; do test -n "$$(dig +notcp +noall +answer +search kubernetes.default A)" && echo OK > /results/jessie_udp@kubernetes.default;test -n "$$(dig +tcp +noall +answer +search kubernetes.default A)" && echo OK > /results/jessie_tcp@kubernetes.default;test -n "$$(dig +notcp +noall +answer +search kubernetes.default.svc A)" && echo OK > /results/jessie_udp@kubernetes.default.svc;test -n "$$(dig +tcp +noall +answer +search kubernetes.default.svc A)" && echo OK > /results/jessie_tcp@kubernetes.default.svc;test -n "$$(dig +notcp +noall +answer +search kubernetes.default.svc.cluster.local A)" && echo OK > /results/jessie_udp@kubernetes.default.svc.cluster.local;test -n "$$(dig +tcp +noall +answer +search kubernetes.default.svc.cluster.local A)" && echo OK > /results/jessie_tcp@kubernetes.default.svc.cluster.local;test -n "$$(getent hosts dns-querier-1.dns-test-service.e2e-tests-dns-jnmsp.svc.cluster.local)" && echo OK > /results/jessie_hosts@dns-querier-1.dns-test-service.e2e-tests-dns-jnmsp.svc.cluster.local;test -n "$$(getent hosts dns-querier-1)" && echo OK > /results/jessie_hosts@dns-querier-1;podARec=$$(hostname -i| awk -F. '{print $$1"-"$$2"-"$$3"-"$$4".e2e-tests-dns-jnmsp.pod.cluster.local"}');test -n "$$(dig +notcp +noall +answer +search $${podARec} A)" && echo OK > /results/jessie_udp@PodARecord;test -n "$$(dig +tcp +noall +answer +search $${podARec} A)" && echo OK > /results/jessie_tcp@PodARecord;sleep 1; done
+
+STEP: creating a pod to probe DNS
+STEP: submitting the pod to kubernetes
+STEP: retrieving the pod
+STEP: looking for the results for each expected name from probers
+Jul  2 13:41:21.794: INFO: DNS probes using dns-test-8e236872-7dfd-11e8-b7a8-22e3071d17c7 succeeded
+
+STEP: deleting the pod
+[AfterEach] [sig-network] DNS
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:41:21.815: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-dns-jnmsp" for this suite.
+Jul  2 13:41:27.882: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:41:27.942: INFO: namespace: e2e-tests-dns-jnmsp, resource: bindings, ignored listing per whitelist
+Jul  2 13:41:27.980: INFO: namespace e2e-tests-dns-jnmsp deletion completed in 6.136733655s
+
+• [SLOW TEST:28.104 seconds]
+[sig-network] DNS
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/network/framework.go:22
+  should provide DNS for the cluster  [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSSSSSSSSS
+------------------------------
+[sig-apps] Daemon set [Serial] 
+  should rollback without unnecessary restarts [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-apps] Daemon set [Serial]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:41:27.980: INFO: >>> kubeConfig: /tmp/kubeconfig-575984058
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-apps] Daemon set [Serial]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/daemon_set.go:99
+[It] should rollback without unnecessary restarts [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+Jul  2 13:41:28.071: INFO: Requires at least 2 nodes (not -1)
+[AfterEach] [sig-apps] Daemon set [Serial]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/daemon_set.go:65
+Jul  2 13:41:28.077: INFO: daemonset: {"kind":"DaemonSetList","apiVersion":"apps/v1","metadata":{"selfLink":"/apis/apps/v1/namespaces/e2e-tests-daemonsets-4p9pb/daemonsets","resourceVersion":"11120"},"items":null}
+
+Jul  2 13:41:28.080: INFO: pods: {"kind":"PodList","apiVersion":"v1","metadata":{"selfLink":"/api/v1/namespaces/e2e-tests-daemonsets-4p9pb/pods","resourceVersion":"11120"},"items":null}
+
+[AfterEach] [sig-apps] Daemon set [Serial]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:41:28.088: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-daemonsets-4p9pb" for this suite.
+Jul  2 13:41:34.167: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:41:34.212: INFO: namespace: e2e-tests-daemonsets-4p9pb, resource: bindings, ignored listing per whitelist
+Jul  2 13:41:34.273: INFO: namespace e2e-tests-daemonsets-4p9pb deletion completed in 6.181241146s
+
+S [SKIPPING] [6.293 seconds]
+[sig-apps] Daemon set [Serial]
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/framework.go:22
+  should rollback without unnecessary restarts [Conformance] [It]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+
+  Jul  2 13:41:28.071: Requires at least 2 nodes (not -1)
+
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/util.go:305
+------------------------------
+[sig-storage] ConfigMap 
+  should be consumable from pods in volume with mappings [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-storage] ConfigMap
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:41:34.274: INFO: >>> kubeConfig: /tmp/kubeconfig-575984058
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should be consumable from pods in volume with mappings [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating configMap with name configmap-test-volume-map-a2a23bf7-7dfd-11e8-b7a8-22e3071d17c7
+STEP: Creating a pod to test consume configMaps
+Jul  2 13:41:34.363: INFO: Waiting up to 5m0s for pod "pod-configmaps-a2a2c274-7dfd-11e8-b7a8-22e3071d17c7" in namespace "e2e-tests-configmap-qpb8f" to be "success or failure"
+Jul  2 13:41:34.367: INFO: Pod "pod-configmaps-a2a2c274-7dfd-11e8-b7a8-22e3071d17c7": Phase="Pending", Reason="", readiness=false. Elapsed: 4.099971ms
+Jul  2 13:41:36.467: INFO: Pod "pod-configmaps-a2a2c274-7dfd-11e8-b7a8-22e3071d17c7": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.103858452s
+STEP: Saw pod success
+Jul  2 13:41:36.467: INFO: Pod "pod-configmaps-a2a2c274-7dfd-11e8-b7a8-22e3071d17c7" satisfied condition "success or failure"
+Jul  2 13:41:36.473: INFO: Trying to get logs from node shoot--core--confos-worker-w6oh6-z1-59946c4f6c-2w6kp pod pod-configmaps-a2a2c274-7dfd-11e8-b7a8-22e3071d17c7 container configmap-volume-test: <nil>
+STEP: delete the pod
+Jul  2 13:41:36.493: INFO: Waiting for pod pod-configmaps-a2a2c274-7dfd-11e8-b7a8-22e3071d17c7 to disappear
+Jul  2 13:41:36.501: INFO: Pod pod-configmaps-a2a2c274-7dfd-11e8-b7a8-22e3071d17c7 no longer exists
+[AfterEach] [sig-storage] ConfigMap
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:41:36.502: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-configmap-qpb8f" for this suite.
+Jul  2 13:41:42.517: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:41:42.600: INFO: namespace: e2e-tests-configmap-qpb8f, resource: bindings, ignored listing per whitelist
+Jul  2 13:41:42.665: INFO: namespace e2e-tests-configmap-qpb8f deletion completed in 6.159965414s
+
+• [SLOW TEST:8.391 seconds]
+[sig-storage] ConfigMap
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/configmap_volume.go:32
+  should be consumable from pods in volume with mappings [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSSS
+------------------------------
+[sig-storage] Downward API volume 
+  should set DefaultMode on files [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:41:42.666: INFO: >>> kubeConfig: /tmp/kubeconfig-575984058
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downwardapi_volume.go:38
+[It] should set DefaultMode on files [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating a pod to test downward API volume plugin
+Jul  2 13:41:42.807: INFO: Waiting up to 5m0s for pod "downwardapi-volume-a7ab5a9e-7dfd-11e8-b7a8-22e3071d17c7" in namespace "e2e-tests-downward-api-v8mfm" to be "success or failure"
+Jul  2 13:41:42.811: INFO: Pod "downwardapi-volume-a7ab5a9e-7dfd-11e8-b7a8-22e3071d17c7": Phase="Pending", Reason="", readiness=false. Elapsed: 4.186322ms
+Jul  2 13:41:44.816: INFO: Pod "downwardapi-volume-a7ab5a9e-7dfd-11e8-b7a8-22e3071d17c7": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.008893064s
+STEP: Saw pod success
+Jul  2 13:41:44.816: INFO: Pod "downwardapi-volume-a7ab5a9e-7dfd-11e8-b7a8-22e3071d17c7" satisfied condition "success or failure"
+Jul  2 13:41:44.819: INFO: Trying to get logs from node shoot--core--confos-worker-w6oh6-z1-59946c4f6c-2w6kp pod downwardapi-volume-a7ab5a9e-7dfd-11e8-b7a8-22e3071d17c7 container client-container: <nil>
+STEP: delete the pod
+Jul  2 13:41:44.886: INFO: Waiting for pod downwardapi-volume-a7ab5a9e-7dfd-11e8-b7a8-22e3071d17c7 to disappear
+Jul  2 13:41:44.890: INFO: Pod downwardapi-volume-a7ab5a9e-7dfd-11e8-b7a8-22e3071d17c7 no longer exists
+[AfterEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:41:44.890: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-downward-api-v8mfm" for this suite.
+Jul  2 13:41:50.912: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:41:50.983: INFO: namespace: e2e-tests-downward-api-v8mfm, resource: bindings, ignored listing per whitelist
+Jul  2 13:41:51.015: INFO: namespace e2e-tests-downward-api-v8mfm deletion completed in 6.121321942s
+
+• [SLOW TEST:8.349 seconds]
+[sig-storage] Downward API volume
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downwardapi_volume.go:33
+  should set DefaultMode on files [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSSSSSS
+------------------------------
+[k8s.io] [sig-node] PreStop 
+  should call prestop when killing a pod  [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [k8s.io] [sig-node] PreStop
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:41:51.016: INFO: >>> kubeConfig: /tmp/kubeconfig-575984058
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should call prestop when killing a pod  [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating server pod server in namespace e2e-tests-prestop-rk6gr
+STEP: Waiting for pods to come up.
+STEP: Creating tester pod tester in namespace e2e-tests-prestop-rk6gr
+STEP: Deleting pre-stop pod
+Jul  2 13:42:04.219: INFO: Saw: {
+	"Hostname": "server",
+	"Sent": null,
+	"Received": {
+		"prestop": 1
+	},
+	"Errors": null,
+	"Log": [
+		"default/nettest has 0 endpoints ([]), which is less than 8 as expected. Waiting for all endpoints to come up.",
+		"default/nettest has 0 endpoints ([]), which is less than 8 as expected. Waiting for all endpoints to come up."
+	],
+	"StillContactingPeers": true
+}
+STEP: Deleting the server pod
+[AfterEach] [k8s.io] [sig-node] PreStop
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:42:04.381: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-prestop-rk6gr" for this suite.
+Jul  2 13:42:42.396: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:42:42.611: INFO: namespace: e2e-tests-prestop-rk6gr, resource: bindings, ignored listing per whitelist
+Jul  2 13:42:42.644: INFO: namespace e2e-tests-prestop-rk6gr deletion completed in 38.258937769s
+
+• [SLOW TEST:51.629 seconds]
+[k8s.io] [sig-node] PreStop
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:679
+  should call prestop when killing a pod  [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+[k8s.io] Probing container 
+  should be restarted with a /healthz http liveness probe [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [k8s.io] Probing container
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:42:42.645: INFO: >>> kubeConfig: /tmp/kubeconfig-575984058
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [k8s.io] Probing container
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/container_probe.go:48
+[It] should be restarted with a /healthz http liveness probe [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating pod liveness-http in namespace e2e-tests-container-probe-4hbhd
+Jul  2 13:42:44.802: INFO: Started pod liveness-http in namespace e2e-tests-container-probe-4hbhd
+STEP: checking the pod's current state and verifying that restartCount is present
+Jul  2 13:42:44.806: INFO: Initial restart count of pod liveness-http is 0
+Jul  2 13:43:06.974: INFO: Restart count of pod e2e-tests-container-probe-4hbhd/liveness-http is now 1 (22.168600514s elapsed)
+STEP: deleting the pod
+[AfterEach] [k8s.io] Probing container
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:43:07.090: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-container-probe-4hbhd" for this suite.
+Jul  2 13:43:13.107: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:43:13.118: INFO: namespace: e2e-tests-container-probe-4hbhd, resource: bindings, ignored listing per whitelist
+Jul  2 13:43:13.263: INFO: namespace e2e-tests-container-probe-4hbhd deletion completed in 6.167886981s
+
+• [SLOW TEST:30.618 seconds]
+[k8s.io] Probing container
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:679
+  should be restarted with a /healthz http liveness probe [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSSSSSSS
+------------------------------
+[k8s.io] Pods 
+  should be updated [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [k8s.io] Pods
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:43:13.263: INFO: >>> kubeConfig: /tmp/kubeconfig-575984058
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [k8s.io] Pods
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/pods.go:127
+[It] should be updated [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: creating the pod
+STEP: submitting the pod to kubernetes
+STEP: verifying the pod is in kubernetes
+STEP: updating the pod
+Jul  2 13:43:15.929: INFO: Successfully updated pod "pod-update-ddab92cb-7dfd-11e8-b7a8-22e3071d17c7"
+STEP: verifying the updated pod is in kubernetes
+Jul  2 13:43:15.935: INFO: Pod update OK
+[AfterEach] [k8s.io] Pods
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:43:15.935: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-pods-xt7cm" for this suite.
+Jul  2 13:43:37.984: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:43:38.074: INFO: namespace: e2e-tests-pods-xt7cm, resource: bindings, ignored listing per whitelist
+Jul  2 13:43:38.079: INFO: namespace e2e-tests-pods-xt7cm deletion completed in 22.140743088s
+
+• [SLOW TEST:24.816 seconds]
+[k8s.io] Pods
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:679
+  should be updated [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSSS
+------------------------------
+[sig-storage] Downward API volume 
+  should provide container's memory limit [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:43:38.079: INFO: >>> kubeConfig: /tmp/kubeconfig-575984058
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downwardapi_volume.go:38
+[It] should provide container's memory limit [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating a pod to test downward API volume plugin
+Jul  2 13:43:38.169: INFO: Waiting up to 5m0s for pod "downwardapi-volume-ec6e11f5-7dfd-11e8-b7a8-22e3071d17c7" in namespace "e2e-tests-downward-api-kx6gz" to be "success or failure"
+Jul  2 13:43:38.171: INFO: Pod "downwardapi-volume-ec6e11f5-7dfd-11e8-b7a8-22e3071d17c7": Phase="Pending", Reason="", readiness=false. Elapsed: 2.600379ms
+Jul  2 13:43:40.175: INFO: Pod "downwardapi-volume-ec6e11f5-7dfd-11e8-b7a8-22e3071d17c7": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.006131669s
+STEP: Saw pod success
+Jul  2 13:43:40.175: INFO: Pod "downwardapi-volume-ec6e11f5-7dfd-11e8-b7a8-22e3071d17c7" satisfied condition "success or failure"
+Jul  2 13:43:40.178: INFO: Trying to get logs from node shoot--core--confos-worker-w6oh6-z1-59946c4f6c-2w6kp pod downwardapi-volume-ec6e11f5-7dfd-11e8-b7a8-22e3071d17c7 container client-container: <nil>
+STEP: delete the pod
+Jul  2 13:43:40.196: INFO: Waiting for pod downwardapi-volume-ec6e11f5-7dfd-11e8-b7a8-22e3071d17c7 to disappear
+Jul  2 13:43:40.199: INFO: Pod downwardapi-volume-ec6e11f5-7dfd-11e8-b7a8-22e3071d17c7 no longer exists
+[AfterEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:43:40.199: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-downward-api-kx6gz" for this suite.
+Jul  2 13:43:46.219: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:43:46.291: INFO: namespace: e2e-tests-downward-api-kx6gz, resource: bindings, ignored listing per whitelist
+Jul  2 13:43:46.373: INFO: namespace e2e-tests-downward-api-kx6gz deletion completed in 6.165599754s
+
+• [SLOW TEST:8.294 seconds]
+[sig-storage] Downward API volume
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downwardapi_volume.go:33
+  should provide container's memory limit [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSSS
+------------------------------
+[k8s.io] Variable Expansion 
+  should allow substituting values in a container's command [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [k8s.io] Variable Expansion
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:43:46.373: INFO: >>> kubeConfig: /tmp/kubeconfig-575984058
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should allow substituting values in a container's command [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating a pod to test substitution in container's command
+Jul  2 13:43:46.487: INFO: Waiting up to 5m0s for pod "var-expansion-f161c0e7-7dfd-11e8-b7a8-22e3071d17c7" in namespace "e2e-tests-var-expansion-mtj64" to be "success or failure"
+Jul  2 13:43:46.489: INFO: Pod "var-expansion-f161c0e7-7dfd-11e8-b7a8-22e3071d17c7": Phase="Pending", Reason="", readiness=false. Elapsed: 2.438719ms
+Jul  2 13:43:48.568: INFO: Pod "var-expansion-f161c0e7-7dfd-11e8-b7a8-22e3071d17c7": Phase="Pending", Reason="", readiness=false. Elapsed: 2.081374142s
+Jul  2 13:43:50.571: INFO: Pod "var-expansion-f161c0e7-7dfd-11e8-b7a8-22e3071d17c7": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.084862085s
+STEP: Saw pod success
+Jul  2 13:43:50.572: INFO: Pod "var-expansion-f161c0e7-7dfd-11e8-b7a8-22e3071d17c7" satisfied condition "success or failure"
+Jul  2 13:43:50.576: INFO: Trying to get logs from node shoot--core--confos-worker-w6oh6-z1-59946c4f6c-2w6kp pod var-expansion-f161c0e7-7dfd-11e8-b7a8-22e3071d17c7 container dapi-container: <nil>
+STEP: delete the pod
+Jul  2 13:43:50.593: INFO: Waiting for pod var-expansion-f161c0e7-7dfd-11e8-b7a8-22e3071d17c7 to disappear
+Jul  2 13:43:50.597: INFO: Pod var-expansion-f161c0e7-7dfd-11e8-b7a8-22e3071d17c7 no longer exists
+[AfterEach] [k8s.io] Variable Expansion
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:43:50.597: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-var-expansion-mtj64" for this suite.
+Jul  2 13:43:56.610: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:43:56.705: INFO: namespace: e2e-tests-var-expansion-mtj64, resource: bindings, ignored listing per whitelist
+Jul  2 13:43:56.711: INFO: namespace e2e-tests-var-expansion-mtj64 deletion completed in 6.110961295s
+
+• [SLOW TEST:10.337 seconds]
+[k8s.io] Variable Expansion
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:679
+  should allow substituting values in a container's command [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+S
+------------------------------
+[sig-storage] EmptyDir volumes 
+  should support (non-root,0777,default) [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-storage] EmptyDir volumes
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:43:56.711: INFO: >>> kubeConfig: /tmp/kubeconfig-575984058
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should support (non-root,0777,default) [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating a pod to test emptydir 0777 on node default medium
+Jul  2 13:43:56.799: INFO: Waiting up to 5m0s for pod "pod-f788f644-7dfd-11e8-b7a8-22e3071d17c7" in namespace "e2e-tests-emptydir-dtzhl" to be "success or failure"
+Jul  2 13:43:56.802: INFO: Pod "pod-f788f644-7dfd-11e8-b7a8-22e3071d17c7": Phase="Pending", Reason="", readiness=false. Elapsed: 2.534003ms
+Jul  2 13:43:58.805: INFO: Pod "pod-f788f644-7dfd-11e8-b7a8-22e3071d17c7": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.00618547s
+STEP: Saw pod success
+Jul  2 13:43:58.805: INFO: Pod "pod-f788f644-7dfd-11e8-b7a8-22e3071d17c7" satisfied condition "success or failure"
+Jul  2 13:43:58.808: INFO: Trying to get logs from node shoot--core--confos-worker-w6oh6-z1-59946c4f6c-2w6kp pod pod-f788f644-7dfd-11e8-b7a8-22e3071d17c7 container test-container: <nil>
+STEP: delete the pod
+Jul  2 13:43:58.824: INFO: Waiting for pod pod-f788f644-7dfd-11e8-b7a8-22e3071d17c7 to disappear
+Jul  2 13:43:58.841: INFO: Pod pod-f788f644-7dfd-11e8-b7a8-22e3071d17c7 no longer exists
+[AfterEach] [sig-storage] EmptyDir volumes
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:43:58.841: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-emptydir-dtzhl" for this suite.
+Jul  2 13:44:04.861: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:44:04.883: INFO: namespace: e2e-tests-emptydir-dtzhl, resource: bindings, ignored listing per whitelist
+Jul  2 13:44:04.957: INFO: namespace e2e-tests-emptydir-dtzhl deletion completed in 6.10869282s
+
+• [SLOW TEST:8.246 seconds]
+[sig-storage] EmptyDir volumes
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/empty_dir.go:40
+  should support (non-root,0777,default) [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SS
+------------------------------
+[sig-storage] ConfigMap 
+  should be consumable from pods in volume as non-root [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-storage] ConfigMap
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:44:04.959: INFO: >>> kubeConfig: /tmp/kubeconfig-575984058
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should be consumable from pods in volume as non-root [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating configMap with name configmap-test-volume-fc73ab5a-7dfd-11e8-b7a8-22e3071d17c7
+STEP: Creating a pod to test consume configMaps
+Jul  2 13:44:05.052: INFO: Waiting up to 5m0s for pod "pod-configmaps-fc743763-7dfd-11e8-b7a8-22e3071d17c7" in namespace "e2e-tests-configmap-wksrb" to be "success or failure"
+Jul  2 13:44:05.055: INFO: Pod "pod-configmaps-fc743763-7dfd-11e8-b7a8-22e3071d17c7": Phase="Pending", Reason="", readiness=false. Elapsed: 2.450044ms
+Jul  2 13:44:07.067: INFO: Pod "pod-configmaps-fc743763-7dfd-11e8-b7a8-22e3071d17c7": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.014906755s
+STEP: Saw pod success
+Jul  2 13:44:07.067: INFO: Pod "pod-configmaps-fc743763-7dfd-11e8-b7a8-22e3071d17c7" satisfied condition "success or failure"
+Jul  2 13:44:07.070: INFO: Trying to get logs from node shoot--core--confos-worker-w6oh6-z1-59946c4f6c-2w6kp pod pod-configmaps-fc743763-7dfd-11e8-b7a8-22e3071d17c7 container configmap-volume-test: <nil>
+STEP: delete the pod
+Jul  2 13:44:07.097: INFO: Waiting for pod pod-configmaps-fc743763-7dfd-11e8-b7a8-22e3071d17c7 to disappear
+Jul  2 13:44:07.111: INFO: Pod pod-configmaps-fc743763-7dfd-11e8-b7a8-22e3071d17c7 no longer exists
+[AfterEach] [sig-storage] ConfigMap
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:44:07.111: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-configmap-wksrb" for this suite.
+Jul  2 13:44:13.167: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:44:13.241: INFO: namespace: e2e-tests-configmap-wksrb, resource: bindings, ignored listing per whitelist
+Jul  2 13:44:13.357: INFO: namespace e2e-tests-configmap-wksrb deletion completed in 6.242088651s
+
+• [SLOW TEST:8.399 seconds]
+[sig-storage] ConfigMap
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/configmap_volume.go:32
+  should be consumable from pods in volume as non-root [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+[sig-storage] Downward API volume 
+  should provide container's cpu limit [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:44:13.357: INFO: >>> kubeConfig: /tmp/kubeconfig-575984058
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downwardapi_volume.go:38
+[It] should provide container's cpu limit [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating a pod to test downward API volume plugin
+Jul  2 13:44:13.510: INFO: Waiting up to 5m0s for pod "downwardapi-volume-017ed10f-7dfe-11e8-b7a8-22e3071d17c7" in namespace "e2e-tests-downward-api-6mrtj" to be "success or failure"
+Jul  2 13:44:13.512: INFO: Pod "downwardapi-volume-017ed10f-7dfe-11e8-b7a8-22e3071d17c7": Phase="Pending", Reason="", readiness=false. Elapsed: 2.411543ms
+Jul  2 13:44:15.517: INFO: Pod "downwardapi-volume-017ed10f-7dfe-11e8-b7a8-22e3071d17c7": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.006584659s
+STEP: Saw pod success
+Jul  2 13:44:15.517: INFO: Pod "downwardapi-volume-017ed10f-7dfe-11e8-b7a8-22e3071d17c7" satisfied condition "success or failure"
+Jul  2 13:44:15.519: INFO: Trying to get logs from node shoot--core--confos-worker-w6oh6-z1-59946c4f6c-2w6kp pod downwardapi-volume-017ed10f-7dfe-11e8-b7a8-22e3071d17c7 container client-container: <nil>
+STEP: delete the pod
+Jul  2 13:44:15.536: INFO: Waiting for pod downwardapi-volume-017ed10f-7dfe-11e8-b7a8-22e3071d17c7 to disappear
+Jul  2 13:44:15.538: INFO: Pod downwardapi-volume-017ed10f-7dfe-11e8-b7a8-22e3071d17c7 no longer exists
+[AfterEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:44:15.538: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-downward-api-6mrtj" for this suite.
+Jul  2 13:44:21.567: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:44:21.592: INFO: namespace: e2e-tests-downward-api-6mrtj, resource: bindings, ignored listing per whitelist
+Jul  2 13:44:21.668: INFO: namespace e2e-tests-downward-api-6mrtj deletion completed in 6.118198652s
+
+• [SLOW TEST:8.311 seconds]
+[sig-storage] Downward API volume
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downwardapi_volume.go:33
+  should provide container's cpu limit [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSSS
+------------------------------
+[sig-apps] ReplicationController 
+  should serve a basic image on each replica with a public image  [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-apps] ReplicationController
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:44:21.669: INFO: >>> kubeConfig: /tmp/kubeconfig-575984058
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should serve a basic image on each replica with a public image  [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating replication controller my-hostname-basic-066a94bb-7dfe-11e8-b7a8-22e3071d17c7
+Jul  2 13:44:21.795: INFO: Pod name my-hostname-basic-066a94bb-7dfe-11e8-b7a8-22e3071d17c7: Found 0 pods out of 1
+Jul  2 13:44:26.800: INFO: Pod name my-hostname-basic-066a94bb-7dfe-11e8-b7a8-22e3071d17c7: Found 1 pods out of 1
+Jul  2 13:44:26.800: INFO: Ensuring all pods for ReplicationController "my-hostname-basic-066a94bb-7dfe-11e8-b7a8-22e3071d17c7" are running
+Jul  2 13:44:26.803: INFO: Pod "my-hostname-basic-066a94bb-7dfe-11e8-b7a8-22e3071d17c7-ptlbk" is running (conditions: [{Type:Initialized Status:True LastProbeTime:0001-01-01 00:00:00 +0000 UTC LastTransitionTime:2018-07-02 13:44:21 +0000 UTC Reason: Message:} {Type:Ready Status:True LastProbeTime:0001-01-01 00:00:00 +0000 UTC LastTransitionTime:2018-07-02 13:44:22 +0000 UTC Reason: Message:} {Type:ContainersReady Status:True LastProbeTime:0001-01-01 00:00:00 +0000 UTC LastTransitionTime:0001-01-01 00:00:00 +0000 UTC Reason: Message:} {Type:PodScheduled Status:True LastProbeTime:0001-01-01 00:00:00 +0000 UTC LastTransitionTime:2018-07-02 13:44:21 +0000 UTC Reason: Message:}])
+Jul  2 13:44:26.803: INFO: Trying to dial the pod
+Jul  2 13:44:31.951: INFO: Controller my-hostname-basic-066a94bb-7dfe-11e8-b7a8-22e3071d17c7: Got expected result from replica 1 [my-hostname-basic-066a94bb-7dfe-11e8-b7a8-22e3071d17c7-ptlbk]: "my-hostname-basic-066a94bb-7dfe-11e8-b7a8-22e3071d17c7-ptlbk", 1 of 1 required successes so far
+[AfterEach] [sig-apps] ReplicationController
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:44:31.951: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-replication-controller-wn6g6" for this suite.
+Jul  2 13:44:37.970: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:44:37.987: INFO: namespace: e2e-tests-replication-controller-wn6g6, resource: bindings, ignored listing per whitelist
+Jul  2 13:44:38.068: INFO: namespace e2e-tests-replication-controller-wn6g6 deletion completed in 6.112424373s
+
+• [SLOW TEST:16.399 seconds]
+[sig-apps] ReplicationController
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/framework.go:22
+  should serve a basic image on each replica with a public image  [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSSS
+------------------------------
+[sig-storage] Downward API volume 
+  should update labels on modification [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:44:38.068: INFO: >>> kubeConfig: /tmp/kubeconfig-575984058
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downwardapi_volume.go:38
+[It] should update labels on modification [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating the pod
+Jul  2 13:44:40.688: INFO: Successfully updated pod "labelsupdate102faeae-7dfe-11e8-b7a8-22e3071d17c7"
+[AfterEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:44:44.784: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-downward-api-qh6qj" for this suite.
+Jul  2 13:45:06.876: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:45:06.917: INFO: namespace: e2e-tests-downward-api-qh6qj, resource: bindings, ignored listing per whitelist
+Jul  2 13:45:06.973: INFO: namespace e2e-tests-downward-api-qh6qj deletion completed in 22.184964358s
+
+• [SLOW TEST:28.905 seconds]
+[sig-storage] Downward API volume
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downwardapi_volume.go:33
+  should update labels on modification [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSSSSSSS
+------------------------------
+[sig-storage] ConfigMap 
+  should be consumable from pods in volume with mappings and Item mode set [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-storage] ConfigMap
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:45:06.973: INFO: >>> kubeConfig: /tmp/kubeconfig-575984058
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should be consumable from pods in volume with mappings and Item mode set [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating configMap with name configmap-test-volume-map-216b3665-7dfe-11e8-b7a8-22e3071d17c7
+STEP: Creating a pod to test consume configMaps
+Jul  2 13:45:07.072: INFO: Waiting up to 5m0s for pod "pod-configmaps-216bd014-7dfe-11e8-b7a8-22e3071d17c7" in namespace "e2e-tests-configmap-mpwvc" to be "success or failure"
+Jul  2 13:45:07.075: INFO: Pod "pod-configmaps-216bd014-7dfe-11e8-b7a8-22e3071d17c7": Phase="Pending", Reason="", readiness=false. Elapsed: 2.622868ms
+Jul  2 13:45:09.084: INFO: Pod "pod-configmaps-216bd014-7dfe-11e8-b7a8-22e3071d17c7": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.01138975s
+STEP: Saw pod success
+Jul  2 13:45:09.084: INFO: Pod "pod-configmaps-216bd014-7dfe-11e8-b7a8-22e3071d17c7" satisfied condition "success or failure"
+Jul  2 13:45:09.087: INFO: Trying to get logs from node shoot--core--confos-worker-w6oh6-z1-59946c4f6c-2w6kp pod pod-configmaps-216bd014-7dfe-11e8-b7a8-22e3071d17c7 container configmap-volume-test: <nil>
+STEP: delete the pod
+Jul  2 13:45:09.185: INFO: Waiting for pod pod-configmaps-216bd014-7dfe-11e8-b7a8-22e3071d17c7 to disappear
+Jul  2 13:45:09.188: INFO: Pod pod-configmaps-216bd014-7dfe-11e8-b7a8-22e3071d17c7 no longer exists
+[AfterEach] [sig-storage] ConfigMap
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:45:09.188: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-configmap-mpwvc" for this suite.
+Jul  2 13:45:15.202: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:45:15.228: INFO: namespace: e2e-tests-configmap-mpwvc, resource: bindings, ignored listing per whitelist
+Jul  2 13:45:15.305: INFO: namespace e2e-tests-configmap-mpwvc deletion completed in 6.11330983s
+
+• [SLOW TEST:8.332 seconds]
+[sig-storage] ConfigMap
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/configmap_volume.go:32
+  should be consumable from pods in volume with mappings and Item mode set [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSS
+------------------------------
+[sig-storage] Projected 
+  should be consumable from pods in volume as non-root [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:45:15.306: INFO: >>> kubeConfig: /tmp/kubeconfig-575984058
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:858
+[It] should be consumable from pods in volume as non-root [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating configMap with name projected-configmap-test-volume-2661a6ac-7dfe-11e8-b7a8-22e3071d17c7
+STEP: Creating a pod to test consume configMaps
+Jul  2 13:45:15.399: INFO: Waiting up to 5m0s for pod "pod-projected-configmaps-2662304f-7dfe-11e8-b7a8-22e3071d17c7" in namespace "e2e-tests-projected-64qhl" to be "success or failure"
+Jul  2 13:45:15.403: INFO: Pod "pod-projected-configmaps-2662304f-7dfe-11e8-b7a8-22e3071d17c7": Phase="Pending", Reason="", readiness=false. Elapsed: 3.980479ms
+Jul  2 13:45:17.408: INFO: Pod "pod-projected-configmaps-2662304f-7dfe-11e8-b7a8-22e3071d17c7": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.008328246s
+STEP: Saw pod success
+Jul  2 13:45:17.408: INFO: Pod "pod-projected-configmaps-2662304f-7dfe-11e8-b7a8-22e3071d17c7" satisfied condition "success or failure"
+Jul  2 13:45:17.411: INFO: Trying to get logs from node shoot--core--confos-worker-w6oh6-z1-59946c4f6c-2w6kp pod pod-projected-configmaps-2662304f-7dfe-11e8-b7a8-22e3071d17c7 container projected-configmap-volume-test: <nil>
+STEP: delete the pod
+Jul  2 13:45:17.500: INFO: Waiting for pod pod-projected-configmaps-2662304f-7dfe-11e8-b7a8-22e3071d17c7 to disappear
+Jul  2 13:45:17.502: INFO: Pod pod-projected-configmaps-2662304f-7dfe-11e8-b7a8-22e3071d17c7 no longer exists
+[AfterEach] [sig-storage] Projected
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:45:17.502: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-64qhl" for this suite.
+Jul  2 13:45:23.517: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:45:23.619: INFO: namespace: e2e-tests-projected-64qhl, resource: bindings, ignored listing per whitelist
+Jul  2 13:45:23.675: INFO: namespace e2e-tests-projected-64qhl deletion completed in 6.169162837s
+
+• [SLOW TEST:8.369 seconds]
+[sig-storage] Projected
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:34
+  should be consumable from pods in volume as non-root [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SS
+------------------------------
+[sig-network] Proxy version v1 
+  should proxy logs on node with explicit kubelet port using proxy subresource  [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] version v1
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:45:23.676: INFO: >>> kubeConfig: /tmp/kubeconfig-575984058
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should proxy logs on node with explicit kubelet port using proxy subresource  [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+Jul  2 13:45:23.767: INFO: (0) /api/v1/nodes/shoot--core--confos-worker-w6oh6-z1-59946c4f6c-2w6kp:10250/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 6.736053ms)
+Jul  2 13:45:23.809: INFO: (1) /api/v1/nodes/shoot--core--confos-worker-w6oh6-z1-59946c4f6c-2w6kp:10250/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 41.969123ms)
+Jul  2 13:45:23.814: INFO: (2) /api/v1/nodes/shoot--core--confos-worker-w6oh6-z1-59946c4f6c-2w6kp:10250/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 5.015679ms)
+Jul  2 13:45:23.819: INFO: (3) /api/v1/nodes/shoot--core--confos-worker-w6oh6-z1-59946c4f6c-2w6kp:10250/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 4.734649ms)
+Jul  2 13:45:23.824: INFO: (4) /api/v1/nodes/shoot--core--confos-worker-w6oh6-z1-59946c4f6c-2w6kp:10250/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 4.858234ms)
+Jul  2 13:45:23.828: INFO: (5) /api/v1/nodes/shoot--core--confos-worker-w6oh6-z1-59946c4f6c-2w6kp:10250/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 4.430027ms)
+Jul  2 13:45:23.833: INFO: (6) /api/v1/nodes/shoot--core--confos-worker-w6oh6-z1-59946c4f6c-2w6kp:10250/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 4.527655ms)
+Jul  2 13:45:23.837: INFO: (7) /api/v1/nodes/shoot--core--confos-worker-w6oh6-z1-59946c4f6c-2w6kp:10250/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 4.17786ms)
+Jul  2 13:45:23.842: INFO: (8) /api/v1/nodes/shoot--core--confos-worker-w6oh6-z1-59946c4f6c-2w6kp:10250/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 4.704291ms)
+Jul  2 13:45:23.847: INFO: (9) /api/v1/nodes/shoot--core--confos-worker-w6oh6-z1-59946c4f6c-2w6kp:10250/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 5.005087ms)
+Jul  2 13:45:23.886: INFO: (10) /api/v1/nodes/shoot--core--confos-worker-w6oh6-z1-59946c4f6c-2w6kp:10250/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 39.525759ms)
+Jul  2 13:45:23.892: INFO: (11) /api/v1/nodes/shoot--core--confos-worker-w6oh6-z1-59946c4f6c-2w6kp:10250/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 5.606465ms)
+Jul  2 13:45:23.897: INFO: (12) /api/v1/nodes/shoot--core--confos-worker-w6oh6-z1-59946c4f6c-2w6kp:10250/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 4.733807ms)
+Jul  2 13:45:23.902: INFO: (13) /api/v1/nodes/shoot--core--confos-worker-w6oh6-z1-59946c4f6c-2w6kp:10250/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 4.649366ms)
+Jul  2 13:45:23.985: INFO: (14) /api/v1/nodes/shoot--core--confos-worker-w6oh6-z1-59946c4f6c-2w6kp:10250/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 82.780484ms)
+Jul  2 13:45:23.990: INFO: (15) /api/v1/nodes/shoot--core--confos-worker-w6oh6-z1-59946c4f6c-2w6kp:10250/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 5.71267ms)
+Jul  2 13:45:23.994: INFO: (16) /api/v1/nodes/shoot--core--confos-worker-w6oh6-z1-59946c4f6c-2w6kp:10250/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 4.073041ms)
+Jul  2 13:45:23.999: INFO: (17) /api/v1/nodes/shoot--core--confos-worker-w6oh6-z1-59946c4f6c-2w6kp:10250/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 4.161891ms)
+Jul  2 13:45:24.003: INFO: (18) /api/v1/nodes/shoot--core--confos-worker-w6oh6-z1-59946c4f6c-2w6kp:10250/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 4.238489ms)
+Jul  2 13:45:24.008: INFO: (19) /api/v1/nodes/shoot--core--confos-worker-w6oh6-z1-59946c4f6c-2w6kp:10250/proxy/logs/: <pre>
+<a href="btmp">btmp</a>
+<a href="containers/">containers/</a>
+<a href="faillog">faillog</a>... (200; 4.867311ms)
+[AfterEach] version v1
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:45:24.008: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-proxy-qlbgp" for this suite.
+Jul  2 13:45:30.023: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:45:30.035: INFO: namespace: e2e-tests-proxy-qlbgp, resource: bindings, ignored listing per whitelist
+Jul  2 13:45:30.117: INFO: namespace e2e-tests-proxy-qlbgp deletion completed in 6.105594241s
+
+• [SLOW TEST:6.441 seconds]
+[sig-network] Proxy
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/network/framework.go:22
+  version v1
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/network/proxy.go:56
+    should proxy logs on node with explicit kubelet port using proxy subresource  [Conformance]
+    /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+S
+------------------------------
+[sig-network] DNS 
+  should provide DNS for services  [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-network] DNS
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:45:30.117: INFO: >>> kubeConfig: /tmp/kubeconfig-575984058
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should provide DNS for services  [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating a test headless service
+STEP: Running these commands on wheezy: for i in `seq 1 600`; do test -n "$$(dig +notcp +noall +answer +search dns-test-service A)" && echo OK > /results/wheezy_udp@dns-test-service;test -n "$$(dig +tcp +noall +answer +search dns-test-service A)" && echo OK > /results/wheezy_tcp@dns-test-service;test -n "$$(dig +notcp +noall +answer +search dns-test-service.e2e-tests-dns-x2p5s A)" && echo OK > /results/wheezy_udp@dns-test-service.e2e-tests-dns-x2p5s;test -n "$$(dig +tcp +noall +answer +search dns-test-service.e2e-tests-dns-x2p5s A)" && echo OK > /results/wheezy_tcp@dns-test-service.e2e-tests-dns-x2p5s;test -n "$$(dig +notcp +noall +answer +search dns-test-service.e2e-tests-dns-x2p5s.svc A)" && echo OK > /results/wheezy_udp@dns-test-service.e2e-tests-dns-x2p5s.svc;test -n "$$(dig +tcp +noall +answer +search dns-test-service.e2e-tests-dns-x2p5s.svc A)" && echo OK > /results/wheezy_tcp@dns-test-service.e2e-tests-dns-x2p5s.svc;test -n "$$(dig +notcp +noall +answer +search _http._tcp.dns-test-service.e2e-tests-dns-x2p5s.svc SRV)" && echo OK > /results/wheezy_udp@_http._tcp.dns-test-service.e2e-tests-dns-x2p5s.svc;test -n "$$(dig +tcp +noall +answer +search _http._tcp.dns-test-service.e2e-tests-dns-x2p5s.svc SRV)" && echo OK > /results/wheezy_tcp@_http._tcp.dns-test-service.e2e-tests-dns-x2p5s.svc;test -n "$$(dig +notcp +noall +answer +search _http._tcp.test-service-2.e2e-tests-dns-x2p5s.svc SRV)" && echo OK > /results/wheezy_udp@_http._tcp.test-service-2.e2e-tests-dns-x2p5s.svc;test -n "$$(dig +tcp +noall +answer +search _http._tcp.test-service-2.e2e-tests-dns-x2p5s.svc SRV)" && echo OK > /results/wheezy_tcp@_http._tcp.test-service-2.e2e-tests-dns-x2p5s.svc;podARec=$$(hostname -i| awk -F. '{print $$1"-"$$2"-"$$3"-"$$4".e2e-tests-dns-x2p5s.pod.cluster.local"}');test -n "$$(dig +notcp +noall +answer +search $${podARec} A)" && echo OK > /results/wheezy_udp@PodARecord;test -n "$$(dig +tcp +noall +answer +search $${podARec} A)" && echo OK > /results/wheezy_tcp@PodARecord;test -n "$$(dig +notcp +noall +answer +search 22.10.64.100.in-addr.arpa. PTR)" && echo OK > /results/100.64.10.22_udp@PTR;test -n "$$(dig +tcp +noall +answer +search 22.10.64.100.in-addr.arpa. PTR)" && echo OK > /results/100.64.10.22_tcp@PTR;sleep 1; done
+
+STEP: Running these commands on jessie: for i in `seq 1 600`; do test -n "$$(dig +notcp +noall +answer +search dns-test-service A)" && echo OK > /results/jessie_udp@dns-test-service;test -n "$$(dig +tcp +noall +answer +search dns-test-service A)" && echo OK > /results/jessie_tcp@dns-test-service;test -n "$$(dig +notcp +noall +answer +search dns-test-service.e2e-tests-dns-x2p5s A)" && echo OK > /results/jessie_udp@dns-test-service.e2e-tests-dns-x2p5s;test -n "$$(dig +tcp +noall +answer +search dns-test-service.e2e-tests-dns-x2p5s A)" && echo OK > /results/jessie_tcp@dns-test-service.e2e-tests-dns-x2p5s;test -n "$$(dig +notcp +noall +answer +search dns-test-service.e2e-tests-dns-x2p5s.svc A)" && echo OK > /results/jessie_udp@dns-test-service.e2e-tests-dns-x2p5s.svc;test -n "$$(dig +tcp +noall +answer +search dns-test-service.e2e-tests-dns-x2p5s.svc A)" && echo OK > /results/jessie_tcp@dns-test-service.e2e-tests-dns-x2p5s.svc;test -n "$$(dig +notcp +noall +answer +search _http._tcp.dns-test-service.e2e-tests-dns-x2p5s.svc SRV)" && echo OK > /results/jessie_udp@_http._tcp.dns-test-service.e2e-tests-dns-x2p5s.svc;test -n "$$(dig +tcp +noall +answer +search _http._tcp.dns-test-service.e2e-tests-dns-x2p5s.svc SRV)" && echo OK > /results/jessie_tcp@_http._tcp.dns-test-service.e2e-tests-dns-x2p5s.svc;test -n "$$(dig +notcp +noall +answer +search _http._tcp.test-service-2.e2e-tests-dns-x2p5s.svc SRV)" && echo OK > /results/jessie_udp@_http._tcp.test-service-2.e2e-tests-dns-x2p5s.svc;test -n "$$(dig +tcp +noall +answer +search _http._tcp.test-service-2.e2e-tests-dns-x2p5s.svc SRV)" && echo OK > /results/jessie_tcp@_http._tcp.test-service-2.e2e-tests-dns-x2p5s.svc;podARec=$$(hostname -i| awk -F. '{print $$1"-"$$2"-"$$3"-"$$4".e2e-tests-dns-x2p5s.pod.cluster.local"}');test -n "$$(dig +notcp +noall +answer +search $${podARec} A)" && echo OK > /results/jessie_udp@PodARecord;test -n "$$(dig +tcp +noall +answer +search $${podARec} A)" && echo OK > /results/jessie_tcp@PodARecord;test -n "$$(dig +notcp +noall +answer +search 22.10.64.100.in-addr.arpa. PTR)" && echo OK > /results/100.64.10.22_udp@PTR;test -n "$$(dig +tcp +noall +answer +search 22.10.64.100.in-addr.arpa. PTR)" && echo OK > /results/100.64.10.22_tcp@PTR;sleep 1; done
+
+STEP: creating a pod to probe DNS
+STEP: submitting the pod to kubernetes
+STEP: retrieving the pod
+STEP: looking for the results for each expected name from probers
+Jul  2 13:45:44.455: INFO: DNS probes using dns-test-2f3693ba-7dfe-11e8-b7a8-22e3071d17c7 succeeded
+
+STEP: deleting the pod
+STEP: deleting the test service
+STEP: deleting the test headless service
+[AfterEach] [sig-network] DNS
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:45:44.515: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-dns-x2p5s" for this suite.
+Jul  2 13:45:50.584: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:45:50.642: INFO: namespace: e2e-tests-dns-x2p5s, resource: bindings, ignored listing per whitelist
+Jul  2 13:45:50.705: INFO: namespace e2e-tests-dns-x2p5s deletion completed in 6.178266553s
+
+• [SLOW TEST:20.588 seconds]
+[sig-network] DNS
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/network/framework.go:22
+  should provide DNS for services  [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+S
+------------------------------
+[k8s.io] Pods 
+  should contain environment variables for services [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [k8s.io] Pods
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:45:50.705: INFO: >>> kubeConfig: /tmp/kubeconfig-575984058
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [k8s.io] Pods
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/pods.go:127
+[It] should contain environment variables for services [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+Jul  2 13:45:52.901: INFO: Waiting up to 5m0s for pod "client-envvars-3cbce80e-7dfe-11e8-b7a8-22e3071d17c7" in namespace "e2e-tests-pods-ck68h" to be "success or failure"
+Jul  2 13:45:52.905: INFO: Pod "client-envvars-3cbce80e-7dfe-11e8-b7a8-22e3071d17c7": Phase="Pending", Reason="", readiness=false. Elapsed: 4.090149ms
+Jul  2 13:45:54.968: INFO: Pod "client-envvars-3cbce80e-7dfe-11e8-b7a8-22e3071d17c7": Phase="Pending", Reason="", readiness=false. Elapsed: 2.06632617s
+Jul  2 13:45:56.972: INFO: Pod "client-envvars-3cbce80e-7dfe-11e8-b7a8-22e3071d17c7": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.070577908s
+STEP: Saw pod success
+Jul  2 13:45:56.972: INFO: Pod "client-envvars-3cbce80e-7dfe-11e8-b7a8-22e3071d17c7" satisfied condition "success or failure"
+Jul  2 13:45:56.975: INFO: Trying to get logs from node shoot--core--confos-worker-w6oh6-z1-59946c4f6c-2w6kp pod client-envvars-3cbce80e-7dfe-11e8-b7a8-22e3071d17c7 container env3cont: <nil>
+STEP: delete the pod
+Jul  2 13:45:56.994: INFO: Waiting for pod client-envvars-3cbce80e-7dfe-11e8-b7a8-22e3071d17c7 to disappear
+Jul  2 13:45:56.997: INFO: Pod client-envvars-3cbce80e-7dfe-11e8-b7a8-22e3071d17c7 no longer exists
+[AfterEach] [k8s.io] Pods
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:45:56.997: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-pods-ck68h" for this suite.
+Jul  2 13:46:19.011: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:46:19.157: INFO: namespace: e2e-tests-pods-ck68h, resource: bindings, ignored listing per whitelist
+Jul  2 13:46:19.163: INFO: namespace e2e-tests-pods-ck68h deletion completed in 22.162416563s
+
+• [SLOW TEST:28.458 seconds]
+[k8s.io] Pods
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:679
+  should contain environment variables for services [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSSSSS
+------------------------------
+[sig-storage] ConfigMap 
+  should be consumable in multiple volumes in the same pod [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-storage] ConfigMap
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:46:19.165: INFO: >>> kubeConfig: /tmp/kubeconfig-575984058
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should be consumable in multiple volumes in the same pod [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating configMap with name configmap-test-volume-4c730203-7dfe-11e8-b7a8-22e3071d17c7
+STEP: Creating a pod to test consume configMaps
+Jul  2 13:46:19.267: INFO: Waiting up to 5m0s for pod "pod-configmaps-4c739f65-7dfe-11e8-b7a8-22e3071d17c7" in namespace "e2e-tests-configmap-rjv7q" to be "success or failure"
+Jul  2 13:46:19.271: INFO: Pod "pod-configmaps-4c739f65-7dfe-11e8-b7a8-22e3071d17c7": Phase="Pending", Reason="", readiness=false. Elapsed: 4.205776ms
+Jul  2 13:46:21.275: INFO: Pod "pod-configmaps-4c739f65-7dfe-11e8-b7a8-22e3071d17c7": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.008667756s
+STEP: Saw pod success
+Jul  2 13:46:21.275: INFO: Pod "pod-configmaps-4c739f65-7dfe-11e8-b7a8-22e3071d17c7" satisfied condition "success or failure"
+Jul  2 13:46:21.278: INFO: Trying to get logs from node shoot--core--confos-worker-w6oh6-z1-59946c4f6c-2w6kp pod pod-configmaps-4c739f65-7dfe-11e8-b7a8-22e3071d17c7 container configmap-volume-test: <nil>
+STEP: delete the pod
+Jul  2 13:46:21.300: INFO: Waiting for pod pod-configmaps-4c739f65-7dfe-11e8-b7a8-22e3071d17c7 to disappear
+Jul  2 13:46:21.306: INFO: Pod pod-configmaps-4c739f65-7dfe-11e8-b7a8-22e3071d17c7 no longer exists
+[AfterEach] [sig-storage] ConfigMap
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:46:21.306: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-configmap-rjv7q" for this suite.
+Jul  2 13:46:27.326: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:46:27.416: INFO: namespace: e2e-tests-configmap-rjv7q, resource: bindings, ignored listing per whitelist
+Jul  2 13:46:27.421: INFO: namespace e2e-tests-configmap-rjv7q deletion completed in 6.106821722s
+
+• [SLOW TEST:8.257 seconds]
+[sig-storage] ConfigMap
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/configmap_volume.go:32
+  should be consumable in multiple volumes in the same pod [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SS
+------------------------------
+[sig-apps] StatefulSet [k8s.io] Basic StatefulSet functionality [StatefulSetBasic] 
+  Burst scaling should run to completion even with unhealthy pods [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-apps] StatefulSet
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:46:27.423: INFO: >>> kubeConfig: /tmp/kubeconfig-575984058
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-apps] StatefulSet
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/statefulset.go:57
+[BeforeEach] [k8s.io] Basic StatefulSet functionality [StatefulSetBasic]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/statefulset.go:72
+STEP: Creating service test in namespace e2e-tests-statefulset-6fr2q
+[It] Burst scaling should run to completion even with unhealthy pods [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating stateful set ss in namespace e2e-tests-statefulset-6fr2q
+STEP: Waiting until all stateful set ss replicas will be running in namespace e2e-tests-statefulset-6fr2q
+Jul  2 13:46:27.508: INFO: Found 0 stateful pods, waiting for 1
+Jul  2 13:46:37.512: INFO: Waiting for pod ss-0 to enter Running - Ready=true, currently Running - Ready=true
+STEP: Confirming that stateful set scale up will not halt with unhealthy stateful pod
+Jul  2 13:46:37.515: INFO: Running '/usr/local/bin/kubectl --kubeconfig=/tmp/kubeconfig-575984058 exec --namespace=e2e-tests-statefulset-6fr2q ss-0 -- /bin/sh -c mv -v /usr/share/nginx/html/index.html /tmp/ || true'
+Jul  2 13:46:37.984: INFO: stderr: ""
+Jul  2 13:46:37.984: INFO: stdout: "'/usr/share/nginx/html/index.html' -> '/tmp/index.html'\n"
+Jul  2 13:46:37.984: INFO: stdout of mv -v /usr/share/nginx/html/index.html /tmp/ || true on ss-0: '/usr/share/nginx/html/index.html' -> '/tmp/index.html'
+
+Jul  2 13:46:37.989: INFO: Waiting for pod ss-0 to enter Running - Ready=false, currently Running - Ready=true
+Jul  2 13:46:47.994: INFO: Waiting for pod ss-0 to enter Running - Ready=false, currently Running - Ready=false
+Jul  2 13:46:47.994: INFO: Waiting for statefulset status.replicas updated to 0
+Jul  2 13:46:48.007: INFO: POD   NODE                                                  PHASE    GRACE  CONDITIONS
+Jul  2 13:46:48.007: INFO: ss-0  shoot--core--confos-worker-w6oh6-z1-59946c4f6c-2w6kp  Running         [{Initialized True 0001-01-01 00:00:00 +0000 UTC 2018-07-02 13:46:27 +0000 UTC  } {Ready False 0001-01-01 00:00:00 +0000 UTC 2018-07-02 13:46:38 +0000 UTC ContainersNotReady containers with unready status: [nginx]} {ContainersReady False 0001-01-01 00:00:00 +0000 UTC 0001-01-01 00:00:00 +0000 UTC ContainersNotReady containers with unready status: [nginx]} {PodScheduled True 0001-01-01 00:00:00 +0000 UTC 2018-07-02 13:46:27 +0000 UTC  }]
+Jul  2 13:46:48.007: INFO: 
+Jul  2 13:46:48.007: INFO: StatefulSet ss has not reached scale 3, at 1
+Jul  2 13:46:49.013: INFO: Verifying statefulset ss doesn't scale past 3 for another 8.996247274s
+Jul  2 13:46:50.018: INFO: Verifying statefulset ss doesn't scale past 3 for another 7.991054264s
+Jul  2 13:46:51.022: INFO: Verifying statefulset ss doesn't scale past 3 for another 6.986167884s
+Jul  2 13:46:52.027: INFO: Verifying statefulset ss doesn't scale past 3 for another 5.981769488s
+Jul  2 13:46:53.031: INFO: Verifying statefulset ss doesn't scale past 3 for another 4.976951834s
+Jul  2 13:46:54.036: INFO: Verifying statefulset ss doesn't scale past 3 for another 3.972156856s
+Jul  2 13:46:55.041: INFO: Verifying statefulset ss doesn't scale past 3 for another 2.967684117s
+Jul  2 13:46:56.046: INFO: Verifying statefulset ss doesn't scale past 3 for another 1.962639732s
+Jul  2 13:46:57.050: INFO: Verifying statefulset ss doesn't scale past 3 for another 957.904613ms
+STEP: Scaling up stateful set ss to 3 replicas and waiting until all of them will be running in namespace e2e-tests-statefulset-6fr2q
+Jul  2 13:46:58.055: INFO: Running '/usr/local/bin/kubectl --kubeconfig=/tmp/kubeconfig-575984058 exec --namespace=e2e-tests-statefulset-6fr2q ss-0 -- /bin/sh -c mv -v /tmp/index.html /usr/share/nginx/html/ || true'
+Jul  2 13:46:58.506: INFO: stderr: ""
+Jul  2 13:46:58.506: INFO: stdout: "'/tmp/index.html' -> '/usr/share/nginx/html/index.html'\n"
+Jul  2 13:46:58.506: INFO: stdout of mv -v /tmp/index.html /usr/share/nginx/html/ || true on ss-0: '/tmp/index.html' -> '/usr/share/nginx/html/index.html'
+
+Jul  2 13:46:58.506: INFO: Running '/usr/local/bin/kubectl --kubeconfig=/tmp/kubeconfig-575984058 exec --namespace=e2e-tests-statefulset-6fr2q ss-1 -- /bin/sh -c mv -v /tmp/index.html /usr/share/nginx/html/ || true'
+Jul  2 13:46:59.025: INFO: stderr: "mv: cannot stat '/tmp/index.html': No such file or directory\n"
+Jul  2 13:46:59.025: INFO: stdout: ""
+Jul  2 13:46:59.025: INFO: stdout of mv -v /tmp/index.html /usr/share/nginx/html/ || true on ss-1: 
+Jul  2 13:46:59.025: INFO: Running '/usr/local/bin/kubectl --kubeconfig=/tmp/kubeconfig-575984058 exec --namespace=e2e-tests-statefulset-6fr2q ss-2 -- /bin/sh -c mv -v /tmp/index.html /usr/share/nginx/html/ || true'
+Jul  2 13:46:59.511: INFO: stderr: "mv: cannot stat '/tmp/index.html': No such file or directory\n"
+Jul  2 13:46:59.511: INFO: stdout: ""
+Jul  2 13:46:59.511: INFO: stdout of mv -v /tmp/index.html /usr/share/nginx/html/ || true on ss-2: 
+Jul  2 13:46:59.515: INFO: Waiting for pod ss-0 to enter Running - Ready=true, currently Running - Ready=true
+Jul  2 13:46:59.515: INFO: Waiting for pod ss-1 to enter Running - Ready=true, currently Running - Ready=true
+Jul  2 13:46:59.515: INFO: Waiting for pod ss-2 to enter Running - Ready=true, currently Running - Ready=true
+STEP: Scale down will not halt with unhealthy stateful pod
+Jul  2 13:46:59.569: INFO: Running '/usr/local/bin/kubectl --kubeconfig=/tmp/kubeconfig-575984058 exec --namespace=e2e-tests-statefulset-6fr2q ss-0 -- /bin/sh -c mv -v /usr/share/nginx/html/index.html /tmp/ || true'
+Jul  2 13:47:00.086: INFO: stderr: ""
+Jul  2 13:47:00.086: INFO: stdout: "'/usr/share/nginx/html/index.html' -> '/tmp/index.html'\n"
+Jul  2 13:47:00.086: INFO: stdout of mv -v /usr/share/nginx/html/index.html /tmp/ || true on ss-0: '/usr/share/nginx/html/index.html' -> '/tmp/index.html'
+
+Jul  2 13:47:00.086: INFO: Running '/usr/local/bin/kubectl --kubeconfig=/tmp/kubeconfig-575984058 exec --namespace=e2e-tests-statefulset-6fr2q ss-1 -- /bin/sh -c mv -v /usr/share/nginx/html/index.html /tmp/ || true'
+Jul  2 13:47:00.550: INFO: stderr: ""
+Jul  2 13:47:00.550: INFO: stdout: "'/usr/share/nginx/html/index.html' -> '/tmp/index.html'\n"
+Jul  2 13:47:00.550: INFO: stdout of mv -v /usr/share/nginx/html/index.html /tmp/ || true on ss-1: '/usr/share/nginx/html/index.html' -> '/tmp/index.html'
+
+Jul  2 13:47:00.550: INFO: Running '/usr/local/bin/kubectl --kubeconfig=/tmp/kubeconfig-575984058 exec --namespace=e2e-tests-statefulset-6fr2q ss-2 -- /bin/sh -c mv -v /usr/share/nginx/html/index.html /tmp/ || true'
+Jul  2 13:47:01.077: INFO: stderr: ""
+Jul  2 13:47:01.077: INFO: stdout: "'/usr/share/nginx/html/index.html' -> '/tmp/index.html'\n"
+Jul  2 13:47:01.077: INFO: stdout of mv -v /usr/share/nginx/html/index.html /tmp/ || true on ss-2: '/usr/share/nginx/html/index.html' -> '/tmp/index.html'
+
+Jul  2 13:47:01.077: INFO: Waiting for statefulset status.replicas updated to 0
+Jul  2 13:47:01.083: INFO: Waiting for stateful set status.readyReplicas to become 0, currently 2
+Jul  2 13:47:11.169: INFO: Waiting for pod ss-0 to enter Running - Ready=false, currently Running - Ready=false
+Jul  2 13:47:11.169: INFO: Waiting for pod ss-1 to enter Running - Ready=false, currently Running - Ready=false
+Jul  2 13:47:11.169: INFO: Waiting for pod ss-2 to enter Running - Ready=false, currently Running - Ready=false
+Jul  2 13:47:11.179: INFO: POD   NODE                                                  PHASE    GRACE  CONDITIONS
+Jul  2 13:47:11.179: INFO: ss-0  shoot--core--confos-worker-w6oh6-z1-59946c4f6c-2w6kp  Running         [{Initialized True 0001-01-01 00:00:00 +0000 UTC 2018-07-02 13:46:27 +0000 UTC  } {Ready False 0001-01-01 00:00:00 +0000 UTC 2018-07-02 13:47:00 +0000 UTC ContainersNotReady containers with unready status: [nginx]} {ContainersReady False 0001-01-01 00:00:00 +0000 UTC 0001-01-01 00:00:00 +0000 UTC ContainersNotReady containers with unready status: [nginx]} {PodScheduled True 0001-01-01 00:00:00 +0000 UTC 2018-07-02 13:46:27 +0000 UTC  }]
+Jul  2 13:47:11.179: INFO: ss-1  shoot--core--confos-worker-w6oh6-z1-59946c4f6c-znspz  Running         [{Initialized True 0001-01-01 00:00:00 +0000 UTC 2018-07-02 13:46:48 +0000 UTC  } {Ready False 0001-01-01 00:00:00 +0000 UTC 2018-07-02 13:47:01 +0000 UTC ContainersNotReady containers with unready status: [nginx]} {ContainersReady False 0001-01-01 00:00:00 +0000 UTC 0001-01-01 00:00:00 +0000 UTC ContainersNotReady containers with unready status: [nginx]} {PodScheduled True 0001-01-01 00:00:00 +0000 UTC 2018-07-02 13:46:48 +0000 UTC  }]
+Jul  2 13:47:11.179: INFO: ss-2  shoot--core--confos-worker-w6oh6-z1-59946c4f6c-2w6kp  Running         [{Initialized True 0001-01-01 00:00:00 +0000 UTC 2018-07-02 13:46:48 +0000 UTC  } {Ready False 0001-01-01 00:00:00 +0000 UTC 2018-07-02 13:47:01 +0000 UTC ContainersNotReady containers with unready status: [nginx]} {ContainersReady False 0001-01-01 00:00:00 +0000 UTC 0001-01-01 00:00:00 +0000 UTC ContainersNotReady containers with unready status: [nginx]} {PodScheduled True 0001-01-01 00:00:00 +0000 UTC 2018-07-02 13:46:48 +0000 UTC  }]
+Jul  2 13:47:11.179: INFO: 
+Jul  2 13:47:11.179: INFO: StatefulSet ss has not reached scale 0, at 3
+Jul  2 13:47:12.184: INFO: POD   NODE                                                  PHASE    GRACE  CONDITIONS
+Jul  2 13:47:12.184: INFO: ss-0  shoot--core--confos-worker-w6oh6-z1-59946c4f6c-2w6kp  Running  30s    [{Initialized True 0001-01-01 00:00:00 +0000 UTC 2018-07-02 13:46:27 +0000 UTC  } {Ready False 0001-01-01 00:00:00 +0000 UTC 2018-07-02 13:47:00 +0000 UTC ContainersNotReady containers with unready status: [nginx]} {ContainersReady False 0001-01-01 00:00:00 +0000 UTC 0001-01-01 00:00:00 +0000 UTC ContainersNotReady containers with unready status: [nginx]} {PodScheduled True 0001-01-01 00:00:00 +0000 UTC 2018-07-02 13:46:27 +0000 UTC  }]
+Jul  2 13:47:12.184: INFO: ss-1  shoot--core--confos-worker-w6oh6-z1-59946c4f6c-znspz  Running  30s    [{Initialized True 0001-01-01 00:00:00 +0000 UTC 2018-07-02 13:46:48 +0000 UTC  } {Ready False 0001-01-01 00:00:00 +0000 UTC 2018-07-02 13:47:01 +0000 UTC ContainersNotReady containers with unready status: [nginx]} {ContainersReady False 0001-01-01 00:00:00 +0000 UTC 0001-01-01 00:00:00 +0000 UTC ContainersNotReady containers with unready status: [nginx]} {PodScheduled True 0001-01-01 00:00:00 +0000 UTC 2018-07-02 13:46:48 +0000 UTC  }]
+Jul  2 13:47:12.184: INFO: ss-2  shoot--core--confos-worker-w6oh6-z1-59946c4f6c-2w6kp  Running  30s    [{Initialized True 0001-01-01 00:00:00 +0000 UTC 2018-07-02 13:46:48 +0000 UTC  } {Ready False 0001-01-01 00:00:00 +0000 UTC 2018-07-02 13:47:01 +0000 UTC ContainersNotReady containers with unready status: [nginx]} {ContainersReady False 0001-01-01 00:00:00 +0000 UTC 0001-01-01 00:00:00 +0000 UTC ContainersNotReady containers with unready status: [nginx]} {PodScheduled True 0001-01-01 00:00:00 +0000 UTC 2018-07-02 13:46:48 +0000 UTC  }]
+Jul  2 13:47:12.184: INFO: 
+Jul  2 13:47:12.184: INFO: StatefulSet ss has not reached scale 0, at 3
+Jul  2 13:47:13.251: INFO: POD   NODE                                                  PHASE    GRACE  CONDITIONS
+Jul  2 13:47:13.251: INFO: ss-0  shoot--core--confos-worker-w6oh6-z1-59946c4f6c-2w6kp  Running  30s    [{Initialized True 0001-01-01 00:00:00 +0000 UTC 2018-07-02 13:46:27 +0000 UTC  } {Ready False 0001-01-01 00:00:00 +0000 UTC 2018-07-02 13:47:00 +0000 UTC ContainersNotReady containers with unready status: [nginx]} {ContainersReady False 0001-01-01 00:00:00 +0000 UTC 0001-01-01 00:00:00 +0000 UTC ContainersNotReady containers with unready status: [nginx]} {PodScheduled True 0001-01-01 00:00:00 +0000 UTC 2018-07-02 13:46:27 +0000 UTC  }]
+Jul  2 13:47:13.251: INFO: ss-2  shoot--core--confos-worker-w6oh6-z1-59946c4f6c-2w6kp  Running  30s    [{Initialized True 0001-01-01 00:00:00 +0000 UTC 2018-07-02 13:46:48 +0000 UTC  } {Ready False 0001-01-01 00:00:00 +0000 UTC 2018-07-02 13:47:01 +0000 UTC ContainersNotReady containers with unready status: [nginx]} {ContainersReady False 0001-01-01 00:00:00 +0000 UTC 0001-01-01 00:00:00 +0000 UTC ContainersNotReady containers with unready status: [nginx]} {PodScheduled True 0001-01-01 00:00:00 +0000 UTC 2018-07-02 13:46:48 +0000 UTC  }]
+Jul  2 13:47:13.251: INFO: 
+Jul  2 13:47:13.251: INFO: StatefulSet ss has not reached scale 0, at 2
+Jul  2 13:47:14.256: INFO: POD   NODE                                                  PHASE    GRACE  CONDITIONS
+Jul  2 13:47:14.256: INFO: ss-0  shoot--core--confos-worker-w6oh6-z1-59946c4f6c-2w6kp  Running  30s    [{Initialized True 0001-01-01 00:00:00 +0000 UTC 2018-07-02 13:46:27 +0000 UTC  } {Ready False 0001-01-01 00:00:00 +0000 UTC 2018-07-02 13:47:00 +0000 UTC ContainersNotReady containers with unready status: [nginx]} {ContainersReady False 0001-01-01 00:00:00 +0000 UTC 0001-01-01 00:00:00 +0000 UTC ContainersNotReady containers with unready status: [nginx]} {PodScheduled True 0001-01-01 00:00:00 +0000 UTC 2018-07-02 13:46:27 +0000 UTC  }]
+Jul  2 13:47:14.256: INFO: ss-2  shoot--core--confos-worker-w6oh6-z1-59946c4f6c-2w6kp  Pending  30s    [{Initialized True 0001-01-01 00:00:00 +0000 UTC 2018-07-02 13:46:48 +0000 UTC  } {Ready False 0001-01-01 00:00:00 +0000 UTC 2018-07-02 13:47:01 +0000 UTC ContainersNotReady containers with unready status: [nginx]} {ContainersReady False 0001-01-01 00:00:00 +0000 UTC 0001-01-01 00:00:00 +0000 UTC ContainersNotReady containers with unready status: [nginx]} {PodScheduled True 0001-01-01 00:00:00 +0000 UTC 2018-07-02 13:46:48 +0000 UTC  }]
+Jul  2 13:47:14.256: INFO: 
+Jul  2 13:47:14.256: INFO: StatefulSet ss has not reached scale 0, at 2
+Jul  2 13:47:15.261: INFO: POD   NODE                                                  PHASE    GRACE  CONDITIONS
+Jul  2 13:47:15.261: INFO: ss-0  shoot--core--confos-worker-w6oh6-z1-59946c4f6c-2w6kp  Running  30s    [{Initialized True 0001-01-01 00:00:00 +0000 UTC 2018-07-02 13:46:27 +0000 UTC  } {Ready False 0001-01-01 00:00:00 +0000 UTC 2018-07-02 13:47:00 +0000 UTC ContainersNotReady containers with unready status: [nginx]} {ContainersReady False 0001-01-01 00:00:00 +0000 UTC 0001-01-01 00:00:00 +0000 UTC ContainersNotReady containers with unready status: [nginx]} {PodScheduled True 0001-01-01 00:00:00 +0000 UTC 2018-07-02 13:46:27 +0000 UTC  }]
+Jul  2 13:47:15.261: INFO: ss-2  shoot--core--confos-worker-w6oh6-z1-59946c4f6c-2w6kp  Pending  30s    [{Initialized True 0001-01-01 00:00:00 +0000 UTC 2018-07-02 13:46:48 +0000 UTC  } {Ready False 0001-01-01 00:00:00 +0000 UTC 2018-07-02 13:47:01 +0000 UTC ContainersNotReady containers with unready status: [nginx]} {ContainersReady False 0001-01-01 00:00:00 +0000 UTC 0001-01-01 00:00:00 +0000 UTC ContainersNotReady containers with unready status: [nginx]} {PodScheduled True 0001-01-01 00:00:00 +0000 UTC 2018-07-02 13:46:48 +0000 UTC  }]
+Jul  2 13:47:15.261: INFO: 
+Jul  2 13:47:15.261: INFO: StatefulSet ss has not reached scale 0, at 2
+Jul  2 13:47:16.270: INFO: POD   NODE                                                  PHASE    GRACE  CONDITIONS
+Jul  2 13:47:16.270: INFO: ss-0  shoot--core--confos-worker-w6oh6-z1-59946c4f6c-2w6kp  Running  30s    [{Initialized True 0001-01-01 00:00:00 +0000 UTC 2018-07-02 13:46:27 +0000 UTC  } {Ready False 0001-01-01 00:00:00 +0000 UTC 2018-07-02 13:47:00 +0000 UTC ContainersNotReady containers with unready status: [nginx]} {ContainersReady False 0001-01-01 00:00:00 +0000 UTC 0001-01-01 00:00:00 +0000 UTC ContainersNotReady containers with unready status: [nginx]} {PodScheduled True 0001-01-01 00:00:00 +0000 UTC 2018-07-02 13:46:27 +0000 UTC  }]
+Jul  2 13:47:16.270: INFO: ss-2  shoot--core--confos-worker-w6oh6-z1-59946c4f6c-2w6kp  Pending  30s    [{Initialized True 0001-01-01 00:00:00 +0000 UTC 2018-07-02 13:46:48 +0000 UTC  } {Ready False 0001-01-01 00:00:00 +0000 UTC 2018-07-02 13:47:01 +0000 UTC ContainersNotReady containers with unready status: [nginx]} {ContainersReady False 0001-01-01 00:00:00 +0000 UTC 0001-01-01 00:00:00 +0000 UTC ContainersNotReady containers with unready status: [nginx]} {PodScheduled True 0001-01-01 00:00:00 +0000 UTC 2018-07-02 13:46:48 +0000 UTC  }]
+Jul  2 13:47:16.270: INFO: 
+Jul  2 13:47:16.270: INFO: StatefulSet ss has not reached scale 0, at 2
+Jul  2 13:47:17.275: INFO: POD   NODE                                                  PHASE    GRACE  CONDITIONS
+Jul  2 13:47:17.276: INFO: ss-0  shoot--core--confos-worker-w6oh6-z1-59946c4f6c-2w6kp  Running  30s    [{Initialized True 0001-01-01 00:00:00 +0000 UTC 2018-07-02 13:46:27 +0000 UTC  } {Ready False 0001-01-01 00:00:00 +0000 UTC 2018-07-02 13:47:00 +0000 UTC ContainersNotReady containers with unready status: [nginx]} {ContainersReady False 0001-01-01 00:00:00 +0000 UTC 0001-01-01 00:00:00 +0000 UTC ContainersNotReady containers with unready status: [nginx]} {PodScheduled True 0001-01-01 00:00:00 +0000 UTC 2018-07-02 13:46:27 +0000 UTC  }]
+Jul  2 13:47:17.276: INFO: ss-2  shoot--core--confos-worker-w6oh6-z1-59946c4f6c-2w6kp  Pending  30s    [{Initialized True 0001-01-01 00:00:00 +0000 UTC 2018-07-02 13:46:48 +0000 UTC  } {Ready False 0001-01-01 00:00:00 +0000 UTC 2018-07-02 13:47:01 +0000 UTC ContainersNotReady containers with unready status: [nginx]} {ContainersReady False 0001-01-01 00:00:00 +0000 UTC 0001-01-01 00:00:00 +0000 UTC ContainersNotReady containers with unready status: [nginx]} {PodScheduled True 0001-01-01 00:00:00 +0000 UTC 2018-07-02 13:46:48 +0000 UTC  }]
+Jul  2 13:47:17.276: INFO: 
+Jul  2 13:47:17.276: INFO: StatefulSet ss has not reached scale 0, at 2
+Jul  2 13:47:18.280: INFO: Verifying statefulset ss doesn't scale past 0 for another 2.899570699s
+Jul  2 13:47:19.284: INFO: Verifying statefulset ss doesn't scale past 0 for another 1.895902808s
+Jul  2 13:47:20.288: INFO: Verifying statefulset ss doesn't scale past 0 for another 891.389387ms
+STEP: Scaling down stateful set ss to 0 replicas and waiting until none of pods will run in namespacee2e-tests-statefulset-6fr2q
+Jul  2 13:47:21.292: INFO: Scaling statefulset ss to 0
+Jul  2 13:47:21.301: INFO: Waiting for statefulset status.replicas updated to 0
+[AfterEach] [k8s.io] Basic StatefulSet functionality [StatefulSetBasic]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/statefulset.go:83
+Jul  2 13:47:21.304: INFO: Deleting all statefulset in ns e2e-tests-statefulset-6fr2q
+Jul  2 13:47:21.306: INFO: Scaling statefulset ss to 0
+Jul  2 13:47:21.315: INFO: Waiting for statefulset status.replicas updated to 0
+Jul  2 13:47:21.318: INFO: Deleting statefulset ss
+[AfterEach] [sig-apps] StatefulSet
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:47:21.336: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-statefulset-6fr2q" for this suite.
+Jul  2 13:47:27.368: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:47:27.426: INFO: namespace: e2e-tests-statefulset-6fr2q, resource: bindings, ignored listing per whitelist
+Jul  2 13:47:27.462: INFO: namespace e2e-tests-statefulset-6fr2q deletion completed in 6.122547845s
+
+• [SLOW TEST:60.039 seconds]
+[sig-apps] StatefulSet
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/framework.go:22
+  [k8s.io] Basic StatefulSet functionality [StatefulSetBasic]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:679
+    Burst scaling should run to completion even with unhealthy pods [Conformance]
+    /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+[sig-storage] Projected 
+  should provide node allocatable (cpu) as default cpu limit if the limit is not set [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:47:27.462: INFO: >>> kubeConfig: /tmp/kubeconfig-575984058
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:858
+[It] should provide node allocatable (cpu) as default cpu limit if the limit is not set [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating a pod to test downward API volume plugin
+Jul  2 13:47:27.545: INFO: Waiting up to 5m0s for pod "downwardapi-volume-75261af2-7dfe-11e8-b7a8-22e3071d17c7" in namespace "e2e-tests-projected-r8dc5" to be "success or failure"
+Jul  2 13:47:27.548: INFO: Pod "downwardapi-volume-75261af2-7dfe-11e8-b7a8-22e3071d17c7": Phase="Pending", Reason="", readiness=false. Elapsed: 2.341094ms
+Jul  2 13:47:29.585: INFO: Pod "downwardapi-volume-75261af2-7dfe-11e8-b7a8-22e3071d17c7": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.039870166s
+STEP: Saw pod success
+Jul  2 13:47:29.585: INFO: Pod "downwardapi-volume-75261af2-7dfe-11e8-b7a8-22e3071d17c7" satisfied condition "success or failure"
+Jul  2 13:47:29.588: INFO: Trying to get logs from node shoot--core--confos-worker-w6oh6-z1-59946c4f6c-2w6kp pod downwardapi-volume-75261af2-7dfe-11e8-b7a8-22e3071d17c7 container client-container: <nil>
+STEP: delete the pod
+Jul  2 13:47:29.604: INFO: Waiting for pod downwardapi-volume-75261af2-7dfe-11e8-b7a8-22e3071d17c7 to disappear
+Jul  2 13:47:29.606: INFO: Pod downwardapi-volume-75261af2-7dfe-11e8-b7a8-22e3071d17c7 no longer exists
+[AfterEach] [sig-storage] Projected
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:47:29.606: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-r8dc5" for this suite.
+Jul  2 13:47:35.625: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:47:35.798: INFO: namespace: e2e-tests-projected-r8dc5, resource: bindings, ignored listing per whitelist
+Jul  2 13:47:35.801: INFO: namespace e2e-tests-projected-r8dc5 deletion completed in 6.191920925s
+
+• [SLOW TEST:8.339 seconds]
+[sig-storage] Projected
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:34
+  should provide node allocatable (cpu) as default cpu limit if the limit is not set [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSSS
+------------------------------
+[sig-storage] Secrets 
+  should be consumable from pods in volume as non-root with defaultMode and fsGroup set [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-storage] Secrets
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:47:35.802: INFO: >>> kubeConfig: /tmp/kubeconfig-575984058
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should be consumable from pods in volume as non-root with defaultMode and fsGroup set [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating secret with name secret-test-7a1eaf9c-7dfe-11e8-b7a8-22e3071d17c7
+STEP: Creating a pod to test consume secrets
+Jul  2 13:47:35.889: INFO: Waiting up to 5m0s for pod "pod-secrets-7a1f4587-7dfe-11e8-b7a8-22e3071d17c7" in namespace "e2e-tests-secrets-hhcdg" to be "success or failure"
+Jul  2 13:47:35.891: INFO: Pod "pod-secrets-7a1f4587-7dfe-11e8-b7a8-22e3071d17c7": Phase="Pending", Reason="", readiness=false. Elapsed: 2.182029ms
+Jul  2 13:47:37.895: INFO: Pod "pod-secrets-7a1f4587-7dfe-11e8-b7a8-22e3071d17c7": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.006020188s
+STEP: Saw pod success
+Jul  2 13:47:37.895: INFO: Pod "pod-secrets-7a1f4587-7dfe-11e8-b7a8-22e3071d17c7" satisfied condition "success or failure"
+Jul  2 13:47:37.897: INFO: Trying to get logs from node shoot--core--confos-worker-w6oh6-z1-59946c4f6c-2w6kp pod pod-secrets-7a1f4587-7dfe-11e8-b7a8-22e3071d17c7 container secret-volume-test: <nil>
+STEP: delete the pod
+Jul  2 13:47:37.988: INFO: Waiting for pod pod-secrets-7a1f4587-7dfe-11e8-b7a8-22e3071d17c7 to disappear
+Jul  2 13:47:37.993: INFO: Pod pod-secrets-7a1f4587-7dfe-11e8-b7a8-22e3071d17c7 no longer exists
+[AfterEach] [sig-storage] Secrets
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:47:37.993: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-secrets-hhcdg" for this suite.
+Jul  2 13:47:44.085: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:47:44.143: INFO: namespace: e2e-tests-secrets-hhcdg, resource: bindings, ignored listing per whitelist
+Jul  2 13:47:44.185: INFO: namespace e2e-tests-secrets-hhcdg deletion completed in 6.188373514s
+
+• [SLOW TEST:8.384 seconds]
+[sig-storage] Secrets
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/secrets_volume.go:33
+  should be consumable from pods in volume as non-root with defaultMode and fsGroup set [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSSSSSS
+------------------------------
+[k8s.io] Probing container 
+  should *not* be restarted with a /healthz http liveness probe [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [k8s.io] Probing container
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:47:44.187: INFO: >>> kubeConfig: /tmp/kubeconfig-575984058
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [k8s.io] Probing container
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/container_probe.go:48
+[It] should *not* be restarted with a /healthz http liveness probe [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating pod liveness-http in namespace e2e-tests-container-probe-94gxg
+Jul  2 13:47:46.369: INFO: Started pod liveness-http in namespace e2e-tests-container-probe-94gxg
+STEP: checking the pod's current state and verifying that restartCount is present
+Jul  2 13:47:46.373: INFO: Initial restart count of pod liveness-http is 0
+STEP: deleting the pod
+[AfterEach] [k8s.io] Probing container
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:51:48.375: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-container-probe-94gxg" for this suite.
+Jul  2 13:51:54.399: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:51:54.491: INFO: namespace: e2e-tests-container-probe-94gxg, resource: bindings, ignored listing per whitelist
+Jul  2 13:51:54.566: INFO: namespace e2e-tests-container-probe-94gxg deletion completed in 6.177872425s
+
+• [SLOW TEST:250.380 seconds]
+[k8s.io] Probing container
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:679
+  should *not* be restarted with a /healthz http liveness probe [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSSSSSS
+------------------------------
+[sig-storage] HostPath 
+  should give a volume the correct mode [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-storage] HostPath
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:51:54.567: INFO: >>> kubeConfig: /tmp/kubeconfig-575984058
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] HostPath
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/host_path.go:36
+[It] should give a volume the correct mode [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating a pod to test hostPath mode
+Jul  2 13:51:54.657: INFO: Waiting up to 5m0s for pod "pod-host-path-test" in namespace "e2e-tests-hostpath-hm86n" to be "success or failure"
+Jul  2 13:51:54.660: INFO: Pod "pod-host-path-test": Phase="Pending", Reason="", readiness=false. Elapsed: 2.516743ms
+Jul  2 13:51:56.684: INFO: Pod "pod-host-path-test": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.026963608s
+STEP: Saw pod success
+Jul  2 13:51:56.684: INFO: Pod "pod-host-path-test" satisfied condition "success or failure"
+Jul  2 13:51:56.687: INFO: Trying to get logs from node shoot--core--confos-worker-w6oh6-z1-59946c4f6c-2w6kp pod pod-host-path-test container test-container-1: <nil>
+STEP: delete the pod
+Jul  2 13:51:56.710: INFO: Waiting for pod pod-host-path-test to disappear
+Jul  2 13:51:56.718: INFO: Pod pod-host-path-test no longer exists
+[AfterEach] [sig-storage] HostPath
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:51:56.719: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-hostpath-hm86n" for this suite.
+Jul  2 13:52:02.768: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:52:02.797: INFO: namespace: e2e-tests-hostpath-hm86n, resource: bindings, ignored listing per whitelist
+Jul  2 13:52:02.865: INFO: namespace e2e-tests-hostpath-hm86n deletion completed in 6.141899433s
+
+• [SLOW TEST:8.297 seconds]
+[sig-storage] HostPath
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/host_path.go:33
+  should give a volume the correct mode [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSS
+------------------------------
+[sig-network] Services 
+  should serve a basic endpoint from pods  [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-network] Services
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:52:02.865: INFO: >>> kubeConfig: /tmp/kubeconfig-575984058
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-network] Services
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/network/service.go:83
+[It] should serve a basic endpoint from pods  [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: creating service endpoint-test2 in namespace e2e-tests-services-9bt4w
+STEP: waiting up to 3m0s for service endpoint-test2 in namespace e2e-tests-services-9bt4w to expose endpoints map[]
+Jul  2 13:52:02.956: INFO: Get endpoints failed (2.460803ms elapsed, ignoring for 5s): endpoints "endpoint-test2" not found
+Jul  2 13:52:03.982: INFO: successfully validated that service endpoint-test2 in namespace e2e-tests-services-9bt4w exposes endpoints map[] (1.028884324s elapsed)
+STEP: Creating pod pod1 in namespace e2e-tests-services-9bt4w
+STEP: waiting up to 3m0s for service endpoint-test2 in namespace e2e-tests-services-9bt4w to expose endpoints map[pod1:[80]]
+Jul  2 13:52:06.011: INFO: successfully validated that service endpoint-test2 in namespace e2e-tests-services-9bt4w exposes endpoints map[pod1:[80]] (2.023088216s elapsed)
+STEP: Creating pod pod2 in namespace e2e-tests-services-9bt4w
+STEP: waiting up to 3m0s for service endpoint-test2 in namespace e2e-tests-services-9bt4w to expose endpoints map[pod1:[80] pod2:[80]]
+Jul  2 13:52:08.190: INFO: successfully validated that service endpoint-test2 in namespace e2e-tests-services-9bt4w exposes endpoints map[pod1:[80] pod2:[80]] (2.174294944s elapsed)
+STEP: Deleting pod pod1 in namespace e2e-tests-services-9bt4w
+STEP: waiting up to 3m0s for service endpoint-test2 in namespace e2e-tests-services-9bt4w to expose endpoints map[pod2:[80]]
+Jul  2 13:52:08.203: INFO: successfully validated that service endpoint-test2 in namespace e2e-tests-services-9bt4w exposes endpoints map[pod2:[80]] (6.952839ms elapsed)
+STEP: Deleting pod pod2 in namespace e2e-tests-services-9bt4w
+STEP: waiting up to 3m0s for service endpoint-test2 in namespace e2e-tests-services-9bt4w to expose endpoints map[]
+Jul  2 13:52:08.211: INFO: successfully validated that service endpoint-test2 in namespace e2e-tests-services-9bt4w exposes endpoints map[] (3.501005ms elapsed)
+[AfterEach] [sig-network] Services
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:52:08.229: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-services-9bt4w" for this suite.
+Jul  2 13:52:14.269: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:52:14.298: INFO: namespace: e2e-tests-services-9bt4w, resource: bindings, ignored listing per whitelist
+Jul  2 13:52:14.364: INFO: namespace e2e-tests-services-9bt4w deletion completed in 6.130671935s
+[AfterEach] [sig-network] Services
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/network/service.go:88
+
+• [SLOW TEST:11.499 seconds]
+[sig-network] Services
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/network/framework.go:22
+  should serve a basic endpoint from pods  [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSSSSSSSSSSSSSSSSSSSSSS
+------------------------------
+[k8s.io] Docker Containers 
+  should be able to override the image's default command (docker entrypoint) [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [k8s.io] Docker Containers
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:52:14.364: INFO: >>> kubeConfig: /tmp/kubeconfig-575984058
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should be able to override the image's default command (docker entrypoint) [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating a pod to test override command
+Jul  2 13:52:14.451: INFO: Waiting up to 5m0s for pod "client-containers-2028b004-7dff-11e8-b7a8-22e3071d17c7" in namespace "e2e-tests-containers-hrh8c" to be "success or failure"
+Jul  2 13:52:14.454: INFO: Pod "client-containers-2028b004-7dff-11e8-b7a8-22e3071d17c7": Phase="Pending", Reason="", readiness=false. Elapsed: 2.434949ms
+Jul  2 13:52:16.460: INFO: Pod "client-containers-2028b004-7dff-11e8-b7a8-22e3071d17c7": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.008122099s
+STEP: Saw pod success
+Jul  2 13:52:16.460: INFO: Pod "client-containers-2028b004-7dff-11e8-b7a8-22e3071d17c7" satisfied condition "success or failure"
+Jul  2 13:52:16.462: INFO: Trying to get logs from node shoot--core--confos-worker-w6oh6-z1-59946c4f6c-2w6kp pod client-containers-2028b004-7dff-11e8-b7a8-22e3071d17c7 container test-container: <nil>
+STEP: delete the pod
+Jul  2 13:52:16.493: INFO: Waiting for pod client-containers-2028b004-7dff-11e8-b7a8-22e3071d17c7 to disappear
+Jul  2 13:52:16.499: INFO: Pod client-containers-2028b004-7dff-11e8-b7a8-22e3071d17c7 no longer exists
+[AfterEach] [k8s.io] Docker Containers
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:52:16.499: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-containers-hrh8c" for this suite.
+Jul  2 13:52:22.519: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:52:22.587: INFO: namespace: e2e-tests-containers-hrh8c, resource: bindings, ignored listing per whitelist
+Jul  2 13:52:22.615: INFO: namespace e2e-tests-containers-hrh8c deletion completed in 6.112149987s
+
+• [SLOW TEST:8.251 seconds]
+[k8s.io] Docker Containers
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:679
+  should be able to override the image's default command (docker entrypoint) [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSSSSS
+------------------------------
+[sig-api-machinery] Garbage collector 
+  should keep the rc around until all its pods are deleted if the deleteOptions says so [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-api-machinery] Garbage collector
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:52:22.615: INFO: >>> kubeConfig: /tmp/kubeconfig-575984058
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should keep the rc around until all its pods are deleted if the deleteOptions says so [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: create the rc
+STEP: delete the rc
+STEP: wait for the rc to be deleted
+STEP: Gathering metrics
+W0702 13:52:28.794637      16 metrics_grabber.go:81] Master node is not registered. Grabbing metrics from Scheduler, ControllerManager and ClusterAutoscaler is disabled.
+Jul  2 13:52:28.794: INFO: For apiserver_request_count:
+For apiserver_request_latencies_summary:
+For etcd_helper_cache_entry_count:
+For etcd_helper_cache_hit_count:
+For etcd_helper_cache_miss_count:
+For etcd_request_cache_add_latencies_summary:
+For etcd_request_cache_get_latencies_summary:
+For etcd_request_latencies_summary:
+For garbage_collector_attempt_to_delete_queue_latency:
+For garbage_collector_attempt_to_delete_work_duration:
+For garbage_collector_attempt_to_orphan_queue_latency:
+For garbage_collector_attempt_to_orphan_work_duration:
+For garbage_collector_dirty_processing_latency_microseconds:
+For garbage_collector_event_processing_latency_microseconds:
+For garbage_collector_graph_changes_queue_latency:
+For garbage_collector_graph_changes_work_duration:
+For garbage_collector_orphan_processing_latency_microseconds:
+For namespace_queue_latency:
+For namespace_queue_latency_sum:
+For namespace_queue_latency_count:
+For namespace_retries:
+For namespace_work_duration:
+For namespace_work_duration_sum:
+For namespace_work_duration_count:
+For function_duration_seconds:
+For errors_total:
+For evicted_pods_total:
+
+[AfterEach] [sig-api-machinery] Garbage collector
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:52:28.794: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-gc-ph7cg" for this suite.
+Jul  2 13:52:34.808: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:52:34.991: INFO: namespace: e2e-tests-gc-ph7cg, resource: bindings, ignored listing per whitelist
+Jul  2 13:52:34.991: INFO: namespace e2e-tests-gc-ph7cg deletion completed in 6.193309597s
+
+• [SLOW TEST:12.375 seconds]
+[sig-api-machinery] Garbage collector
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apimachinery/framework.go:22
+  should keep the rc around until all its pods are deleted if the deleteOptions says so [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SS
+------------------------------
+[sig-storage] EmptyDir volumes 
+  should support (non-root,0644,tmpfs) [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-storage] EmptyDir volumes
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:52:34.991: INFO: >>> kubeConfig: /tmp/kubeconfig-575984058
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should support (non-root,0644,tmpfs) [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating a pod to test emptydir 0644 on tmpfs
+Jul  2 13:52:35.079: INFO: Waiting up to 5m0s for pod "pod-2c741e80-7dff-11e8-b7a8-22e3071d17c7" in namespace "e2e-tests-emptydir-kd5k2" to be "success or failure"
+Jul  2 13:52:35.081: INFO: Pod "pod-2c741e80-7dff-11e8-b7a8-22e3071d17c7": Phase="Pending", Reason="", readiness=false. Elapsed: 2.631843ms
+Jul  2 13:52:37.086: INFO: Pod "pod-2c741e80-7dff-11e8-b7a8-22e3071d17c7": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.007291748s
+STEP: Saw pod success
+Jul  2 13:52:37.086: INFO: Pod "pod-2c741e80-7dff-11e8-b7a8-22e3071d17c7" satisfied condition "success or failure"
+Jul  2 13:52:37.089: INFO: Trying to get logs from node shoot--core--confos-worker-w6oh6-z1-59946c4f6c-2w6kp pod pod-2c741e80-7dff-11e8-b7a8-22e3071d17c7 container test-container: <nil>
+STEP: delete the pod
+Jul  2 13:52:37.108: INFO: Waiting for pod pod-2c741e80-7dff-11e8-b7a8-22e3071d17c7 to disappear
+Jul  2 13:52:37.112: INFO: Pod pod-2c741e80-7dff-11e8-b7a8-22e3071d17c7 no longer exists
+[AfterEach] [sig-storage] EmptyDir volumes
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:52:37.112: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-emptydir-kd5k2" for this suite.
+Jul  2 13:52:43.138: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:52:43.238: INFO: namespace: e2e-tests-emptydir-kd5k2, resource: bindings, ignored listing per whitelist
+Jul  2 13:52:43.294: INFO: namespace e2e-tests-emptydir-kd5k2 deletion completed in 6.177563522s
+
+• [SLOW TEST:8.303 seconds]
+[sig-storage] EmptyDir volumes
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/empty_dir.go:40
+  should support (non-root,0644,tmpfs) [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSS
+------------------------------
+[sig-api-machinery] Garbage collector 
+  should not be blocked by dependency circle [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-api-machinery] Garbage collector
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:52:43.295: INFO: >>> kubeConfig: /tmp/kubeconfig-575984058
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should not be blocked by dependency circle [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+Jul  2 13:52:43.425: INFO: pod1.ObjectMeta.OwnerReferences=[]v1.OwnerReference{v1.OwnerReference{APIVersion:"v1", Kind:"Pod", Name:"pod3", UID:"317111b1-7dff-11e8-a560-160e0404a9f8", Controller:(*bool)(0xc4221384a6), BlockOwnerDeletion:(*bool)(0xc4221384a7)}}
+Jul  2 13:52:43.449: INFO: pod2.ObjectMeta.OwnerReferences=[]v1.OwnerReference{v1.OwnerReference{APIVersion:"v1", Kind:"Pod", Name:"pod1", UID:"317002be-7dff-11e8-a560-160e0404a9f8", Controller:(*bool)(0xc4226c2796), BlockOwnerDeletion:(*bool)(0xc4226c2797)}}
+Jul  2 13:52:43.452: INFO: pod3.ObjectMeta.OwnerReferences=[]v1.OwnerReference{v1.OwnerReference{APIVersion:"v1", Kind:"Pod", Name:"pod2", UID:"317079b8-7dff-11e8-a560-160e0404a9f8", Controller:(*bool)(0xc42213866e), BlockOwnerDeletion:(*bool)(0xc42213866f)}}
+[AfterEach] [sig-api-machinery] Garbage collector
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:52:48.461: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-gc-pjxbz" for this suite.
+Jul  2 13:52:54.489: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:52:54.550: INFO: namespace: e2e-tests-gc-pjxbz, resource: bindings, ignored listing per whitelist
+Jul  2 13:52:54.587: INFO: namespace e2e-tests-gc-pjxbz deletion completed in 6.12238891s
+
+• [SLOW TEST:11.292 seconds]
+[sig-api-machinery] Garbage collector
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apimachinery/framework.go:22
+  should not be blocked by dependency circle [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSSSSSSSSSSS
+------------------------------
+[sig-api-machinery] Garbage collector 
+  should not delete dependents that have both valid owner and owner that's waiting for dependents to be deleted [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-api-machinery] Garbage collector
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:52:54.587: INFO: >>> kubeConfig: /tmp/kubeconfig-575984058
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should not delete dependents that have both valid owner and owner that's waiting for dependents to be deleted [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: create the rc1
+STEP: create the rc2
+STEP: set half of pods created by rc simpletest-rc-to-be-deleted to have rc simpletest-rc-to-stay as owner as well
+STEP: delete the rc simpletest-rc-to-be-deleted
+STEP: wait for the rc to be deleted
+STEP: Gathering metrics
+W0702 13:53:04.791934      16 metrics_grabber.go:81] Master node is not registered. Grabbing metrics from Scheduler, ControllerManager and ClusterAutoscaler is disabled.
+Jul  2 13:53:04.792: INFO: For apiserver_request_count:
+For apiserver_request_latencies_summary:
+For etcd_helper_cache_entry_count:
+For etcd_helper_cache_hit_count:
+For etcd_helper_cache_miss_count:
+For etcd_request_cache_add_latencies_summary:
+For etcd_request_cache_get_latencies_summary:
+For etcd_request_latencies_summary:
+For garbage_collector_attempt_to_delete_queue_latency:
+For garbage_collector_attempt_to_delete_work_duration:
+For garbage_collector_attempt_to_orphan_queue_latency:
+For garbage_collector_attempt_to_orphan_work_duration:
+For garbage_collector_dirty_processing_latency_microseconds:
+For garbage_collector_event_processing_latency_microseconds:
+For garbage_collector_graph_changes_queue_latency:
+For garbage_collector_graph_changes_work_duration:
+For garbage_collector_orphan_processing_latency_microseconds:
+For namespace_queue_latency:
+For namespace_queue_latency_sum:
+For namespace_queue_latency_count:
+For namespace_retries:
+For namespace_work_duration:
+For namespace_work_duration_sum:
+For namespace_work_duration_count:
+For function_duration_seconds:
+For errors_total:
+For evicted_pods_total:
+
+[AfterEach] [sig-api-machinery] Garbage collector
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:53:04.792: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-gc-w5tw9" for this suite.
+Jul  2 13:53:10.807: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:53:10.846: INFO: namespace: e2e-tests-gc-w5tw9, resource: bindings, ignored listing per whitelist
+Jul  2 13:53:10.907: INFO: namespace e2e-tests-gc-w5tw9 deletion completed in 6.11210412s
+
+• [SLOW TEST:16.320 seconds]
+[sig-api-machinery] Garbage collector
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apimachinery/framework.go:22
+  should not delete dependents that have both valid owner and owner that's waiting for dependents to be deleted [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+S
+------------------------------
+[sig-network] Networking Granular Checks: Pods 
+  should function for intra-pod communication: http [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-network] Networking
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:53:10.908: INFO: >>> kubeConfig: /tmp/kubeconfig-575984058
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should function for intra-pod communication: http [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Performing setup for networking test in namespace e2e-tests-pod-network-test-4lzf7
+STEP: creating a selector
+STEP: Creating the service pods in kubernetes
+Jul  2 13:53:10.994: INFO: Waiting up to 10m0s for all (but 0) nodes to be schedulable
+STEP: Creating test pods
+Jul  2 13:53:33.276: INFO: ExecWithOptions {Command:[/bin/sh -c curl -g -q -s 'http://100.96.1.180:8080/dial?request=hostName&protocol=http&host=100.96.1.179&port=8080&tries=1'] Namespace:e2e-tests-pod-network-test-4lzf7 PodName:host-test-container-pod ContainerName:hostexec Stdin:<nil> CaptureStdout:true CaptureStderr:true PreserveWhitespace:false}
+Jul  2 13:53:33.277: INFO: >>> kubeConfig: /tmp/kubeconfig-575984058
+Jul  2 13:53:33.654: INFO: Waiting for endpoints: map[]
+Jul  2 13:53:33.658: INFO: ExecWithOptions {Command:[/bin/sh -c curl -g -q -s 'http://100.96.1.180:8080/dial?request=hostName&protocol=http&host=100.96.0.49&port=8080&tries=1'] Namespace:e2e-tests-pod-network-test-4lzf7 PodName:host-test-container-pod ContainerName:hostexec Stdin:<nil> CaptureStdout:true CaptureStderr:true PreserveWhitespace:false}
+Jul  2 13:53:33.658: INFO: >>> kubeConfig: /tmp/kubeconfig-575984058
+Jul  2 13:53:34.008: INFO: Waiting for endpoints: map[]
+[AfterEach] [sig-network] Networking
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:53:34.008: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-pod-network-test-4lzf7" for this suite.
+Jul  2 13:53:56.083: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:53:56.109: INFO: namespace: e2e-tests-pod-network-test-4lzf7, resource: bindings, ignored listing per whitelist
+Jul  2 13:53:56.184: INFO: namespace e2e-tests-pod-network-test-4lzf7 deletion completed in 22.171726712s
+
+• [SLOW TEST:45.277 seconds]
+[sig-network] Networking
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/networking.go:25
+  Granular Checks: Pods
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/networking.go:28
+    should function for intra-pod communication: http [NodeConformance] [Conformance]
+    /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSSSS
+------------------------------
+[sig-storage] Downward API volume 
+  should provide node allocatable (memory) as default memory limit if the limit is not set [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:53:56.185: INFO: >>> kubeConfig: /tmp/kubeconfig-575984058
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downwardapi_volume.go:38
+[It] should provide node allocatable (memory) as default memory limit if the limit is not set [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating a pod to test downward API volume plugin
+Jul  2 13:53:56.274: INFO: Waiting up to 5m0s for pod "downwardapi-volume-5cd99c4f-7dff-11e8-b7a8-22e3071d17c7" in namespace "e2e-tests-downward-api-mcxqm" to be "success or failure"
+Jul  2 13:53:56.276: INFO: Pod "downwardapi-volume-5cd99c4f-7dff-11e8-b7a8-22e3071d17c7": Phase="Pending", Reason="", readiness=false. Elapsed: 2.331589ms
+Jul  2 13:53:58.280: INFO: Pod "downwardapi-volume-5cd99c4f-7dff-11e8-b7a8-22e3071d17c7": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.006287412s
+STEP: Saw pod success
+Jul  2 13:53:58.280: INFO: Pod "downwardapi-volume-5cd99c4f-7dff-11e8-b7a8-22e3071d17c7" satisfied condition "success or failure"
+Jul  2 13:53:58.283: INFO: Trying to get logs from node shoot--core--confos-worker-w6oh6-z1-59946c4f6c-2w6kp pod downwardapi-volume-5cd99c4f-7dff-11e8-b7a8-22e3071d17c7 container client-container: <nil>
+STEP: delete the pod
+Jul  2 13:53:58.300: INFO: Waiting for pod downwardapi-volume-5cd99c4f-7dff-11e8-b7a8-22e3071d17c7 to disappear
+Jul  2 13:53:58.303: INFO: Pod downwardapi-volume-5cd99c4f-7dff-11e8-b7a8-22e3071d17c7 no longer exists
+[AfterEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:53:58.303: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-downward-api-mcxqm" for this suite.
+Jul  2 13:54:04.327: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:54:04.547: INFO: namespace: e2e-tests-downward-api-mcxqm, resource: bindings, ignored listing per whitelist
+Jul  2 13:54:04.579: INFO: namespace e2e-tests-downward-api-mcxqm deletion completed in 6.262515672s
+
+• [SLOW TEST:8.394 seconds]
+[sig-storage] Downward API volume
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downwardapi_volume.go:33
+  should provide node allocatable (memory) as default memory limit if the limit is not set [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+[sig-storage] Projected 
+  should be consumable from pods in volume with defaultMode set [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:54:04.579: INFO: >>> kubeConfig: /tmp/kubeconfig-575984058
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:858
+[It] should be consumable from pods in volume with defaultMode set [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: Creating configMap with name projected-configmap-test-volume-61da3588-7dff-11e8-b7a8-22e3071d17c7
+STEP: Creating a pod to test consume configMaps
+Jul  2 13:54:04.670: INFO: Waiting up to 5m0s for pod "pod-projected-configmaps-61daa92a-7dff-11e8-b7a8-22e3071d17c7" in namespace "e2e-tests-projected-trpt7" to be "success or failure"
+Jul  2 13:54:04.673: INFO: Pod "pod-projected-configmaps-61daa92a-7dff-11e8-b7a8-22e3071d17c7": Phase="Pending", Reason="", readiness=false. Elapsed: 2.69972ms
+Jul  2 13:54:06.676: INFO: Pod "pod-projected-configmaps-61daa92a-7dff-11e8-b7a8-22e3071d17c7": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.006437044s
+STEP: Saw pod success
+Jul  2 13:54:06.676: INFO: Pod "pod-projected-configmaps-61daa92a-7dff-11e8-b7a8-22e3071d17c7" satisfied condition "success or failure"
+Jul  2 13:54:06.679: INFO: Trying to get logs from node shoot--core--confos-worker-w6oh6-z1-59946c4f6c-2w6kp pod pod-projected-configmaps-61daa92a-7dff-11e8-b7a8-22e3071d17c7 container projected-configmap-volume-test: <nil>
+STEP: delete the pod
+Jul  2 13:54:06.702: INFO: Waiting for pod pod-projected-configmaps-61daa92a-7dff-11e8-b7a8-22e3071d17c7 to disappear
+Jul  2 13:54:06.705: INFO: Pod pod-projected-configmaps-61daa92a-7dff-11e8-b7a8-22e3071d17c7 no longer exists
+[AfterEach] [sig-storage] Projected
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:54:06.705: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-trpt7" for this suite.
+Jul  2 13:54:12.768: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:54:12.953: INFO: namespace: e2e-tests-projected-trpt7, resource: bindings, ignored listing per whitelist
+Jul  2 13:54:12.953: INFO: namespace e2e-tests-projected-trpt7 deletion completed in 6.238561818s
+
+• [SLOW TEST:8.374 seconds]
+[sig-storage] Projected
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:34
+  should be consumable from pods in volume with defaultMode set [NodeConformance] [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+[sig-api-machinery] Garbage collector 
+  should delete RS created by deployment when not orphaning [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+[BeforeEach] [sig-api-machinery] Garbage collector
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Jul  2 13:54:12.954: INFO: >>> kubeConfig: /tmp/kubeconfig-575984058
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should delete RS created by deployment when not orphaning [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+STEP: create the deployment
+STEP: Wait for the Deployment to create new ReplicaSet
+STEP: delete the deployment
+STEP: wait for all rs to be garbage collected
+STEP: expected 0 rs, got 1 rs
+STEP: expected 0 Pods, got 2 Pods
+STEP: Gathering metrics
+W0702 13:54:14.141722      16 metrics_grabber.go:81] Master node is not registered. Grabbing metrics from Scheduler, ControllerManager and ClusterAutoscaler is disabled.
+Jul  2 13:54:14.141: INFO: For apiserver_request_count:
+For apiserver_request_latencies_summary:
+For etcd_helper_cache_entry_count:
+For etcd_helper_cache_hit_count:
+For etcd_helper_cache_miss_count:
+For etcd_request_cache_add_latencies_summary:
+For etcd_request_cache_get_latencies_summary:
+For etcd_request_latencies_summary:
+For garbage_collector_attempt_to_delete_queue_latency:
+For garbage_collector_attempt_to_delete_work_duration:
+For garbage_collector_attempt_to_orphan_queue_latency:
+For garbage_collector_attempt_to_orphan_work_duration:
+For garbage_collector_dirty_processing_latency_microseconds:
+For garbage_collector_event_processing_latency_microseconds:
+For garbage_collector_graph_changes_queue_latency:
+For garbage_collector_graph_changes_work_duration:
+For garbage_collector_orphan_processing_latency_microseconds:
+For namespace_queue_latency:
+For namespace_queue_latency_sum:
+For namespace_queue_latency_count:
+For namespace_retries:
+For namespace_work_duration:
+For namespace_work_duration_sum:
+For namespace_work_duration_count:
+For function_duration_seconds:
+For errors_total:
+For evicted_pods_total:
+
+[AfterEach] [sig-api-machinery] Garbage collector
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Jul  2 13:54:14.141: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-gc-c7nsb" for this suite.
+Jul  2 13:54:20.155: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Jul  2 13:54:20.287: INFO: namespace: e2e-tests-gc-c7nsb, resource: bindings, ignored listing per whitelist
+Jul  2 13:54:20.293: INFO: namespace e2e-tests-gc-c7nsb deletion completed in 6.148228381s
+
+• [SLOW TEST:7.339 seconds]
+[sig-api-machinery] Garbage collector
+/workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apimachinery/framework.go:22
+  should delete RS created by deployment when not orphaning [Conformance]
+  /workspace/anago-v1.11.0-rc.3.3+91e7b4fd31fcd3/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:684
+------------------------------
+SSSJul  2 13:54:20.293: INFO: Running AfterSuite actions on all node
+Jul  2 13:54:20.293: INFO: Running AfterSuite actions on node 1
+Jul  2 13:54:20.293: INFO: Skipping dumping logs from cluster
+
+Ran 143 of 998 Specs in 3610.422 seconds
+SUCCESS! -- 143 Passed | 0 Failed | 0 Pending | 855 Skipped PASS
+
+Ginkgo ran 1 suite in 1h0m10.876487715s
+Test Suite Passed

--- a/v1.11/gardener-openstack/junit_01.xml
+++ b/v1.11/gardener-openstack/junit_01.xml
@@ -1,0 +1,2711 @@
+<?xml version="1.0" encoding="UTF-8"?>
+  <testsuite tests="143" failures="0" time="3610.422247706">
+      <testcase name="[sig-storage] PersistentVolumes:vsphere should test that deleting the Namespace of a PVC and Pod causes the successful detach of vsphere volume" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: dir-link] One pod requesting one prebound PVC should be able to mount volume and write from pod1" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: dir-link] Two pods mounting a local volume at the same time should be able to write from pod1 and read from pod2" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-instrumentation] [Feature:PrometheusMonitoring] Prometheus should scrape metrics from annotated pods." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gluster] should support creating multiple subpath from same volumes [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-instrumentation] Monitoring should verify monitoring pods and all cluster nodes are available on influxdb using heapster [Feature:InfluxdbMonitoring]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: emptyDir] should support non-existent path" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: nfsPVC] should support readOnly file specified in the volumeMount" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [Feature:Example] [k8s.io] Redis should create and stop redis servers" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volume plugin streaming [Slow] NFS should write files of various sizes, verify size, validate content" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: dir-bindmounted] Two pods mounting a local volume one after the other should be able to write from pod1 and read from pod2" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Dynamic Provisioning DynamicProvisioner should test that deleting a claim before the volume is provisioned deletes the volume." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Projected should provide container&#39;s cpu limit [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="10.462998924"></testcase>
+      <testcase name="[sig-storage] Pod Disks schedule pods each with a PD, delete pod and verify detach [Slow] for read-only PD with pod delete grace period of &#34;default (30s)&#34;" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] StatefulSet [k8s.io] Deploy clustered applications [Feature:StatefulSet] [Slow] should creating a working CockroachDB cluster" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cluster-lifecycle] [Feature:BootstrapTokens] should resign the bootstrap tokens when the clusterInfo ConfigMap updated [Serial][Disruptive]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] ConfigMap updates should be reflected in volume [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="26.384605421"></testcase>
+      <testcase name="[sig-storage] PersistentVolumes GCEPD should test that deleting the PV before the pod does not cause pod deletion to fail on PD detach" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Services should have session affinity work for NodePort service" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: nfsPVC] should support non-existent path" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] InitContainer [NodeConformance] should invoke init containers on a RestartAlways pod" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Kubectl patch should add annotations for pods in rc  [Conformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Loadbalancing: L7 GCE [Slow] [Feature:kubemci] should conform to Ingress spec" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes NFS with multiple PVs and PVCs all in same ns should create 3 PVs and 3 PVCs: test write access" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Simple pod should handle in-cluster config" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] ConfigMap should be consumable from pods in volume with mappings as non-root [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="8.404316499"></testcase>
+      <testcase name="[sig-storage] Pod Disks schedule a pod w/ RW PD(s) mounted to 1 or more containers, write to PD, verify content, delete pod, and repeat in rapid succession [Slow] using 4 containers and 1 PDs" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Etcd failure [Disruptive] should recover from SIGKILL" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Secrets should be consumable in multiple volumes in a pod [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="10.379619111"></testcase>
+      <testcase name="[sig-storage] Mounted volume expand[Slow] Should verify mounted devices can be resized" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Servers with support for API chunking should return chunks of results for list calls" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl Port forwarding [k8s.io] With a server listening on 0.0.0.0 should support forwarding over websockets" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: nfsPVC] should fail if non-existent subpath is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] Should not scale GPU pool up if pod does not require GPUs [GpuType:nvidia-tesla-p100] [Feature:ClusterSizeAutoscalingGpu]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Variable Expansion should allow substituting values in a container&#39;s args [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="10.31271126"></testcase>
+      <testcase name="[sig-storage] ConfigMap should be consumable from pods in volume with defaultMode set [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="8.254790358"></testcase>
+      <testcase name="[sig-network] DNS configMap nameserver Forward external name lookup should forward externalname lookup to upstream nameserver [Slow][Serial]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] ESIPP [Slow] [DisabledForLargeClusters] should handle updates to ExternalTrafficPolicy field" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] should increase cluster size if pending pods are small [Feature:ClusterSizeAutoscalingScaleUp]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Networking Granular Checks: Services [Slow] should function for endpoint-Service: udp" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Aggregator Should be able to support the 1.7 Sample API Server using the current Aggregator" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Initializers [Feature:Initializers] should be invisible to controllers by default" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Projected should provide podname only [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="8.332415476"></testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: dir] Two pods mounting a local volume at the same time should be able to write from pod1 and read from pod2" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [sig-node] Security Context [Feature:SecurityContext] should support seccomp alpha runtime/default annotation [Feature:Seccomp]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] [Feature:PerformanceDNS] Should answer DNS query for maximum number of services per cluster" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Downward API volume should update annotations on modification [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="28.913627669"></testcase>
+      <testcase name="[sig-network] Services should be able to change the type from ExternalName to NodePort" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Storage Policy Based Volume Provisioning [Feature:vsphere] verify if a SPBM policy is not honored on a non-compatible datastore for dynamically provisioned pvc using storageclass" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] StatefulSet [k8s.io] Deploy clustered applications [Feature:StatefulSet] [Slow] should creating a working mysql cluster" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Simple pod should support exec through kubectl proxy" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Job should adopt matching orphans and release non-matching pods" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cluster-lifecycle] Reboot [Disruptive] [Feature:Reboot] each node by dropping all outbound packets for a while and ensure they function afterwards" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] CronJob should schedule multiple jobs concurrently" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] PrivilegedPod [NodeConformance] should enable privileged commands" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cluster-lifecycle] kube-proxy migration [Feature:KubeProxyDaemonSetMigration] Downgrade kube-proxy from a DaemonSet to static pods should maintain a functioning cluster [Feature:KubeProxyDaemonSetDowngrade]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: dir] One pod requesting one prebound PVC should be able to mount volume and write from pod1" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gcePDPartitioned] should fail for new directories when readOnly specified in the volumeSource" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Loadbalancing: L7 GCE [Slow] [Feature:kubemci] should remove clusters as expected" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] SchedulerPredicates [Serial] validates that NodeAffinity is respected if not matching" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: dir-link-bindmounted] One pod requesting one prebound PVC should be able to mount volume and read from pod1" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-instrumentation] MetricsGrabber should grab all metrics from a Kubelet." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: gce-localssd-scsi-fs] [Serial] One pod requesting one prebound PVC should be able to mount volume and read from pod1" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: hostPath] should unmount if pod is force deleted while kubelet is down [Disruptive][Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Loadbalancing: L7 Scalability GCE [Slow] [Serial] [Feature:IngressScale] Creating and updating ingresses should happen promptly with small/medium/large amount of ingresses" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: dir-bindmounted] Two pods mounting a local volume at the same time should be able to write from pod1 and read from pod2" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] [Feature:ClusterSizeAutoscalingScaleUp] [Slow] Autoscaling [sig-autoscaling] Autoscaling a service from 1 pod and 3 nodes to 8 pods and &gt;=4 nodes takes less than 15 minutes" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Projected should set mode on item file [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="8.381284838"></testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: hostPath] should support file as subpath" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Firewall rule should have correct firewall rules for e2e cluster" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Pod Disks schedule pods each with a PD, delete pod and verify detach [Slow] for RW PD with pod delete grace period of &#34;default (30s)&#34;" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gluster] should fail if subpath with backstepping is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] vcp-performance [Feature:vsphere] vcp performance tests" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Servers with support for Table transformation should return a 406 for a backend which does not implement metadata" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] AdmissionWebhook Should mutate pod and apply defaults after mutation" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Secrets should be consumable from pods in volume [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="8.321510145"></testcase>
+      <testcase name="[sig-network] Services should be able to switch session affinity for service with type clusterIP" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: dir-link] Set fsGroup for local volume should set same fsGroup for two pods simultaneously" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] ResourceQuota should create a ResourceQuota and capture the life of a persistent volume claim. [sig-storage]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] DNS should provide DNS for pods for Hostname and Subdomain" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gluster] should unmount if pod is gracefully deleted while kubelet is down [Disruptive][Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: dir] Set fsGroup for local volume should set same fsGroup for two pods simultaneously" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] [HPA] Horizontal pod autoscaling (scale resource: CPU) [sig-autoscaling] [Serial] [Slow] Deployment Should scale from 5 pods to 3 pods and from 3 to 1" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Loadbalancing: L7 GCE [Slow] [Feature:NEG] should be able to create a ClusterIP service [Unreleased]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gcePDPVC] should support non-existent path" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Kubectl apply should apply a new configuration to an existing RC" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] NFSPersistentVolumes[Disruptive][Flaky] when kubelet restarts Should test that a volume mounted to a pod that is force deleted while the kubelet is down unmounts when the kubelet returns." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Downward API should provide host IP as an env var [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="10.321160747"></testcase>
+      <testcase name="[sig-storage] PersistentVolumes:vsphere should test that deleting the PV before the pod does not cause pod deletion to fail on vspehre volume detach" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Probing container with readiness probe should not be ready before initial delay and never restart [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="44.453205997"></testcase>
+      <testcase name="[sig-network] Services should be able to create a functioning NodePort service" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Proxy server should support --unix-socket=/path  [Conformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scalability] Density [Feature:ManualPerformance] should allow starting 30 pods per node using {extensions Deployment} with 2 secrets, 0 configmaps and 0 daemons" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: hostPathSymlink] should support readOnly file specified in the volumeMount" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Storage Policy Based Volume Provisioning [Feature:vsphere] verify an existing and compatible SPBM policy is honored for dynamically provisioned pvc using storageclass" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cluster-lifecycle] Upgrade [Feature:Upgrade] node upgrade should maintain a functioning cluster [Feature:NodeUpgrade]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Secrets should be able to mount in a volume regardless of a different secret existing with same name in different namespace [NodeConformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] should add node to the particular mig [Feature:ClusterSizeAutoscalingScaleUp]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: gce-localssd-scsi-fs] [Serial] Two pods mounting a local volume one after the other should be able to write from pod1 and read from pod2" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] EmptyDir volumes volume on tmpfs should have the correct mode [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="8.289808814"></testcase>
+      <testcase name="[sig-cluster-lifecycle] gpu Upgrade [Feature:GPUUpgrade] cluster upgrade should be able to run gpu pod after upgrade [Feature:GPUClusterUpgrade]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: dir-bindmounted] One pod requesting one prebound PVC should be able to mount volume and read from pod1" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: dir-link] One pod requesting one prebound PVC should be able to mount volume and read from pod1" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Networking Granular Checks: Services [Slow] should update nodePort: udp [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Storage Policy Based Volume Provisioning [Feature:vsphere] verify VSAN storage capability with invalid diskStripes value is not honored for dynamically provisioned pvc using storageclass" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Downward API volume should provide container&#39;s memory request [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="8.296876613"></testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] Should scale up GPU pool from 0 [GpuType:nvidia-tesla-v100] [Feature:ClusterSizeAutoscalingGpu]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] CronJob should not emit unexpected warnings" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-auth] Certificates API should support building a client with a CSR" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gcePDPartitioned] should fail if subpath file is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] EmptyDir volumes should support (root,0666,tmpfs) [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="8.23305097"></testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Simple pod should return command exit codes" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Sysctls [NodeFeature:Sysctls] should support unsafe sysctls which are actually whitelisted" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: hostPath] should support existing single file" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] GCP Volumes NFSv3 should be mountable for NFSv3" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] [HPA] Horizontal pod autoscaling (scale resource: CPU) [sig-autoscaling] ReplicationController light Should scale from 2 pods to 1 pod" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: hostPathSymlink] should support existing single file" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] EmptyDir volumes should support (root,0644,tmpfs) [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="8.494694361"></testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Simple pod should support inline execution and attach" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: emptyDir] should support creating multiple subpath from same volumes [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [sig-node] Kubelet [Serial] [Slow] [k8s.io] [sig-node] regular resource usage tracking resource tracking for 0 pods per node" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Loadbalancing: L7 GCE [Slow] [Feature:Ingress] should create ingress with given static-ip" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Loadbalancing: L7 GCE [Slow] [Feature:Ingress] should create ingress with backend HTTPS" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Projected should be consumable from pods in volume with mappings as non-root [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="8.254760245"></testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] should scale down when expendable pod is running [Feature:ClusterSizeAutoscalingScaleDown]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Projected should set DefaultMode on files [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="8.315977439"></testcase>
+      <testcase name="[sig-storage] Projected should provide container&#39;s memory limit [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="8.305754581"></testcase>
+      <testcase name="[sig-storage] HostPath should support subPath [NodeConformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Storage Policy Based Volume Provisioning [Feature:vsphere] verify VSAN storage capability with valid objectSpaceReservation and iopsLimit values is honored for dynamically provisioned pvc using storageclass" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Networking Granular Checks: Services [Slow] should update endpoints: http" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gcePDPartitioned] should support restarting containers using file as subpath [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Deployment RecreateDeployment should delete old pods and create new ones" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scalability] Density [Feature:ManualPerformance] should allow starting 30 pods per node using {batch Job} with 0 secrets, 0 configmaps and 0 daemons" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-auth] ServiceAccounts should mount an API token into pods  [Conformance]" classname="Kubernetes e2e suite" time="16.951277816"></testcase>
+      <testcase name="[k8s.io] [sig-node] kubelet [k8s.io] [sig-node] host cleanup with volume mounts [sig-storage][HostCleanup][Flaky] Host cleanup after disrupting NFS volume [NFS] after stopping the nfs-server and deleting the (sleeping) client pod, the NFS mount and the pod&#39;s UID directory should be removed." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Storage Policy Based Volume Provisioning [Feature:vsphere] verify an if a SPBM policy and VSAN capabilities cannot be honored for dynamically provisioned pvc using storageclass" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Networking Granular Checks: Services [Slow] should function for client IP based session affinity: udp" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] Multi-AZ Clusters should spread the pods of a replication controller across zones" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Services should be able to change the type and ports of a service [Slow] [DisabledForLargeClusters]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl Port forwarding [k8s.io] With a server listening on 0.0.0.0 [k8s.io] that expects NO client request should support a client that connects, sends DATA, and disconnects" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] Should be able to scale a node group up from 0[Feature:ClusterSizeAutoscalingScaleUp]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] DaemonRestart [Disruptive] Scheduler should continue assigning pods to nodes across restart" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] should increase cluster size if pods are pending due to pod anti-affinity [Feature:ClusterSizeAutoscalingScaleUp]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cluster-lifecycle] Reboot [Disruptive] [Feature:Reboot] each node by ordering unclean reboot and ensure they function upon restart" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Ephemeralstorage When pod refers to non-existent ephemeral storage should allow deletion of pod with invalid volume : projected" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Deployment deployment should delete old replica sets" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Downward API [Serial] [Disruptive] [NodeFeature:EphemeralStorage] Downward API tests for local ephemeral storage should provide container&#39;s limits.ephemeral-storage and requests.ephemeral-storage as env vars" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes:vsphere should test that a file written to the vspehre volume mount before kubelet restart can be read after restart [Disruptive]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] StatefulSet [k8s.io] Basic StatefulSet functionality [StatefulSetBasic] Scaling should happen in predictable order and halt if any stateful pod is unhealthy [Conformance]" classname="Kubernetes e2e suite" time="90.874947146"></testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: hostPath] should support readOnly directory specified in the volumeMount" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-auth] [Feature:NodeAuthorizer] Getting a secret for a workload the node has access to should succeed" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gcePDPVC] should unmount if pod is force deleted while kubelet is down [Disruptive][Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: nfs] should support creating multiple subpath from same volumes [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Services should be able to change the type from ExternalName to ClusterIP" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Secrets optional updates should be reflected in volume [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="26.782550838"></testcase>
+      <testcase name="[sig-api-machinery] Watchers should be able to start watching from a specific resource version [Conformance]" classname="Kubernetes e2e suite" time="6.312220923"></testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  Local volume provisioner [Serial] should discover dynamicly created local persistent volume mountpoint in discovery directory" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] DisruptionController evictions: too few pods, absolute =&gt; should not allow an eviction" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] StatefulSet [k8s.io] Basic StatefulSet functionality [StatefulSetBasic] should not deadlock when a pod&#39;s predecessor fails" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Kubectl run --rm job should create a job from an image, then delete the job  [Conformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Probing container should *not* be restarted with a exec &#34;cat /tmp/health&#34; liveness probe [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="250.373940093"></testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Simple pod should support exec through an HTTP proxy" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: gce-localssd-scsi-fs] [Serial] Set fsGroup for local volume should set different fsGroup for second pod if first pod is deleted" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] should scale up correct target pool [Feature:ClusterSizeAutoscalingScaleUp]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Services should have session affinity work for LoadBalancer service with ESIPP off [Slow] [DisabledForLargeClusters]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Storage Policy Based Volume Provisioning [Feature:vsphere] verify VSAN storage capability with invalid capability name objectSpaceReserve is not honored for dynamically provisioned pvc using storageclass" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-instrumentation] Cluster level logging implemented by Stackdriver should ingest system logs from all nodes [Feature:StackdriverLogging]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] EquivalenceCache [Serial] validates pod anti-affinity works properly when new replica pod is scheduled" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Job should run a job to completion when tasks succeed" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scalability] Load capacity [Feature:ManualPerformance] should be able to handle 3 pods per node { ReplicationController} with 0 secrets, 0 configmaps and 0 daemons" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] NFSPersistentVolumes[Disruptive][Flaky] when kubelet restarts Should test that a file written to the mount before kubelet restart is readable after restart." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] DisruptionController evictions: no PDB =&gt; should allow an eviction" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Update Demo should scale a replication controller  [Conformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: hostPathSymlink] should support file as subpath" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Variable Expansion should fail substituting values in a volume subpath with absolute path [Feature:VolumeSubpathEnvExpansion][NodeAlphaFeature:VolumeSubpathEnvExpansion][Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] EmptyDir volumes should support (non-root,0777,tmpfs) [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="8.411908982"></testcase>
+      <testcase name="[sig-scheduling] SchedulerPredicates [Serial] validates that there is no conflict between pods with same hostPort but different hostIP and protocol" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Downward API volume should provide podname as non-root with fsgroup and defaultMode [NodeFeature:FSGroup]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Job should run a job to completion when tasks sometimes fail and are locally restarted" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Watchers should be able to restart watching from the last resource version observed by the previous watch [Conformance]" classname="Kubernetes e2e suite" time="6.276305254"></testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: blockfs] One pod requesting one prebound PVC should be able to mount volume and write from pod1" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Proxy version v1 should proxy through a service and a pod  [Conformance]" classname="Kubernetes e2e suite" time="27.108225131"></testcase>
+      <testcase name="[sig-storage] Projected should provide container&#39;s memory request [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="8.262943655"></testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] should increase cluster size if pending pods are small and one node is broken [Feature:ClusterSizeAutoscalingScaleUp]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: emptyDir] should support file as subpath" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] SchedulerPriorities [Serial] Pod should perfer to scheduled to nodes pod can tolerate" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Kubectl logs should be able to retrieve and filter logs  [Conformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Pods should cap back-off at MaxContainerBackOff [Slow][NodeConformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes [Feature:LabelSelector] [sig-storage] Selector-Label Volume Binding:vsphere should bind volume with claim for given label" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Services should release NodePorts on delete" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] [Serial] Volume metrics PVController should create bound pv/pvc count metrics for pvc controller after creating both pv and pvc" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Networking should check kube-proxy urls" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] ResourceQuota should create a ResourceQuota and capture the life of a replication controller." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Job should exceed active deadline" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] [HPA] Horizontal pod autoscaling (scale resource: Custom Metrics from Stackdriver) should scale up with two metrics of type Pod from Stackdriver [Feature:CustomMetricsAutoscaling]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl Port forwarding [k8s.io] With a server listening on localhost [k8s.io] that expects NO client request should support a client that connects, sends DATA, and disconnects" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] EmptyDir volumes when FSGroup is specified [NodeFeature:FSGroup] files with FSGroup ownership should support (root,0644,tmpfs)" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gcePDPVC] should support readOnly directory specified in the volumeMount" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] DisruptionController should create a PodDisruptionBudget" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Network Partition [Disruptive] [Slow] [k8s.io] [ReplicationController] should recreate pods scheduled on the unreachable node AND allow scheduling of pods on a node after it rejoins the cluster" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] GCP Volumes NFSv4 should be mountable for NFSv4" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: blockfs] One pod requesting one prebound PVC should be able to mount volume and read from pod1" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: dir-link-bindmounted] Set fsGroup for local volume should not set different fsGroups for two pods simultaneously" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes [Feature:ReclaimPolicy] [sig-storage] persistentvolumereclaim:vsphere should delete persistent volume when reclaimPolicy set to delete and associated claim is deleted" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gcePDPVC] should fail if subpath file is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] AdmissionWebhook Should be able to deny custom resource creation" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] Should not scale GPU pool up if pod does not require GPUs [GpuType:nvidia-tesla-v100] [Feature:ClusterSizeAutoscalingGpu]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-auth] PodSecurityPolicy should enforce the restricted policy.PodSecurityPolicy" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Probing container should be restarted with a exec &#34;cat /tmp/health&#34; liveness probe [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="62.845510647"></testcase>
+      <testcase name="[sig-storage] Flexvolumes [Disruptive] should be mountable when attachable" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] ConfigMap should be consumable from pods in volume [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="8.357755284"></testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] Shouldn&#39;t perform scale up operation and should list unhealthy status if most of the cluster is broken[Feature:ClusterSizeAutoscalingScaleUp]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Downward API should provide pod UID as env vars [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="12.258367237"></testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Kubectl taint [Serial] should remove all the taints with the same key off a node" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Services should check NodePort out-of-range" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Pod Disks detach in a disrupted environment [Slow] [Disruptive] when pod is evicted" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gluster] should fail if non-existent subpath is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Deployment deployment should support proportional scaling" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Cluster size autoscaler scalability [Slow] should scale down empty nodes [Feature:ClusterAutoscalerScalability3]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Projected should update annotations on modification [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="28.993597239"></testcase>
+      <testcase name="[sig-cluster-lifecycle] ingress Upgrade [Feature:IngressUpgrade] ingress upgrade should maintain a functioning ingress" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] ResourceQuota should verify ResourceQuota with best effort scope." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Namespaces [Serial] should delete fast enough (90 percent of 100 namespaces in 150 seconds)" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Storage Policy Based Volume Provisioning [Feature:vsphere] verify if a non-existing SPBM policy is not honored for dynamically provisioned pvc using storageclass" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  Pod with node different from PV&#39;s NodeAffinity should fail scheduling due to different NodeSelector" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: dir-link] Set fsGroup for local volume should set different fsGroup for second pod if first pod is deleted" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cluster-lifecycle] Reboot [Disruptive] [Feature:Reboot] each node by triggering kernel panic and ensure they function upon restart" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Loadbalancing: L7 GCE [Slow] [Feature:Ingress] should not reconcile manually modified health check for ingress" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: nfs] should support non-existent path" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Dynamic Provisioning DynamicProvisioner External should let an external dynamic provisioner create and delete persistent volumes [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [Feature:Example] [k8s.io] Secret should create a pod that reads a secret" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gcePDPartitioned] should support existing directory" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Dynamic Provisioning DynamicProvisioner should provision storage with mount options" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: emptyDir] should unmount if pod is gracefully deleted while kubelet is down [Disruptive][Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scalability] Load capacity [Feature:ManualPerformance] should be able to handle 30 pods per node {extensions Deployment} with 2 secrets, 0 configmaps and 0 daemons" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes NFS with Single PV - PVC pairs should create a non-pre-bound PV and PVC: test write access " classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] shouldn&#39;t scale up when expendable pod is preempted [Feature:ClusterSizeAutoscalingScaleUp]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Kubectl run CronJob should create a CronJob" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scalability] Load capacity [Feature:ManualPerformance] should be able to handle 30 pods per node { ReplicationController} with 0 secrets, 0 configmaps and 0 daemons with quotas" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-instrumentation] Kibana Logging Instances Is Alive [Feature:Elasticsearch] should check that the Kibana logging instance is alive" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volume Disk Format [Feature:vsphere] verify disk format type - thin is honored for dynamically provisioned pv using storageclass" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: gce-localssd-scsi-fs] [Serial] Set fsGroup for local volume should set same fsGroup for two pods simultaneously" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: blockfs] Set fsGroup for local volume should set same fsGroup for two pods simultaneously" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Projected should be consumable from pods in volume with defaultMode set [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="8.290883123"></testcase>
+      <testcase name="[k8s.io] [sig-node] Security Context [Feature:SecurityContext] should support volume SELinux relabeling when using hostPID" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Projected should provide podname as non-root with fsgroup [NodeFeature:FSGroup]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] StatefulSet [k8s.io] Deploy clustered applications [Feature:StatefulSet] [Slow] should creating a working redis cluster" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volume Operations Storm [Feature:vsphere] should create pod with many volumes and verify no attach call fails" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] DNS configMap nameserver Forward PTR lookup should forward PTR records lookup to upstream nameserver [Slow][Serial]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gcePDPVC] should support creating multiple subpath from same volumes [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volume Placement should create and delete pod with the same volume source on the same worker node" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Services should be able to update NodePorts with two same port numbers but different protocols" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] ResourceQuota should create a ResourceQuota and capture the life of a configMap." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: emptyDir] should fail for new directories when readOnly specified in the volumeSource" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Projected should be consumable from pods in volume with mappings as non-root with FSGroup [NodeFeature:FSGroup]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] StatefulSet [k8s.io] Basic StatefulSet functionality [StatefulSetBasic] should adopt matching orphans and release non-matching pods" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] should be able to scale down by draining multiple pods one by one as dictated by pdb[Feature:ClusterSizeAutoscalingScaleDown]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volumes CephFS [Feature:Volumes] should be mountable" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Networking IPerf IPv6 [Experimental] [Feature:Networking-IPv6] [Slow] [Feature:Networking-Performance] should transfer ~ 1GB onto the service endpoint 1 servers (maximum of 1 clients)" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Network Partition [Disruptive] [Slow] [k8s.io] Pods should be evicted from unready Node [Feature:TaintEviction] All pods on the unreachable node should be marked as NotReady upon the node turn NotReady AND all pods should be evicted after eviction timeout passes" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Network Partition [Disruptive] [Slow] [k8s.io] [StatefulSet] should come back up if node goes down [Slow] [Disruptive]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-instrumentation] Cluster level logging implemented by Stackdriver should ingest events" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Kubectl run pod should create a pod from an image when restart is Never  [Conformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] CustomResourceDefinition resources Simple CustomResourceDefinition creating/deleting custom resource definition objects works  [Conformance]" classname="Kubernetes e2e suite" time="7.500935041"></testcase>
+      <testcase name="[sig-storage] vsphere statefulset vsphere statefulset testing" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [sig-node] Mount propagation should propagate mounts to the host" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: nfsPVC] should support existing directory" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] NetworkPolicy NetworkPolicy between server and client should allow ingress access on one named port [Feature:NetworkPolicy]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Kubectl cluster-info should check if Kubernetes master services is included in cluster-info  [Conformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Pods should have their auto-restart back-off timer reset on image update [Slow][NodeConformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] DisruptionController evictions: too few pods, replicaSet, percentage =&gt; should not allow an eviction" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: dir-link-bindmounted] Set fsGroup for local volume should set same fsGroup for two pods simultaneously" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: tmpfs] One pod requesting one prebound PVC should be able to mount volume and write from pod1" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [sig-node] Pods Extended [k8s.io] Pods Set QOS Class should be submitted and removed  [Conformance]" classname="Kubernetes e2e suite" time="22.210681113"></testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] Should scale up GPU pool from 1 [GpuType:nvidia-tesla-p100] [Feature:ClusterSizeAutoscalingGpu]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Proxy version v1 should proxy logs on node using proxy subresource  [Conformance]" classname="Kubernetes e2e suite" time="6.414817713"></testcase>
+      <testcase name="[sig-storage] Pod Disks detach in a disrupted environment [Slow] [Disruptive] when node&#39;s API object is deleted" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] [HPA] Horizontal pod autoscaling (scale resource: Custom Metrics from Stackdriver) should scale down with Custom Metric of type Pod from Stackdriver with Prometheus [Feature:CustomMetricsAutoscaling]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-instrumentation] [Feature:PrometheusMonitoring] Prometheus should scrape container metrics from all nodes." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] EmptyDir volumes volume on default medium should have the correct mode [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="8.317927022"></testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: tmpfs] Two pods mounting a local volume one after the other should be able to write from pod1 and read from pod2" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  Local volume that cannot be mounted [Slow] should fail due to wrong node" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] ResourceQuota should create a ResourceQuota and ensure its status is promptly calculated." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Kubectl create quota should reject quota with invalid scopes" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cluster-lifecycle] Reboot [Disruptive] [Feature:Reboot] each node by switching off the network interface and ensure they function upon switch on" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] EmptyDir volumes should support (non-root,0666,tmpfs) [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="8.297850836"></testcase>
+      <testcase name="[sig-network] Networking Granular Checks: Services [Slow] should function for pod-Service: udp" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] Rescheduler [Serial] should ensure that critical pod is scheduled in case there is no resources available" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] ConfigMap should be consumable from pods in volume with mappings as non-root with FSGroup [NodeFeature:FSGroup]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Loadbalancing: L7 GCE [Slow] [Feature:kubemci] single and multi-cluster ingresses should be able to exist together" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: hostPath] should fail if subpath file is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Storage Policy Based Volume Provisioning [Feature:vsphere] verify VSAN storage capability with valid diskStripes and objectSpaceReservation values is honored for dynamically provisioned pvc using storageclass" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] SchedulerPredicates [Serial] validates resource limits of pods that are allowed to run  [Conformance]" classname="Kubernetes e2e suite" time="85.547029206"></testcase>
+      <testcase name="[sig-scalability] Load capacity [Feature:ManualPerformance] should be able to handle 30 pods per node { ReplicationController} with 0 secrets, 0 configmaps and 2 daemons" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: dir-link-bindmounted] Two pods mounting a local volume at the same time should be able to write from pod1 and read from pod2" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: hostPathSymlink] should fail if subpath file is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-instrumentation] Logging soak [Performance] [Slow] [Disruptive] should survive logging 1KB every 1s seconds, for a duration of 2m0s, scaling up to 1 pods per node" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gcePDPartitioned] should unmount if pod is force deleted while kubelet is down [Disruptive][Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [sig-node] SSH should SSH to all nodes and run commands" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] [HPA] Horizontal pod autoscaling (scale resource: CPU) [sig-autoscaling] [Serial] [Slow] ReplicaSet Should scale from 5 pods to 3 pods and from 3 to 1" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl Port forwarding [k8s.io] With a server listening on localhost [k8s.io] that expects a client request should support a client that connects, sends NO DATA, and disconnects" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-instrumentation] Cluster level logging using Elasticsearch [Feature:Elasticsearch] should check that logs from containers are ingested into Elasticsearch" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Update Demo should do a rolling update of a replication controller  [Conformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Dynamic Provisioning DynamicProvisioner should provision storage with non-default reclaim policy Retain" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volume Disk Size [Feature:vsphere] verify dynamically provisioned pv using storageclass with an invalid disk size fails" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] ConfigMap should be consumable from pods in volume as non-root with FSGroup [NodeFeature:FSGroup]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: tmpfs] Two pods mounting a local volume at the same time should be able to write from pod1 and read from pod2" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes GCEPD should test that deleting the Namespace of a PVC and Pod causes the successful detach of Persistent Disk" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] DNS configMap federations should be able to change federation configuration [Slow][Serial]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-auth] ServiceAccounts should ensure a single API token exists" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath Atomic writer volumes should support subpaths with downward pod" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: nfs] should support restarting containers using file as subpath [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Storage Policy Based Volume Provisioning [Feature:vsphere] verify VSAN storage capability with invalid hostFailuresToTolerate value is not honored for dynamically provisioned pvc using storageclass" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: nfs] should support readOnly file specified in the volumeMount" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: block] [Feature:BlockVolume] Set fsGroup for local volume should set same fsGroup for two pods simultaneously" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Garbage collector should orphan pods created by rc if delete options say so [Conformance]" classname="Kubernetes e2e suite" time="46.237262083"></testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: nfsPVC] should support restarting containers using file as subpath [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: gce-localssd-scsi-fs] [Serial] Two pods mounting a local volume at the same time should be able to write from pod1 and read from pod2" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Projected updates should be reflected in volume [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="28.385552731"></testcase>
+      <testcase name="[sig-apps] Daemon set [Serial] should update pod when spec was updated and update strategy is RollingUpdate [Conformance]" classname="Kubernetes e2e suite" time="48.234274633"></testcase>
+      <testcase name="[sig-api-machinery] Generated clientset should create v1beta1 cronJobs, delete cronJobs, watch cronJobs" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Projected should provide node allocatable (memory) as default memory limit if the limit is not set [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="8.417724925"></testcase>
+      <testcase name="[sig-cluster-lifecycle] Addon update should propagate add-on file changes [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gcePDPVC] should support existing directory" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Services should be able to switch session affinity for NodePort service" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gcePDPartitioned] should unmount if pod is gracefully deleted while kubelet is down [Disruptive][Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Daemon set [Serial] should retry creating failed daemon pods [Conformance]" classname="Kubernetes e2e suite" time="14.11575285"></testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] Should scale up GPU pool from 0 [GpuType:nvidia-tesla-p100] [Feature:ClusterSizeAutoscalingGpu]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scalability] Load capacity [Feature:Performance] should be able to handle 30 pods per node { ReplicationController} with 0 secrets, 0 configmaps and 0 daemons" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scalability] Density [Feature:ManualPerformance] should allow starting 30 pods per node using {extensions Deployment} with 0 secrets, 0 configmaps and 0 daemons" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] StatefulSet [k8s.io] Basic StatefulSet functionality [StatefulSetBasic] should perform canary updates and phased rolling updates of template modifications [Conformance]" classname="Kubernetes e2e suite" time="106.63156385"></testcase>
+      <testcase name="[sig-network] Services should use same NodePort with same port but different protocols" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volume plugin streaming [Slow] Ceph-RBD [Feature:Volumes] should write files of various sizes, verify size, validate content" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Pods should get a host IP [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="24.232539563"></testcase>
+      <testcase name="[sig-apps] ReplicaSet should surface a failure condition on a common issue like exceeded quota" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] ResourceQuota should create a ResourceQuota and capture the life of a secret." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath Atomic writer volumes should support subpaths with projected pod" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] [HPA] Horizontal pod autoscaling (scale resource: CPU) [sig-autoscaling] ReplicationController light Should scale from 1 pod to 2 pods" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: dir-link-bindmounted] One pod requesting one prebound PVC should be able to mount volume and write from pod1" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] EmptyDir volumes should support (root,0777,tmpfs) [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="8.296197269"></testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: hostPath] should support readOnly file specified in the volumeMount" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-service-catalog] [Feature:PodPreset] PodPreset should not modify the pod on conflict" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [sig-node] Security Context [Feature:SecurityContext] should support seccomp alpha unconfined annotation on the container [Feature:Seccomp]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: block] [Feature:BlockVolume] One pod requesting one prebound PVC should be able to mount volume and write from pod1" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scalability] Density [Feature:Performance] should allow starting 30 pods per node using { ReplicationController} with 0 secrets, 0 configmaps and 0 daemons" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Daemon set [Serial] should run and stop complex daemon [Conformance]" classname="Kubernetes e2e suite" time="22.400031096"></testcase>
+      <testcase name="[sig-scalability] Empty [Feature:Empty] starts a pod" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scalability] Load capacity [Feature:ManualPerformance] should be able to handle 30 pods per node {extensions Deployment} with 0 secrets, 0 configmaps and 0 daemons" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] ReplicationController should adopt matching pods on creation" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-instrumentation] Cluster level logging implemented by Stackdriver should ingest logs" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [sig-node] AppArmor load AppArmor profiles can disable an AppArmor profile, using unconfined" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] [Serial] Volume metrics PVController should create unbound pvc count metrics for pvc controller after creating pvc only" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: nfsPVC] should fail for new directories when readOnly specified in the volumeSource" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: emptyDir] should support existing directory" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: hostPath] should fail for new directories when readOnly specified in the volumeSource" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] ReplicaSet should serve a basic image on each replica with a public image  [Conformance]" classname="Kubernetes e2e suite" time="16.337693727"></testcase>
+      <testcase name="[sig-network] Services should be able to change the type from ClusterIP to ExternalName" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gcePDPVC] should support readOnly file specified in the volumeMount" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Kubectl replace should update a single-container pod&#39;s image  [Conformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gluster] should support readOnly directory specified in the volumeMount" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gcePDPVC] should fail if subpath with backstepping is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Ephemeralstorage When pod refers to non-existent ephemeral storage should allow deletion of pod with invalid volume : secret" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Secrets should be consumable from pods in volume with defaultMode set [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="8.319922427"></testcase>
+      <testcase name="[sig-api-machinery] Garbage collector should support cascading deletion of custom resources" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volume Placement test back to back pod creation and deletion with different volume sources on the same worker node" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Loadbalancing: L7 GCE [Slow] [Feature:NEG] rolling update backend pods should not cause service disruption" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Downward API should provide pod name, namespace and IP address as env vars [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="10.337870155"></testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: dir-link] Two pods mounting a local volume one after the other should be able to write from pod1 and read from pod2" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] ESIPP [Slow] [DisabledForLargeClusters] should work from pods" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volumes PD should be mountable with ext4" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volume Provisioning On Clustered Datastore [Feature:vsphere] verify static provisioning on clustered datastore" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [Feature:Example] [k8s.io] Hazelcast should create and scale hazelcast" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Networking should provide Internet connection for containers [Feature:Networking-IPv4]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Services should preserve source pod IP for traffic thru service cluster IP" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] [HPA] Horizontal pod autoscaling (scale resource: CPU) [sig-autoscaling] [Serial] [Slow] Deployment Should scale from 1 pod to 3 pods and from 3 to 5" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volumes PD should be mountable with xfs" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: hostPath] should support creating multiple subpath from same volumes [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-auth] PodSecurityPolicy should forbid pod creation when no PSP is available" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Projected should be consumable from pods in volume [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="8.360947716"></testcase>
+      <testcase name="[sig-storage] Secrets should be consumable from pods in volume with mappings [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="8.348633305"></testcase>
+      <testcase name="[sig-network] NetworkPolicy NetworkPolicy between server and client should support allow-all policy [Feature:NetworkPolicy]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-instrumentation] Stackdriver Monitoring should run Custom Metrics - Stackdriver Adapter for external metrics [Feature:StackdriverExternalMetrics]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Secrets should be consumable from pods in volume with mappings and Item Mode set [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="8.36072171"></testcase>
+      <testcase name="[sig-network] NetworkPolicy NetworkPolicy between server and client should enforce policy based on Ports [Feature:NetworkPolicy]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] should increase cluster size if pods are pending due to host port conflict [Feature:ClusterSizeAutoscalingScaleUp]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Downward API volume should set mode on item file [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="8.316687653"></testcase>
+      <testcase name="[sig-storage] Projected should be consumable from pods in volume with mappings [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="8.515372618"></testcase>
+      <testcase name="[sig-cli] Kubectl alpha client [k8s.io] Kubectl run CronJob should create a CronJob" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Kubectl taint [Serial] should update the taint on a node" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Garbage collector should delete pods created by rc when not orphaning [Conformance]" classname="Kubernetes e2e suite" time="16.462685407"></testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: tmpfs] Set fsGroup for local volume should not set different fsGroups for two pods simultaneously" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] ESIPP [Slow] [DisabledForLargeClusters] should only target nodes with endpoints" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volume Disk Format [Feature:vsphere] verify disk format type - eagerzeroedthick is honored for dynamically provisioned pv using storageclass" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Networking Granular Checks: Pods should function for intra-pod communication: udp [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="45.29052295"></testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gcePDPVC] should support restarting containers using directory as subpath [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volume plugin streaming [Slow] iSCSI [Feature:Volumes] should write files of various sizes, verify size, validate content" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cluster-lifecycle] Reboot [Disruptive] [Feature:Reboot] each node by ordering clean reboot and ensure they function upon restart" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Projected should be consumable in multiple volumes in a pod [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="8.474162139"></testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] should correctly scale down after a node is not needed [Feature:ClusterSizeAutoscalingScaleDown]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] [HPA] Horizontal pod autoscaling (scale resource: Custom Metrics from Stackdriver) should scale down with External Metric with target average value from Stackdriver [Feature:CustomMetricsAutoscaling]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Networking Granular Checks: Services [Slow] should function for pod-Service: http" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Services should create endpoints for unready pods" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: emptyDir] should support readOnly directory specified in the volumeMount" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gluster] should fail if subpath file is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] shouldn&#39;t scale down when non expendable pod is running [Feature:ClusterSizeAutoscalingScaleDown]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [Feature:Example] [k8s.io] Storm should create and stop Zookeeper, Nimbus and Storm worker servers" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Networking Granular Checks: Services [Slow] should function for node-Service: http" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] DNS horizontal autoscaling [Serial] [Slow] kube-dns-autoscaler should scale kube-dns pods when cluster size changed" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: nfsPVC] should unmount if pod is force deleted while kubelet is down [Disruptive][Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scalability] Density [Feature:ManualPerformance] should allow starting 100 pods per node using { ReplicationController} with 0 secrets, 0 configmaps and 0 daemons" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] CronJob should not schedule jobs when suspended [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volumes ConfigMap should be mountable" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Kubectl rolling-update should support rolling-update to same image  [Conformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-service-catalog] [Feature:PodPreset] PodPreset should create a pod preset" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Secrets should be consumable from pods in env vars [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="10.533461984"></testcase>
+      <testcase name="[sig-api-machinery] Initializers [Feature:Initializers] will be set to nil if a patch removes the last pending initializer" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] SchedulerPredicates [Serial] validates MaxPods limit number of pods that are allowed to run [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: nfsPVC] should support creating multiple subpath from same volumes [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Job should run a job to completion when tasks sometimes fail and are not locally restarted" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Services should have session affinity work for service with type clusterIP" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gcePDPartitioned] should support existing single file" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Downward API should provide container&#39;s limits.cpu/memory and requests.cpu/memory as env vars [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="10.388133684"></testcase>
+      <testcase name="[sig-storage] Projected should project all components that make up the projection API [Projection][NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="10.4463348"></testcase>
+      <testcase name="[sig-network] Loadbalancing: L7 GCE [Slow] [Feature:NEG] should conform to Ingress spec" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Cluster size autoscaler scalability [Slow] should scale up twice [Feature:ClusterAutoscalerScalability2]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volumes GlusterFS should be mountable" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: blockfs] Two pods mounting a local volume one after the other should be able to write from pod1 and read from pod2" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] EmptyDir volumes should support (non-root,0644,default) [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="8.335975584"></testcase>
+      <testcase name="[sig-storage] Pod Disks schedule pods each with a PD, delete pod and verify detach [Slow] for RW PD with pod delete grace period of &#34;immediate (0s)&#34;" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cluster-lifecycle] [Feature:BootstrapTokens] should sign the new added bootstrap tokens" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Docker Containers should be able to override the image&#39;s default command and arguments [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="10.261385308"></testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: nfs] should support existing single file" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Kubectl expose should create services for rc  [Conformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes:vsphere should test that a vspehre volume mounted to a pod that is deleted while the kubelet is down unmounts when the kubelet returns [Disruptive]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Variable Expansion should allow composing env vars into new env vars [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="10.278947527"></testcase>
+      <testcase name="[k8s.io] Probing container should be restarted with a docker exec liveness probe with timeout " classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] Should scale up GPU pool from 0 [GpuType:nvidia-tesla-k80] [Feature:ClusterSizeAutoscalingGpu]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] GenericPersistentVolume[Disruptive] When kubelet restarts Should test that a file written to the mount before kubelet restart is readable after restart." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Projected should be consumable from pods in volume as non-root with defaultMode and fsGroup set [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="8.278134695"></testcase>
+      <testcase name="[k8s.io] [Feature:Example] [k8s.io] Liveness liveness pods should be automatically restarted" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Services should be able to switch session affinity for LoadBalancer service with ESIPP off [Slow] [DisabledForLargeClusters]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] HostPath should support r/w [NodeConformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Services should work after restarting apiserver [Disruptive]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] [HPA] Horizontal pod autoscaling (scale resource: CPU) [sig-autoscaling] [Serial] [Slow] ReplicationController Should scale from 5 pods to 3 pods and from 3 to 1 and verify decision stability" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Namespaces [Serial] should ensure that all services are removed when a namespace is deleted." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-auth] [Feature:NodeAuthorizer] Getting a non-existent secret should exit with the Forbidden error, not a NotFound error" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: hostPathSymlink] should support existing directories when readOnly specified in the volumeSource" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: hostPath] should support restarting containers using file as subpath [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: gce-localssd-scsi-fs] [Serial] Set fsGroup for local volume should set fsGroup for one pod" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] ReplicaSet should adopt matching pods on creation and release no longer matching pods" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Pods should allow activeDeadlineSeconds to be updated [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="12.89098738"></testcase>
+      <testcase name="[sig-storage] EmptyDir volumes should support (non-root,0666,default) [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="8.24947243"></testcase>
+      <testcase name="[k8s.io] [sig-node] Kubelet [Serial] [Slow] [k8s.io] [sig-node] experimental resource usage tracking [Feature:ExperimentalResourceUsageTracking] resource tracking for 100 pods per node" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volume Placement should create and delete pod with the same volume source attach/detach to different worker nodes" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Services should provide secure master service  [Conformance]" classname="Kubernetes e2e suite" time="6.229064083"></testcase>
+      <testcase name="[sig-api-machinery] Garbage collector should orphan pods created by rc if deleteOptions.OrphanDependents is nil" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Loadbalancing: L7 GCE [Slow] [Feature:Ingress] should be able to switch between HTTPS and HTTP2 modes" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] DNS should provide DNS for ExternalName services" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gcePDPVC] should fail if non-existent subpath is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Kubectl label should update the label on a resource  [Conformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volumes NFS should be mountable" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] EmptyDir volumes when FSGroup is specified [NodeFeature:FSGroup] nonexistent volume subPath should have the correct mode and owner using FSGroup" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [sig-node] Pod garbage collector [Feature:PodGarbageCollector] [Slow] should handle the creation of 1000 pods" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: dir] Set fsGroup for local volume should set fsGroup for one pod" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: hostPath] should fail if subpath directory is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PV Protection Verify &#34;immediate&#34; deletion of a PV that is not bound to a PVC" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Kubectl run deployment should create a deployment from an image  [Conformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Network Partition [Disruptive] [Slow] [k8s.io] [ReplicationController] should eagerly create replacement pod during network partition when termination grace is non-zero" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-ui] Kubernetes Dashboard should check that the kubernetes-dashboard instance is alive" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] ResourceQuota should create a ResourceQuota and capture the life of a persistent volume claim with a storage class. [sig-storage]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes GCEPD should test that deleting a PVC before the pod does not cause pod deletion to fail on PD detach" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Networking should provide Internet connection for containers [Feature:Networking-IPv6][Experimental]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [sig-node] Security Context [Feature:SecurityContext] should support pod.Spec.SecurityContext.RunAsUser" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cluster-lifecycle] Reboot [Disruptive] [Feature:Reboot] each node by dropping all inbound packets for a while and ensure they function afterwards" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [Feature:Example] [k8s.io] Downward API should create a pod that prints his name and namespace" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] should increase cluster size if pod requesting volume is pending [Feature:ClusterSizeAutoscalingScaleUp]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Networking Granular Checks: Services [Slow] should update endpoints: udp" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] ESIPP [Slow] [DisabledForLargeClusters] should work for type=NodePort" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gcePDPVC] should support existing single file" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] EmptyDir volumes should support (root,0644,default) [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="8.298710222"></testcase>
+      <testcase name="[sig-storage] Flexvolumes [Disruptive] should be mountable when non-attachable" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PV Protection Verify that PV bound to a PVC is not removed immediately" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  Local volume provisioner [Serial] should create and recreate local persistent volume" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Downward API [Serial] [Disruptive] [NodeFeature:EphemeralStorage] Downward API tests for local ephemeral storage should provide default limits.ephemeral-storage from node allocatable" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Storage Policy Based Volume Provisioning [Feature:vsphere] verify VSAN storage capability with valid diskStripes and objectSpaceReservation values and a VSAN datastore is honored for dynamically provisioned pvc using storageclass" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [sig-node] Events should be sent by kubelets and the scheduler about pods scheduling and running  [Conformance]" classname="Kubernetes e2e suite" time="28.387714384"></testcase>
+      <testcase name="[k8s.io] Cluster size autoscaler scalability [Slow] CA ignores unschedulable pods while scheduling schedulable pods [Feature:ClusterAutoscalerScalability6]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [Feature:Example] [k8s.io] RethinkDB should create and stop rethinkdb servers" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Docker Containers should use the image defaults if command and args are blank [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="8.317780999"></testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: nfs] should support existing directory" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: nfs] should fail if subpath with backstepping is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-instrumentation] Cluster level logging implemented by Stackdriver [Feature:StackdriverLogging] [Soak] should ingest logs from applications running for a prolonged amount of time" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cluster-lifecycle] Upgrade [Feature:Upgrade] cluster upgrade should maintain a functioning cluster [Feature:ClusterUpgrade]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Sysctls [NodeFeature:Sysctls] should support sysctls" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Projected should be consumable from pods in volume with mappings and Item mode set [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="8.286522336"></testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: hostPath] should support existing directory" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [sig-node] Kubelet [Serial] [Slow] [k8s.io] [sig-node] regular resource usage tracking resource tracking for 100 pods per node" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Networking Granular Checks: Services [Slow] should update nodePort: http [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] AdmissionWebhook Should not be able to prevent deleting validating-webhook-configurations or mutating-webhook-configurations" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] [HPA] Horizontal pod autoscaling (scale resource: Custom Metrics from Stackdriver) should scale down with Custom Metric of type Object from Stackdriver [Feature:CustomMetricsAutoscaling]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Services should prevent NodePort collisions" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Projected should be consumable from pods in volume [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="10.48396147"></testcase>
+      <testcase name="[sig-storage] [Serial] Volume metrics should create volume metrics with the correct PVC ref" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl Port forwarding [k8s.io] With a server listening on 0.0.0.0 [k8s.io] that expects a client request should support a client that connects, sends NO DATA, and disconnects" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] CronJob should not schedule new jobs when ForbidConcurrent [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] [HPA] Horizontal pod autoscaling (scale resource: CPU) [sig-autoscaling] [Serial] [Slow] ReplicaSet Should scale from 1 pod to 3 pods and from 3 to 5" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volumes Azure Disk [Feature:Volumes] should be mountable [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Generated clientset should create pods, set the deletionTimestamp and deletionGracePeriodSeconds of the pod" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Variable Expansion should allow substituting values in a volume subpath [Feature:VolumeSubpathEnvExpansion][NodeAlphaFeature:VolumeSubpathEnvExpansion]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Secrets should be consumable via the environment [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="10.339912217"></testcase>
+      <testcase name="[sig-storage] Projected should provide container&#39;s cpu request [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="8.299742628"></testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: nfs] should support restarting containers using directory as subpath [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Downward API volume should provide podname only [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="8.359871268"></testcase>
+      <testcase name="[sig-storage] Volumes iSCSI [Feature:Volumes] should be mountable" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] LimitRange should create a LimitRange with defaults and ensure pod has those defaults applied." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volume Provisioning on Datastore [Feature:vsphere] verify dynamically provisioned pv using storageclass fails on an invalid datastore" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [sig-node] Security Context [Feature:SecurityContext] should support container.SecurityContext.RunAsUser And container.SecurityContext.RunAsGroup [Feature:RunAsGroup]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: blockfs] Set fsGroup for local volume should set different fsGroup for second pod if first pod is deleted" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: hostPath] should fail if non-existent subpath is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Daemon set [Serial] should not update pod when spec was updated and update strategy is OnDelete" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] InitContainer [NodeConformance] should not start app containers if init containers fail on a RestartAlways pod" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] ConfigMap binary data should be reflected in volume [NodeConformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] Should scale down GPU pool from 1 [GpuType:nvidia-tesla-k80] [Feature:ClusterSizeAutoscalingGpu]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gcePDPartitioned] should support file as subpath" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Pods should be submitted and removed [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="21.830858627"></testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: hostPathSymlink] should support creating multiple subpath from same volumes [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Projected should provide podname as non-root with fsgroup and defaultMode [NodeFeature:FSGroup]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Dynamic Provisioning DynamicProvisioner Default should be disabled by removing the default annotation [Serial] [Disruptive]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Deployment deployment should support rollback" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] should correctly scale down after a node is not needed when there is non autoscaled pool[Feature:ClusterSizeAutoscalingScaleDown]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Pods should support remote command execution over websockets [NodeConformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Deployment iterative rollouts should eventually progress" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] NetworkPolicy NetworkPolicy between server and client should enforce policy based on PodSelector [Feature:NetworkPolicy]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Kubectl describe should check if kubectl describe prints relevant information for rc and pods  [Conformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cluster-lifecycle] gpu Upgrade [Feature:GPUUpgrade] master upgrade should NOT disrupt gpu pod [Feature:GPUMasterUpgrade]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: dir-link-bindmounted] Two pods mounting a local volume one after the other should be able to write from pod1 and read from pod2" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] KubeletManagedEtcHosts should test kubelet managed /etc/hosts file [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="58.491199397"></testcase>
+      <testcase name="[sig-api-machinery] Watchers should observe add, update, and delete watch notifications on configmaps [Conformance]" classname="Kubernetes e2e suite" time="66.794581593"></testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: nfs] should fail if subpath file is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] DNS horizontal autoscaling [DisabledForLargeClusters] kube-dns-autoscaler should scale kube-dns pods in both nonfaulty and faulty scenarios" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] shouldn&#39;t trigger additional scale-ups during processing scale-up [Feature:ClusterSizeAutoscalingScaleUp]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Services should only allow access from service loadbalancer source ranges [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-instrumentation] Stackdriver Monitoring should run Custom Metrics - Stackdriver Adapter for old resource model [Feature:StackdriverCustomMetrics]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Kubectl apply apply set/view last-applied" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: hostPathSymlink] should fail for new directories when readOnly specified in the volumeSource" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Cluster size autoscaler scalability [Slow] shouldn&#39;t scale down with underutilized nodes due to host port conflicts [Feature:ClusterAutoscalerScalability5]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Projected should update labels on modification [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="26.75002219"></testcase>
+      <testcase name="[sig-apps] DisruptionController evictions: enough pods, absolute =&gt; should allow an eviction" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] StatefulSet [k8s.io] Basic StatefulSet functionality [StatefulSetBasic] should perform rolling updates and roll backs of template modifications [Conformance]" classname="Kubernetes e2e suite" time="148.806980643"></testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] should create new node if there is no node for node selector [Feature:ClusterSizeAutoscalingScaleWithNAP]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Daemon set [Serial] should run and stop simple daemon [Conformance]" classname="Kubernetes e2e suite" time="23.915983777"></testcase>
+      <testcase name="[sig-cluster-lifecycle] Upgrade [Feature:Upgrade] master upgrade should maintain a functioning cluster [Feature:MasterUpgrade]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: nfsPVC] should unmount if pod is gracefully deleted while kubelet is down [Disruptive][Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] EmptyDir volumes when FSGroup is specified [NodeFeature:FSGroup] volume on default medium should have the correct mode using FSGroup" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: dir-link] Set fsGroup for local volume should set fsGroup for one pod" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] EmptyDir volumes should support (root,0666,default) [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="8.254661937"></testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: dir] Set fsGroup for local volume should not set different fsGroups for two pods simultaneously" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Servers with support for Table transformation should return chunks of table results for list calls" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] [Serial] Volume metrics PVController should create unbound pv count metrics for pvc controller after creating pv only" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gcePDPartitioned] should fail if subpath with backstepping is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] NFSPersistentVolumes[Disruptive][Flaky] when kubelet restarts Should test that a volume mounted to a pod that is deleted while the kubelet is down unmounts when the kubelet returns." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] ConfigMap should be consumable from pods in volume as non-root with defaultMode and fsGroup set [NodeFeature:FSGroup]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-instrumentation] MetricsGrabber should grab all metrics from a ControllerManager." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Kubectl run rc should create an rc from an image  [Conformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: hostPathSymlink] should fail if non-existent subpath is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: emptyDir] should support existing directories when readOnly specified in the volumeSource" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: hostPath] should unmount if pod is gracefully deleted while kubelet is down [Disruptive][Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-instrumentation] Stackdriver Monitoring should run Stackdriver Metadata Agent [Feature:StackdriverMetadataAgent]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: hostPathSymlink] should support restarting containers using directory as subpath [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] Should scale up GPU pool from 1 [GpuType:nvidia-tesla-v100] [Feature:ClusterSizeAutoscalingGpu]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Loadbalancing: L7 GCE [Slow] [Feature:Ingress] should update ingress while sync failures occur on other ingresses" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] CSI Volumes CSI plugin test using CSI driver: [Feature: GCE PD CSI Plugin] gcePD should provision storage" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: nfsPVC] should support existing directories when readOnly specified in the volumeSource" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Network Partition [Disruptive] [Slow] [k8s.io] [Job] should create new pods when node is partitioned" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Pods should support retrieving logs from the container over websockets [NodeConformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volume Disk Format [Feature:vsphere] verify disk format type - zeroedthick is honored for dynamically provisioned pv using storageclass" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Update Demo should create and stop a replication controller  [Conformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-auth] PodSecurityPolicy should allow pods under the privileged policy.PodSecurityPolicy" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: nfs] should unmount if pod is gracefully deleted while kubelet is down [Disruptive][Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gluster] should unmount if pod is force deleted while kubelet is down [Disruptive][Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: emptyDir] should fail if subpath directory is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Projected should be consumable from pods in volume as non-root with defaultMode and fsGroup set [NodeFeature:FSGroup]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] StatefulSet [k8s.io] Basic StatefulSet functionality [StatefulSetBasic] Should recreate evicted statefulset [Conformance]" classname="Kubernetes e2e suite" time="22.674467789"></testcase>
+      <testcase name="[sig-network] Services should be able to switch session affinity for LoadBalancer service with ESIPP on [Slow] [DisabledForLargeClusters]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] EmptyDir wrapper volumes should not conflict" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Network Partition [Disruptive] [Slow] [k8s.io] Pods should return to running and ready state after network partition is healed All pods on the unreachable node should be marked as NotReady upon the node turn NotReady AND all pods should be mark back to Ready when the node get back to Ready before pod eviction timeout" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: nfsPVC] should support existing single file" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: dir-bindmounted] Set fsGroup for local volume should set fsGroup for one pod" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] Should not scale GPU pool up if pod does not require GPUs [GpuType:nvidia-tesla-k80] [Feature:ClusterSizeAutoscalingGpu]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Services [Feature:GCEAlphaFeature][Slow] should be able to create and tear down a standard-tier load balancer [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Initializers [Feature:Initializers] don&#39;t cause replicaset controller creating extra pods if the initializer is not handled [Serial]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Networking Granular Checks: Pods should function for node-pod communication: udp [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="45.15541005"></testcase>
+      <testcase name="[k8s.io] Probing container should have monotonically increasing restart count [Slow][NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="153.304794852"></testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gcePDPartitioned] should support readOnly directory specified in the volumeMount" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gcePDPVC] should fail for new directories when readOnly specified in the volumeSource" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scalability] Density [Feature:HighDensityPerformance] should allow starting 95 pods per node using { ReplicationController} with 0 secrets, 0 configmaps and 0 daemons" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Downward API volume should provide container&#39;s cpu request [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="8.344757943"></testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  StatefulSet with pod anti-affinity should use volumes spread across nodes" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [sig-node] Security Context [Feature:SecurityContext] should support seccomp alpha unconfined annotation on the pod [Feature:Seccomp]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] NetworkPolicy NetworkPolicy between server and client should enforce policy based on NamespaceSelector [Feature:NetworkPolicy]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Watchers should observe an object deletion if it stops meeting the requirements of the selector [Conformance]" classname="Kubernetes e2e suite" time="16.424620641"></testcase>
+      <testcase name="[sig-autoscaling] [HPA] Horizontal pod autoscaling (scale resource: Custom Metrics from Stackdriver) should scale up with two External metrics from Stackdriver [Feature:CustomMetricsAutoscaling]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gcePDPartitioned] should support existing directories when readOnly specified in the volumeSource" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes NFS with multiple PVs and PVCs all in same ns should create 4 PVs and 2 PVCs: test write access [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] ConfigMap should be consumable via the environment [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="10.298412021"></testcase>
+      <testcase name="[sig-network] ESIPP [Slow] [DisabledForLargeClusters] should work for type=LoadBalancer" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] SchedulerPredicates [Serial] validates that NodeSelector is respected if matching  [Conformance]" classname="Kubernetes e2e suite" time="86.606074354"></testcase>
+      <testcase name="[sig-storage] PersistentVolumes [Feature:ReclaimPolicy] [sig-storage] persistentvolumereclaim:vsphere should retain persistent volume when reclaimPolicy set to retain when associated claim is deleted" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] [Feature:GPUDevicePlugin] run Nvidia GPU Device Plugin tests on Container Optimized OS only" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: nfs] should unmount if pod is force deleted while kubelet is down [Disruptive][Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Pod Disks schedule a pod w/ RW PD(s) mounted to 1 or more containers, write to PD, verify content, delete pod, and repeat in rapid succession [Slow] using 1 containers and 2 PDs" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Garbage collector should orphan RS created by deployment when deleteOptions.PropagationPolicy is Orphan [Conformance]" classname="Kubernetes e2e suite" time="37.001784658"></testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: nfs] should support readOnly directory specified in the volumeMount" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] DisruptionController evictions: maxUnavailable deny evictions, integer =&gt; should not allow an eviction" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: nfs] should support existing directories when readOnly specified in the volumeSource" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Projected optional updates should be reflected in volume [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="94.282691057"></testcase>
+      <testcase name="[sig-network] Services should work after restarting kube-proxy [Disruptive]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] NFSPersistentVolumes[Disruptive][Flaky] when kube-controller-manager restarts should delete a bound PVC from a clientPod, restart the kube-control-manager, and ensure the kube-controller-manager does not crash" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Services should be able to create an internal type load balancer [Slow] [DisabledForLargeClusters]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-auth] PodSecurityPolicy should enforce the restricted extensions.PodSecurityPolicy" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: nfsPVC] should fail if subpath file is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: tmpfs] One pod requesting one prebound PVC should be able to mount volume and read from pod1" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-auth] [Feature:NodeAuthorizer] A node shouldn&#39;t be able to delete another node" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volume FStype [Feature:vsphere] verify invalid fstype" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] ReplicationController should surface a failure condition on a common issue like exceeded quota" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes [Feature:ReclaimPolicy] [sig-storage] persistentvolumereclaim:vsphere should not detach and unmount PV when associated pvc with delete as reclaimPolicy is deleted when it is in use by the pod" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Dynamic Provisioning DynamicProvisioner deletion should be idempotent" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: hostPathSymlink] should fail if subpath directory is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cluster-lifecycle] Nodes [Disruptive] Resize [Slow] should be able to add nodes" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] [HPA] Horizontal pod autoscaling (scale resource: Custom Metrics from Stackdriver) should scale down with Custom Metric of type Pod from Stackdriver [Feature:CustomMetricsAutoscaling]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gluster] should support restarting containers using directory as subpath [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  Local volume provisioner [Serial] should not create local persistent volume for filesystem volume that was not bind mounted" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Projected should be consumable from pods in volume with mappings [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="8.347069683"></testcase>
+      <testcase name="[sig-auth] [Feature:NodeAuthorizer] Getting an existing secret should exit with the Forbidden error" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Network Partition [Disruptive] [Slow] [k8s.io] [StatefulSet] should not reschedule stateful pods if there is a network partition [Slow] [Disruptive]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] ResourceQuota should create a ResourceQuota and capture the life of a service." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Ephemeralstorage When pod refers to non-existent ephemeral storage should allow deletion of pod with invalid volume : configmap" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PVC Protection Verify &#34;immediate&#34; deletion of a PVC that is not in active use by a pod" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] ConfigMap optional updates should be reflected in volume [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="26.735307381"></testcase>
+      <testcase name="[k8s.io] Cluster size autoscaler scalability [Slow] should scale up at all [Feature:ClusterAutoscalerScalability1]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scalability] Load capacity [Feature:ManualPerformance] should be able to handle 30 pods per node {batch Job} with 0 secrets, 0 configmaps and 0 daemons" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Loadbalancing: L7 GCE [Slow] [Feature:kubemci] should create ingress with backend HTTPS" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Proxy server should support proxy with --port 0  [Conformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: hostPathSymlink] should unmount if pod is gracefully deleted while kubelet is down [Disruptive][Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: tmpfs] Set fsGroup for local volume should set same fsGroup for two pods simultaneously" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Networking Granular Checks: Pods should function for node-pod communication: http [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="39.21196373"></testcase>
+      <testcase name="[k8s.io] EquivalenceCache [Serial] validates GeneralPredicates is properly invalidated when a pod is scheduled [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PVC Protection Verify that PVC in active use by a pod is not removed immediately" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] [Serial] Volume metrics should create prometheus metrics for volume provisioning and attach/detach" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] EmptyDir volumes should support (root,0777,default) [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="8.286048313"></testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: hostPathSymlink] should support non-existent path" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Dynamic Provisioning Block volume provisioning [Feature:BlockVolume] should create and delete block persistent volumes" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] shouldn&#39;t scale up when expendable pod is created [Feature:ClusterSizeAutoscalingScaleUp]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: emptyDir] should fail if subpath with backstepping is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-auth] Metadata Concealment should run a check-metadata-concealment job to completion" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Downward API volume should provide node allocatable (cpu) as default cpu limit if the limit is not set [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="8.325650555"></testcase>
+      <testcase name="[sig-scheduling] ResourceQuota should create a ResourceQuota and capture the life of a replica set." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] vsphere cloud provider stress [Feature:vsphere] vsphere stress tests" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Storage Policy Based Volume Provisioning [Feature:vsphere] verify clean up of stale dummy VM for dynamically provisioned pvc using SPBM policy" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] ResourceQuota should create a ResourceQuota and capture the life of a pod." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Loadbalancing: L7 GCE [Slow] [Feature:Ingress] should conform to Ingress spec" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Dynamic Provisioning DynamicProvisioner Default should create and delete default persistent volumes [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] CronJob should delete successful finished jobs with limit of one successful job" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Firewall rule [Slow] [Serial] should create valid firewall rules for LoadBalancer type service" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-instrumentation] MetricsGrabber should grab all metrics from a Scheduler." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] should be able to scale down when rescheduling a pod is required and pdb allows for it[Feature:ClusterSizeAutoscalingScaleDown]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-auth] ServiceAccounts should allow opting out of API token automount  [Conformance]" classname="Kubernetes e2e suite" time="6.869466804"></testcase>
+      <testcase name="[sig-cluster-lifecycle] [Feature:BootstrapTokens] should delete the signed bootstrap tokens from clusterInfo ConfigMap when bootstrap token is deleted" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] AdmissionWebhook Should deny crd creation" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] shouldn&#39;t add new node group if not needed [Feature:ClusterSizeAutoscalingScaleWithNAP]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] ClusterDns [Feature:Example] should create pod that uses dns" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: nfs] should support file as subpath" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cluster-lifecycle] [Feature:BootstrapTokens] should delete the token secret when the secret expired" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Deployment deployment reaping should cascade to its replica sets and pods" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] DaemonRestart [Disruptive] Kubelet should not restart containers across restart" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Networking IPerf IPv4 [Experimental] [Feature:Networking-IPv4] [Slow] [Feature:Networking-Performance] should transfer ~ 1GB onto the service endpoint 1 servers (maximum of 1 clients)" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] InitContainer [NodeConformance] should invoke init containers on a RestartNever pod" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Dynamic Provisioning DynamicProvisioner should not provision a volume in an unmanaged GCE zone." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-instrumentation] Stackdriver Monitoring should have accelerator metrics [Feature:StackdriverAcceleratorMonitoring]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] Should scale down GPU pool from 1 [GpuType:nvidia-tesla-v100] [Feature:ClusterSizeAutoscalingGpu]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] ResourceQuota should verify ResourceQuota with terminating scopes." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gcePDPartitioned] should support readOnly file specified in the volumeMount" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scalability] Density [Feature:ManualPerformance] should allow starting 50 pods per node using { ReplicationController} with 0 secrets, 0 configmaps and 0 daemons" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] DisruptionController should update PodDisruptionBudget status" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Servers with support for Table transformation should return generic metadata details across all namespaces for nodes" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scalability] Load capacity [Feature:ManualPerformance] should be able to handle 30 pods per node { Random} with 0 secrets, 0 configmaps and 0 daemons" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: hostPathSymlink] should fail if subpath with backstepping is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: dir] Two pods mounting a local volume one after the other should be able to write from pod1 and read from pod2" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Job should exceed backoffLimit" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gcePDPartitioned] should fail if non-existent subpath is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] NetworkPolicy NetworkPolicy between server and client should enforce multiple, stacked policies with overlapping podSelectors [Feature:NetworkPolicy]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Loadbalancing: L7 GCE [Slow] [Feature:kubemci] should support https-only annotation" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] EmptyDir wrapper volumes should not cause race condition when used for configmaps [Serial] [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] HostPath should support existing single file subPath" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] Multi-AZ Cluster Volumes [sig-storage] should only be allowed to provision PDs in zones where nodes exist" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Networking Granular Checks: Services [Slow] should function for client IP based session affinity: http" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  Pod with node different from PV&#39;s NodeAffinity should fail scheduling due to different NodeAffinity" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volume expand [Slow] Verify if editing PVC allows resize" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] CronJob should remove from active list jobs that have been deleted" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gluster] should support existing directories when readOnly specified in the volumeSource" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: hostPathSymlink] should support existing directory" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: gce-localssd-scsi-fs] [Serial] Set fsGroup for local volume should not set different fsGroups for two pods simultaneously" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] StatefulSet [k8s.io] Basic StatefulSet functionality [StatefulSetBasic] should implement legacy replacement when the update strategy is OnDelete" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cluster-lifecycle] HA-master [Feature:HAMaster] survive addition/removal replicas multizone workers [Serial][Disruptive]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] should increase cluster size if pending pods are small and there is another node pool that is not autoscaled [Feature:ClusterSizeAutoscalingScaleUp]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gluster] should support existing directory" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gcePDPartitioned] should support restarting containers using directory as subpath [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-auth] Advanced Audit should audit API calls [DisabledForLargeClusters]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Networking Granular Checks: Services [Slow] should function for node-Service: udp" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-instrumentation] [Feature:PrometheusMonitoring] Prometheus should contain correct container CPU metric." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] GenericPersistentVolume[Disruptive] When kubelet restarts Should test that a volume mounted to a pod that is deleted while the kubelet is down unmounts when the kubelet returns." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Kubectl create quota should create a quota without scopes" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volume FStype [Feature:vsphere] verify fstype - default value should be ext4" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] SchedulerPredicates [Serial] validates that required NodeAffinity setting is respected if matching" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath Atomic writer volumes should support subpaths with configmap pod with mountPath of existing file" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-auth] [Feature:NodeAuthorizer] Getting a non-existent configmap should exit with the Forbidden error, not a NotFound error" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] CustomResourceDefinition Watch CustomResourceDefinition Watch watch on custom resource definition objects" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gcePDPVC] should support existing directories when readOnly specified in the volumeSource" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Sysctls [NodeFeature:Sysctls] should reject invalid sysctls" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cluster-lifecycle] Restart [Disruptive] should restart all nodes and ensure all nodes and pods recover" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: blockfs] Set fsGroup for local volume should not set different fsGroups for two pods simultaneously" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] SchedulerPriorities [Serial] Pod should avoid to schedule to node that have avoidPod annotation" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volumes Ceph RBD [Feature:Volumes] should be mountable" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volume Placement should create and delete pod with multiple volumes from same datastore" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] ConfigMap should be consumable via environment variable [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="10.263077564"></testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] should correctly scale down after a node is not needed and one node is broken [Feature:ClusterSizeAutoscalingScaleDown]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cluster-lifecycle] kube-proxy migration [Feature:KubeProxyDaemonSetMigration] Upgrade kube-proxy from static pods to a DaemonSet should maintain a functioning cluster [Feature:KubeProxyDaemonSetUpgrade]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: emptyDir] should fail if subpath file is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Cluster size autoscaler scalability [Slow] should scale down underutilized nodes [Feature:ClusterAutoscalerScalability4]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] StatefulSet [k8s.io] Basic StatefulSet functionality [StatefulSetBasic] should provide basic identity" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: hostPath] should support existing directories when readOnly specified in the volumeSource" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes NFS with Single PV - PVC pairs create a PV and a pre-bound PVC: test write access" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: block] [Feature:BlockVolume] One pod requesting one prebound PVC should be able to mount volume and read from pod1" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [sig-node] Security Context [Feature:SecurityContext] should support pod.Spec.SecurityContext.RunAsUser And pod.Spec.SecurityContext.RunAsGroup [Feature:RunAsGroup]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] SchedulerPredicates [Serial] validates that NodeSelector is respected if not matching  [Conformance]" classname="Kubernetes e2e suite" time="83.539685635"></testcase>
+      <testcase name="[sig-scheduling] SchedulerPredicates [Serial] validates that taints-tolerations is respected if not matching" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Initializers [Feature:Initializers] should dynamically register and apply initializers to pods [Serial]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] NetworkPolicy NetworkPolicy between server and client should support a &#39;default-deny&#39; policy [Feature:NetworkPolicy]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] vcp at scale [Feature:vsphere]  vsphere scale tests" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gluster] should fail if subpath directory is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Node Poweroff [Feature:vsphere] [Slow] [Disruptive] verify volume status after node power off" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Projected should be consumable in multiple volumes in the same pod [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="8.294619869"></testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gcePDPartitioned] should support non-existent path" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] AdmissionWebhook Should be able to deny pod and configmap creation" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Projected optional updates should be reflected in volume [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="28.805360716"></testcase>
+      <testcase name="[sig-network] Loadbalancing: L7 GCE [Slow] [Feature:Ingress] multicluster ingress should get instance group annotation" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Docker Containers should be able to override the image&#39;s default arguments (docker cmd) [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="8.313561869"></testcase>
+      <testcase name="[sig-storage] Volume Placement should create and delete pod with multiple volumes from different datastore" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cluster-lifecycle] [Feature:BootstrapTokens] should not delete the token secret when the secret is not expired" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: emptyDir] should support existing single file" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volumes Cinder [Feature:Volumes] should be mountable" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: emptyDir] should unmount if pod is force deleted while kubelet is down [Disruptive][Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Loadbalancing: L7 GCE [Slow] [Feature:Ingress] should create ingress with pre-shared certificate" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-auth] [Feature:NodeAuthorizer] A node shouldn&#39;t be able to create another node" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes NFS with Single PV - PVC pairs create a PVC and a pre-bound PV: test write access" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: block] [Feature:BlockVolume] Set fsGroup for local volume should set different fsGroup for second pod if first pod is deleted" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Kubectl api-versions should check if v1 is in available api versions  [Conformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl Port forwarding [k8s.io] With a server listening on localhost should support forwarding over websockets" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gcePDPVC] should fail if subpath directory is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Service endpoints latency should not be very high  [Conformance]" classname="Kubernetes e2e suite" time="33.076026541"></testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] should increase cluster size if pod requesting EmptyDir volume is pending [Feature:ClusterSizeAutoscalingScaleUp]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scalability] Density [Feature:ManualPerformance] should allow starting 30 pods per node using {extensions Deployment} with 0 secrets, 2 configmaps and 0 daemons" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: nfsPVC] should support file as subpath" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: dir-link-bindmounted] Set fsGroup for local volume should set fsGroup for one pod" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scalability] Density [Feature:ManualPerformance] should allow starting 30 pods per node using { ReplicationController} with 0 secrets, 0 configmaps and 2 daemons" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [sig-node] Pods Extended [k8s.io] Delete Grace Period should be submitted and removed  [Flaky] [Conformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gluster] should support non-existent path" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: block] [Feature:BlockVolume] Set fsGroup for local volume should set fsGroup for one pod" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [sig-node] Security Context [Feature:SecurityContext] should support container.SecurityContext.RunAsUser" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gcePDPartitioned] should fail if subpath directory is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Probing container with readiness probe that fails should never be ready and never restart [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="82.270396551"></testcase>
+      <testcase name="[sig-network] Services should serve multiport endpoints from pods  [Conformance]" classname="Kubernetes e2e suite" time="27.643381689"></testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: hostPath] should support non-existent path" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] PodPriorityResolution [Serial] [Feature:PodPreemption] validates critical system priorities are created and resolved" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] ReplicationController should serve a basic image on each replica with a private image" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] StatefulSet [k8s.io] Deploy clustered applications [Feature:StatefulSet] [Slow] should creating a working zookeeper cluster" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-instrumentation] Stackdriver Monitoring should have cluster metrics [Feature:StackdriverMonitoring]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volume plugin streaming [Slow] GlusterFS should write files of various sizes, verify size, validate content" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: dir] One pod requesting one prebound PVC should be able to mount volume and read from pod1" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Kubectl version should check is all data is printed  [Conformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] SchedulerPreemption [Serial] [Feature:PodPreemption] validates basic preemption works" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-instrumentation] Stackdriver Monitoring should run Custom Metrics - Stackdriver Adapter for new resource model [Feature:StackdriverCustomMetrics]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-instrumentation] Cadvisor should be healthy on every node." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Deployment deployment should support rollover" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Downward API should provide default limits.cpu/memory from node allocatable [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="10.37117114"></testcase>
+      <testcase name="[sig-network] Loadbalancing: L7 [Slow] Nginx should conform to Ingress spec" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] GenericPersistentVolume[Disruptive] When kubelet restarts Should test that a volume mounted to a pod that is force deleted while the kubelet is down unmounts when the kubelet returns." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] shouldn&#39;t be able to scale down when rescheduling a pod is required, but pdb doesn&#39;t allow drain[Feature:ClusterSizeAutoscalingScaleDown]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volumes vsphere [Feature:Volumes] should be mountable" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] DisruptionController evictions: enough pods, replicaSet, percentage =&gt; should allow an eviction" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-instrumentation] MetricsGrabber should grab all metrics from API server." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scalability] Load capacity [Feature:ManualPerformance] should be able to handle 30 pods per node { Random} with 0 secrets, 0 configmaps and 0 daemons with quotas" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Garbage collector should support orphan deletion of custom resources" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Pod Disks should be able to delete a non-existent PD without error" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: block] [Feature:BlockVolume] Set fsGroup for local volume should not set different fsGroups for two pods simultaneously" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Simple pod should support exec" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Projected should be consumable from pods in volume with mappings and Item Mode set [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="8.344985446"></testcase>
+      <testcase name="[sig-network] DNS should provide DNS for the cluster  [Conformance]" classname="Kubernetes e2e suite" time="28.104253436"></testcase>
+      <testcase name="[k8s.io] [sig-node] kubelet [k8s.io] [sig-node] Clean up pods on node kubelet should be able to delete 10 pods per node in 1m0s." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: emptyDir] should fail if non-existent subpath is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: dir-bindmounted] One pod requesting one prebound PVC should be able to mount volume and write from pod1" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cluster-lifecycle] ingress Downgrade [Feature:IngressDowngrade] ingress downgrade should maintain a functioning ingress" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [sig-node] Security Context [Feature:SecurityContext] should support volume SELinux relabeling" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] Should scale down GPU pool from 1 [GpuType:nvidia-tesla-p100] [Feature:ClusterSizeAutoscalingGpu]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Deployment RollingUpdateDeployment should delete old pods and create new ones" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: block] [Feature:BlockVolume] Two pods mounting a local volume at the same time should be able to write from pod1 and read from pod2" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] CSI Volumes CSI plugin test using CSI driver: hostPath should provision storage" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gcePDPartitioned] should support creating multiple subpath from same volumes [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] AdmissionWebhook Should mutate configmap" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Daemon set [Serial] should rollback without unnecessary restarts [Conformance]" classname="Kubernetes e2e suite" time="6.292837681">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] ConfigMap should be consumable from pods in volume with mappings [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="8.390787789"></testcase>
+      <testcase name="[sig-apps] Job should delete a job" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Servers with support for Table transformation should return pod details" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] EmptyDir volumes when FSGroup is specified [NodeFeature:FSGroup] new files should be created with FSGroup ownership when container is root" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: dir-bindmounted] Set fsGroup for local volume should set different fsGroup for second pod if first pod is deleted" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] InitContainer [NodeConformance] should not start app containers and fail the pod if init containers fail on a RestartNever pod" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Downward API volume should set DefaultMode on files [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="8.349462267"></testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Kubectl run job should create a job from an image when restart is OnFailure  [Conformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl Port forwarding [k8s.io] With a server listening on localhost [k8s.io] that expects a client request should support a client that connects, sends DATA, and disconnects" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Services should be able to up and down services" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] Multi-AZ Cluster Volumes [sig-storage] should schedule pods in the same zones as statically provisioned PVs" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Dynamic Provisioning DynamicProvisioner Default should be disabled by changing the default annotation [Serial] [Disruptive]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Storage Policy Based Volume Provisioning [Feature:vsphere] verify VSAN storage capability with valid hostFailuresToTolerate and cacheReservation values is honored for dynamically provisioned pvc using storageclass" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Loadbalancing: L7 GCE [Slow] [Feature:NEG] should be able to switch between IG and NEG modes" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] AdmissionWebhook Should mutate custom resource" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [sig-node] PreStop should call prestop when killing a pod  [Conformance]" classname="Kubernetes e2e suite" time="51.62883564"></testcase>
+      <testcase name="[k8s.io] Probing container should be restarted with a /healthz http liveness probe [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="30.618252257"></testcase>
+      <testcase name="[sig-storage] Volume Attach Verify [Feature:vsphere][Serial][Disruptive] verify volume remains attached after master kubelet restart" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  Stress with local volume provisioner [Serial] should use be able to process many pods and reuse local volumes" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: nfs] should fail if non-existent subpath is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] should disable node pool autoscaling [Feature:ClusterSizeAutoscalingScaleUp]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: dir-bindmounted] Set fsGroup for local volume should not set different fsGroups for two pods simultaneously" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Deployment test Deployment ReplicaSet orphaning and adoption regarding controllerRef" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: nfs] should fail if subpath directory is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Dynamic Provisioning DynamicProvisioner should provision storage with different parameters [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Node Unregister [Feature:vsphere] [Slow] [Disruptive] node unregister" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Pods should be updated [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="24.815830998"></testcase>
+      <testcase name="[sig-instrumentation] [Feature:PrometheusMonitoring] Prometheus should successfully scrape all targets" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gcePDPVC] should unmount if pod is gracefully deleted while kubelet is down [Disruptive][Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gluster] should support restarting containers using file as subpath [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Sysctls [NodeFeature:Sysctls] should not launch unsafe, but not explicitly enabled sysctls on the node" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Verify Volume Attach Through vpxd Restart [Feature:vsphere][Serial][Disruptive] verify volume remains attached through vpxd restart" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Downward API volume should provide container&#39;s memory limit [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="8.294076389"></testcase>
+      <testcase name="[sig-apps] CronJob should replace jobs when ReplaceConcurrent" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] SchedulerPreemption [Serial] [Feature:PodPreemption] validates lower priority pod preemption by critical pod" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Pod Disks detach in a disrupted environment [Slow] [Disruptive] when node is deleted" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [sig-node] Security Context [Feature:SecurityContext] should support pod.Spec.SecurityContext.SupplementalGroups" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Etcd failure [Disruptive] should recover from network partition with master" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Variable Expansion should allow substituting values in a container&#39;s command [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="10.337390022"></testcase>
+      <testcase name="[sig-cluster-lifecycle] etcd Upgrade [Feature:EtcdUpgrade] etcd upgrade should maintain a functioning cluster" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] EmptyDir volumes should support (non-root,0777,default) [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="8.246330626"></testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gcePDPVC] should support restarting containers using file as subpath [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] AdmissionWebhook Should unconditionally reject operations on fail closed webhook" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] ConfigMap should be consumable from pods in volume as non-root [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="8.398631466"></testcase>
+      <testcase name="[sig-storage] Downward API volume should provide container&#39;s cpu limit [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="8.31114274"></testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: dir-bindmounted] Set fsGroup for local volume should set same fsGroup for two pods simultaneously" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Guestbook application should create and stop a working application  [Conformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] EmptyDir volumes when FSGroup is specified [NodeFeature:FSGroup] volume on tmpfs should have the correct mode using FSGroup" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: blockfs] Two pods mounting a local volume at the same time should be able to write from pod1 and read from pod2" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volume Provisioning On Clustered Datastore [Feature:vsphere] verify dynamic provision with spbm policy on clustered datastore" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] ReplicationController should serve a basic image on each replica with a public image  [Conformance]" classname="Kubernetes e2e suite" time="16.399229226"></testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: hostPathSymlink] should unmount if pod is force deleted while kubelet is down [Disruptive][Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes:vsphere should test that deleting a PVC before the pod does not cause pod deletion to fail on vsphere volume detach" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Simple pod should support port-forward" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] SchedulerPredicates [Serial] validates that taints-tolerations is respected if matching" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] Should scale up GPU pool from 1 [GpuType:nvidia-tesla-k80] [Feature:ClusterSizeAutoscalingGpu]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Downward API volume should update labels on modification [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="28.904886066"></testcase>
+      <testcase name="[sig-storage] Flexvolumes [Disruptive] should install plugin without kubelet restart" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cluster-lifecycle] Nodes [Disruptive] Resize [Slow] should be able to delete nodes" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: gce-localssd-scsi-fs] [Serial] One pod requesting one prebound PVC should be able to mount volume and write from pod1" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  Local volume that cannot be mounted [Slow] should fail due to non-existent path" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes NFS when invoking the Recycle reclaim policy should test that a PV becomes Available and is clean after the PVC is deleted." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] EmptyDir volumes when FSGroup is specified [NodeFeature:FSGroup] new files should be created with FSGroup ownership when container is non-root" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Garbage collector should delete jobs and pods created by cronjob" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: blockfs] Set fsGroup for local volume should set fsGroup for one pod" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-auth] PodSecurityPolicy should allow pods under the privileged extensions.PodSecurityPolicy" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] ConfigMap should be consumable from pods in volume with mappings and Item mode set [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="8.332310706"></testcase>
+      <testcase name="[sig-scheduling] ResourceQuota [Feature:Initializers] should create a ResourceQuota and capture the life of an uninitialized pod." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gluster] should support file as subpath" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cluster-lifecycle] Downgrade [Feature:Downgrade] cluster downgrade should maintain a functioning cluster [Feature:ClusterDowngrade]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Projected should be consumable from pods in volume as non-root [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="8.369195177"></testcase>
+      <testcase name="[sig-network] Network should set TCP CLOSE_WAIT timeout" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] [HPA] Horizontal pod autoscaling (scale resource: Custom Metrics from Stackdriver) should scale down with External Metric with target value from Stackdriver [Feature:CustomMetricsAutoscaling]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Proxy version v1 should proxy logs on node with explicit kubelet port using proxy subresource  [Conformance]" classname="Kubernetes e2e suite" time="6.441123768"></testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: hostPath] should support restarting containers using directory as subpath [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] DNS should provide DNS for services  [Conformance]" classname="Kubernetes e2e suite" time="20.588020941"></testcase>
+      <testcase name="[sig-storage] Regional PD RegionalPD should failover to a different zone when all nodes in one zone become unreachable [Slow] [Disruptive]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Pods should contain environment variables for services [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="28.458428745"></testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] should add new node and new node pool on too big pod, scale down to 1 and scale down to 0 [Feature:ClusterSizeAutoscalingScaleWithNAP]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes NFS with Single PV - PVC pairs create a PVC and non-pre-bound PV: test write access" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: emptyDir] should support restarting containers using file as subpath [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volumes PD should be mountable with ext3" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] should scale up when non expendable pod is created [Feature:ClusterSizeAutoscalingScaleUp]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] should be able to scale down by draining system pods with pdb[Feature:ClusterSizeAutoscalingScaleDown]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gluster] should support existing single file" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] ConfigMap should be consumable in multiple volumes in the same pod [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="8.256554442"></testcase>
+      <testcase name="[sig-network] ServiceLoadBalancer [Feature:ServiceLoadBalancer] should support simple GET on Ingress ips" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] ReplicaSet should serve a basic image on each replica with a private image" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] StatefulSet [k8s.io] Basic StatefulSet functionality [StatefulSetBasic] Burst scaling should run to completion even with unhealthy pods [Conformance]" classname="Kubernetes e2e suite" time="60.039181786"></testcase>
+      <testcase name="[sig-storage] Projected should provide node allocatable (cpu) as default cpu limit if the limit is not set [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="8.339264066"></testcase>
+      <testcase name="[sig-network] Networking should provide unchanging, static URL paths for kubernetes api services" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] EquivalenceCache [Serial] validates pod affinity works properly when new replica pod is scheduled" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Services should be able to change the type from NodePort to ExternalName" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: nfsPVC] should fail if subpath directory is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: dir-link-bindmounted] Set fsGroup for local volume should set different fsGroup for second pod if first pod is deleted" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Secrets should be consumable from pods in volume as non-root with defaultMode and fsGroup set [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="8.383894768"></testcase>
+      <testcase name="[sig-apps] Daemon set [Serial] should run and stop complex daemon with node affinity" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gluster] should fail for new directories when readOnly specified in the volumeSource" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] NoSNAT [Feature:NoSNAT] [Slow] Should be able to send traffic between Pods without SNAT" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Loadbalancing: L7 GCE [Slow] [Feature:kubemci] should create ingress with pre-shared certificate" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volume FStype [Feature:vsphere] verify fstype - ext3 formatted volume" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: emptyDir] should support readOnly file specified in the volumeMount" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: nfs] should fail for new directories when readOnly specified in the volumeSource" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Projected should be consumable from pods in volume as non-root with FSGroup [NodeFeature:FSGroup]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Probing container should *not* be restarted with a /healthz http liveness probe [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="250.37972983"></testcase>
+      <testcase name="[sig-scheduling] SchedulerPreemption [Serial] [Feature:PodPreemption] validates pod anti-affinity works in preemption" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [sig-node] Security Context [Feature:SecurityContext] should support volume SELinux relabeling when using hostIPC" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [Feature:Example] [k8s.io] Cassandra should create and scale cassandra" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] SchedulerPredicates [Serial] validates that there exists conflict between pods with same hostPort and protocol but one using 0.0.0.0 hostIP" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Projected should be able to mount in a volume regardless of a different secret existing with same name in different namespace [NodeConformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] GKE local SSD [Feature:GKELocalSSD] should write and read from node local SSD [Feature:GKELocalSSD]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: emptyDir] should support restarting containers using directory as subpath [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Pod Disks schedule pods each with a PD, delete pod and verify detach [Slow] for read-only PD with pod delete grace period of &#34;immediate (0s)&#34;" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] HostPath should give a volume the correct mode [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="8.297498951"></testcase>
+      <testcase name="[sig-storage] Dynamic Provisioning [k8s.io] GlusterDynamicProvisioner should create and delete persistent volumes [fast]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [Feature:Example] [k8s.io] Spark should start spark master, driver and workers" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] Multi-AZ Clusters should spread the pods of a service across zones" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-auth] [Feature:NodeAuthorizer] Getting an existing configmap should exit with the Forbidden error" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Services should serve a basic endpoint from pods  [Conformance]" classname="Kubernetes e2e suite" time="11.499012326"></testcase>
+      <testcase name="[sig-cluster-lifecycle] HA-master [Feature:HAMaster] survive addition/removal replicas same zone [Serial][Disruptive]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] DNS should support configurable pod resolv.conf" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: tmpfs] Set fsGroup for local volume should set different fsGroup for second pod if first pod is deleted" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] HostPath should support existing directory subPath" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Services should have session affinity work for LoadBalancer service with ESIPP on [Slow] [DisabledForLargeClusters]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Networking Granular Checks: Services [Slow] should function for endpoint-Service: http" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Namespaces [Serial] should ensure that all pods are removed when a namespace is deleted." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: nfsPVC] should fail if subpath with backstepping is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] DNS configMap nameserver Change stubDomain should be able to change stubDomain configuration [Slow][Serial]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gluster] should support readOnly file specified in the volumeMount" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Loadbalancing: L7 GCE [Slow] [Feature:Ingress] should support multiple TLS certs" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [Feature:Example] [k8s.io] CassandraStatefulSet should create statefulset" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] EmptyDir wrapper volumes should not cause race condition when used for git_repo [Serial] [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] [Serial] Volume metrics PVController should create none metrics for pvc controller before creating any PV or PVC" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] Should be able to scale a node group down to 0[Feature:ClusterSizeAutoscalingScaleDown]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PVC Protection Verify that scheduling of a pod that uses PVC that is being deleted fails and the pod becomes Unschedulable" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Kubectl run default should create an rc or deployment from an image  [Conformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volume Provisioning On Clustered Datastore [Feature:vsphere] verify dynamic provision with default parameter on clustered datastore" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: block] [Feature:BlockVolume] Two pods mounting a local volume one after the other should be able to write from pod1 and read from pod2" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl Port forwarding [k8s.io] With a server listening on 0.0.0.0 [k8s.io] that expects a client request should support a client that connects, sends DATA, and disconnects" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] stateful Upgrade [Feature:StatefulUpgrade] [k8s.io] stateful upgrade should maintain a functioning cluster" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] ReplicationController should release no longer matching pods" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scalability] Density [Feature:ManualPerformance] should allow starting 30 pods per node using { ReplicationController} with 0 secrets, 0 configmaps and 0 daemons with quotas" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cluster-lifecycle] HA-master [Feature:HAMaster] survive addition/removal replicas different zones [Serial][Disruptive]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Docker Containers should be able to override the image&#39;s default command (docker entrypoint) [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="8.251204654"></testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: hostPath] should fail if subpath with backstepping is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Kubectl apply should reuse port when apply to an existing SVC" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Regional PD RegionalPD should provision storage [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Loadbalancing: L7 GCE [Slow] [Feature:NEG] should sync endpoints to NEG" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [sig-node] AppArmor load AppArmor profiles should enforce an AppArmor profile" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] GCP Volumes GlusterFS should be mountable" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] GKE node pools [Feature:GKENodePool] should create a cluster with multiple node pools [Feature:GKENodePool]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Garbage collector should keep the rc around until all its pods are deleted if the deleteOptions says so [Conformance]" classname="Kubernetes e2e suite" time="12.375387869"></testcase>
+      <testcase name="[sig-storage] Storage Policy Based Volume Provisioning [Feature:vsphere] verify VSAN storage capability with non-vsan datastore is not honored for dynamically provisioned pvc using storageclass" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath Atomic writer volumes should support subpaths with configmap pod" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] EmptyDir volumes should support (non-root,0644,tmpfs) [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="8.303266135"></testcase>
+      <testcase name="[sig-storage] Downward API volume should provide podname as non-root with fsgroup [NodeFeature:FSGroup]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] SchedulerPriorities [Serial] Pod should be schedule to node that don&#39;t match the PodAntiAffinity terms" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Namespaces [Serial] should always delete fast (ALL of 100 namespaces in 150 seconds) [Feature:ComprehensiveNamespaceDraining]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: dir] Set fsGroup for local volume should set different fsGroup for second pod if first pod is deleted" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Garbage collector should not be blocked by dependency circle [Conformance]" classname="Kubernetes e2e suite" time="11.29242014"></testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: nfsPVC] should support readOnly directory specified in the volumeMount" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] DaemonRestart [Disruptive] Controller Manager should not create/delete replicas across restart" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [sig-node] kubelet [k8s.io] [sig-node] host cleanup with volume mounts [sig-storage][HostCleanup][Flaky] Host cleanup after disrupting NFS volume [NFS] after stopping the nfs-server and deleting the (active) client pod, the NFS mount and the pod&#39;s UID directory should be removed." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] SchedulerPredicates [Serial] validates local ephemeral storage resource limits of pods that are allowed to run [Feature:LocalStorageCapacityIsolation]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gcePDPVC] should support file as subpath" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: dir-link] Set fsGroup for local volume should not set different fsGroups for two pods simultaneously" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath Atomic writer volumes should support subpaths with secret pod" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Variable Expansion should fail substituting values in a volume subpath with backticks [Feature:VolumeSubpathEnvExpansion][NodeAlphaFeature:VolumeSubpathEnvExpansion][Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] shouldn&#39;t increase cluster size if pending pod is too large [Feature:ClusterSizeAutoscalingScaleUp]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-instrumentation] [Feature:PrometheusMonitoring] Prometheus should scrape metrics from annotated services." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [sig-node] Security Context [Feature:SecurityContext] should support seccomp default which is unconfined [Feature:Seccomp]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: tmpfs] Set fsGroup for local volume should set fsGroup for one pod" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: hostPathSymlink] should support restarting containers using file as subpath [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Garbage collector should not delete dependents that have both valid owner and owner that&#39;s waiting for dependents to be deleted [Conformance]" classname="Kubernetes e2e suite" time="16.320371489"></testcase>
+      <testcase name="[sig-storage] PersistentVolumes NFS with multiple PVs and PVCs all in same ns should create 2 PVs and 4 PVCs: test write access" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Networking Granular Checks: Pods should function for intra-pod communication: http [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="45.276747471"></testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: nfsPVC] should support restarting containers using directory as subpath [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scalability] Density [Feature:ManualPerformance] should allow starting 3 pods per node using { ReplicationController} with 0 secrets, 0 configmaps and 0 daemons" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] NetworkPolicy NetworkPolicy between server and client should allow egress access on one named port [Feature:NetworkPolicy]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] [HPA] Horizontal pod autoscaling (scale resource: CPU) [sig-autoscaling] [Serial] [Slow] ReplicationController Should scale from 1 pod to 3 pods and from 3 to 5 and verify decision stability" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: hostPathSymlink] should support readOnly directory specified in the volumeMount" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] DisruptionController evictions: maxUnavailable allow single eviction, percentage =&gt; should allow an eviction" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Downward API volume should provide node allocatable (memory) as default memory limit if the limit is not set [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="8.393768727"></testcase>
+      <testcase name="[sig-storage] Projected should be consumable from pods in volume with defaultMode set [NodeConformance] [Conformance]" classname="Kubernetes e2e suite" time="8.374019215"></testcase>
+      <testcase name="[sig-api-machinery] Garbage collector should delete RS created by deployment when not orphaning [Conformance]" classname="Kubernetes e2e suite" time="7.339122833"></testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Kubectl create quota should create a quota with scopes" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scalability] Load capacity [Feature:ManualPerformance] should be able to handle 30 pods per node {extensions Deployment} with 0 secrets, 2 configmaps and 0 daemons" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] shouldn&#39;t scale up if cores limit too low, should scale up after limit is changed [Feature:ClusterSizeAutoscalingScaleWithNAP]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+  </testsuite>

--- a/v1.11/gardener-openstack/version.txt
+++ b/v1.11/gardener-openstack/version.txt
@@ -1,0 +1,2 @@
+Client Version: version.Info{Major:"1", Minor:"11", GitVersion:"v1.11.0", GitCommit:"91e7b4fd31fcd3d5f436da26c980becec37ceefe", GitTreeState:"clean", BuildDate:"2018-06-27T20:17:28Z", GoVersion:"go1.10.2", Compiler:"gc", Platform:"linux/amd64"}
+Server Version: version.Info{Major:"1", Minor:"11", GitVersion:"v1.11.0", GitCommit:"91e7b4fd31fcd3d5f436da26c980becec37ceefe", GitTreeState:"clean", BuildDate:"2018-06-27T20:08:34Z", GoVersion:"go1.10.2", Compiler:"gc", Platform:"linux/amd64"}


### PR DESCRIPTION
Conformance test results for kubernetes clusters deployed using
open source Gardener 0.8.0.

v1.11/gardener-aws : cluster deployed on Amazon Web Services
v1.11/gardener-azure : cluster deployed on Microsoft Azure
v1.11/gardener-gcp : cluster deployed on Google Cloud Platform
v1.11/gardener-openstack : cluster deployed on OpenStack