### PR TITLE
Add conformance results for 1.11/cloud-pks

### DIFF
--- a/v1.11/cloud-pks/PRODUCT.yaml
+++ b/v1.11/cloud-pks/PRODUCT.yaml
@@ -1,0 +1,7 @@
+vendor: VMware
+name: VMware Cloud PKS
+description: A fully managed cloud service that provides Kubernetes clusters
+version: v1.11.5
+type: hosted
+website_url: https://cloud.vmware.com/vmware-cloud-pks
+documentation_url: https://cloud.vmware.com/vmware-cloud-pks/resources

--- a/v1.11/cloud-pks/README.md
+++ b/v1.11/cloud-pks/README.md
@@ -1,0 +1,21 @@
+# VMware Cloud PKS
+
+[VMware Cloud PKS](https://cloud.vmware.com/vmware-cloud-pks) is a cloud service that provides managed Kubernetes clusters. 
+
+## Creating a VMware Cloud PKS Cluster
+```
+vke cluster create --name my-cluster --cluster-type PRODUCTION --region us-west-2 --privilegedMode 
+```
+
+## Creating a Kubernetes configuration file
+```
+vke cluster auth setup my-cluster
+```
+
+## Running the Kubernetes conformance tests
+```
+sonobuoy run --skip-preflight
+```
+
+The preflight checks are skipped because CoreDNS is run in a different
+namespace (vke-system) than expected by the preflight checks. 

--- a/v1.11/cloud-pks/e2e.log
+++ b/v1.11/cloud-pks/e2e.log
@@ -1,0 +1,6883 @@
+Nov 29 07:34:11.023: INFO: Overriding default scale value of zero to 1
+Nov 29 07:34:11.023: INFO: Overriding default milliseconds value of zero to 5000
+I1129 07:34:11.147046      13 test_context.go:360] Using a temporary kubeconfig file from in-cluster config : /tmp/kubeconfig-385092372
+I1129 07:34:11.147224      13 e2e.go:333] Starting e2e run "29b520b2-f3a9-11e8-9124-e6180d057dc8" on Ginkgo node 1
+Running Suite: Kubernetes e2e suite
+===================================
+Random Seed: 1543476850 - Will randomize all specs
+Will run 141 of 890 specs
+
+Nov 29 07:34:11.229: INFO: >>> kubeConfig: /tmp/kubeconfig-385092372
+Nov 29 07:34:11.260: INFO: Waiting up to 4h0m0s for all (but 0) nodes to be schedulable
+Nov 29 07:34:11.268: INFO: Waiting up to 10m0s for all pods (need at least 0) in namespace 'kube-system' to be running and ready
+Nov 29 07:34:11.281: INFO: 0 / 0 pods in namespace 'kube-system' are running and ready (0 seconds elapsed)
+Nov 29 07:34:11.281: INFO: expected 0 pod replicas in namespace 'kube-system', 0 are Running and Ready.
+Nov 29 07:34:11.282: INFO: Waiting for pods to enter Success, but no pods in "kube-system" match label map[name:e2e-image-puller]
+Nov 29 07:34:11.282: INFO: Dumping network health container logs from all nodes to file /tmp/results/nethealth.txt
+Nov 29 07:34:11.283: INFO: e2e test version: v1.10.5
+Nov 29 07:34:11.284: INFO: kube-apiserver version: v1.11.5
+S
+------------------------------
+[sig-storage] Projected 
+  should be consumable from pods in volume with mappings [Conformance]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Nov 29 07:34:11.284: INFO: >>> kubeConfig: /tmp/kubeconfig-385092372
+STEP: Building a namespace api object
+Nov 29 07:34:11.329: INFO: No PodSecurityPolicies found; assuming PodSecurityPolicy is disabled.
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:858
+[It] should be consumable from pods in volume with mappings [Conformance]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating projection with secret that has name projected-secret-test-map-29ee4d53-f3a9-11e8-9124-e6180d057dc8
+STEP: Creating a pod to test consume secrets
+Nov 29 07:34:11.338: INFO: Waiting up to 5m0s for pod "pod-projected-secrets-29ee946c-f3a9-11e8-9124-e6180d057dc8" in namespace "e2e-tests-projected-hv6nk" to be "success or failure"
+Nov 29 07:34:11.344: INFO: Pod "pod-projected-secrets-29ee946c-f3a9-11e8-9124-e6180d057dc8": Phase="Pending", Reason="", readiness=false. Elapsed: 6.564509ms
+Nov 29 07:34:13.346: INFO: Pod "pod-projected-secrets-29ee946c-f3a9-11e8-9124-e6180d057dc8": Phase="Running", Reason="", readiness=true. Elapsed: 2.008351835s
+Nov 29 07:34:15.348: INFO: Pod "pod-projected-secrets-29ee946c-f3a9-11e8-9124-e6180d057dc8": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.009941394s
+STEP: Saw pod success
+Nov 29 07:34:15.348: INFO: Pod "pod-projected-secrets-29ee946c-f3a9-11e8-9124-e6180d057dc8" satisfied condition "success or failure"
+Nov 29 07:34:15.349: INFO: Trying to get logs from node worker-bdccfcb0-f3a8-11e8-90fa-062be367adf0 pod pod-projected-secrets-29ee946c-f3a9-11e8-9124-e6180d057dc8 container projected-secret-volume-test: <nil>
+STEP: delete the pod
+Nov 29 07:34:15.370: INFO: Waiting for pod pod-projected-secrets-29ee946c-f3a9-11e8-9124-e6180d057dc8 to disappear
+Nov 29 07:34:15.374: INFO: Pod pod-projected-secrets-29ee946c-f3a9-11e8-9124-e6180d057dc8 no longer exists
+[AfterEach] [sig-storage] Projected
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Nov 29 07:34:15.374: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-hv6nk" for this suite.
+Nov 29 07:34:21.386: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Nov 29 07:34:21.431: INFO: namespace: e2e-tests-projected-hv6nk, resource: bindings, ignored listing per whitelist
+Nov 29 07:34:21.438: INFO: namespace e2e-tests-projected-hv6nk deletion completed in 6.060995155s
+
+• [SLOW TEST:10.154 seconds]
+[sig-storage] Projected
+/workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:34
+  should be consumable from pods in volume with mappings [Conformance]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SS
+------------------------------
+[sig-storage] Downward API volume 
+  should set DefaultMode on files  [Conformance]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Nov 29 07:34:21.438: INFO: >>> kubeConfig: /tmp/kubeconfig-385092372
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downwardapi_volume.go:38
+[It] should set DefaultMode on files  [Conformance]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating a pod to test downward API volume plugin
+Nov 29 07:34:21.469: INFO: Waiting up to 5m0s for pod "downwardapi-volume-2ff8ee07-f3a9-11e8-9124-e6180d057dc8" in namespace "e2e-tests-downward-api-cxjmk" to be "success or failure"
+Nov 29 07:34:21.472: INFO: Pod "downwardapi-volume-2ff8ee07-f3a9-11e8-9124-e6180d057dc8": Phase="Pending", Reason="", readiness=false. Elapsed: 2.858486ms
+Nov 29 07:34:23.473: INFO: Pod "downwardapi-volume-2ff8ee07-f3a9-11e8-9124-e6180d057dc8": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.004513956s
+STEP: Saw pod success
+Nov 29 07:34:23.473: INFO: Pod "downwardapi-volume-2ff8ee07-f3a9-11e8-9124-e6180d057dc8" satisfied condition "success or failure"
+Nov 29 07:34:23.475: INFO: Trying to get logs from node worker-bdccfcb0-f3a8-11e8-90fa-062be367adf0 pod downwardapi-volume-2ff8ee07-f3a9-11e8-9124-e6180d057dc8 container client-container: <nil>
+STEP: delete the pod
+Nov 29 07:34:23.494: INFO: Waiting for pod downwardapi-volume-2ff8ee07-f3a9-11e8-9124-e6180d057dc8 to disappear
+Nov 29 07:34:23.496: INFO: Pod downwardapi-volume-2ff8ee07-f3a9-11e8-9124-e6180d057dc8 no longer exists
+[AfterEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Nov 29 07:34:23.496: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-downward-api-cxjmk" for this suite.
+Nov 29 07:34:29.503: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Nov 29 07:34:29.535: INFO: namespace: e2e-tests-downward-api-cxjmk, resource: bindings, ignored listing per whitelist
+Nov 29 07:34:29.553: INFO: namespace e2e-tests-downward-api-cxjmk deletion completed in 6.056331996s
+
+• [SLOW TEST:8.115 seconds]
+[sig-storage] Downward API volume
+/workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downwardapi_volume.go:33
+  should set DefaultMode on files  [Conformance]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SSSSSSSSSSSSSSSSSSSSS
+------------------------------
+[sig-api-machinery] Garbage collector 
+  should keep the rc around until all its pods are deleted if the deleteOptions says so [Conformance]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-api-machinery] Garbage collector
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Nov 29 07:34:29.554: INFO: >>> kubeConfig: /tmp/kubeconfig-385092372
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should keep the rc around until all its pods are deleted if the deleteOptions says so [Conformance]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: create the rc
+STEP: delete the rc
+STEP: wait for the rc to be deleted
+STEP: Gathering metrics
+W1129 07:34:35.604317      13 metrics_grabber.go:81] Master node is not registered. Grabbing metrics from Scheduler, ControllerManager and ClusterAutoscaler is disabled.
+Nov 29 07:34:35.604: INFO: For apiserver_request_count:
+For apiserver_request_latencies_summary:
+For etcd_helper_cache_entry_count:
+For etcd_helper_cache_hit_count:
+For etcd_helper_cache_miss_count:
+For etcd_request_cache_add_latencies_summary:
+For etcd_request_cache_get_latencies_summary:
+For etcd_request_latencies_summary:
+For garbage_collector_attempt_to_delete_queue_latency:
+For garbage_collector_attempt_to_delete_work_duration:
+For garbage_collector_attempt_to_orphan_queue_latency:
+For garbage_collector_attempt_to_orphan_work_duration:
+For garbage_collector_dirty_processing_latency_microseconds:
+For garbage_collector_event_processing_latency_microseconds:
+For garbage_collector_graph_changes_queue_latency:
+For garbage_collector_graph_changes_work_duration:
+For garbage_collector_orphan_processing_latency_microseconds:
+For namespace_queue_latency:
+For namespace_queue_latency_sum:
+For namespace_queue_latency_count:
+For namespace_retries:
+For namespace_work_duration:
+For namespace_work_duration_sum:
+For namespace_work_duration_count:
+For function_duration_seconds:
+For errors_total:
+For evicted_pods_total:
+
+[AfterEach] [sig-api-machinery] Garbage collector
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Nov 29 07:34:35.604: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-gc-866wg" for this suite.
+Nov 29 07:34:41.611: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Nov 29 07:34:41.656: INFO: namespace: e2e-tests-gc-866wg, resource: bindings, ignored listing per whitelist
+Nov 29 07:34:41.662: INFO: namespace e2e-tests-gc-866wg deletion completed in 6.05652847s
+
+• [SLOW TEST:12.108 seconds]
+[sig-api-machinery] Garbage collector
+/workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apimachinery/framework.go:22
+  should keep the rc around until all its pods are deleted if the deleteOptions says so [Conformance]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SSSS
+------------------------------
+[k8s.io] Pods 
+  should be submitted and removed  [Conformance]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [k8s.io] Pods
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Nov 29 07:34:41.662: INFO: >>> kubeConfig: /tmp/kubeconfig-385092372
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [k8s.io] Pods
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/pods.go:127
+[It] should be submitted and removed  [Conformance]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: creating the pod
+STEP: setting up watch
+STEP: submitting the pod to kubernetes
+STEP: verifying the pod is in kubernetes
+STEP: verifying pod creation was observed
+Nov 29 07:34:45.715: INFO: running pod: &v1.Pod{TypeMeta:v1.TypeMeta{Kind:"", APIVersion:""}, ObjectMeta:v1.ObjectMeta{Name:"pod-submit-remove-3c0808d9-f3a9-11e8-9124-e6180d057dc8", GenerateName:"", Namespace:"e2e-tests-pods-cgd9k", SelfLink:"/api/v1/namespaces/e2e-tests-pods-cgd9k/pods/pod-submit-remove-3c0808d9-f3a9-11e8-9124-e6180d057dc8", UID:"3c0bd562-f3a9-11e8-9c33-06ce02f7f1c8", ResourceVersion:"2507", Generation:0, CreationTimestamp:v1.Time{Time:time.Time{wall:0x0, ext:63679073681, loc:(*time.Location)(0x676bfc0)}}, DeletionTimestamp:(*v1.Time)(nil), DeletionGracePeriodSeconds:(*int64)(nil), Labels:map[string]string{"name":"foo", "time":"698227738"}, Annotations:map[string]string(nil), OwnerReferences:[]v1.OwnerReference(nil), Initializers:(*v1.Initializers)(nil), Finalizers:[]string(nil), ClusterName:""}, Spec:v1.PodSpec{Volumes:[]v1.Volume{v1.Volume{Name:"default-token-l4m8w", VolumeSource:v1.VolumeSource{HostPath:(*v1.HostPathVolumeSource)(nil), EmptyDir:(*v1.EmptyDirVolumeSource)(nil), GCEPersistentDisk:(*v1.GCEPersistentDiskVolumeSource)(nil), AWSElasticBlockStore:(*v1.AWSElasticBlockStoreVolumeSource)(nil), GitRepo:(*v1.GitRepoVolumeSource)(nil), Secret:(*v1.SecretVolumeSource)(0xc4212a9700), NFS:(*v1.NFSVolumeSource)(nil), ISCSI:(*v1.ISCSIVolumeSource)(nil), Glusterfs:(*v1.GlusterfsVolumeSource)(nil), PersistentVolumeClaim:(*v1.PersistentVolumeClaimVolumeSource)(nil), RBD:(*v1.RBDVolumeSource)(nil), FlexVolume:(*v1.FlexVolumeSource)(nil), Cinder:(*v1.CinderVolumeSource)(nil), CephFS:(*v1.CephFSVolumeSource)(nil), Flocker:(*v1.FlockerVolumeSource)(nil), DownwardAPI:(*v1.DownwardAPIVolumeSource)(nil), FC:(*v1.FCVolumeSource)(nil), AzureFile:(*v1.AzureFileVolumeSource)(nil), ConfigMap:(*v1.ConfigMapVolumeSource)(nil), VsphereVolume:(*v1.VsphereVirtualDiskVolumeSource)(nil), Quobyte:(*v1.QuobyteVolumeSource)(nil), AzureDisk:(*v1.AzureDiskVolumeSource)(nil), PhotonPersistentDisk:(*v1.PhotonPersistentDiskVolumeSource)(nil), Projected:(*v1.ProjectedVolumeSource)(nil), PortworxVolume:(*v1.PortworxVolumeSource)(nil), ScaleIO:(*v1.ScaleIOVolumeSource)(nil), StorageOS:(*v1.StorageOSVolumeSource)(nil)}}}, InitContainers:[]v1.Container(nil), Containers:[]v1.Container{v1.Container{Name:"nginx", Image:"k8s.gcr.io/nginx-slim-amd64:0.20", Command:[]string(nil), Args:[]string(nil), WorkingDir:"", Ports:[]v1.ContainerPort(nil), EnvFrom:[]v1.EnvFromSource(nil), Env:[]v1.EnvVar(nil), Resources:v1.ResourceRequirements{Limits:v1.ResourceList(nil), Requests:v1.ResourceList(nil)}, VolumeMounts:[]v1.VolumeMount{v1.VolumeMount{Name:"default-token-l4m8w", ReadOnly:true, MountPath:"/var/run/secrets/kubernetes.io/serviceaccount", SubPath:"", MountPropagation:(*v1.MountPropagationMode)(nil)}}, VolumeDevices:[]v1.VolumeDevice(nil), LivenessProbe:(*v1.Probe)(nil), ReadinessProbe:(*v1.Probe)(nil), Lifecycle:(*v1.Lifecycle)(nil), TerminationMessagePath:"/dev/termination-log", TerminationMessagePolicy:"File", ImagePullPolicy:"IfNotPresent", SecurityContext:(*v1.SecurityContext)(nil), Stdin:false, StdinOnce:false, TTY:false}}, RestartPolicy:"Always", TerminationGracePeriodSeconds:(*int64)(0xc4218772a8), ActiveDeadlineSeconds:(*int64)(nil), DNSPolicy:"ClusterFirst", NodeSelector:map[string]string(nil), ServiceAccountName:"default", DeprecatedServiceAccount:"default", AutomountServiceAccountToken:(*bool)(nil), NodeName:"worker-bdccfcb0-f3a8-11e8-90fa-062be367adf0", HostNetwork:false, HostPID:false, HostIPC:false, ShareProcessNamespace:(*bool)(nil), SecurityContext:(*v1.PodSecurityContext)(0xc4212a9780), ImagePullSecrets:[]v1.LocalObjectReference(nil), Hostname:"", Subdomain:"", Affinity:(*v1.Affinity)(nil), SchedulerName:"default-scheduler", Tolerations:[]v1.Toleration{v1.Toleration{Key:"node.kubernetes.io/not-ready", Operator:"Exists", Value:"", Effect:"NoExecute", TolerationSeconds:(*int64)(0xc4218772e0)}, v1.Toleration{Key:"node.kubernetes.io/unreachable", Operator:"Exists", Value:"", Effect:"NoExecute", TolerationSeconds:(*int64)(0xc421877300)}}, HostAliases:[]v1.HostAlias(nil), PriorityClassName:"", Priority:(*int32)(0xc421877308), DNSConfig:(*v1.PodDNSConfig)(nil)}, Status:v1.PodStatus{Phase:"Running", Conditions:[]v1.PodCondition{v1.PodCondition{Type:"Initialized", Status:"True", LastProbeTime:v1.Time{Time:time.Time{wall:0x0, ext:0, loc:(*time.Location)(nil)}}, LastTransitionTime:v1.Time{Time:time.Time{wall:0x0, ext:63679073682, loc:(*time.Location)(0x676bfc0)}}, Reason:"", Message:""}, v1.PodCondition{Type:"Ready", Status:"True", LastProbeTime:v1.Time{Time:time.Time{wall:0x0, ext:0, loc:(*time.Location)(nil)}}, LastTransitionTime:v1.Time{Time:time.Time{wall:0x0, ext:63679073685, loc:(*time.Location)(0x676bfc0)}}, Reason:"", Message:""}, v1.PodCondition{Type:"ContainersReady", Status:"True", LastProbeTime:v1.Time{Time:time.Time{wall:0x0, ext:0, loc:(*time.Location)(nil)}}, LastTransitionTime:v1.Time{Time:time.Time{wall:0x0, ext:0, loc:(*time.Location)(nil)}}, Reason:"", Message:""}, v1.PodCondition{Type:"PodScheduled", Status:"True", LastProbeTime:v1.Time{Time:time.Time{wall:0x0, ext:0, loc:(*time.Location)(nil)}}, LastTransitionTime:v1.Time{Time:time.Time{wall:0x0, ext:63679073681, loc:(*time.Location)(0x676bfc0)}}, Reason:"", Message:""}}, Message:"", Reason:"", NominatedNodeName:"", HostIP:"10.1.191.253", PodIP:"10.2.1.16", StartTime:(*v1.Time)(0xc42185cba0), InitContainerStatuses:[]v1.ContainerStatus(nil), ContainerStatuses:[]v1.ContainerStatus{v1.ContainerStatus{Name:"nginx", State:v1.ContainerState{Waiting:(*v1.ContainerStateWaiting)(nil), Running:(*v1.ContainerStateRunning)(0xc42185cbc0), Terminated:(*v1.ContainerStateTerminated)(nil)}, LastTerminationState:v1.ContainerState{Waiting:(*v1.ContainerStateWaiting)(nil), Running:(*v1.ContainerStateRunning)(nil), Terminated:(*v1.ContainerStateTerminated)(nil)}, Ready:true, RestartCount:0, Image:"k8s.gcr.io/nginx-slim-amd64:0.20", ImageID:"docker-pullable://k8s.gcr.io/nginx-slim-amd64@sha256:6654db6d4028756062edac466454ee5c9cf9b20ef79e35a81e3c840031eb1e2b", ContainerID:"docker://6ae2e020997e3f221b8ce72609039b7eda0496b636ee761099f6ecf4f686d450"}}, QOSClass:"BestEffort"}}
+STEP: deleting the pod gracefully
+STEP: verifying the kubelet observed the termination notice
+Nov 29 07:34:50.721: INFO: no pod exists with the name we were looking for, assuming the termination request was observed and completed
+STEP: verifying pod deletion was observed
+[AfterEach] [k8s.io] Pods
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Nov 29 07:34:50.723: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-pods-cgd9k" for this suite.
+Nov 29 07:34:56.730: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Nov 29 07:34:56.767: INFO: namespace: e2e-tests-pods-cgd9k, resource: bindings, ignored listing per whitelist
+Nov 29 07:34:56.783: INFO: namespace e2e-tests-pods-cgd9k deletion completed in 6.058249856s
+
+• [SLOW TEST:15.121 seconds]
+[k8s.io] Pods
+/workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:669
+  should be submitted and removed  [Conformance]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SSSS
+------------------------------
+[sig-network] Networking Granular Checks: Pods 
+  should function for node-pod communication: http  [Conformance]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-network] Networking
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Nov 29 07:34:56.783: INFO: >>> kubeConfig: /tmp/kubeconfig-385092372
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should function for node-pod communication: http  [Conformance]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Performing setup for networking test in namespace e2e-tests-pod-network-test-xl7hx
+STEP: creating a selector
+STEP: Creating the service pods in kubernetes
+Nov 29 07:34:56.861: INFO: Waiting up to 10m0s for all (but 0) nodes to be schedulable
+STEP: Creating test pods
+Nov 29 07:35:18.905: INFO: ExecWithOptions {Command:[/bin/sh -c timeout -t 15 curl -g -q -s --connect-timeout 1 http://10.2.1.17:8080/hostName | grep -v '^\s*$'] Namespace:e2e-tests-pod-network-test-xl7hx PodName:host-test-container-pod ContainerName:hostexec Stdin:<nil> CaptureStdout:true CaptureStderr:true PreserveWhitespace:false}
+Nov 29 07:35:18.906: INFO: >>> kubeConfig: /tmp/kubeconfig-385092372
+Nov 29 07:35:18.944: INFO: Found all expected endpoints: [netserver-0]
+[AfterEach] [sig-network] Networking
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Nov 29 07:35:18.944: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-pod-network-test-xl7hx" for this suite.
+Nov 29 07:35:40.956: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Nov 29 07:35:41.001: INFO: namespace: e2e-tests-pod-network-test-xl7hx, resource: bindings, ignored listing per whitelist
+Nov 29 07:35:41.059: INFO: namespace e2e-tests-pod-network-test-xl7hx deletion completed in 22.112884616s
+
+• [SLOW TEST:44.276 seconds]
+[sig-network] Networking
+/workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/networking.go:25
+  Granular Checks: Pods
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/networking.go:28
+    should function for node-pod communication: http  [Conformance]
+    /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SSSS
+------------------------------
+[sig-storage] EmptyDir volumes 
+  should support (non-root,0666,default) [Conformance]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-storage] EmptyDir volumes
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Nov 29 07:35:41.059: INFO: >>> kubeConfig: /tmp/kubeconfig-385092372
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should support (non-root,0666,default) [Conformance]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating a pod to test emptydir 0666 on node default medium
+Nov 29 07:35:41.093: INFO: Waiting up to 5m0s for pod "pod-5f6e5c86-f3a9-11e8-9124-e6180d057dc8" in namespace "e2e-tests-emptydir-bvhq4" to be "success or failure"
+Nov 29 07:35:41.099: INFO: Pod "pod-5f6e5c86-f3a9-11e8-9124-e6180d057dc8": Phase="Pending", Reason="", readiness=false. Elapsed: 6.486464ms
+Nov 29 07:35:43.101: INFO: Pod "pod-5f6e5c86-f3a9-11e8-9124-e6180d057dc8": Phase="Pending", Reason="", readiness=false. Elapsed: 2.007908727s
+Nov 29 07:35:45.102: INFO: Pod "pod-5f6e5c86-f3a9-11e8-9124-e6180d057dc8": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.009430138s
+STEP: Saw pod success
+Nov 29 07:35:45.102: INFO: Pod "pod-5f6e5c86-f3a9-11e8-9124-e6180d057dc8" satisfied condition "success or failure"
+Nov 29 07:35:45.103: INFO: Trying to get logs from node worker-bdccfcb0-f3a8-11e8-90fa-062be367adf0 pod pod-5f6e5c86-f3a9-11e8-9124-e6180d057dc8 container test-container: <nil>
+STEP: delete the pod
+Nov 29 07:35:45.132: INFO: Waiting for pod pod-5f6e5c86-f3a9-11e8-9124-e6180d057dc8 to disappear
+Nov 29 07:35:45.134: INFO: Pod pod-5f6e5c86-f3a9-11e8-9124-e6180d057dc8 no longer exists
+[AfterEach] [sig-storage] EmptyDir volumes
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Nov 29 07:35:45.134: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-emptydir-bvhq4" for this suite.
+Nov 29 07:35:51.143: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Nov 29 07:35:51.192: INFO: namespace: e2e-tests-emptydir-bvhq4, resource: bindings, ignored listing per whitelist
+Nov 29 07:35:51.196: INFO: namespace e2e-tests-emptydir-bvhq4 deletion completed in 6.057784326s
+
+• [SLOW TEST:10.137 seconds]
+[sig-storage] EmptyDir volumes
+/workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/empty_dir.go:41
+  should support (non-root,0666,default) [Conformance]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SSSSSS
+------------------------------
+[sig-api-machinery] ConfigMap 
+  should be consumable via the environment  [Conformance]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-api-machinery] ConfigMap
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Nov 29 07:35:51.197: INFO: >>> kubeConfig: /tmp/kubeconfig-385092372
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should be consumable via the environment  [Conformance]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating configMap e2e-tests-configmap-x99xm/configmap-test-65794a4e-f3a9-11e8-9124-e6180d057dc8
+STEP: Creating a pod to test consume configMaps
+Nov 29 07:35:51.231: INFO: Waiting up to 5m0s for pod "pod-configmaps-657983aa-f3a9-11e8-9124-e6180d057dc8" in namespace "e2e-tests-configmap-x99xm" to be "success or failure"
+Nov 29 07:35:51.233: INFO: Pod "pod-configmaps-657983aa-f3a9-11e8-9124-e6180d057dc8": Phase="Pending", Reason="", readiness=false. Elapsed: 2.056279ms
+Nov 29 07:35:53.235: INFO: Pod "pod-configmaps-657983aa-f3a9-11e8-9124-e6180d057dc8": Phase="Pending", Reason="", readiness=false. Elapsed: 2.00431815s
+Nov 29 07:35:55.237: INFO: Pod "pod-configmaps-657983aa-f3a9-11e8-9124-e6180d057dc8": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.006769862s
+STEP: Saw pod success
+Nov 29 07:35:55.237: INFO: Pod "pod-configmaps-657983aa-f3a9-11e8-9124-e6180d057dc8" satisfied condition "success or failure"
+Nov 29 07:35:55.240: INFO: Trying to get logs from node worker-bdccfcb0-f3a8-11e8-90fa-062be367adf0 pod pod-configmaps-657983aa-f3a9-11e8-9124-e6180d057dc8 container env-test: <nil>
+STEP: delete the pod
+Nov 29 07:35:55.252: INFO: Waiting for pod pod-configmaps-657983aa-f3a9-11e8-9124-e6180d057dc8 to disappear
+Nov 29 07:35:55.257: INFO: Pod pod-configmaps-657983aa-f3a9-11e8-9124-e6180d057dc8 no longer exists
+[AfterEach] [sig-api-machinery] ConfigMap
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Nov 29 07:35:55.260: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-configmap-x99xm" for this suite.
+Nov 29 07:36:01.266: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Nov 29 07:36:01.300: INFO: namespace: e2e-tests-configmap-x99xm, resource: bindings, ignored listing per whitelist
+Nov 29 07:36:01.319: INFO: namespace e2e-tests-configmap-x99xm deletion completed in 6.058112625s
+
+• [SLOW TEST:10.122 seconds]
+[sig-api-machinery] ConfigMap
+/workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/configmap.go:29
+  should be consumable via the environment  [Conformance]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+S
+------------------------------
+[sig-storage] Projected 
+  should provide node allocatable (cpu) as default cpu limit if the limit is not set [Conformance]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Nov 29 07:36:01.320: INFO: >>> kubeConfig: /tmp/kubeconfig-385092372
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:858
+[It] should provide node allocatable (cpu) as default cpu limit if the limit is not set [Conformance]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating a pod to test downward API volume plugin
+Nov 29 07:36:01.401: INFO: Waiting up to 5m0s for pod "downwardapi-volume-6b896d13-f3a9-11e8-9124-e6180d057dc8" in namespace "e2e-tests-projected-9gxp7" to be "success or failure"
+Nov 29 07:36:01.409: INFO: Pod "downwardapi-volume-6b896d13-f3a9-11e8-9124-e6180d057dc8": Phase="Pending", Reason="", readiness=false. Elapsed: 7.318437ms
+Nov 29 07:36:03.411: INFO: Pod "downwardapi-volume-6b896d13-f3a9-11e8-9124-e6180d057dc8": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.009292053s
+STEP: Saw pod success
+Nov 29 07:36:03.411: INFO: Pod "downwardapi-volume-6b896d13-f3a9-11e8-9124-e6180d057dc8" satisfied condition "success or failure"
+Nov 29 07:36:03.413: INFO: Trying to get logs from node worker-bdccfcb0-f3a8-11e8-90fa-062be367adf0 pod downwardapi-volume-6b896d13-f3a9-11e8-9124-e6180d057dc8 container client-container: <nil>
+STEP: delete the pod
+Nov 29 07:36:03.431: INFO: Waiting for pod downwardapi-volume-6b896d13-f3a9-11e8-9124-e6180d057dc8 to disappear
+Nov 29 07:36:03.432: INFO: Pod downwardapi-volume-6b896d13-f3a9-11e8-9124-e6180d057dc8 no longer exists
+[AfterEach] [sig-storage] Projected
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Nov 29 07:36:03.432: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-9gxp7" for this suite.
+Nov 29 07:36:09.439: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Nov 29 07:36:09.481: INFO: namespace: e2e-tests-projected-9gxp7, resource: bindings, ignored listing per whitelist
+Nov 29 07:36:09.497: INFO: namespace e2e-tests-projected-9gxp7 deletion completed in 6.062857117s
+
+• [SLOW TEST:8.177 seconds]
+[sig-storage] Projected
+/workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:34
+  should provide node allocatable (cpu) as default cpu limit if the limit is not set [Conformance]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SSSS
+------------------------------
+[sig-scheduling] SchedulerPredicates [Serial] 
+  validates that NodeSelector is respected if not matching  [Conformance]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-scheduling] SchedulerPredicates [Serial]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Nov 29 07:36:09.497: INFO: >>> kubeConfig: /tmp/kubeconfig-385092372
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-scheduling] SchedulerPredicates [Serial]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/scheduling/predicates.go:78
+Nov 29 07:36:09.525: INFO: Waiting up to 1m0s for all nodes to be ready
+Nov 29 07:37:09.533: INFO: Waiting for terminating namespaces to be deleted...
+Nov 29 07:37:09.535: INFO: Waiting up to 5m0s for all pods (need at least 0) in namespace 'kube-system' to be running and ready
+Nov 29 07:37:09.538: INFO: 0 / 0 pods in namespace 'kube-system' are running and ready (0 seconds elapsed)
+Nov 29 07:37:09.538: INFO: expected 0 pod replicas in namespace 'kube-system', 0 are Running and Ready.
+Nov 29 07:37:09.539: INFO: Waiting for pods to enter Success, but no pods in "kube-system" match label map[name:e2e-image-puller]
+Nov 29 07:37:09.539: INFO: 
+Logging pods the kubelet thinks is on node worker-bdccfcb0-f3a8-11e8-90fa-062be367adf0 before test
+Nov 29 07:37:09.541: INFO: sonobuoy from sonobuoy started at 2018-11-29 07:33:28 +0000 UTC (1 container statuses recorded)
+Nov 29 07:37:09.541: INFO: 	Container kube-sonobuoy ready: true, restart count 0
+Nov 29 07:37:09.541: INFO: sonobuoy-e2e-job from sonobuoy started at 2018-11-29 07:33:40 +0000 UTC (2 container statuses recorded)
+Nov 29 07:37:09.541: INFO: 	Container e2e ready: true, restart count 0
+Nov 29 07:37:09.541: INFO: 	Container sonobuoy-worker ready: true, restart count 0
+Nov 29 07:37:09.541: INFO: canal-node-test15434755641-11-5-1-dtcp7 from vke-system started at 2018-11-29 07:33:18 +0000 UTC (3 container statuses recorded)
+Nov 29 07:37:09.541: INFO: 	Container calico-node ready: true, restart count 0
+Nov 29 07:37:09.541: INFO: 	Container flannel ready: true, restart count 0
+Nov 29 07:37:09.541: INFO: 	Container install-calico-cni ready: true, restart count 0
+[It] validates that NodeSelector is respected if not matching  [Conformance]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Trying to schedule Pod with nonempty NodeSelector.
+STEP: Considering event: 
+Type = [Warning], Name = [restricted-pod.156b882e42806884], Reason = [FailedScheduling], Message = [0/2 nodes are available: 2 node(s) didn't match node selector.]
+[AfterEach] [sig-scheduling] SchedulerPredicates [Serial]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Nov 29 07:37:10.556: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-sched-pred-bxjv5" for this suite.
+Nov 29 07:37:32.562: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Nov 29 07:37:32.622: INFO: namespace: e2e-tests-sched-pred-bxjv5, resource: bindings, ignored listing per whitelist
+Nov 29 07:37:32.632: INFO: namespace e2e-tests-sched-pred-bxjv5 deletion completed in 22.074604218s
+[AfterEach] [sig-scheduling] SchedulerPredicates [Serial]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/scheduling/predicates.go:69
+
+• [SLOW TEST:83.136 seconds]
+[sig-scheduling] SchedulerPredicates [Serial]
+/workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/scheduling/framework.go:22
+  validates that NodeSelector is respected if not matching  [Conformance]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+[sig-storage] EmptyDir volumes 
+  should support (non-root,0644,default) [Conformance]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-storage] EmptyDir volumes
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Nov 29 07:37:32.633: INFO: >>> kubeConfig: /tmp/kubeconfig-385092372
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should support (non-root,0644,default) [Conformance]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating a pod to test emptydir 0644 on node default medium
+Nov 29 07:37:32.718: INFO: Waiting up to 5m0s for pod "pod-a1f6916d-f3a9-11e8-9124-e6180d057dc8" in namespace "e2e-tests-emptydir-t5sjm" to be "success or failure"
+Nov 29 07:37:32.722: INFO: Pod "pod-a1f6916d-f3a9-11e8-9124-e6180d057dc8": Phase="Pending", Reason="", readiness=false. Elapsed: 4.413803ms
+Nov 29 07:37:34.726: INFO: Pod "pod-a1f6916d-f3a9-11e8-9124-e6180d057dc8": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.007465612s
+STEP: Saw pod success
+Nov 29 07:37:34.726: INFO: Pod "pod-a1f6916d-f3a9-11e8-9124-e6180d057dc8" satisfied condition "success or failure"
+Nov 29 07:37:34.728: INFO: Trying to get logs from node worker-bdccfcb0-f3a8-11e8-90fa-062be367adf0 pod pod-a1f6916d-f3a9-11e8-9124-e6180d057dc8 container test-container: <nil>
+STEP: delete the pod
+Nov 29 07:37:34.747: INFO: Waiting for pod pod-a1f6916d-f3a9-11e8-9124-e6180d057dc8 to disappear
+Nov 29 07:37:34.750: INFO: Pod pod-a1f6916d-f3a9-11e8-9124-e6180d057dc8 no longer exists
+[AfterEach] [sig-storage] EmptyDir volumes
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Nov 29 07:37:34.750: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-emptydir-t5sjm" for this suite.
+Nov 29 07:37:40.758: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Nov 29 07:37:40.772: INFO: namespace: e2e-tests-emptydir-t5sjm, resource: bindings, ignored listing per whitelist
+Nov 29 07:37:40.807: INFO: namespace e2e-tests-emptydir-t5sjm deletion completed in 6.056168242s
+
+• [SLOW TEST:8.175 seconds]
+[sig-storage] EmptyDir volumes
+/workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/empty_dir.go:41
+  should support (non-root,0644,default) [Conformance]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SSSSS
+------------------------------
+[sig-network] DNS 
+  should provide DNS for the cluster  [Conformance]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-network] DNS
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Nov 29 07:37:40.808: INFO: >>> kubeConfig: /tmp/kubeconfig-385092372
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should provide DNS for the cluster  [Conformance]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Running these commands on wheezy: for i in `seq 1 600`; do test -n "$$(dig +notcp +noall +answer +search kubernetes.default A)" && echo OK > /results/wheezy_udp@kubernetes.default;test -n "$$(dig +tcp +noall +answer +search kubernetes.default A)" && echo OK > /results/wheezy_tcp@kubernetes.default;test -n "$$(dig +notcp +noall +answer +search kubernetes.default.svc A)" && echo OK > /results/wheezy_udp@kubernetes.default.svc;test -n "$$(dig +tcp +noall +answer +search kubernetes.default.svc A)" && echo OK > /results/wheezy_tcp@kubernetes.default.svc;test -n "$$(dig +notcp +noall +answer +search kubernetes.default.svc.cluster.local A)" && echo OK > /results/wheezy_udp@kubernetes.default.svc.cluster.local;test -n "$$(dig +tcp +noall +answer +search kubernetes.default.svc.cluster.local A)" && echo OK > /results/wheezy_tcp@kubernetes.default.svc.cluster.local;test -n "$$(getent hosts dns-querier-1.dns-test-service.e2e-tests-dns-cvdrb.svc.cluster.local)" && echo OK > /results/wheezy_hosts@dns-querier-1.dns-test-service.e2e-tests-dns-cvdrb.svc.cluster.local;test -n "$$(getent hosts dns-querier-1)" && echo OK > /results/wheezy_hosts@dns-querier-1;podARec=$$(hostname -i| awk -F. '{print $$1"-"$$2"-"$$3"-"$$4".e2e-tests-dns-cvdrb.pod.cluster.local"}');test -n "$$(dig +notcp +noall +answer +search $${podARec} A)" && echo OK > /results/wheezy_udp@PodARecord;test -n "$$(dig +tcp +noall +answer +search $${podARec} A)" && echo OK > /results/wheezy_tcp@PodARecord;sleep 1; done
+
+STEP: Running these commands on jessie: for i in `seq 1 600`; do test -n "$$(dig +notcp +noall +answer +search kubernetes.default A)" && echo OK > /results/jessie_udp@kubernetes.default;test -n "$$(dig +tcp +noall +answer +search kubernetes.default A)" && echo OK > /results/jessie_tcp@kubernetes.default;test -n "$$(dig +notcp +noall +answer +search kubernetes.default.svc A)" && echo OK > /results/jessie_udp@kubernetes.default.svc;test -n "$$(dig +tcp +noall +answer +search kubernetes.default.svc A)" && echo OK > /results/jessie_tcp@kubernetes.default.svc;test -n "$$(dig +notcp +noall +answer +search kubernetes.default.svc.cluster.local A)" && echo OK > /results/jessie_udp@kubernetes.default.svc.cluster.local;test -n "$$(dig +tcp +noall +answer +search kubernetes.default.svc.cluster.local A)" && echo OK > /results/jessie_tcp@kubernetes.default.svc.cluster.local;test -n "$$(getent hosts dns-querier-1.dns-test-service.e2e-tests-dns-cvdrb.svc.cluster.local)" && echo OK > /results/jessie_hosts@dns-querier-1.dns-test-service.e2e-tests-dns-cvdrb.svc.cluster.local;test -n "$$(getent hosts dns-querier-1)" && echo OK > /results/jessie_hosts@dns-querier-1;podARec=$$(hostname -i| awk -F. '{print $$1"-"$$2"-"$$3"-"$$4".e2e-tests-dns-cvdrb.pod.cluster.local"}');test -n "$$(dig +notcp +noall +answer +search $${podARec} A)" && echo OK > /results/jessie_udp@PodARecord;test -n "$$(dig +tcp +noall +answer +search $${podARec} A)" && echo OK > /results/jessie_tcp@PodARecord;sleep 1; done
+
+STEP: creating a pod to probe DNS
+STEP: submitting the pod to kubernetes
+STEP: retrieving the pod
+STEP: looking for the results for each expected name from probers
+Nov 29 07:38:00.874: INFO: DNS probes using dns-test-a6ce80c4-f3a9-11e8-9124-e6180d057dc8 succeeded
+
+STEP: deleting the pod
+[AfterEach] [sig-network] DNS
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Nov 29 07:38:00.888: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-dns-cvdrb" for this suite.
+Nov 29 07:38:06.905: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Nov 29 07:38:06.939: INFO: namespace: e2e-tests-dns-cvdrb, resource: bindings, ignored listing per whitelist
+Nov 29 07:38:06.958: INFO: namespace e2e-tests-dns-cvdrb deletion completed in 6.059169574s
+
+• [SLOW TEST:26.150 seconds]
+[sig-network] DNS
+/workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/network/framework.go:22
+  should provide DNS for the cluster  [Conformance]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SS
+------------------------------
+[sig-api-machinery] ConfigMap 
+  should be consumable via environment variable  [Conformance]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-api-machinery] ConfigMap
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Nov 29 07:38:06.958: INFO: >>> kubeConfig: /tmp/kubeconfig-385092372
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should be consumable via environment variable  [Conformance]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating configMap e2e-tests-configmap-955mr/configmap-test-b6648c7d-f3a9-11e8-9124-e6180d057dc8
+STEP: Creating a pod to test consume configMaps
+Nov 29 07:38:06.990: INFO: Waiting up to 5m0s for pod "pod-configmaps-b664c8eb-f3a9-11e8-9124-e6180d057dc8" in namespace "e2e-tests-configmap-955mr" to be "success or failure"
+Nov 29 07:38:06.994: INFO: Pod "pod-configmaps-b664c8eb-f3a9-11e8-9124-e6180d057dc8": Phase="Pending", Reason="", readiness=false. Elapsed: 3.593529ms
+Nov 29 07:38:08.995: INFO: Pod "pod-configmaps-b664c8eb-f3a9-11e8-9124-e6180d057dc8": Phase="Pending", Reason="", readiness=false. Elapsed: 2.005099649s
+Nov 29 07:38:10.997: INFO: Pod "pod-configmaps-b664c8eb-f3a9-11e8-9124-e6180d057dc8": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.006939797s
+STEP: Saw pod success
+Nov 29 07:38:10.997: INFO: Pod "pod-configmaps-b664c8eb-f3a9-11e8-9124-e6180d057dc8" satisfied condition "success or failure"
+Nov 29 07:38:10.998: INFO: Trying to get logs from node worker-bdccfcb0-f3a8-11e8-90fa-062be367adf0 pod pod-configmaps-b664c8eb-f3a9-11e8-9124-e6180d057dc8 container env-test: <nil>
+STEP: delete the pod
+Nov 29 07:38:11.012: INFO: Waiting for pod pod-configmaps-b664c8eb-f3a9-11e8-9124-e6180d057dc8 to disappear
+Nov 29 07:38:11.016: INFO: Pod pod-configmaps-b664c8eb-f3a9-11e8-9124-e6180d057dc8 no longer exists
+[AfterEach] [sig-api-machinery] ConfigMap
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Nov 29 07:38:11.018: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-configmap-955mr" for this suite.
+Nov 29 07:38:17.027: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Nov 29 07:38:17.080: INFO: namespace: e2e-tests-configmap-955mr, resource: bindings, ignored listing per whitelist
+Nov 29 07:38:17.082: INFO: namespace e2e-tests-configmap-955mr deletion completed in 6.063076307s
+
+• [SLOW TEST:10.124 seconds]
+[sig-api-machinery] ConfigMap
+/workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/configmap.go:29
+  should be consumable via environment variable  [Conformance]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+[sig-storage] ConfigMap 
+  should be consumable from pods in volume with mappings  [Conformance]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-storage] ConfigMap
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Nov 29 07:38:17.082: INFO: >>> kubeConfig: /tmp/kubeconfig-385092372
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should be consumable from pods in volume with mappings  [Conformance]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating configMap with name configmap-test-volume-map-bc750d7e-f3a9-11e8-9124-e6180d057dc8
+STEP: Creating a pod to test consume configMaps
+Nov 29 07:38:17.174: INFO: Waiting up to 5m0s for pod "pod-configmaps-bc754c5b-f3a9-11e8-9124-e6180d057dc8" in namespace "e2e-tests-configmap-v5cnv" to be "success or failure"
+Nov 29 07:38:17.175: INFO: Pod "pod-configmaps-bc754c5b-f3a9-11e8-9124-e6180d057dc8": Phase="Pending", Reason="", readiness=false. Elapsed: 1.39125ms
+Nov 29 07:38:19.177: INFO: Pod "pod-configmaps-bc754c5b-f3a9-11e8-9124-e6180d057dc8": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.003024315s
+STEP: Saw pod success
+Nov 29 07:38:19.177: INFO: Pod "pod-configmaps-bc754c5b-f3a9-11e8-9124-e6180d057dc8" satisfied condition "success or failure"
+Nov 29 07:38:19.178: INFO: Trying to get logs from node worker-bdccfcb0-f3a8-11e8-90fa-062be367adf0 pod pod-configmaps-bc754c5b-f3a9-11e8-9124-e6180d057dc8 container configmap-volume-test: <nil>
+STEP: delete the pod
+Nov 29 07:38:19.191: INFO: Waiting for pod pod-configmaps-bc754c5b-f3a9-11e8-9124-e6180d057dc8 to disappear
+Nov 29 07:38:19.193: INFO: Pod pod-configmaps-bc754c5b-f3a9-11e8-9124-e6180d057dc8 no longer exists
+[AfterEach] [sig-storage] ConfigMap
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Nov 29 07:38:19.193: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-configmap-v5cnv" for this suite.
+Nov 29 07:38:25.200: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Nov 29 07:38:25.256: INFO: namespace: e2e-tests-configmap-v5cnv, resource: bindings, ignored listing per whitelist
+Nov 29 07:38:25.258: INFO: namespace e2e-tests-configmap-v5cnv deletion completed in 6.063277418s
+
+• [SLOW TEST:8.175 seconds]
+[sig-storage] ConfigMap
+/workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/configmap_volume.go:32
+  should be consumable from pods in volume with mappings  [Conformance]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+S
+------------------------------
+[sig-storage] Projected 
+  should be consumable from pods in volume [Conformance]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Nov 29 07:38:25.258: INFO: >>> kubeConfig: /tmp/kubeconfig-385092372
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:858
+[It] should be consumable from pods in volume [Conformance]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating projection with secret that has name projected-secret-test-c14ceeab-f3a9-11e8-9124-e6180d057dc8
+STEP: Creating a pod to test consume secrets
+Nov 29 07:38:25.293: INFO: Waiting up to 5m0s for pod "pod-projected-secrets-c14d296c-f3a9-11e8-9124-e6180d057dc8" in namespace "e2e-tests-projected-9x8rb" to be "success or failure"
+Nov 29 07:38:25.299: INFO: Pod "pod-projected-secrets-c14d296c-f3a9-11e8-9124-e6180d057dc8": Phase="Pending", Reason="", readiness=false. Elapsed: 5.982956ms
+Nov 29 07:38:27.301: INFO: Pod "pod-projected-secrets-c14d296c-f3a9-11e8-9124-e6180d057dc8": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.007791538s
+STEP: Saw pod success
+Nov 29 07:38:27.301: INFO: Pod "pod-projected-secrets-c14d296c-f3a9-11e8-9124-e6180d057dc8" satisfied condition "success or failure"
+Nov 29 07:38:27.302: INFO: Trying to get logs from node worker-bdccfcb0-f3a8-11e8-90fa-062be367adf0 pod pod-projected-secrets-c14d296c-f3a9-11e8-9124-e6180d057dc8 container projected-secret-volume-test: <nil>
+STEP: delete the pod
+Nov 29 07:38:27.319: INFO: Waiting for pod pod-projected-secrets-c14d296c-f3a9-11e8-9124-e6180d057dc8 to disappear
+Nov 29 07:38:27.325: INFO: Pod pod-projected-secrets-c14d296c-f3a9-11e8-9124-e6180d057dc8 no longer exists
+[AfterEach] [sig-storage] Projected
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Nov 29 07:38:27.325: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-9x8rb" for this suite.
+Nov 29 07:38:33.331: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Nov 29 07:38:33.380: INFO: namespace: e2e-tests-projected-9x8rb, resource: bindings, ignored listing per whitelist
+Nov 29 07:38:33.384: INFO: namespace e2e-tests-projected-9x8rb deletion completed in 6.056781889s
+
+• [SLOW TEST:8.126 seconds]
+[sig-storage] Projected
+/workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:34
+  should be consumable from pods in volume [Conformance]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SSSSSSSS
+------------------------------
+[sig-network] Networking Granular Checks: Pods 
+  should function for node-pod communication: udp  [Conformance]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-network] Networking
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Nov 29 07:38:33.384: INFO: >>> kubeConfig: /tmp/kubeconfig-385092372
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should function for node-pod communication: udp  [Conformance]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Performing setup for networking test in namespace e2e-tests-pod-network-test-wx745
+STEP: creating a selector
+STEP: Creating the service pods in kubernetes
+Nov 29 07:38:33.416: INFO: Waiting up to 10m0s for all (but 0) nodes to be schedulable
+STEP: Creating test pods
+Nov 29 07:38:49.441: INFO: ExecWithOptions {Command:[/bin/sh -c echo 'hostName' | timeout -t 2 nc -w 1 -u 10.2.1.27 8081 | grep -v '^\s*$'] Namespace:e2e-tests-pod-network-test-wx745 PodName:host-test-container-pod ContainerName:hostexec Stdin:<nil> CaptureStdout:true CaptureStderr:true PreserveWhitespace:false}
+Nov 29 07:38:49.441: INFO: >>> kubeConfig: /tmp/kubeconfig-385092372
+Nov 29 07:38:50.480: INFO: Found all expected endpoints: [netserver-0]
+[AfterEach] [sig-network] Networking
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Nov 29 07:38:50.480: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-pod-network-test-wx745" for this suite.
+Nov 29 07:39:12.487: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Nov 29 07:39:12.531: INFO: namespace: e2e-tests-pod-network-test-wx745, resource: bindings, ignored listing per whitelist
+Nov 29 07:39:12.538: INFO: namespace e2e-tests-pod-network-test-wx745 deletion completed in 22.056554333s
+
+• [SLOW TEST:39.154 seconds]
+[sig-network] Networking
+/workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/networking.go:25
+  Granular Checks: Pods
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/networking.go:28
+    should function for node-pod communication: udp  [Conformance]
+    /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+[sig-network] DNS 
+  should provide DNS for services  [Conformance]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-network] DNS
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Nov 29 07:39:12.538: INFO: >>> kubeConfig: /tmp/kubeconfig-385092372
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should provide DNS for services  [Conformance]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating a test headless service
+STEP: Running these commands on wheezy: for i in `seq 1 600`; do test -n "$$(dig +notcp +noall +answer +search dns-test-service A)" && echo OK > /results/wheezy_udp@dns-test-service;test -n "$$(dig +tcp +noall +answer +search dns-test-service A)" && echo OK > /results/wheezy_tcp@dns-test-service;test -n "$$(dig +notcp +noall +answer +search dns-test-service.e2e-tests-dns-sjsdd A)" && echo OK > /results/wheezy_udp@dns-test-service.e2e-tests-dns-sjsdd;test -n "$$(dig +tcp +noall +answer +search dns-test-service.e2e-tests-dns-sjsdd A)" && echo OK > /results/wheezy_tcp@dns-test-service.e2e-tests-dns-sjsdd;test -n "$$(dig +notcp +noall +answer +search dns-test-service.e2e-tests-dns-sjsdd.svc A)" && echo OK > /results/wheezy_udp@dns-test-service.e2e-tests-dns-sjsdd.svc;test -n "$$(dig +tcp +noall +answer +search dns-test-service.e2e-tests-dns-sjsdd.svc A)" && echo OK > /results/wheezy_tcp@dns-test-service.e2e-tests-dns-sjsdd.svc;test -n "$$(dig +notcp +noall +answer +search _http._tcp.dns-test-service.e2e-tests-dns-sjsdd.svc SRV)" && echo OK > /results/wheezy_udp@_http._tcp.dns-test-service.e2e-tests-dns-sjsdd.svc;test -n "$$(dig +tcp +noall +answer +search _http._tcp.dns-test-service.e2e-tests-dns-sjsdd.svc SRV)" && echo OK > /results/wheezy_tcp@_http._tcp.dns-test-service.e2e-tests-dns-sjsdd.svc;test -n "$$(dig +notcp +noall +answer +search _http._tcp.test-service-2.e2e-tests-dns-sjsdd.svc SRV)" && echo OK > /results/wheezy_udp@_http._tcp.test-service-2.e2e-tests-dns-sjsdd.svc;test -n "$$(dig +tcp +noall +answer +search _http._tcp.test-service-2.e2e-tests-dns-sjsdd.svc SRV)" && echo OK > /results/wheezy_tcp@_http._tcp.test-service-2.e2e-tests-dns-sjsdd.svc;podARec=$$(hostname -i| awk -F. '{print $$1"-"$$2"-"$$3"-"$$4".e2e-tests-dns-sjsdd.pod.cluster.local"}');test -n "$$(dig +notcp +noall +answer +search $${podARec} A)" && echo OK > /results/wheezy_udp@PodARecord;test -n "$$(dig +tcp +noall +answer +search $${podARec} A)" && echo OK > /results/wheezy_tcp@PodARecord;test -n "$$(dig +notcp +noall +answer +search 72.0.0.10.in-addr.arpa. PTR)" && echo OK > /results/10.0.0.72_udp@PTR;test -n "$$(dig +tcp +noall +answer +search 72.0.0.10.in-addr.arpa. PTR)" && echo OK > /results/10.0.0.72_tcp@PTR;sleep 1; done
+
+STEP: Running these commands on jessie: for i in `seq 1 600`; do test -n "$$(dig +notcp +noall +answer +search dns-test-service A)" && echo OK > /results/jessie_udp@dns-test-service;test -n "$$(dig +tcp +noall +answer +search dns-test-service A)" && echo OK > /results/jessie_tcp@dns-test-service;test -n "$$(dig +notcp +noall +answer +search dns-test-service.e2e-tests-dns-sjsdd A)" && echo OK > /results/jessie_udp@dns-test-service.e2e-tests-dns-sjsdd;test -n "$$(dig +tcp +noall +answer +search dns-test-service.e2e-tests-dns-sjsdd A)" && echo OK > /results/jessie_tcp@dns-test-service.e2e-tests-dns-sjsdd;test -n "$$(dig +notcp +noall +answer +search dns-test-service.e2e-tests-dns-sjsdd.svc A)" && echo OK > /results/jessie_udp@dns-test-service.e2e-tests-dns-sjsdd.svc;test -n "$$(dig +tcp +noall +answer +search dns-test-service.e2e-tests-dns-sjsdd.svc A)" && echo OK > /results/jessie_tcp@dns-test-service.e2e-tests-dns-sjsdd.svc;test -n "$$(dig +notcp +noall +answer +search _http._tcp.dns-test-service.e2e-tests-dns-sjsdd.svc SRV)" && echo OK > /results/jessie_udp@_http._tcp.dns-test-service.e2e-tests-dns-sjsdd.svc;test -n "$$(dig +tcp +noall +answer +search _http._tcp.dns-test-service.e2e-tests-dns-sjsdd.svc SRV)" && echo OK > /results/jessie_tcp@_http._tcp.dns-test-service.e2e-tests-dns-sjsdd.svc;test -n "$$(dig +notcp +noall +answer +search _http._tcp.test-service-2.e2e-tests-dns-sjsdd.svc SRV)" && echo OK > /results/jessie_udp@_http._tcp.test-service-2.e2e-tests-dns-sjsdd.svc;test -n "$$(dig +tcp +noall +answer +search _http._tcp.test-service-2.e2e-tests-dns-sjsdd.svc SRV)" && echo OK > /results/jessie_tcp@_http._tcp.test-service-2.e2e-tests-dns-sjsdd.svc;podARec=$$(hostname -i| awk -F. '{print $$1"-"$$2"-"$$3"-"$$4".e2e-tests-dns-sjsdd.pod.cluster.local"}');test -n "$$(dig +notcp +noall +answer +search $${podARec} A)" && echo OK > /results/jessie_udp@PodARecord;test -n "$$(dig +tcp +noall +answer +search $${podARec} A)" && echo OK > /results/jessie_tcp@PodARecord;test -n "$$(dig +notcp +noall +answer +search 72.0.0.10.in-addr.arpa. PTR)" && echo OK > /results/10.0.0.72_udp@PTR;test -n "$$(dig +tcp +noall +answer +search 72.0.0.10.in-addr.arpa. PTR)" && echo OK > /results/10.0.0.72_tcp@PTR;sleep 1; done
+
+STEP: creating a pod to probe DNS
+STEP: submitting the pod to kubernetes
+STEP: retrieving the pod
+STEP: looking for the results for each expected name from probers
+Nov 29 07:39:24.607: INFO: Unable to read wheezy_tcp@dns-test-service from pod dns-test-dd7c81e2-f3a9-11e8-9124-e6180d057dc8: the server could not find the requested resource (get pods dns-test-dd7c81e2-f3a9-11e8-9124-e6180d057dc8)
+Nov 29 07:39:24.621: INFO: Unable to read wheezy_tcp@dns-test-service.e2e-tests-dns-sjsdd from pod dns-test-dd7c81e2-f3a9-11e8-9124-e6180d057dc8: the server could not find the requested resource (get pods dns-test-dd7c81e2-f3a9-11e8-9124-e6180d057dc8)
+Nov 29 07:39:24.623: INFO: Unable to read wheezy_tcp@dns-test-service.e2e-tests-dns-sjsdd.svc from pod dns-test-dd7c81e2-f3a9-11e8-9124-e6180d057dc8: the server could not find the requested resource (get pods dns-test-dd7c81e2-f3a9-11e8-9124-e6180d057dc8)
+Nov 29 07:39:24.626: INFO: Unable to read wheezy_tcp@_http._tcp.dns-test-service.e2e-tests-dns-sjsdd.svc from pod dns-test-dd7c81e2-f3a9-11e8-9124-e6180d057dc8: the server could not find the requested resource (get pods dns-test-dd7c81e2-f3a9-11e8-9124-e6180d057dc8)
+Nov 29 07:39:24.636: INFO: Unable to read jessie_udp@dns-test-service from pod dns-test-dd7c81e2-f3a9-11e8-9124-e6180d057dc8: the server could not find the requested resource (get pods dns-test-dd7c81e2-f3a9-11e8-9124-e6180d057dc8)
+Nov 29 07:39:24.637: INFO: Unable to read jessie_tcp@dns-test-service from pod dns-test-dd7c81e2-f3a9-11e8-9124-e6180d057dc8: the server could not find the requested resource (get pods dns-test-dd7c81e2-f3a9-11e8-9124-e6180d057dc8)
+Nov 29 07:39:24.638: INFO: Unable to read jessie_udp@dns-test-service.e2e-tests-dns-sjsdd from pod dns-test-dd7c81e2-f3a9-11e8-9124-e6180d057dc8: the server could not find the requested resource (get pods dns-test-dd7c81e2-f3a9-11e8-9124-e6180d057dc8)
+Nov 29 07:39:24.640: INFO: Unable to read jessie_tcp@dns-test-service.e2e-tests-dns-sjsdd from pod dns-test-dd7c81e2-f3a9-11e8-9124-e6180d057dc8: the server could not find the requested resource (get pods dns-test-dd7c81e2-f3a9-11e8-9124-e6180d057dc8)
+Nov 29 07:39:24.641: INFO: Unable to read jessie_udp@dns-test-service.e2e-tests-dns-sjsdd.svc from pod dns-test-dd7c81e2-f3a9-11e8-9124-e6180d057dc8: the server could not find the requested resource (get pods dns-test-dd7c81e2-f3a9-11e8-9124-e6180d057dc8)
+Nov 29 07:39:24.642: INFO: Unable to read jessie_tcp@dns-test-service.e2e-tests-dns-sjsdd.svc from pod dns-test-dd7c81e2-f3a9-11e8-9124-e6180d057dc8: the server could not find the requested resource (get pods dns-test-dd7c81e2-f3a9-11e8-9124-e6180d057dc8)
+Nov 29 07:39:24.643: INFO: Unable to read jessie_udp@_http._tcp.dns-test-service.e2e-tests-dns-sjsdd.svc from pod dns-test-dd7c81e2-f3a9-11e8-9124-e6180d057dc8: the server could not find the requested resource (get pods dns-test-dd7c81e2-f3a9-11e8-9124-e6180d057dc8)
+Nov 29 07:39:24.645: INFO: Unable to read jessie_tcp@_http._tcp.dns-test-service.e2e-tests-dns-sjsdd.svc from pod dns-test-dd7c81e2-f3a9-11e8-9124-e6180d057dc8: the server could not find the requested resource (get pods dns-test-dd7c81e2-f3a9-11e8-9124-e6180d057dc8)
+Nov 29 07:39:24.653: INFO: Lookups using dns-test-dd7c81e2-f3a9-11e8-9124-e6180d057dc8 failed for: [wheezy_tcp@dns-test-service wheezy_tcp@dns-test-service.e2e-tests-dns-sjsdd wheezy_tcp@dns-test-service.e2e-tests-dns-sjsdd.svc wheezy_tcp@_http._tcp.dns-test-service.e2e-tests-dns-sjsdd.svc jessie_udp@dns-test-service jessie_tcp@dns-test-service jessie_udp@dns-test-service.e2e-tests-dns-sjsdd jessie_tcp@dns-test-service.e2e-tests-dns-sjsdd jessie_udp@dns-test-service.e2e-tests-dns-sjsdd.svc jessie_tcp@dns-test-service.e2e-tests-dns-sjsdd.svc jessie_udp@_http._tcp.dns-test-service.e2e-tests-dns-sjsdd.svc jessie_tcp@_http._tcp.dns-test-service.e2e-tests-dns-sjsdd.svc]
+
+Nov 29 07:39:34.607: INFO: Unable to read wheezy_tcp@dns-test-service from pod dns-test-dd7c81e2-f3a9-11e8-9124-e6180d057dc8: the server could not find the requested resource (get pods dns-test-dd7c81e2-f3a9-11e8-9124-e6180d057dc8)
+Nov 29 07:39:34.610: INFO: Unable to read wheezy_tcp@dns-test-service.e2e-tests-dns-sjsdd from pod dns-test-dd7c81e2-f3a9-11e8-9124-e6180d057dc8: the server could not find the requested resource (get pods dns-test-dd7c81e2-f3a9-11e8-9124-e6180d057dc8)
+Nov 29 07:39:34.613: INFO: Unable to read wheezy_tcp@dns-test-service.e2e-tests-dns-sjsdd.svc from pod dns-test-dd7c81e2-f3a9-11e8-9124-e6180d057dc8: the server could not find the requested resource (get pods dns-test-dd7c81e2-f3a9-11e8-9124-e6180d057dc8)
+Nov 29 07:39:34.615: INFO: Unable to read wheezy_tcp@_http._tcp.dns-test-service.e2e-tests-dns-sjsdd.svc from pod dns-test-dd7c81e2-f3a9-11e8-9124-e6180d057dc8: the server could not find the requested resource (get pods dns-test-dd7c81e2-f3a9-11e8-9124-e6180d057dc8)
+Nov 29 07:39:34.625: INFO: Unable to read jessie_udp@dns-test-service from pod dns-test-dd7c81e2-f3a9-11e8-9124-e6180d057dc8: the server could not find the requested resource (get pods dns-test-dd7c81e2-f3a9-11e8-9124-e6180d057dc8)
+Nov 29 07:39:34.626: INFO: Unable to read jessie_tcp@dns-test-service from pod dns-test-dd7c81e2-f3a9-11e8-9124-e6180d057dc8: the server could not find the requested resource (get pods dns-test-dd7c81e2-f3a9-11e8-9124-e6180d057dc8)
+Nov 29 07:39:34.627: INFO: Unable to read jessie_udp@dns-test-service.e2e-tests-dns-sjsdd from pod dns-test-dd7c81e2-f3a9-11e8-9124-e6180d057dc8: the server could not find the requested resource (get pods dns-test-dd7c81e2-f3a9-11e8-9124-e6180d057dc8)
+Nov 29 07:39:34.629: INFO: Unable to read jessie_tcp@dns-test-service.e2e-tests-dns-sjsdd from pod dns-test-dd7c81e2-f3a9-11e8-9124-e6180d057dc8: the server could not find the requested resource (get pods dns-test-dd7c81e2-f3a9-11e8-9124-e6180d057dc8)
+Nov 29 07:39:34.630: INFO: Unable to read jessie_udp@dns-test-service.e2e-tests-dns-sjsdd.svc from pod dns-test-dd7c81e2-f3a9-11e8-9124-e6180d057dc8: the server could not find the requested resource (get pods dns-test-dd7c81e2-f3a9-11e8-9124-e6180d057dc8)
+Nov 29 07:39:34.631: INFO: Unable to read jessie_tcp@dns-test-service.e2e-tests-dns-sjsdd.svc from pod dns-test-dd7c81e2-f3a9-11e8-9124-e6180d057dc8: the server could not find the requested resource (get pods dns-test-dd7c81e2-f3a9-11e8-9124-e6180d057dc8)
+Nov 29 07:39:34.633: INFO: Unable to read jessie_udp@_http._tcp.dns-test-service.e2e-tests-dns-sjsdd.svc from pod dns-test-dd7c81e2-f3a9-11e8-9124-e6180d057dc8: the server could not find the requested resource (get pods dns-test-dd7c81e2-f3a9-11e8-9124-e6180d057dc8)
+Nov 29 07:39:34.634: INFO: Unable to read jessie_tcp@_http._tcp.dns-test-service.e2e-tests-dns-sjsdd.svc from pod dns-test-dd7c81e2-f3a9-11e8-9124-e6180d057dc8: the server could not find the requested resource (get pods dns-test-dd7c81e2-f3a9-11e8-9124-e6180d057dc8)
+Nov 29 07:39:34.642: INFO: Lookups using dns-test-dd7c81e2-f3a9-11e8-9124-e6180d057dc8 failed for: [wheezy_tcp@dns-test-service wheezy_tcp@dns-test-service.e2e-tests-dns-sjsdd wheezy_tcp@dns-test-service.e2e-tests-dns-sjsdd.svc wheezy_tcp@_http._tcp.dns-test-service.e2e-tests-dns-sjsdd.svc jessie_udp@dns-test-service jessie_tcp@dns-test-service jessie_udp@dns-test-service.e2e-tests-dns-sjsdd jessie_tcp@dns-test-service.e2e-tests-dns-sjsdd jessie_udp@dns-test-service.e2e-tests-dns-sjsdd.svc jessie_tcp@dns-test-service.e2e-tests-dns-sjsdd.svc jessie_udp@_http._tcp.dns-test-service.e2e-tests-dns-sjsdd.svc jessie_tcp@_http._tcp.dns-test-service.e2e-tests-dns-sjsdd.svc]
+
+Nov 29 07:39:44.615: INFO: Unable to read wheezy_tcp@_http._tcp.dns-test-service.e2e-tests-dns-sjsdd.svc from pod dns-test-dd7c81e2-f3a9-11e8-9124-e6180d057dc8: the server could not find the requested resource (get pods dns-test-dd7c81e2-f3a9-11e8-9124-e6180d057dc8)
+Nov 29 07:39:44.642: INFO: Lookups using dns-test-dd7c81e2-f3a9-11e8-9124-e6180d057dc8 failed for: [wheezy_tcp@_http._tcp.dns-test-service.e2e-tests-dns-sjsdd.svc]
+
+Nov 29 07:39:54.641: INFO: DNS probes using dns-test-dd7c81e2-f3a9-11e8-9124-e6180d057dc8 succeeded
+
+STEP: deleting the pod
+STEP: deleting the test service
+STEP: deleting the test headless service
+[AfterEach] [sig-network] DNS
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Nov 29 07:39:54.694: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-dns-sjsdd" for this suite.
+Nov 29 07:40:00.702: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Nov 29 07:40:00.723: INFO: namespace: e2e-tests-dns-sjsdd, resource: bindings, ignored listing per whitelist
+Nov 29 07:40:00.753: INFO: namespace e2e-tests-dns-sjsdd deletion completed in 6.057541993s
+
+• [SLOW TEST:48.215 seconds]
+[sig-network] DNS
+/workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/network/framework.go:22
+  should provide DNS for services  [Conformance]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SS
+------------------------------
+[sig-storage] Projected 
+  should provide podname only [Conformance]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Nov 29 07:40:00.753: INFO: >>> kubeConfig: /tmp/kubeconfig-385092372
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:858
+[It] should provide podname only [Conformance]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating a pod to test downward API volume plugin
+Nov 29 07:40:00.795: INFO: Waiting up to 5m0s for pod "downwardapi-volume-fa399279-f3a9-11e8-9124-e6180d057dc8" in namespace "e2e-tests-projected-d75bk" to be "success or failure"
+Nov 29 07:40:00.800: INFO: Pod "downwardapi-volume-fa399279-f3a9-11e8-9124-e6180d057dc8": Phase="Pending", Reason="", readiness=false. Elapsed: 4.505121ms
+Nov 29 07:40:02.801: INFO: Pod "downwardapi-volume-fa399279-f3a9-11e8-9124-e6180d057dc8": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.005842962s
+STEP: Saw pod success
+Nov 29 07:40:02.801: INFO: Pod "downwardapi-volume-fa399279-f3a9-11e8-9124-e6180d057dc8" satisfied condition "success or failure"
+Nov 29 07:40:02.802: INFO: Trying to get logs from node worker-bdccfcb0-f3a8-11e8-90fa-062be367adf0 pod downwardapi-volume-fa399279-f3a9-11e8-9124-e6180d057dc8 container client-container: <nil>
+STEP: delete the pod
+Nov 29 07:40:02.814: INFO: Waiting for pod downwardapi-volume-fa399279-f3a9-11e8-9124-e6180d057dc8 to disappear
+Nov 29 07:40:02.818: INFO: Pod downwardapi-volume-fa399279-f3a9-11e8-9124-e6180d057dc8 no longer exists
+[AfterEach] [sig-storage] Projected
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Nov 29 07:40:02.818: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-d75bk" for this suite.
+Nov 29 07:40:08.830: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Nov 29 07:40:08.874: INFO: namespace: e2e-tests-projected-d75bk, resource: bindings, ignored listing per whitelist
+Nov 29 07:40:08.880: INFO: namespace e2e-tests-projected-d75bk deletion completed in 6.054355717s
+
+• [SLOW TEST:8.127 seconds]
+[sig-storage] Projected
+/workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:34
+  should provide podname only [Conformance]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SSSSSSSSSS
+------------------------------
+[sig-scheduling] SchedulerPredicates [Serial] 
+  validates resource limits of pods that are allowed to run  [Conformance]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-scheduling] SchedulerPredicates [Serial]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Nov 29 07:40:08.880: INFO: >>> kubeConfig: /tmp/kubeconfig-385092372
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-scheduling] SchedulerPredicates [Serial]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/scheduling/predicates.go:78
+Nov 29 07:40:08.908: INFO: Waiting up to 1m0s for all nodes to be ready
+Nov 29 07:41:08.916: INFO: Waiting for terminating namespaces to be deleted...
+Nov 29 07:41:08.918: INFO: Waiting up to 5m0s for all pods (need at least 0) in namespace 'kube-system' to be running and ready
+Nov 29 07:41:08.921: INFO: 0 / 0 pods in namespace 'kube-system' are running and ready (0 seconds elapsed)
+Nov 29 07:41:08.921: INFO: expected 0 pod replicas in namespace 'kube-system', 0 are Running and Ready.
+Nov 29 07:41:08.922: INFO: Waiting for pods to enter Success, but no pods in "kube-system" match label map[name:e2e-image-puller]
+Nov 29 07:41:08.922: INFO: 
+Logging pods the kubelet thinks is on node worker-bdccfcb0-f3a8-11e8-90fa-062be367adf0 before test
+Nov 29 07:41:08.924: INFO: canal-node-test15434755641-11-5-1-dtcp7 from vke-system started at 2018-11-29 07:33:18 +0000 UTC (3 container statuses recorded)
+Nov 29 07:41:08.924: INFO: 	Container calico-node ready: true, restart count 0
+Nov 29 07:41:08.924: INFO: 	Container flannel ready: true, restart count 0
+Nov 29 07:41:08.924: INFO: 	Container install-calico-cni ready: true, restart count 0
+Nov 29 07:41:08.924: INFO: sonobuoy from sonobuoy started at 2018-11-29 07:33:28 +0000 UTC (1 container statuses recorded)
+Nov 29 07:41:08.924: INFO: 	Container kube-sonobuoy ready: true, restart count 0
+Nov 29 07:41:08.924: INFO: sonobuoy-e2e-job from sonobuoy started at 2018-11-29 07:33:40 +0000 UTC (2 container statuses recorded)
+Nov 29 07:41:08.924: INFO: 	Container e2e ready: true, restart count 0
+Nov 29 07:41:08.924: INFO: 	Container sonobuoy-worker ready: true, restart count 0
+[It] validates resource limits of pods that are allowed to run  [Conformance]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: verifying the node has the label node worker-bdccfcb0-f3a8-11e8-90fa-062be367adf0
+Nov 29 07:41:08.938: INFO: Pod sonobuoy requesting resource cpu=0m on Node worker-bdccfcb0-f3a8-11e8-90fa-062be367adf0
+Nov 29 07:41:08.938: INFO: Pod sonobuoy-e2e-job requesting resource cpu=0m on Node worker-bdccfcb0-f3a8-11e8-90fa-062be367adf0
+Nov 29 07:41:08.938: INFO: Pod canal-node-test15434755641-11-5-1-dtcp7 requesting resource cpu=250m on Node worker-bdccfcb0-f3a8-11e8-90fa-062be367adf0
+STEP: Starting Pods to consume most of the cluster CPU.
+STEP: Creating another pod that requires unavailable amount of CPU.
+STEP: Considering event: 
+Type = [Normal], Name = [filler-pod-22d82871-f3aa-11e8-9124-e6180d057dc8.156b8865ffbb8014], Reason = [Scheduled], Message = [Successfully assigned e2e-tests-sched-pred-2v2xw/filler-pod-22d82871-f3aa-11e8-9124-e6180d057dc8 to worker-bdccfcb0-f3a8-11e8-90fa-062be367adf0]
+STEP: Considering event: 
+Type = [Normal], Name = [filler-pod-22d82871-f3aa-11e8-9124-e6180d057dc8.156b886621b35b1c], Reason = [Pulling], Message = [pulling image "k8s.gcr.io/pause-amd64:3.1"]
+STEP: Considering event: 
+Type = [Normal], Name = [filler-pod-22d82871-f3aa-11e8-9124-e6180d057dc8.156b88664acd7e53], Reason = [Pulled], Message = [Successfully pulled image "k8s.gcr.io/pause-amd64:3.1"]
+STEP: Considering event: 
+Type = [Normal], Name = [filler-pod-22d82871-f3aa-11e8-9124-e6180d057dc8.156b88664d6e689d], Reason = [Created], Message = [Created container]
+STEP: Considering event: 
+Type = [Normal], Name = [filler-pod-22d82871-f3aa-11e8-9124-e6180d057dc8.156b886651d13327], Reason = [Started], Message = [Started container]
+STEP: Considering event: 
+Type = [Warning], Name = [additional-pod.156b886677535707], Reason = [FailedScheduling], Message = [0/2 nodes are available: 1 Insufficient cpu, 1 node(s) had taints that the pod didn't tolerate.]
+STEP: removing the label node off the node worker-bdccfcb0-f3a8-11e8-90fa-062be367adf0
+STEP: verifying the node doesn't have the label node
+[AfterEach] [sig-scheduling] SchedulerPredicates [Serial]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Nov 29 07:41:11.967: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-sched-pred-2v2xw" for this suite.
+Nov 29 07:41:33.974: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Nov 29 07:41:34.029: INFO: namespace: e2e-tests-sched-pred-2v2xw, resource: bindings, ignored listing per whitelist
+Nov 29 07:41:34.032: INFO: namespace e2e-tests-sched-pred-2v2xw deletion completed in 22.063137503s
+[AfterEach] [sig-scheduling] SchedulerPredicates [Serial]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/scheduling/predicates.go:69
+
+• [SLOW TEST:85.152 seconds]
+[sig-scheduling] SchedulerPredicates [Serial]
+/workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/scheduling/framework.go:22
+  validates resource limits of pods that are allowed to run  [Conformance]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SSSSS
+------------------------------
+[sig-storage] Downward API volume 
+  should provide podname only  [Conformance]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Nov 29 07:41:34.033: INFO: >>> kubeConfig: /tmp/kubeconfig-385092372
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downwardapi_volume.go:38
+[It] should provide podname only  [Conformance]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating a pod to test downward API volume plugin
+Nov 29 07:41:34.062: INFO: Waiting up to 5m0s for pod "downwardapi-volume-31d1776b-f3aa-11e8-9124-e6180d057dc8" in namespace "e2e-tests-downward-api-rmqfn" to be "success or failure"
+Nov 29 07:41:34.066: INFO: Pod "downwardapi-volume-31d1776b-f3aa-11e8-9124-e6180d057dc8": Phase="Pending", Reason="", readiness=false. Elapsed: 3.620349ms
+Nov 29 07:41:36.068: INFO: Pod "downwardapi-volume-31d1776b-f3aa-11e8-9124-e6180d057dc8": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.005360737s
+STEP: Saw pod success
+Nov 29 07:41:36.068: INFO: Pod "downwardapi-volume-31d1776b-f3aa-11e8-9124-e6180d057dc8" satisfied condition "success or failure"
+Nov 29 07:41:36.069: INFO: Trying to get logs from node worker-bdccfcb0-f3a8-11e8-90fa-062be367adf0 pod downwardapi-volume-31d1776b-f3aa-11e8-9124-e6180d057dc8 container client-container: <nil>
+STEP: delete the pod
+Nov 29 07:41:36.080: INFO: Waiting for pod downwardapi-volume-31d1776b-f3aa-11e8-9124-e6180d057dc8 to disappear
+Nov 29 07:41:36.082: INFO: Pod downwardapi-volume-31d1776b-f3aa-11e8-9124-e6180d057dc8 no longer exists
+[AfterEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Nov 29 07:41:36.083: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-downward-api-rmqfn" for this suite.
+Nov 29 07:41:42.091: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Nov 29 07:41:42.124: INFO: namespace: e2e-tests-downward-api-rmqfn, resource: bindings, ignored listing per whitelist
+Nov 29 07:41:42.141: INFO: namespace e2e-tests-downward-api-rmqfn deletion completed in 6.055167815s
+
+• [SLOW TEST:8.109 seconds]
+[sig-storage] Downward API volume
+/workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downwardapi_volume.go:33
+  should provide podname only  [Conformance]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SSS
+------------------------------
+[sig-storage] ConfigMap 
+  should be consumable from pods in volume with mappings as non-root  [Conformance]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-storage] ConfigMap
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Nov 29 07:41:42.141: INFO: >>> kubeConfig: /tmp/kubeconfig-385092372
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should be consumable from pods in volume with mappings as non-root  [Conformance]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating configMap with name configmap-test-volume-map-36a6e8b0-f3aa-11e8-9124-e6180d057dc8
+STEP: Creating a pod to test consume configMaps
+Nov 29 07:41:42.173: INFO: Waiting up to 5m0s for pod "pod-configmaps-36a7256f-f3aa-11e8-9124-e6180d057dc8" in namespace "e2e-tests-configmap-nc9xv" to be "success or failure"
+Nov 29 07:41:42.176: INFO: Pod "pod-configmaps-36a7256f-f3aa-11e8-9124-e6180d057dc8": Phase="Pending", Reason="", readiness=false. Elapsed: 2.956065ms
+Nov 29 07:41:44.178: INFO: Pod "pod-configmaps-36a7256f-f3aa-11e8-9124-e6180d057dc8": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.004805089s
+STEP: Saw pod success
+Nov 29 07:41:44.178: INFO: Pod "pod-configmaps-36a7256f-f3aa-11e8-9124-e6180d057dc8" satisfied condition "success or failure"
+Nov 29 07:41:44.179: INFO: Trying to get logs from node worker-bdccfcb0-f3a8-11e8-90fa-062be367adf0 pod pod-configmaps-36a7256f-f3aa-11e8-9124-e6180d057dc8 container configmap-volume-test: <nil>
+STEP: delete the pod
+Nov 29 07:41:44.190: INFO: Waiting for pod pod-configmaps-36a7256f-f3aa-11e8-9124-e6180d057dc8 to disappear
+Nov 29 07:41:44.193: INFO: Pod pod-configmaps-36a7256f-f3aa-11e8-9124-e6180d057dc8 no longer exists
+[AfterEach] [sig-storage] ConfigMap
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Nov 29 07:41:44.193: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-configmap-nc9xv" for this suite.
+Nov 29 07:41:50.200: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Nov 29 07:41:50.254: INFO: namespace: e2e-tests-configmap-nc9xv, resource: bindings, ignored listing per whitelist
+Nov 29 07:41:50.256: INFO: namespace e2e-tests-configmap-nc9xv deletion completed in 6.061193908s
+
+• [SLOW TEST:8.115 seconds]
+[sig-storage] ConfigMap
+/workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/configmap_volume.go:32
+  should be consumable from pods in volume with mappings as non-root  [Conformance]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+S
+------------------------------
+[k8s.io] [sig-node] Events 
+  should be sent by kubelets and the scheduler about pods scheduling and running  [Conformance]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [k8s.io] [sig-node] Events
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Nov 29 07:41:50.256: INFO: >>> kubeConfig: /tmp/kubeconfig-385092372
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should be sent by kubelets and the scheduler about pods scheduling and running  [Conformance]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: creating the pod
+STEP: submitting the pod to kubernetes
+STEP: verifying the pod is in kubernetes
+STEP: retrieving the pod
+&Pod{ObjectMeta:k8s_io_apimachinery_pkg_apis_meta_v1.ObjectMeta{Name:send-events-3b84c8cb-f3aa-11e8-9124-e6180d057dc8,GenerateName:,Namespace:e2e-tests-events-5jjcf,SelfLink:/api/v1/namespaces/e2e-tests-events-5jjcf/pods/send-events-3b84c8cb-f3aa-11e8-9124-e6180d057dc8,UID:3b884f4b-f3aa-11e8-9c33-06ce02f7f1c8,ResourceVersion:4315,Generation:0,CreationTimestamp:2018-11-29 07:41:50 +0000 UTC,DeletionTimestamp:<nil>,DeletionGracePeriodSeconds:nil,Labels:map[string]string{name: foo,time: 334795697,},Annotations:map[string]string{},OwnerReferences:[],Finalizers:[],ClusterName:,Initializers:nil,},Spec:PodSpec{Volumes:[{default-token-59zfz {nil nil nil nil nil SecretVolumeSource{SecretName:default-token-59zfz,Items:[],DefaultMode:*420,Optional:nil,} nil nil nil nil nil nil nil nil nil nil nil nil nil nil nil nil nil nil nil nil nil}}],Containers:[{p gcr.io/kubernetes-e2e-test-images/serve-hostname-amd64:1.0 [] []  [{ 0 80 TCP }] [] [] {map[] map[]} [{default-token-59zfz true /var/run/secrets/kubernetes.io/serviceaccount  <nil>}] [] nil nil nil /dev/termination-log File IfNotPresent nil false false false}],RestartPolicy:Always,TerminationGracePeriodSeconds:*30,ActiveDeadlineSeconds:nil,DNSPolicy:ClusterFirst,NodeSelector:map[string]string{},ServiceAccountName:default,DeprecatedServiceAccount:default,NodeName:worker-bdccfcb0-f3a8-11e8-90fa-062be367adf0,HostNetwork:false,HostPID:false,HostIPC:false,SecurityContext:&PodSecurityContext{SELinuxOptions:nil,RunAsUser:nil,RunAsNonRoot:nil,SupplementalGroups:[],FSGroup:nil,RunAsGroup:nil,},ImagePullSecrets:[],Hostname:,Subdomain:,Affinity:nil,SchedulerName:default-scheduler,InitContainers:[],AutomountServiceAccountToken:nil,Tolerations:[{node.kubernetes.io/not-ready Exists  NoExecute 0xc4210b4d00} {node.kubernetes.io/unreachable Exists  NoExecute 0xc4210b4d20}],HostAliases:[],PriorityClassName:,Priority:*0,DNSConfig:nil,ShareProcessNamespace:nil,},Status:PodStatus{Phase:Running,Conditions:[{Initialized True 0001-01-01 00:00:00 +0000 UTC 2018-11-29 07:41:50 +0000 UTC  } {Ready True 0001-01-01 00:00:00 +0000 UTC 2018-11-29 07:41:52 +0000 UTC  } {ContainersReady True 0001-01-01 00:00:00 +0000 UTC 0001-01-01 00:00:00 +0000 UTC  } {PodScheduled True 0001-01-01 00:00:00 +0000 UTC 2018-11-29 07:41:50 +0000 UTC  }],Message:,Reason:,HostIP:10.1.191.253,PodIP:10.2.1.34,StartTime:2018-11-29 07:41:50 +0000 UTC,ContainerStatuses:[{p {nil ContainerStateRunning{StartedAt:2018-11-29 07:41:52 +0000 UTC,} nil} {nil nil nil} true 0 gcr.io/kubernetes-e2e-test-images/serve-hostname-amd64:1.0 docker-pullable://gcr.io/kubernetes-e2e-test-images/serve-hostname-amd64@sha256:2dd4032e98a0450d95a0ac71a5e465f542a900812d8c41bc6ca635aed1a5fc91 docker://a0494127688db83bd43fbed779c9e722cc440ac4b4215f094f6350a176ac2672}],QOSClass:BestEffort,InitContainerStatuses:[],NominatedNodeName:,},}
+STEP: checking for scheduler event about the pod
+Saw scheduler event for our pod.
+STEP: checking for kubelet event about the pod
+Saw kubelet event for our pod.
+STEP: deleting the pod
+[AfterEach] [k8s.io] [sig-node] Events
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Nov 29 07:41:58.356: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-events-5jjcf" for this suite.
+Nov 29 07:42:20.371: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Nov 29 07:42:20.414: INFO: namespace: e2e-tests-events-5jjcf, resource: bindings, ignored listing per whitelist
+Nov 29 07:42:20.425: INFO: namespace e2e-tests-events-5jjcf deletion completed in 22.064354409s
+
+• [SLOW TEST:30.169 seconds]
+[k8s.io] [sig-node] Events
+/workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:669
+  should be sent by kubelets and the scheduler about pods scheduling and running  [Conformance]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SSSSSSSSSSSSSSSSSS
+------------------------------
+[sig-storage] Secrets 
+  should be consumable in multiple volumes in a pod  [Conformance]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-storage] Secrets
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Nov 29 07:42:20.426: INFO: >>> kubeConfig: /tmp/kubeconfig-385092372
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should be consumable in multiple volumes in a pod  [Conformance]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating secret with name secret-test-4d803481-f3aa-11e8-9124-e6180d057dc8
+STEP: Creating a pod to test consume secrets
+Nov 29 07:42:20.509: INFO: Waiting up to 5m0s for pod "pod-secrets-4d807032-f3aa-11e8-9124-e6180d057dc8" in namespace "e2e-tests-secrets-6cmxt" to be "success or failure"
+Nov 29 07:42:20.510: INFO: Pod "pod-secrets-4d807032-f3aa-11e8-9124-e6180d057dc8": Phase="Pending", Reason="", readiness=false. Elapsed: 1.315033ms
+Nov 29 07:42:22.512: INFO: Pod "pod-secrets-4d807032-f3aa-11e8-9124-e6180d057dc8": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.003050633s
+STEP: Saw pod success
+Nov 29 07:42:22.512: INFO: Pod "pod-secrets-4d807032-f3aa-11e8-9124-e6180d057dc8" satisfied condition "success or failure"
+Nov 29 07:42:22.513: INFO: Trying to get logs from node worker-bdccfcb0-f3a8-11e8-90fa-062be367adf0 pod pod-secrets-4d807032-f3aa-11e8-9124-e6180d057dc8 container secret-volume-test: <nil>
+STEP: delete the pod
+Nov 29 07:42:22.529: INFO: Waiting for pod pod-secrets-4d807032-f3aa-11e8-9124-e6180d057dc8 to disappear
+Nov 29 07:42:22.532: INFO: Pod pod-secrets-4d807032-f3aa-11e8-9124-e6180d057dc8 no longer exists
+[AfterEach] [sig-storage] Secrets
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Nov 29 07:42:22.532: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-secrets-6cmxt" for this suite.
+Nov 29 07:42:28.539: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Nov 29 07:42:28.587: INFO: namespace: e2e-tests-secrets-6cmxt, resource: bindings, ignored listing per whitelist
+Nov 29 07:42:28.589: INFO: namespace e2e-tests-secrets-6cmxt deletion completed in 6.054684061s
+
+• [SLOW TEST:8.163 seconds]
+[sig-storage] Secrets
+/workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/secrets_volume.go:33
+  should be consumable in multiple volumes in a pod  [Conformance]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SSSSSSS
+------------------------------
+[sig-api-machinery] Downward API 
+  should provide pod UID as env vars  [Conformance]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-api-machinery] Downward API
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Nov 29 07:42:28.589: INFO: >>> kubeConfig: /tmp/kubeconfig-385092372
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should provide pod UID as env vars  [Conformance]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating a pod to test downward api env vars
+Nov 29 07:42:28.634: INFO: Waiting up to 5m0s for pod "downward-api-5257d00c-f3aa-11e8-9124-e6180d057dc8" in namespace "e2e-tests-downward-api-bj6nl" to be "success or failure"
+Nov 29 07:42:28.644: INFO: Pod "downward-api-5257d00c-f3aa-11e8-9124-e6180d057dc8": Phase="Pending", Reason="", readiness=false. Elapsed: 9.594664ms
+Nov 29 07:42:30.645: INFO: Pod "downward-api-5257d00c-f3aa-11e8-9124-e6180d057dc8": Phase="Pending", Reason="", readiness=false. Elapsed: 2.011318194s
+Nov 29 07:42:32.647: INFO: Pod "downward-api-5257d00c-f3aa-11e8-9124-e6180d057dc8": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.012888268s
+STEP: Saw pod success
+Nov 29 07:42:32.647: INFO: Pod "downward-api-5257d00c-f3aa-11e8-9124-e6180d057dc8" satisfied condition "success or failure"
+Nov 29 07:42:32.648: INFO: Trying to get logs from node worker-bdccfcb0-f3a8-11e8-90fa-062be367adf0 pod downward-api-5257d00c-f3aa-11e8-9124-e6180d057dc8 container dapi-container: <nil>
+STEP: delete the pod
+Nov 29 07:42:32.660: INFO: Waiting for pod downward-api-5257d00c-f3aa-11e8-9124-e6180d057dc8 to disappear
+Nov 29 07:42:32.662: INFO: Pod downward-api-5257d00c-f3aa-11e8-9124-e6180d057dc8 no longer exists
+[AfterEach] [sig-api-machinery] Downward API
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Nov 29 07:42:32.662: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-downward-api-bj6nl" for this suite.
+Nov 29 07:42:38.673: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Nov 29 07:42:38.708: INFO: namespace: e2e-tests-downward-api-bj6nl, resource: bindings, ignored listing per whitelist
+Nov 29 07:42:38.724: INFO: namespace e2e-tests-downward-api-bj6nl deletion completed in 6.060320119s
+
+• [SLOW TEST:10.135 seconds]
+[sig-api-machinery] Downward API
+/workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downward_api.go:37
+  should provide pod UID as env vars  [Conformance]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+[sig-api-machinery] Garbage collector 
+  should delete RS created by deployment when not orphaning [Conformance]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-api-machinery] Garbage collector
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Nov 29 07:42:38.724: INFO: >>> kubeConfig: /tmp/kubeconfig-385092372
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should delete RS created by deployment when not orphaning [Conformance]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: create the deployment
+STEP: Wait for the Deployment to create new ReplicaSet
+STEP: delete the deployment
+STEP: wait for all rs to be garbage collected
+STEP: expected 0 rs, got 1 rs
+STEP: expected 0 Pods, got 2 Pods
+STEP: Gathering metrics
+W1129 07:42:39.340978      13 metrics_grabber.go:81] Master node is not registered. Grabbing metrics from Scheduler, ControllerManager and ClusterAutoscaler is disabled.
+Nov 29 07:42:39.341: INFO: For apiserver_request_count:
+For apiserver_request_latencies_summary:
+For etcd_helper_cache_entry_count:
+For etcd_helper_cache_hit_count:
+For etcd_helper_cache_miss_count:
+For etcd_request_cache_add_latencies_summary:
+For etcd_request_cache_get_latencies_summary:
+For etcd_request_latencies_summary:
+For garbage_collector_attempt_to_delete_queue_latency:
+For garbage_collector_attempt_to_delete_work_duration:
+For garbage_collector_attempt_to_orphan_queue_latency:
+For garbage_collector_attempt_to_orphan_work_duration:
+For garbage_collector_dirty_processing_latency_microseconds:
+For garbage_collector_event_processing_latency_microseconds:
+For garbage_collector_graph_changes_queue_latency:
+For garbage_collector_graph_changes_work_duration:
+For garbage_collector_orphan_processing_latency_microseconds:
+For namespace_queue_latency:
+For namespace_queue_latency_sum:
+For namespace_queue_latency_count:
+For namespace_retries:
+For namespace_work_duration:
+For namespace_work_duration_sum:
+For namespace_work_duration_count:
+For function_duration_seconds:
+For errors_total:
+For evicted_pods_total:
+
+[AfterEach] [sig-api-machinery] Garbage collector
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Nov 29 07:42:39.341: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-gc-8cvfk" for this suite.
+Nov 29 07:42:45.347: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Nov 29 07:42:45.369: INFO: namespace: e2e-tests-gc-8cvfk, resource: bindings, ignored listing per whitelist
+Nov 29 07:42:45.398: INFO: namespace e2e-tests-gc-8cvfk deletion completed in 6.055793252s
+
+• [SLOW TEST:6.673 seconds]
+[sig-api-machinery] Garbage collector
+/workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apimachinery/framework.go:22
+  should delete RS created by deployment when not orphaning [Conformance]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+S
+------------------------------
+[sig-storage] ConfigMap 
+  should be consumable from pods in volume  [Conformance]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-storage] ConfigMap
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Nov 29 07:42:45.398: INFO: >>> kubeConfig: /tmp/kubeconfig-385092372
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should be consumable from pods in volume  [Conformance]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating configMap with name configmap-test-volume-5c5b4883-f3aa-11e8-9124-e6180d057dc8
+STEP: Creating a pod to test consume configMaps
+Nov 29 07:42:45.434: INFO: Waiting up to 5m0s for pod "pod-configmaps-5c5b8715-f3aa-11e8-9124-e6180d057dc8" in namespace "e2e-tests-configmap-8qtm8" to be "success or failure"
+Nov 29 07:42:45.436: INFO: Pod "pod-configmaps-5c5b8715-f3aa-11e8-9124-e6180d057dc8": Phase="Pending", Reason="", readiness=false. Elapsed: 1.830059ms
+Nov 29 07:42:47.438: INFO: Pod "pod-configmaps-5c5b8715-f3aa-11e8-9124-e6180d057dc8": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.004559285s
+STEP: Saw pod success
+Nov 29 07:42:47.438: INFO: Pod "pod-configmaps-5c5b8715-f3aa-11e8-9124-e6180d057dc8" satisfied condition "success or failure"
+Nov 29 07:42:47.440: INFO: Trying to get logs from node worker-bdccfcb0-f3a8-11e8-90fa-062be367adf0 pod pod-configmaps-5c5b8715-f3aa-11e8-9124-e6180d057dc8 container configmap-volume-test: <nil>
+STEP: delete the pod
+Nov 29 07:42:47.455: INFO: Waiting for pod pod-configmaps-5c5b8715-f3aa-11e8-9124-e6180d057dc8 to disappear
+Nov 29 07:42:47.457: INFO: Pod pod-configmaps-5c5b8715-f3aa-11e8-9124-e6180d057dc8 no longer exists
+[AfterEach] [sig-storage] ConfigMap
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Nov 29 07:42:47.457: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-configmap-8qtm8" for this suite.
+Nov 29 07:42:53.464: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Nov 29 07:42:53.509: INFO: namespace: e2e-tests-configmap-8qtm8, resource: bindings, ignored listing per whitelist
+Nov 29 07:42:53.518: INFO: namespace e2e-tests-configmap-8qtm8 deletion completed in 6.058944519s
+
+• [SLOW TEST:8.120 seconds]
+[sig-storage] ConfigMap
+/workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/configmap_volume.go:32
+  should be consumable from pods in volume  [Conformance]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+[sig-network] Services 
+  should serve multiport endpoints from pods  [Conformance]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-network] Services
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Nov 29 07:42:53.518: INFO: >>> kubeConfig: /tmp/kubeconfig-385092372
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-network] Services
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/network/service.go:53
+[It] should serve multiport endpoints from pods  [Conformance]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: creating service multi-endpoint-test in namespace e2e-tests-services-z76wr
+STEP: waiting up to 1m0s for service multi-endpoint-test in namespace e2e-tests-services-z76wr to expose endpoints map[]
+Nov 29 07:42:53.609: INFO: successfully validated that service multi-endpoint-test in namespace e2e-tests-services-z76wr exposes endpoints map[] (10.727967ms elapsed)
+STEP: Creating pod pod1 in namespace e2e-tests-services-z76wr
+STEP: waiting up to 1m0s for service multi-endpoint-test in namespace e2e-tests-services-z76wr to expose endpoints map[pod1:[100]]
+Nov 29 07:42:55.635: INFO: successfully validated that service multi-endpoint-test in namespace e2e-tests-services-z76wr exposes endpoints map[pod1:[100]] (2.019922761s elapsed)
+STEP: Creating pod pod2 in namespace e2e-tests-services-z76wr
+STEP: waiting up to 1m0s for service multi-endpoint-test in namespace e2e-tests-services-z76wr to expose endpoints map[pod1:[100] pod2:[101]]
+Nov 29 07:42:57.653: INFO: successfully validated that service multi-endpoint-test in namespace e2e-tests-services-z76wr exposes endpoints map[pod1:[100] pod2:[101]] (2.016239463s elapsed)
+STEP: Deleting pod pod1 in namespace e2e-tests-services-z76wr
+STEP: waiting up to 1m0s for service multi-endpoint-test in namespace e2e-tests-services-z76wr to expose endpoints map[pod2:[101]]
+Nov 29 07:42:58.669: INFO: successfully validated that service multi-endpoint-test in namespace e2e-tests-services-z76wr exposes endpoints map[pod2:[101]] (1.014154239s elapsed)
+STEP: Deleting pod pod2 in namespace e2e-tests-services-z76wr
+STEP: waiting up to 1m0s for service multi-endpoint-test in namespace e2e-tests-services-z76wr to expose endpoints map[]
+Nov 29 07:42:58.678: INFO: successfully validated that service multi-endpoint-test in namespace e2e-tests-services-z76wr exposes endpoints map[] (1.191849ms elapsed)
+[AfterEach] [sig-network] Services
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Nov 29 07:42:58.692: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-services-z76wr" for this suite.
+Nov 29 07:43:20.706: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Nov 29 07:43:20.747: INFO: namespace: e2e-tests-services-z76wr, resource: bindings, ignored listing per whitelist
+Nov 29 07:43:20.762: INFO: namespace e2e-tests-services-z76wr deletion completed in 22.066528158s
+[AfterEach] [sig-network] Services
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/network/service.go:58
+
+• [SLOW TEST:27.244 seconds]
+[sig-network] Services
+/workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/network/framework.go:22
+  should serve multiport endpoints from pods  [Conformance]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+S
+------------------------------
+[sig-apps] StatefulSet [k8s.io] Basic StatefulSet functionality [StatefulSetBasic] 
+  should perform rolling updates and roll backs of template modifications [Conformance]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-apps] StatefulSet
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Nov 29 07:43:20.762: INFO: >>> kubeConfig: /tmp/kubeconfig-385092372
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-apps] StatefulSet
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/statefulset.go:57
+[BeforeEach] [k8s.io] Basic StatefulSet functionality [StatefulSetBasic]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/statefulset.go:72
+STEP: Creating service test in namespace e2e-tests-statefulset-cmd4g
+[It] should perform rolling updates and roll backs of template modifications [Conformance]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating a new StatefulSet
+Nov 29 07:43:20.805: INFO: Found 0 stateful pods, waiting for 3
+Nov 29 07:43:30.807: INFO: Waiting for pod ss2-0 to enter Running - Ready=true, currently Running - Ready=true
+Nov 29 07:43:30.807: INFO: Waiting for pod ss2-1 to enter Running - Ready=true, currently Running - Ready=true
+Nov 29 07:43:30.807: INFO: Waiting for pod ss2-2 to enter Running - Ready=true, currently Running - Ready=true
+Nov 29 07:43:30.811: INFO: Running '/usr/local/bin/kubectl --kubeconfig=/tmp/kubeconfig-385092372 exec --namespace=e2e-tests-statefulset-cmd4g ss2-1 -- /bin/sh -c mv -v /usr/share/nginx/html/index.html /tmp/ || true'
+Nov 29 07:43:30.923: INFO: stderr: ""
+Nov 29 07:43:30.923: INFO: stdout of mv -v /usr/share/nginx/html/index.html /tmp/ || true on ss2-1: '/usr/share/nginx/html/index.html' -> '/tmp/index.html'
+
+STEP: Updating StatefulSet template: update image from k8s.gcr.io/nginx-slim-amd64:0.20 to k8s.gcr.io/nginx-slim-amd64:0.21
+Nov 29 07:43:40.943: INFO: Updating stateful set ss2
+STEP: Creating a new revision
+STEP: Updating Pods in reverse ordinal order
+Nov 29 07:43:50.952: INFO: Running '/usr/local/bin/kubectl --kubeconfig=/tmp/kubeconfig-385092372 exec --namespace=e2e-tests-statefulset-cmd4g ss2-1 -- /bin/sh -c mv -v /tmp/index.html /usr/share/nginx/html/ || true'
+Nov 29 07:43:51.063: INFO: stderr: ""
+Nov 29 07:43:51.063: INFO: stdout of mv -v /tmp/index.html /usr/share/nginx/html/ || true on ss2-1: '/tmp/index.html' -> '/usr/share/nginx/html/index.html'
+
+Nov 29 07:44:01.072: INFO: Waiting for StatefulSet e2e-tests-statefulset-cmd4g/ss2 to complete update
+Nov 29 07:44:01.072: INFO: Waiting for Pod e2e-tests-statefulset-cmd4g/ss2-0 to have revision ss2-56dd5fb9c4 update revision ss2-76cb68b6ff
+Nov 29 07:44:01.072: INFO: Waiting for Pod e2e-tests-statefulset-cmd4g/ss2-1 to have revision ss2-56dd5fb9c4 update revision ss2-76cb68b6ff
+Nov 29 07:44:11.075: INFO: Waiting for StatefulSet e2e-tests-statefulset-cmd4g/ss2 to complete update
+Nov 29 07:44:11.075: INFO: Waiting for Pod e2e-tests-statefulset-cmd4g/ss2-0 to have revision ss2-56dd5fb9c4 update revision ss2-76cb68b6ff
+Nov 29 07:44:21.074: INFO: Waiting for StatefulSet e2e-tests-statefulset-cmd4g/ss2 to complete update
+STEP: Rolling back to a previous revision
+Nov 29 07:44:31.075: INFO: Running '/usr/local/bin/kubectl --kubeconfig=/tmp/kubeconfig-385092372 exec --namespace=e2e-tests-statefulset-cmd4g ss2-1 -- /bin/sh -c mv -v /usr/share/nginx/html/index.html /tmp/ || true'
+Nov 29 07:44:31.185: INFO: stderr: ""
+Nov 29 07:44:31.185: INFO: stdout of mv -v /usr/share/nginx/html/index.html /tmp/ || true on ss2-1: '/usr/share/nginx/html/index.html' -> '/tmp/index.html'
+
+Nov 29 07:44:41.205: INFO: Updating stateful set ss2
+STEP: Rolling back update in reverse ordinal order
+Nov 29 07:44:51.213: INFO: Running '/usr/local/bin/kubectl --kubeconfig=/tmp/kubeconfig-385092372 exec --namespace=e2e-tests-statefulset-cmd4g ss2-1 -- /bin/sh -c mv -v /tmp/index.html /usr/share/nginx/html/ || true'
+Nov 29 07:44:51.323: INFO: stderr: ""
+Nov 29 07:44:51.323: INFO: stdout of mv -v /tmp/index.html /usr/share/nginx/html/ || true on ss2-1: '/tmp/index.html' -> '/usr/share/nginx/html/index.html'
+
+[AfterEach] [k8s.io] Basic StatefulSet functionality [StatefulSetBasic]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/statefulset.go:83
+Nov 29 07:45:21.331: INFO: Deleting all statefulset in ns e2e-tests-statefulset-cmd4g
+Nov 29 07:45:21.332: INFO: Scaling statefulset ss2 to 0
+Nov 29 07:45:31.340: INFO: Waiting for statefulset status.replicas updated to 0
+Nov 29 07:45:31.341: INFO: Deleting statefulset ss2
+[AfterEach] [sig-apps] StatefulSet
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Nov 29 07:45:31.350: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-statefulset-cmd4g" for this suite.
+Nov 29 07:45:37.359: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Nov 29 07:45:37.386: INFO: namespace: e2e-tests-statefulset-cmd4g, resource: bindings, ignored listing per whitelist
+Nov 29 07:45:37.414: INFO: namespace e2e-tests-statefulset-cmd4g deletion completed in 6.06106269s
+
+• [SLOW TEST:136.651 seconds]
+[sig-apps] StatefulSet
+/workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/framework.go:22
+  [k8s.io] Basic StatefulSet functionality [StatefulSetBasic]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:669
+    should perform rolling updates and roll backs of template modifications [Conformance]
+    /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SSS
+------------------------------
+[sig-storage] Projected 
+  should be consumable from pods in volume with mappings and Item mode set [Conformance]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Nov 29 07:45:37.414: INFO: >>> kubeConfig: /tmp/kubeconfig-385092372
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:858
+[It] should be consumable from pods in volume with mappings and Item mode set [Conformance]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating configMap with name projected-configmap-test-volume-map-c2e2b6b6-f3aa-11e8-9124-e6180d057dc8
+STEP: Creating a pod to test consume configMaps
+Nov 29 07:45:37.446: INFO: Waiting up to 5m0s for pod "pod-projected-configmaps-c2e2ebb9-f3aa-11e8-9124-e6180d057dc8" in namespace "e2e-tests-projected-6lxt7" to be "success or failure"
+Nov 29 07:45:37.450: INFO: Pod "pod-projected-configmaps-c2e2ebb9-f3aa-11e8-9124-e6180d057dc8": Phase="Pending", Reason="", readiness=false. Elapsed: 3.878918ms
+Nov 29 07:45:39.452: INFO: Pod "pod-projected-configmaps-c2e2ebb9-f3aa-11e8-9124-e6180d057dc8": Phase="Pending", Reason="", readiness=false. Elapsed: 2.005447128s
+Nov 29 07:45:41.454: INFO: Pod "pod-projected-configmaps-c2e2ebb9-f3aa-11e8-9124-e6180d057dc8": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.007435853s
+STEP: Saw pod success
+Nov 29 07:45:41.454: INFO: Pod "pod-projected-configmaps-c2e2ebb9-f3aa-11e8-9124-e6180d057dc8" satisfied condition "success or failure"
+Nov 29 07:45:41.455: INFO: Trying to get logs from node worker-266bbc56-f3aa-11e8-ab5c-0a406d6cb422 pod pod-projected-configmaps-c2e2ebb9-f3aa-11e8-9124-e6180d057dc8 container projected-configmap-volume-test: <nil>
+STEP: delete the pod
+Nov 29 07:45:41.472: INFO: Waiting for pod pod-projected-configmaps-c2e2ebb9-f3aa-11e8-9124-e6180d057dc8 to disappear
+Nov 29 07:45:41.474: INFO: Pod pod-projected-configmaps-c2e2ebb9-f3aa-11e8-9124-e6180d057dc8 no longer exists
+[AfterEach] [sig-storage] Projected
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Nov 29 07:45:41.475: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-6lxt7" for this suite.
+Nov 29 07:45:47.482: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Nov 29 07:45:47.524: INFO: namespace: e2e-tests-projected-6lxt7, resource: bindings, ignored listing per whitelist
+Nov 29 07:45:47.536: INFO: namespace e2e-tests-projected-6lxt7 deletion completed in 6.059648802s
+
+• [SLOW TEST:10.122 seconds]
+[sig-storage] Projected
+/workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:34
+  should be consumable from pods in volume with mappings and Item mode set [Conformance]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SS
+------------------------------
+[sig-api-machinery] Downward API 
+  should provide container's limits.cpu/memory and requests.cpu/memory as env vars  [Conformance]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-api-machinery] Downward API
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Nov 29 07:45:47.536: INFO: >>> kubeConfig: /tmp/kubeconfig-385092372
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should provide container's limits.cpu/memory and requests.cpu/memory as env vars  [Conformance]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating a pod to test downward api env vars
+Nov 29 07:45:47.568: INFO: Waiting up to 5m0s for pod "downward-api-c8eb22b5-f3aa-11e8-9124-e6180d057dc8" in namespace "e2e-tests-downward-api-xrkb8" to be "success or failure"
+Nov 29 07:45:47.571: INFO: Pod "downward-api-c8eb22b5-f3aa-11e8-9124-e6180d057dc8": Phase="Pending", Reason="", readiness=false. Elapsed: 2.501459ms
+Nov 29 07:45:49.573: INFO: Pod "downward-api-c8eb22b5-f3aa-11e8-9124-e6180d057dc8": Phase="Pending", Reason="", readiness=false. Elapsed: 2.004319721s
+Nov 29 07:45:51.575: INFO: Pod "downward-api-c8eb22b5-f3aa-11e8-9124-e6180d057dc8": Phase="Pending", Reason="", readiness=false. Elapsed: 4.00610876s
+Nov 29 07:45:53.576: INFO: Pod "downward-api-c8eb22b5-f3aa-11e8-9124-e6180d057dc8": Phase="Succeeded", Reason="", readiness=false. Elapsed: 6.007900426s
+STEP: Saw pod success
+Nov 29 07:45:53.576: INFO: Pod "downward-api-c8eb22b5-f3aa-11e8-9124-e6180d057dc8" satisfied condition "success or failure"
+Nov 29 07:45:53.578: INFO: Trying to get logs from node worker-266bbc56-f3aa-11e8-ab5c-0a406d6cb422 pod downward-api-c8eb22b5-f3aa-11e8-9124-e6180d057dc8 container dapi-container: <nil>
+STEP: delete the pod
+Nov 29 07:45:53.593: INFO: Waiting for pod downward-api-c8eb22b5-f3aa-11e8-9124-e6180d057dc8 to disappear
+Nov 29 07:45:53.594: INFO: Pod downward-api-c8eb22b5-f3aa-11e8-9124-e6180d057dc8 no longer exists
+[AfterEach] [sig-api-machinery] Downward API
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Nov 29 07:45:53.594: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-downward-api-xrkb8" for this suite.
+Nov 29 07:45:59.601: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Nov 29 07:45:59.620: INFO: namespace: e2e-tests-downward-api-xrkb8, resource: bindings, ignored listing per whitelist
+Nov 29 07:45:59.654: INFO: namespace e2e-tests-downward-api-xrkb8 deletion completed in 6.05816283s
+
+• [SLOW TEST:12.118 seconds]
+[sig-api-machinery] Downward API
+/workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downward_api.go:37
+  should provide container's limits.cpu/memory and requests.cpu/memory as env vars  [Conformance]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SSSSSSSSSSSS
+------------------------------
+[sig-storage] Projected 
+  should be consumable from pods in volume with mappings as non-root [Conformance]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Nov 29 07:45:59.655: INFO: >>> kubeConfig: /tmp/kubeconfig-385092372
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:858
+[It] should be consumable from pods in volume with mappings as non-root [Conformance]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating configMap with name projected-configmap-test-volume-map-d0244302-f3aa-11e8-9124-e6180d057dc8
+STEP: Creating a pod to test consume configMaps
+Nov 29 07:45:59.686: INFO: Waiting up to 5m0s for pod "pod-projected-configmaps-d0247d79-f3aa-11e8-9124-e6180d057dc8" in namespace "e2e-tests-projected-hq4lk" to be "success or failure"
+Nov 29 07:45:59.689: INFO: Pod "pod-projected-configmaps-d0247d79-f3aa-11e8-9124-e6180d057dc8": Phase="Pending", Reason="", readiness=false. Elapsed: 2.733648ms
+Nov 29 07:46:01.691: INFO: Pod "pod-projected-configmaps-d0247d79-f3aa-11e8-9124-e6180d057dc8": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.004572966s
+STEP: Saw pod success
+Nov 29 07:46:01.691: INFO: Pod "pod-projected-configmaps-d0247d79-f3aa-11e8-9124-e6180d057dc8" satisfied condition "success or failure"
+Nov 29 07:46:01.692: INFO: Trying to get logs from node worker-266bbc56-f3aa-11e8-ab5c-0a406d6cb422 pod pod-projected-configmaps-d0247d79-f3aa-11e8-9124-e6180d057dc8 container projected-configmap-volume-test: <nil>
+STEP: delete the pod
+Nov 29 07:46:01.704: INFO: Waiting for pod pod-projected-configmaps-d0247d79-f3aa-11e8-9124-e6180d057dc8 to disappear
+Nov 29 07:46:01.707: INFO: Pod pod-projected-configmaps-d0247d79-f3aa-11e8-9124-e6180d057dc8 no longer exists
+[AfterEach] [sig-storage] Projected
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Nov 29 07:46:01.707: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-hq4lk" for this suite.
+Nov 29 07:46:07.716: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Nov 29 07:46:07.747: INFO: namespace: e2e-tests-projected-hq4lk, resource: bindings, ignored listing per whitelist
+Nov 29 07:46:07.778: INFO: namespace e2e-tests-projected-hq4lk deletion completed in 6.06748945s
+
+• [SLOW TEST:8.124 seconds]
+[sig-storage] Projected
+/workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:34
+  should be consumable from pods in volume with mappings as non-root [Conformance]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SSSSSSSSSSSSSSSSSSSSSS
+------------------------------
+[sig-storage] Downward API volume 
+  should set mode on item file  [Conformance]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Nov 29 07:46:07.779: INFO: >>> kubeConfig: /tmp/kubeconfig-385092372
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downwardapi_volume.go:38
+[It] should set mode on item file  [Conformance]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating a pod to test downward API volume plugin
+Nov 29 07:46:07.838: INFO: Waiting up to 5m0s for pod "downwardapi-volume-d5001fbd-f3aa-11e8-9124-e6180d057dc8" in namespace "e2e-tests-downward-api-89fww" to be "success or failure"
+Nov 29 07:46:07.840: INFO: Pod "downwardapi-volume-d5001fbd-f3aa-11e8-9124-e6180d057dc8": Phase="Pending", Reason="", readiness=false. Elapsed: 1.589902ms
+Nov 29 07:46:09.842: INFO: Pod "downwardapi-volume-d5001fbd-f3aa-11e8-9124-e6180d057dc8": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.003597451s
+STEP: Saw pod success
+Nov 29 07:46:09.842: INFO: Pod "downwardapi-volume-d5001fbd-f3aa-11e8-9124-e6180d057dc8" satisfied condition "success or failure"
+Nov 29 07:46:09.843: INFO: Trying to get logs from node worker-266bbc56-f3aa-11e8-ab5c-0a406d6cb422 pod downwardapi-volume-d5001fbd-f3aa-11e8-9124-e6180d057dc8 container client-container: <nil>
+STEP: delete the pod
+Nov 29 07:46:09.856: INFO: Waiting for pod downwardapi-volume-d5001fbd-f3aa-11e8-9124-e6180d057dc8 to disappear
+Nov 29 07:46:09.860: INFO: Pod downwardapi-volume-d5001fbd-f3aa-11e8-9124-e6180d057dc8 no longer exists
+[AfterEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Nov 29 07:46:09.860: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-downward-api-89fww" for this suite.
+Nov 29 07:46:15.866: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Nov 29 07:46:15.899: INFO: namespace: e2e-tests-downward-api-89fww, resource: bindings, ignored listing per whitelist
+Nov 29 07:46:15.922: INFO: namespace e2e-tests-downward-api-89fww deletion completed in 6.060712442s
+
+• [SLOW TEST:8.144 seconds]
+[sig-storage] Downward API volume
+/workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downwardapi_volume.go:33
+  should set mode on item file  [Conformance]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+[k8s.io] Pods 
+  should allow activeDeadlineSeconds to be updated  [Conformance]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [k8s.io] Pods
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Nov 29 07:46:15.923: INFO: >>> kubeConfig: /tmp/kubeconfig-385092372
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [k8s.io] Pods
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/pods.go:127
+[It] should allow activeDeadlineSeconds to be updated  [Conformance]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: creating the pod
+STEP: submitting the pod to kubernetes
+STEP: verifying the pod is in kubernetes
+STEP: updating the pod
+Nov 29 07:46:18.471: INFO: Successfully updated pod "pod-update-activedeadlineseconds-d9d6d3cb-f3aa-11e8-9124-e6180d057dc8"
+Nov 29 07:46:18.471: INFO: Waiting up to 5m0s for pod "pod-update-activedeadlineseconds-d9d6d3cb-f3aa-11e8-9124-e6180d057dc8" in namespace "e2e-tests-pods-lw5rx" to be "terminated due to deadline exceeded"
+Nov 29 07:46:18.474: INFO: Pod "pod-update-activedeadlineseconds-d9d6d3cb-f3aa-11e8-9124-e6180d057dc8": Phase="Running", Reason="", readiness=true. Elapsed: 3.138823ms
+Nov 29 07:46:20.475: INFO: Pod "pod-update-activedeadlineseconds-d9d6d3cb-f3aa-11e8-9124-e6180d057dc8": Phase="Running", Reason="", readiness=true. Elapsed: 2.004531492s
+Nov 29 07:46:22.477: INFO: Pod "pod-update-activedeadlineseconds-d9d6d3cb-f3aa-11e8-9124-e6180d057dc8": Phase="Failed", Reason="DeadlineExceeded", readiness=false. Elapsed: 4.00600168s
+Nov 29 07:46:22.477: INFO: Pod "pod-update-activedeadlineseconds-d9d6d3cb-f3aa-11e8-9124-e6180d057dc8" satisfied condition "terminated due to deadline exceeded"
+[AfterEach] [k8s.io] Pods
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Nov 29 07:46:22.477: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-pods-lw5rx" for this suite.
+Nov 29 07:46:28.484: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Nov 29 07:46:28.502: INFO: namespace: e2e-tests-pods-lw5rx, resource: bindings, ignored listing per whitelist
+Nov 29 07:46:28.539: INFO: namespace e2e-tests-pods-lw5rx deletion completed in 6.06030003s
+
+• [SLOW TEST:12.616 seconds]
+[k8s.io] Pods
+/workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:669
+  should allow activeDeadlineSeconds to be updated  [Conformance]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SSSSSSSSSSSSSSSSS
+------------------------------
+[sig-storage] EmptyDir volumes 
+  should support (non-root,0777,default) [Conformance]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-storage] EmptyDir volumes
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Nov 29 07:46:28.539: INFO: >>> kubeConfig: /tmp/kubeconfig-385092372
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should support (non-root,0777,default) [Conformance]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating a pod to test emptydir 0777 on node default medium
+Nov 29 07:46:28.575: INFO: Waiting up to 5m0s for pod "pod-e15bd088-f3aa-11e8-9124-e6180d057dc8" in namespace "e2e-tests-emptydir-69555" to be "success or failure"
+Nov 29 07:46:28.580: INFO: Pod "pod-e15bd088-f3aa-11e8-9124-e6180d057dc8": Phase="Pending", Reason="", readiness=false. Elapsed: 5.0178ms
+Nov 29 07:46:30.582: INFO: Pod "pod-e15bd088-f3aa-11e8-9124-e6180d057dc8": Phase="Pending", Reason="", readiness=false. Elapsed: 2.006445378s
+Nov 29 07:46:32.584: INFO: Pod "pod-e15bd088-f3aa-11e8-9124-e6180d057dc8": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.008681719s
+STEP: Saw pod success
+Nov 29 07:46:32.584: INFO: Pod "pod-e15bd088-f3aa-11e8-9124-e6180d057dc8" satisfied condition "success or failure"
+Nov 29 07:46:32.585: INFO: Trying to get logs from node worker-266bbc56-f3aa-11e8-ab5c-0a406d6cb422 pod pod-e15bd088-f3aa-11e8-9124-e6180d057dc8 container test-container: <nil>
+STEP: delete the pod
+Nov 29 07:46:32.596: INFO: Waiting for pod pod-e15bd088-f3aa-11e8-9124-e6180d057dc8 to disappear
+Nov 29 07:46:32.599: INFO: Pod pod-e15bd088-f3aa-11e8-9124-e6180d057dc8 no longer exists
+[AfterEach] [sig-storage] EmptyDir volumes
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Nov 29 07:46:32.599: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-emptydir-69555" for this suite.
+Nov 29 07:46:38.607: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Nov 29 07:46:38.624: INFO: namespace: e2e-tests-emptydir-69555, resource: bindings, ignored listing per whitelist
+Nov 29 07:46:38.661: INFO: namespace e2e-tests-emptydir-69555 deletion completed in 6.060214602s
+
+• [SLOW TEST:10.122 seconds]
+[sig-storage] EmptyDir volumes
+/workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/empty_dir.go:41
+  should support (non-root,0777,default) [Conformance]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+S
+------------------------------
+[k8s.io] Docker Containers 
+  should be able to override the image's default command and arguments  [Conformance]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [k8s.io] Docker Containers
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Nov 29 07:46:38.661: INFO: >>> kubeConfig: /tmp/kubeconfig-385092372
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should be able to override the image's default command and arguments  [Conformance]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating a pod to test override all
+Nov 29 07:46:38.693: INFO: Waiting up to 5m0s for pod "client-containers-e7644ec4-f3aa-11e8-9124-e6180d057dc8" in namespace "e2e-tests-containers-xmrlb" to be "success or failure"
+Nov 29 07:46:38.698: INFO: Pod "client-containers-e7644ec4-f3aa-11e8-9124-e6180d057dc8": Phase="Pending", Reason="", readiness=false. Elapsed: 4.827002ms
+Nov 29 07:46:40.700: INFO: Pod "client-containers-e7644ec4-f3aa-11e8-9124-e6180d057dc8": Phase="Pending", Reason="", readiness=false. Elapsed: 2.006622475s
+Nov 29 07:46:42.701: INFO: Pod "client-containers-e7644ec4-f3aa-11e8-9124-e6180d057dc8": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.007996215s
+STEP: Saw pod success
+Nov 29 07:46:42.701: INFO: Pod "client-containers-e7644ec4-f3aa-11e8-9124-e6180d057dc8" satisfied condition "success or failure"
+Nov 29 07:46:42.702: INFO: Trying to get logs from node worker-266bbc56-f3aa-11e8-ab5c-0a406d6cb422 pod client-containers-e7644ec4-f3aa-11e8-9124-e6180d057dc8 container test-container: <nil>
+STEP: delete the pod
+Nov 29 07:46:42.713: INFO: Waiting for pod client-containers-e7644ec4-f3aa-11e8-9124-e6180d057dc8 to disappear
+Nov 29 07:46:42.715: INFO: Pod client-containers-e7644ec4-f3aa-11e8-9124-e6180d057dc8 no longer exists
+[AfterEach] [k8s.io] Docker Containers
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Nov 29 07:46:42.715: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-containers-xmrlb" for this suite.
+Nov 29 07:46:48.724: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Nov 29 07:46:48.770: INFO: namespace: e2e-tests-containers-xmrlb, resource: bindings, ignored listing per whitelist
+Nov 29 07:46:48.778: INFO: namespace e2e-tests-containers-xmrlb deletion completed in 6.059756542s
+
+• [SLOW TEST:10.117 seconds]
+[k8s.io] Docker Containers
+/workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:669
+  should be able to override the image's default command and arguments  [Conformance]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SSSSSSS
+------------------------------
+[sig-apps] Daemon set [Serial] 
+  should update pod when spec was updated and update strategy is RollingUpdate [Conformance]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-apps] Daemon set [Serial]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Nov 29 07:46:48.778: INFO: >>> kubeConfig: /tmp/kubeconfig-385092372
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-apps] Daemon set [Serial]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/daemon_set.go:103
+[It] should update pod when spec was updated and update strategy is RollingUpdate [Conformance]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+Nov 29 07:46:48.821: INFO: Creating simple daemon set daemon-set
+STEP: Check that daemon pods launch on every node of the cluster.
+Nov 29 07:46:48.833: INFO: DaemonSet pods can't tolerate node master-75fc9ea0-f3a7-11e8-90fa-062be367adf0 with taints [{Key:Dedicated Value:Master Effect:NoSchedule TimeAdded:<nil>}], skip checking this node
+Nov 29 07:46:48.835: INFO: Number of nodes with available pods: 0
+Nov 29 07:46:48.835: INFO: Node worker-266bbc56-f3aa-11e8-ab5c-0a406d6cb422 is running more than one daemon pod
+Nov 29 07:46:49.837: INFO: DaemonSet pods can't tolerate node master-75fc9ea0-f3a7-11e8-90fa-062be367adf0 with taints [{Key:Dedicated Value:Master Effect:NoSchedule TimeAdded:<nil>}], skip checking this node
+Nov 29 07:46:49.839: INFO: Number of nodes with available pods: 0
+Nov 29 07:46:49.839: INFO: Node worker-266bbc56-f3aa-11e8-ab5c-0a406d6cb422 is running more than one daemon pod
+Nov 29 07:46:50.837: INFO: DaemonSet pods can't tolerate node master-75fc9ea0-f3a7-11e8-90fa-062be367adf0 with taints [{Key:Dedicated Value:Master Effect:NoSchedule TimeAdded:<nil>}], skip checking this node
+Nov 29 07:46:50.838: INFO: Number of nodes with available pods: 1
+Nov 29 07:46:50.838: INFO: Node worker-266bbc56-f3aa-11e8-ab5c-0a406d6cb422 is running more than one daemon pod
+Nov 29 07:46:51.837: INFO: DaemonSet pods can't tolerate node master-75fc9ea0-f3a7-11e8-90fa-062be367adf0 with taints [{Key:Dedicated Value:Master Effect:NoSchedule TimeAdded:<nil>}], skip checking this node
+Nov 29 07:46:51.839: INFO: Number of nodes with available pods: 2
+Nov 29 07:46:51.839: INFO: Number of running nodes: 2, number of available pods: 2
+STEP: Update daemon pods image.
+STEP: Check that daemon pods images are updated.
+Nov 29 07:46:51.853: INFO: Wrong image for pod: daemon-set-44qnr. Expected: gcr.io/kubernetes-e2e-test-images/redis-amd64:1.0, got: gcr.io/kubernetes-e2e-test-images/serve-hostname-amd64:1.0.
+Nov 29 07:46:51.853: INFO: Wrong image for pod: daemon-set-x28k6. Expected: gcr.io/kubernetes-e2e-test-images/redis-amd64:1.0, got: gcr.io/kubernetes-e2e-test-images/serve-hostname-amd64:1.0.
+Nov 29 07:46:51.854: INFO: DaemonSet pods can't tolerate node master-75fc9ea0-f3a7-11e8-90fa-062be367adf0 with taints [{Key:Dedicated Value:Master Effect:NoSchedule TimeAdded:<nil>}], skip checking this node
+Nov 29 07:46:52.856: INFO: Wrong image for pod: daemon-set-44qnr. Expected: gcr.io/kubernetes-e2e-test-images/redis-amd64:1.0, got: gcr.io/kubernetes-e2e-test-images/serve-hostname-amd64:1.0.
+Nov 29 07:46:52.856: INFO: Wrong image for pod: daemon-set-x28k6. Expected: gcr.io/kubernetes-e2e-test-images/redis-amd64:1.0, got: gcr.io/kubernetes-e2e-test-images/serve-hostname-amd64:1.0.
+Nov 29 07:46:52.858: INFO: DaemonSet pods can't tolerate node master-75fc9ea0-f3a7-11e8-90fa-062be367adf0 with taints [{Key:Dedicated Value:Master Effect:NoSchedule TimeAdded:<nil>}], skip checking this node
+Nov 29 07:46:53.856: INFO: Wrong image for pod: daemon-set-44qnr. Expected: gcr.io/kubernetes-e2e-test-images/redis-amd64:1.0, got: gcr.io/kubernetes-e2e-test-images/serve-hostname-amd64:1.0.
+Nov 29 07:46:53.856: INFO: Wrong image for pod: daemon-set-x28k6. Expected: gcr.io/kubernetes-e2e-test-images/redis-amd64:1.0, got: gcr.io/kubernetes-e2e-test-images/serve-hostname-amd64:1.0.
+Nov 29 07:46:53.858: INFO: DaemonSet pods can't tolerate node master-75fc9ea0-f3a7-11e8-90fa-062be367adf0 with taints [{Key:Dedicated Value:Master Effect:NoSchedule TimeAdded:<nil>}], skip checking this node
+Nov 29 07:46:54.856: INFO: Wrong image for pod: daemon-set-44qnr. Expected: gcr.io/kubernetes-e2e-test-images/redis-amd64:1.0, got: gcr.io/kubernetes-e2e-test-images/serve-hostname-amd64:1.0.
+Nov 29 07:46:54.856: INFO: Wrong image for pod: daemon-set-x28k6. Expected: gcr.io/kubernetes-e2e-test-images/redis-amd64:1.0, got: gcr.io/kubernetes-e2e-test-images/serve-hostname-amd64:1.0.
+Nov 29 07:46:54.856: INFO: Pod daemon-set-x28k6 is not available
+Nov 29 07:46:54.858: INFO: DaemonSet pods can't tolerate node master-75fc9ea0-f3a7-11e8-90fa-062be367adf0 with taints [{Key:Dedicated Value:Master Effect:NoSchedule TimeAdded:<nil>}], skip checking this node
+Nov 29 07:46:55.856: INFO: Wrong image for pod: daemon-set-44qnr. Expected: gcr.io/kubernetes-e2e-test-images/redis-amd64:1.0, got: gcr.io/kubernetes-e2e-test-images/serve-hostname-amd64:1.0.
+Nov 29 07:46:55.856: INFO: Pod daemon-set-h26b6 is not available
+Nov 29 07:46:55.858: INFO: DaemonSet pods can't tolerate node master-75fc9ea0-f3a7-11e8-90fa-062be367adf0 with taints [{Key:Dedicated Value:Master Effect:NoSchedule TimeAdded:<nil>}], skip checking this node
+Nov 29 07:46:56.856: INFO: Wrong image for pod: daemon-set-44qnr. Expected: gcr.io/kubernetes-e2e-test-images/redis-amd64:1.0, got: gcr.io/kubernetes-e2e-test-images/serve-hostname-amd64:1.0.
+Nov 29 07:46:56.856: INFO: Pod daemon-set-h26b6 is not available
+Nov 29 07:46:56.858: INFO: DaemonSet pods can't tolerate node master-75fc9ea0-f3a7-11e8-90fa-062be367adf0 with taints [{Key:Dedicated Value:Master Effect:NoSchedule TimeAdded:<nil>}], skip checking this node
+Nov 29 07:46:57.856: INFO: Wrong image for pod: daemon-set-44qnr. Expected: gcr.io/kubernetes-e2e-test-images/redis-amd64:1.0, got: gcr.io/kubernetes-e2e-test-images/serve-hostname-amd64:1.0.
+Nov 29 07:46:57.858: INFO: DaemonSet pods can't tolerate node master-75fc9ea0-f3a7-11e8-90fa-062be367adf0 with taints [{Key:Dedicated Value:Master Effect:NoSchedule TimeAdded:<nil>}], skip checking this node
+Nov 29 07:46:58.857: INFO: Wrong image for pod: daemon-set-44qnr. Expected: gcr.io/kubernetes-e2e-test-images/redis-amd64:1.0, got: gcr.io/kubernetes-e2e-test-images/serve-hostname-amd64:1.0.
+Nov 29 07:46:58.857: INFO: Pod daemon-set-44qnr is not available
+Nov 29 07:46:58.859: INFO: DaemonSet pods can't tolerate node master-75fc9ea0-f3a7-11e8-90fa-062be367adf0 with taints [{Key:Dedicated Value:Master Effect:NoSchedule TimeAdded:<nil>}], skip checking this node
+Nov 29 07:46:59.856: INFO: Pod daemon-set-8xxwd is not available
+Nov 29 07:46:59.858: INFO: DaemonSet pods can't tolerate node master-75fc9ea0-f3a7-11e8-90fa-062be367adf0 with taints [{Key:Dedicated Value:Master Effect:NoSchedule TimeAdded:<nil>}], skip checking this node
+STEP: Check that daemon pods are still running on every node of the cluster.
+Nov 29 07:46:59.860: INFO: DaemonSet pods can't tolerate node master-75fc9ea0-f3a7-11e8-90fa-062be367adf0 with taints [{Key:Dedicated Value:Master Effect:NoSchedule TimeAdded:<nil>}], skip checking this node
+Nov 29 07:46:59.862: INFO: Number of nodes with available pods: 1
+Nov 29 07:46:59.862: INFO: Node worker-bdccfcb0-f3a8-11e8-90fa-062be367adf0 is running more than one daemon pod
+Nov 29 07:47:00.864: INFO: DaemonSet pods can't tolerate node master-75fc9ea0-f3a7-11e8-90fa-062be367adf0 with taints [{Key:Dedicated Value:Master Effect:NoSchedule TimeAdded:<nil>}], skip checking this node
+Nov 29 07:47:00.865: INFO: Number of nodes with available pods: 1
+Nov 29 07:47:00.865: INFO: Node worker-bdccfcb0-f3a8-11e8-90fa-062be367adf0 is running more than one daemon pod
+Nov 29 07:47:01.864: INFO: DaemonSet pods can't tolerate node master-75fc9ea0-f3a7-11e8-90fa-062be367adf0 with taints [{Key:Dedicated Value:Master Effect:NoSchedule TimeAdded:<nil>}], skip checking this node
+Nov 29 07:47:01.865: INFO: Number of nodes with available pods: 2
+Nov 29 07:47:01.865: INFO: Number of running nodes: 2, number of available pods: 2
+[AfterEach] [sig-apps] Daemon set [Serial]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/daemon_set.go:66
+STEP: Deleting DaemonSet "daemon-set" with reaper
+Nov 29 07:47:11.883: INFO: Number of nodes with available pods: 0
+Nov 29 07:47:11.883: INFO: Number of running nodes: 0, number of available pods: 0
+Nov 29 07:47:11.884: INFO: daemonset: {"kind":"DaemonSetList","apiVersion":"apps/v1","metadata":{"selfLink":"/apis/apps/v1/namespaces/e2e-tests-daemonsets-g5bdl/daemonsets","resourceVersion":"6113"},"items":null}
+
+Nov 29 07:47:11.888: INFO: pods: {"kind":"PodList","apiVersion":"v1","metadata":{"selfLink":"/api/v1/namespaces/e2e-tests-daemonsets-g5bdl/pods","resourceVersion":"6113"},"items":null}
+
+[AfterEach] [sig-apps] Daemon set [Serial]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Nov 29 07:47:11.895: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-daemonsets-g5bdl" for this suite.
+Nov 29 07:47:17.902: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Nov 29 07:47:17.918: INFO: namespace: e2e-tests-daemonsets-g5bdl, resource: bindings, ignored listing per whitelist
+Nov 29 07:47:17.955: INFO: namespace e2e-tests-daemonsets-g5bdl deletion completed in 6.058399223s
+
+• [SLOW TEST:29.177 seconds]
+[sig-apps] Daemon set [Serial]
+/workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/framework.go:22
+  should update pod when spec was updated and update strategy is RollingUpdate [Conformance]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SSS
+------------------------------
+[sig-storage] Projected 
+  should be consumable from pods in volume with mappings and Item Mode set [Conformance]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Nov 29 07:47:17.955: INFO: >>> kubeConfig: /tmp/kubeconfig-385092372
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:858
+[It] should be consumable from pods in volume with mappings and Item Mode set [Conformance]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating projection with secret that has name projected-secret-test-map-fed0317b-f3aa-11e8-9124-e6180d057dc8
+STEP: Creating a pod to test consume secrets
+Nov 29 07:47:17.992: INFO: Waiting up to 5m0s for pod "pod-projected-secrets-fed06fd0-f3aa-11e8-9124-e6180d057dc8" in namespace "e2e-tests-projected-zn8xq" to be "success or failure"
+Nov 29 07:47:17.993: INFO: Pod "pod-projected-secrets-fed06fd0-f3aa-11e8-9124-e6180d057dc8": Phase="Pending", Reason="", readiness=false. Elapsed: 1.643392ms
+Nov 29 07:47:19.995: INFO: Pod "pod-projected-secrets-fed06fd0-f3aa-11e8-9124-e6180d057dc8": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.003479228s
+STEP: Saw pod success
+Nov 29 07:47:19.995: INFO: Pod "pod-projected-secrets-fed06fd0-f3aa-11e8-9124-e6180d057dc8" satisfied condition "success or failure"
+Nov 29 07:47:19.996: INFO: Trying to get logs from node worker-266bbc56-f3aa-11e8-ab5c-0a406d6cb422 pod pod-projected-secrets-fed06fd0-f3aa-11e8-9124-e6180d057dc8 container projected-secret-volume-test: <nil>
+STEP: delete the pod
+Nov 29 07:47:20.009: INFO: Waiting for pod pod-projected-secrets-fed06fd0-f3aa-11e8-9124-e6180d057dc8 to disappear
+Nov 29 07:47:20.011: INFO: Pod pod-projected-secrets-fed06fd0-f3aa-11e8-9124-e6180d057dc8 no longer exists
+[AfterEach] [sig-storage] Projected
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Nov 29 07:47:20.011: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-zn8xq" for this suite.
+Nov 29 07:47:26.020: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Nov 29 07:47:26.042: INFO: namespace: e2e-tests-projected-zn8xq, resource: bindings, ignored listing per whitelist
+Nov 29 07:47:26.070: INFO: namespace e2e-tests-projected-zn8xq deletion completed in 6.055365241s
+
+• [SLOW TEST:8.115 seconds]
+[sig-storage] Projected
+/workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:34
+  should be consumable from pods in volume with mappings and Item Mode set [Conformance]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+[sig-storage] Projected 
+  should set mode on item file [Conformance]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Nov 29 07:47:26.070: INFO: >>> kubeConfig: /tmp/kubeconfig-385092372
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:858
+[It] should set mode on item file [Conformance]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating a pod to test downward API volume plugin
+Nov 29 07:47:26.105: INFO: Waiting up to 5m0s for pod "downwardapi-volume-03a66c8d-f3ab-11e8-9124-e6180d057dc8" in namespace "e2e-tests-projected-xgzvx" to be "success or failure"
+Nov 29 07:47:26.110: INFO: Pod "downwardapi-volume-03a66c8d-f3ab-11e8-9124-e6180d057dc8": Phase="Pending", Reason="", readiness=false. Elapsed: 5.278723ms
+Nov 29 07:47:28.113: INFO: Pod "downwardapi-volume-03a66c8d-f3ab-11e8-9124-e6180d057dc8": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.007964985s
+STEP: Saw pod success
+Nov 29 07:47:28.113: INFO: Pod "downwardapi-volume-03a66c8d-f3ab-11e8-9124-e6180d057dc8" satisfied condition "success or failure"
+Nov 29 07:47:28.114: INFO: Trying to get logs from node worker-266bbc56-f3aa-11e8-ab5c-0a406d6cb422 pod downwardapi-volume-03a66c8d-f3ab-11e8-9124-e6180d057dc8 container client-container: <nil>
+STEP: delete the pod
+Nov 29 07:47:28.125: INFO: Waiting for pod downwardapi-volume-03a66c8d-f3ab-11e8-9124-e6180d057dc8 to disappear
+Nov 29 07:47:28.131: INFO: Pod downwardapi-volume-03a66c8d-f3ab-11e8-9124-e6180d057dc8 no longer exists
+[AfterEach] [sig-storage] Projected
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Nov 29 07:47:28.131: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-xgzvx" for this suite.
+Nov 29 07:47:34.140: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Nov 29 07:47:34.171: INFO: namespace: e2e-tests-projected-xgzvx, resource: bindings, ignored listing per whitelist
+Nov 29 07:47:34.195: INFO: namespace e2e-tests-projected-xgzvx deletion completed in 6.061898267s
+
+• [SLOW TEST:8.125 seconds]
+[sig-storage] Projected
+/workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:34
+  should set mode on item file [Conformance]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SSSSSSSSSS
+------------------------------
+[sig-api-machinery] Garbage collector 
+  should not delete dependents that have both valid owner and owner that's waiting for dependents to be deleted [Conformance]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-api-machinery] Garbage collector
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Nov 29 07:47:34.196: INFO: >>> kubeConfig: /tmp/kubeconfig-385092372
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should not delete dependents that have both valid owner and owner that's waiting for dependents to be deleted [Conformance]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: create the rc1
+STEP: create the rc2
+STEP: set half of pods created by rc simpletest-rc-to-be-deleted to have rc simpletest-rc-to-stay as owner as well
+STEP: delete the rc simpletest-rc-to-be-deleted
+STEP: wait for the rc to be deleted
+STEP: Gathering metrics
+W1129 07:47:44.272680      13 metrics_grabber.go:81] Master node is not registered. Grabbing metrics from Scheduler, ControllerManager and ClusterAutoscaler is disabled.
+Nov 29 07:47:44.272: INFO: For apiserver_request_count:
+For apiserver_request_latencies_summary:
+For etcd_helper_cache_entry_count:
+For etcd_helper_cache_hit_count:
+For etcd_helper_cache_miss_count:
+For etcd_request_cache_add_latencies_summary:
+For etcd_request_cache_get_latencies_summary:
+For etcd_request_latencies_summary:
+For garbage_collector_attempt_to_delete_queue_latency:
+For garbage_collector_attempt_to_delete_work_duration:
+For garbage_collector_attempt_to_orphan_queue_latency:
+For garbage_collector_attempt_to_orphan_work_duration:
+For garbage_collector_dirty_processing_latency_microseconds:
+For garbage_collector_event_processing_latency_microseconds:
+For garbage_collector_graph_changes_queue_latency:
+For garbage_collector_graph_changes_work_duration:
+For garbage_collector_orphan_processing_latency_microseconds:
+For namespace_queue_latency:
+For namespace_queue_latency_sum:
+For namespace_queue_latency_count:
+For namespace_retries:
+For namespace_work_duration:
+For namespace_work_duration_sum:
+For namespace_work_duration_count:
+For function_duration_seconds:
+For errors_total:
+For evicted_pods_total:
+
+[AfterEach] [sig-api-machinery] Garbage collector
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Nov 29 07:47:44.272: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-gc-qrkjb" for this suite.
+Nov 29 07:47:50.279: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Nov 29 07:47:50.329: INFO: namespace: e2e-tests-gc-qrkjb, resource: bindings, ignored listing per whitelist
+Nov 29 07:47:50.332: INFO: namespace e2e-tests-gc-qrkjb deletion completed in 6.057825888s
+
+• [SLOW TEST:16.136 seconds]
+[sig-api-machinery] Garbage collector
+/workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apimachinery/framework.go:22
+  should not delete dependents that have both valid owner and owner that's waiting for dependents to be deleted [Conformance]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SSSSSSS
+------------------------------
+[sig-storage] Downward API volume 
+  should provide node allocatable (cpu) as default cpu limit if the limit is not set  [Conformance]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Nov 29 07:47:50.332: INFO: >>> kubeConfig: /tmp/kubeconfig-385092372
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downwardapi_volume.go:38
+[It] should provide node allocatable (cpu) as default cpu limit if the limit is not set  [Conformance]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating a pod to test downward API volume plugin
+Nov 29 07:47:50.367: INFO: Waiting up to 5m0s for pod "downwardapi-volume-121c77a0-f3ab-11e8-9124-e6180d057dc8" in namespace "e2e-tests-downward-api-l8kzh" to be "success or failure"
+Nov 29 07:47:50.371: INFO: Pod "downwardapi-volume-121c77a0-f3ab-11e8-9124-e6180d057dc8": Phase="Pending", Reason="", readiness=false. Elapsed: 4.547853ms
+Nov 29 07:47:52.373: INFO: Pod "downwardapi-volume-121c77a0-f3ab-11e8-9124-e6180d057dc8": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.006412983s
+STEP: Saw pod success
+Nov 29 07:47:52.373: INFO: Pod "downwardapi-volume-121c77a0-f3ab-11e8-9124-e6180d057dc8" satisfied condition "success or failure"
+Nov 29 07:47:52.374: INFO: Trying to get logs from node worker-266bbc56-f3aa-11e8-ab5c-0a406d6cb422 pod downwardapi-volume-121c77a0-f3ab-11e8-9124-e6180d057dc8 container client-container: <nil>
+STEP: delete the pod
+Nov 29 07:47:52.385: INFO: Waiting for pod downwardapi-volume-121c77a0-f3ab-11e8-9124-e6180d057dc8 to disappear
+Nov 29 07:47:52.387: INFO: Pod downwardapi-volume-121c77a0-f3ab-11e8-9124-e6180d057dc8 no longer exists
+[AfterEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Nov 29 07:47:52.387: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-downward-api-l8kzh" for this suite.
+Nov 29 07:47:58.396: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Nov 29 07:47:58.442: INFO: namespace: e2e-tests-downward-api-l8kzh, resource: bindings, ignored listing per whitelist
+Nov 29 07:47:58.446: INFO: namespace e2e-tests-downward-api-l8kzh deletion completed in 6.056368391s
+
+• [SLOW TEST:8.115 seconds]
+[sig-storage] Downward API volume
+/workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downwardapi_volume.go:33
+  should provide node allocatable (cpu) as default cpu limit if the limit is not set  [Conformance]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+[k8s.io] Pods 
+  should contain environment variables for services  [Conformance]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [k8s.io] Pods
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Nov 29 07:47:58.446: INFO: >>> kubeConfig: /tmp/kubeconfig-385092372
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [k8s.io] Pods
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/pods.go:127
+[It] should contain environment variables for services  [Conformance]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+Nov 29 07:48:00.507: INFO: Waiting up to 5m0s for pod "client-envvars-18280e09-f3ab-11e8-9124-e6180d057dc8" in namespace "e2e-tests-pods-4q59x" to be "success or failure"
+Nov 29 07:48:00.515: INFO: Pod "client-envvars-18280e09-f3ab-11e8-9124-e6180d057dc8": Phase="Pending", Reason="", readiness=false. Elapsed: 7.559562ms
+Nov 29 07:48:02.516: INFO: Pod "client-envvars-18280e09-f3ab-11e8-9124-e6180d057dc8": Phase="Pending", Reason="", readiness=false. Elapsed: 2.009375781s
+Nov 29 07:48:04.518: INFO: Pod "client-envvars-18280e09-f3ab-11e8-9124-e6180d057dc8": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.01118471s
+STEP: Saw pod success
+Nov 29 07:48:04.518: INFO: Pod "client-envvars-18280e09-f3ab-11e8-9124-e6180d057dc8" satisfied condition "success or failure"
+Nov 29 07:48:04.519: INFO: Trying to get logs from node worker-266bbc56-f3aa-11e8-ab5c-0a406d6cb422 pod client-envvars-18280e09-f3ab-11e8-9124-e6180d057dc8 container env3cont: <nil>
+STEP: delete the pod
+Nov 29 07:48:04.536: INFO: Waiting for pod client-envvars-18280e09-f3ab-11e8-9124-e6180d057dc8 to disappear
+Nov 29 07:48:04.541: INFO: Pod client-envvars-18280e09-f3ab-11e8-9124-e6180d057dc8 no longer exists
+[AfterEach] [k8s.io] Pods
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Nov 29 07:48:04.541: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-pods-4q59x" for this suite.
+Nov 29 07:48:26.547: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Nov 29 07:48:26.579: INFO: namespace: e2e-tests-pods-4q59x, resource: bindings, ignored listing per whitelist
+Nov 29 07:48:26.609: INFO: namespace e2e-tests-pods-4q59x deletion completed in 22.065897121s
+
+• [SLOW TEST:28.162 seconds]
+[k8s.io] Pods
+/workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:669
+  should contain environment variables for services  [Conformance]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+S
+------------------------------
+[k8s.io] Docker Containers 
+  should be able to override the image's default arguments (docker cmd)  [Conformance]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [k8s.io] Docker Containers
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Nov 29 07:48:26.609: INFO: >>> kubeConfig: /tmp/kubeconfig-385092372
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should be able to override the image's default arguments (docker cmd)  [Conformance]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating a pod to test override arguments
+Nov 29 07:48:26.646: INFO: Waiting up to 5m0s for pod "client-containers-27bcc829-f3ab-11e8-9124-e6180d057dc8" in namespace "e2e-tests-containers-h5zqn" to be "success or failure"
+Nov 29 07:48:26.650: INFO: Pod "client-containers-27bcc829-f3ab-11e8-9124-e6180d057dc8": Phase="Pending", Reason="", readiness=false. Elapsed: 3.593741ms
+Nov 29 07:48:28.651: INFO: Pod "client-containers-27bcc829-f3ab-11e8-9124-e6180d057dc8": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.005323218s
+STEP: Saw pod success
+Nov 29 07:48:28.651: INFO: Pod "client-containers-27bcc829-f3ab-11e8-9124-e6180d057dc8" satisfied condition "success or failure"
+Nov 29 07:48:28.653: INFO: Trying to get logs from node worker-266bbc56-f3aa-11e8-ab5c-0a406d6cb422 pod client-containers-27bcc829-f3ab-11e8-9124-e6180d057dc8 container test-container: <nil>
+STEP: delete the pod
+Nov 29 07:48:28.664: INFO: Waiting for pod client-containers-27bcc829-f3ab-11e8-9124-e6180d057dc8 to disappear
+Nov 29 07:48:28.669: INFO: Pod client-containers-27bcc829-f3ab-11e8-9124-e6180d057dc8 no longer exists
+[AfterEach] [k8s.io] Docker Containers
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Nov 29 07:48:28.669: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-containers-h5zqn" for this suite.
+Nov 29 07:48:34.676: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Nov 29 07:48:34.702: INFO: namespace: e2e-tests-containers-h5zqn, resource: bindings, ignored listing per whitelist
+Nov 29 07:48:34.746: INFO: namespace e2e-tests-containers-h5zqn deletion completed in 6.075611911s
+
+• [SLOW TEST:8.137 seconds]
+[k8s.io] Docker Containers
+/workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:669
+  should be able to override the image's default arguments (docker cmd)  [Conformance]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SSSSSS
+------------------------------
+[sig-api-machinery] Garbage collector 
+  should delete pods created by rc when not orphaning [Conformance]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-api-machinery] Garbage collector
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Nov 29 07:48:34.746: INFO: >>> kubeConfig: /tmp/kubeconfig-385092372
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should delete pods created by rc when not orphaning [Conformance]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: create the rc
+STEP: delete the rc
+STEP: wait for all pods to be garbage collected
+STEP: Gathering metrics
+W1129 07:48:44.813940      13 metrics_grabber.go:81] Master node is not registered. Grabbing metrics from Scheduler, ControllerManager and ClusterAutoscaler is disabled.
+Nov 29 07:48:44.814: INFO: For apiserver_request_count:
+For apiserver_request_latencies_summary:
+For etcd_helper_cache_entry_count:
+For etcd_helper_cache_hit_count:
+For etcd_helper_cache_miss_count:
+For etcd_request_cache_add_latencies_summary:
+For etcd_request_cache_get_latencies_summary:
+For etcd_request_latencies_summary:
+For garbage_collector_attempt_to_delete_queue_latency:
+For garbage_collector_attempt_to_delete_work_duration:
+For garbage_collector_attempt_to_orphan_queue_latency:
+For garbage_collector_attempt_to_orphan_work_duration:
+For garbage_collector_dirty_processing_latency_microseconds:
+For garbage_collector_event_processing_latency_microseconds:
+For garbage_collector_graph_changes_queue_latency:
+For garbage_collector_graph_changes_work_duration:
+For garbage_collector_orphan_processing_latency_microseconds:
+For namespace_queue_latency:
+For namespace_queue_latency_sum:
+For namespace_queue_latency_count:
+For namespace_retries:
+For namespace_work_duration:
+For namespace_work_duration_sum:
+For namespace_work_duration_count:
+For function_duration_seconds:
+For errors_total:
+For evicted_pods_total:
+
+[AfterEach] [sig-api-machinery] Garbage collector
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Nov 29 07:48:44.814: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-gc-2wfrg" for this suite.
+Nov 29 07:48:50.820: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Nov 29 07:48:50.872: INFO: namespace: e2e-tests-gc-2wfrg, resource: bindings, ignored listing per whitelist
+Nov 29 07:48:50.877: INFO: namespace e2e-tests-gc-2wfrg deletion completed in 6.0622062s
+
+• [SLOW TEST:16.131 seconds]
+[sig-api-machinery] Garbage collector
+/workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apimachinery/framework.go:22
+  should delete pods created by rc when not orphaning [Conformance]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SS
+------------------------------
+[sig-storage] Projected 
+  should provide container's cpu request [Conformance]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Nov 29 07:48:50.877: INFO: >>> kubeConfig: /tmp/kubeconfig-385092372
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:858
+[It] should provide container's cpu request [Conformance]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating a pod to test downward API volume plugin
+Nov 29 07:48:50.961: INFO: Waiting up to 5m0s for pod "downwardapi-volume-363a7fed-f3ab-11e8-9124-e6180d057dc8" in namespace "e2e-tests-projected-ng8p2" to be "success or failure"
+Nov 29 07:48:50.963: INFO: Pod "downwardapi-volume-363a7fed-f3ab-11e8-9124-e6180d057dc8": Phase="Pending", Reason="", readiness=false. Elapsed: 1.918743ms
+Nov 29 07:48:52.965: INFO: Pod "downwardapi-volume-363a7fed-f3ab-11e8-9124-e6180d057dc8": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.003751517s
+STEP: Saw pod success
+Nov 29 07:48:52.965: INFO: Pod "downwardapi-volume-363a7fed-f3ab-11e8-9124-e6180d057dc8" satisfied condition "success or failure"
+Nov 29 07:48:52.966: INFO: Trying to get logs from node worker-266bbc56-f3aa-11e8-ab5c-0a406d6cb422 pod downwardapi-volume-363a7fed-f3ab-11e8-9124-e6180d057dc8 container client-container: <nil>
+STEP: delete the pod
+Nov 29 07:48:52.981: INFO: Waiting for pod downwardapi-volume-363a7fed-f3ab-11e8-9124-e6180d057dc8 to disappear
+Nov 29 07:48:52.984: INFO: Pod downwardapi-volume-363a7fed-f3ab-11e8-9124-e6180d057dc8 no longer exists
+[AfterEach] [sig-storage] Projected
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Nov 29 07:48:52.984: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-ng8p2" for this suite.
+Nov 29 07:48:58.991: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Nov 29 07:48:59.031: INFO: namespace: e2e-tests-projected-ng8p2, resource: bindings, ignored listing per whitelist
+Nov 29 07:48:59.042: INFO: namespace e2e-tests-projected-ng8p2 deletion completed in 6.056729311s
+
+• [SLOW TEST:8.165 seconds]
+[sig-storage] Projected
+/workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:34
+  should provide container's cpu request [Conformance]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SSSS
+------------------------------
+[k8s.io] Probing container 
+  should have monotonically increasing restart count  [Slow] [Conformance]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [k8s.io] Probing container
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Nov 29 07:48:59.043: INFO: >>> kubeConfig: /tmp/kubeconfig-385092372
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [k8s.io] Probing container
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/container_probe.go:48
+[It] should have monotonically increasing restart count  [Slow] [Conformance]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating pod liveness-http in namespace e2e-tests-container-probe-6n7kr
+Nov 29 07:49:03.128: INFO: Started pod liveness-http in namespace e2e-tests-container-probe-6n7kr
+STEP: checking the pod's current state and verifying that restartCount is present
+Nov 29 07:49:03.129: INFO: Initial restart count of pod liveness-http is 0
+Nov 29 07:49:15.140: INFO: Restart count of pod e2e-tests-container-probe-6n7kr/liveness-http is now 1 (12.01059881s elapsed)
+Nov 29 07:49:33.156: INFO: Restart count of pod e2e-tests-container-probe-6n7kr/liveness-http is now 2 (30.026401798s elapsed)
+Nov 29 07:49:53.174: INFO: Restart count of pod e2e-tests-container-probe-6n7kr/liveness-http is now 3 (50.044276765s elapsed)
+Nov 29 07:50:39.213: INFO: Restart count of pod e2e-tests-container-probe-6n7kr/liveness-http is now 4 (1m36.08405475s elapsed)
+Nov 29 07:50:53.232: INFO: Restart count of pod e2e-tests-container-probe-6n7kr/liveness-http is now 5 (1m50.102946189s elapsed)
+STEP: deleting the pod
+[AfterEach] [k8s.io] Probing container
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Nov 29 07:50:53.244: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-container-probe-6n7kr" for this suite.
+Nov 29 07:50:59.250: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Nov 29 07:50:59.300: INFO: namespace: e2e-tests-container-probe-6n7kr, resource: bindings, ignored listing per whitelist
+Nov 29 07:50:59.300: INFO: namespace e2e-tests-container-probe-6n7kr deletion completed in 6.054988288s
+
+• [SLOW TEST:120.258 seconds]
+[k8s.io] Probing container
+/workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:669
+  should have monotonically increasing restart count  [Slow] [Conformance]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SSSSSSS
+------------------------------
+[k8s.io] Pods 
+  should be updated  [Conformance]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [k8s.io] Pods
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Nov 29 07:50:59.301: INFO: >>> kubeConfig: /tmp/kubeconfig-385092372
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [k8s.io] Pods
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/pods.go:127
+[It] should be updated  [Conformance]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: creating the pod
+STEP: submitting the pod to kubernetes
+STEP: verifying the pod is in kubernetes
+STEP: updating the pod
+Nov 29 07:51:01.892: INFO: Successfully updated pod "pod-update-82c637e2-f3ab-11e8-9124-e6180d057dc8"
+STEP: verifying the updated pod is in kubernetes
+Nov 29 07:51:01.897: INFO: Pod update OK
+[AfterEach] [k8s.io] Pods
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Nov 29 07:51:01.897: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-pods-vwfkf" for this suite.
+Nov 29 07:51:23.904: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Nov 29 07:51:23.934: INFO: namespace: e2e-tests-pods-vwfkf, resource: bindings, ignored listing per whitelist
+Nov 29 07:51:23.960: INFO: namespace e2e-tests-pods-vwfkf deletion completed in 22.061175995s
+
+• [SLOW TEST:24.659 seconds]
+[k8s.io] Pods
+/workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:669
+  should be updated  [Conformance]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SSSSSSS
+------------------------------
+[sig-storage] Downward API volume 
+  should provide container's memory limit  [Conformance]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Nov 29 07:51:23.960: INFO: >>> kubeConfig: /tmp/kubeconfig-385092372
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downwardapi_volume.go:38
+[It] should provide container's memory limit  [Conformance]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating a pod to test downward API volume plugin
+Nov 29 07:51:24.042: INFO: Waiting up to 5m0s for pod "downwardapi-volume-91793686-f3ab-11e8-9124-e6180d057dc8" in namespace "e2e-tests-downward-api-vh4s8" to be "success or failure"
+Nov 29 07:51:24.047: INFO: Pod "downwardapi-volume-91793686-f3ab-11e8-9124-e6180d057dc8": Phase="Pending", Reason="", readiness=false. Elapsed: 5.343775ms
+Nov 29 07:51:26.049: INFO: Pod "downwardapi-volume-91793686-f3ab-11e8-9124-e6180d057dc8": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.007292702s
+STEP: Saw pod success
+Nov 29 07:51:26.049: INFO: Pod "downwardapi-volume-91793686-f3ab-11e8-9124-e6180d057dc8" satisfied condition "success or failure"
+Nov 29 07:51:26.051: INFO: Trying to get logs from node worker-266bbc56-f3aa-11e8-ab5c-0a406d6cb422 pod downwardapi-volume-91793686-f3ab-11e8-9124-e6180d057dc8 container client-container: <nil>
+STEP: delete the pod
+Nov 29 07:51:26.065: INFO: Waiting for pod downwardapi-volume-91793686-f3ab-11e8-9124-e6180d057dc8 to disappear
+Nov 29 07:51:26.070: INFO: Pod downwardapi-volume-91793686-f3ab-11e8-9124-e6180d057dc8 no longer exists
+[AfterEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Nov 29 07:51:26.070: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-downward-api-vh4s8" for this suite.
+Nov 29 07:51:32.076: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Nov 29 07:51:32.124: INFO: namespace: e2e-tests-downward-api-vh4s8, resource: bindings, ignored listing per whitelist
+Nov 29 07:51:32.127: INFO: namespace e2e-tests-downward-api-vh4s8 deletion completed in 6.055858903s
+
+• [SLOW TEST:8.167 seconds]
+[sig-storage] Downward API volume
+/workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downwardapi_volume.go:33
+  should provide container's memory limit  [Conformance]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+[sig-storage] EmptyDir volumes 
+  should support (root,0777,tmpfs) [Conformance]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-storage] EmptyDir volumes
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Nov 29 07:51:32.127: INFO: >>> kubeConfig: /tmp/kubeconfig-385092372
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should support (root,0777,tmpfs) [Conformance]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating a pod to test emptydir 0777 on tmpfs
+Nov 29 07:51:32.158: INFO: Waiting up to 5m0s for pod "pod-964fad5d-f3ab-11e8-9124-e6180d057dc8" in namespace "e2e-tests-emptydir-wd5wq" to be "success or failure"
+Nov 29 07:51:32.161: INFO: Pod "pod-964fad5d-f3ab-11e8-9124-e6180d057dc8": Phase="Pending", Reason="", readiness=false. Elapsed: 2.272189ms
+Nov 29 07:51:34.162: INFO: Pod "pod-964fad5d-f3ab-11e8-9124-e6180d057dc8": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.003971225s
+STEP: Saw pod success
+Nov 29 07:51:34.162: INFO: Pod "pod-964fad5d-f3ab-11e8-9124-e6180d057dc8" satisfied condition "success or failure"
+Nov 29 07:51:34.164: INFO: Trying to get logs from node worker-266bbc56-f3aa-11e8-ab5c-0a406d6cb422 pod pod-964fad5d-f3ab-11e8-9124-e6180d057dc8 container test-container: <nil>
+STEP: delete the pod
+Nov 29 07:51:34.176: INFO: Waiting for pod pod-964fad5d-f3ab-11e8-9124-e6180d057dc8 to disappear
+Nov 29 07:51:34.179: INFO: Pod pod-964fad5d-f3ab-11e8-9124-e6180d057dc8 no longer exists
+[AfterEach] [sig-storage] EmptyDir volumes
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Nov 29 07:51:34.179: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-emptydir-wd5wq" for this suite.
+Nov 29 07:51:40.185: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Nov 29 07:51:40.220: INFO: namespace: e2e-tests-emptydir-wd5wq, resource: bindings, ignored listing per whitelist
+Nov 29 07:51:40.237: INFO: namespace e2e-tests-emptydir-wd5wq deletion completed in 6.05649141s
+
+• [SLOW TEST:8.110 seconds]
+[sig-storage] EmptyDir volumes
+/workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/empty_dir.go:41
+  should support (root,0777,tmpfs) [Conformance]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+S
+------------------------------
+[sig-storage] ConfigMap 
+  should be consumable from pods in volume as non-root  [Conformance]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-storage] ConfigMap
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Nov 29 07:51:40.237: INFO: >>> kubeConfig: /tmp/kubeconfig-385092372
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should be consumable from pods in volume as non-root  [Conformance]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating configMap with name configmap-test-volume-9b253be4-f3ab-11e8-9124-e6180d057dc8
+STEP: Creating a pod to test consume configMaps
+Nov 29 07:51:40.274: INFO: Waiting up to 5m0s for pod "pod-configmaps-9b257510-f3ab-11e8-9124-e6180d057dc8" in namespace "e2e-tests-configmap-ctr48" to be "success or failure"
+Nov 29 07:51:40.284: INFO: Pod "pod-configmaps-9b257510-f3ab-11e8-9124-e6180d057dc8": Phase="Pending", Reason="", readiness=false. Elapsed: 10.513379ms
+Nov 29 07:51:42.286: INFO: Pod "pod-configmaps-9b257510-f3ab-11e8-9124-e6180d057dc8": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.012193105s
+STEP: Saw pod success
+Nov 29 07:51:42.286: INFO: Pod "pod-configmaps-9b257510-f3ab-11e8-9124-e6180d057dc8" satisfied condition "success or failure"
+Nov 29 07:51:42.287: INFO: Trying to get logs from node worker-266bbc56-f3aa-11e8-ab5c-0a406d6cb422 pod pod-configmaps-9b257510-f3ab-11e8-9124-e6180d057dc8 container configmap-volume-test: <nil>
+STEP: delete the pod
+Nov 29 07:51:42.299: INFO: Waiting for pod pod-configmaps-9b257510-f3ab-11e8-9124-e6180d057dc8 to disappear
+Nov 29 07:51:42.302: INFO: Pod pod-configmaps-9b257510-f3ab-11e8-9124-e6180d057dc8 no longer exists
+[AfterEach] [sig-storage] ConfigMap
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Nov 29 07:51:42.302: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-configmap-ctr48" for this suite.
+Nov 29 07:51:48.309: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Nov 29 07:51:48.368: INFO: namespace: e2e-tests-configmap-ctr48, resource: bindings, ignored listing per whitelist
+Nov 29 07:51:48.370: INFO: namespace e2e-tests-configmap-ctr48 deletion completed in 6.066227039s
+
+• [SLOW TEST:8.133 seconds]
+[sig-storage] ConfigMap
+/workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/configmap_volume.go:32
+  should be consumable from pods in volume as non-root  [Conformance]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+S
+------------------------------
+[sig-storage] EmptyDir volumes 
+  should support (root,0666,default) [Conformance]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-storage] EmptyDir volumes
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Nov 29 07:51:48.370: INFO: >>> kubeConfig: /tmp/kubeconfig-385092372
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should support (root,0666,default) [Conformance]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating a pod to test emptydir 0666 on node default medium
+Nov 29 07:51:48.403: INFO: Waiting up to 5m0s for pod "pod-9ffe6409-f3ab-11e8-9124-e6180d057dc8" in namespace "e2e-tests-emptydir-qhlrt" to be "success or failure"
+Nov 29 07:51:48.405: INFO: Pod "pod-9ffe6409-f3ab-11e8-9124-e6180d057dc8": Phase="Pending", Reason="", readiness=false. Elapsed: 2.536192ms
+Nov 29 07:51:50.407: INFO: Pod "pod-9ffe6409-f3ab-11e8-9124-e6180d057dc8": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.004298672s
+STEP: Saw pod success
+Nov 29 07:51:50.407: INFO: Pod "pod-9ffe6409-f3ab-11e8-9124-e6180d057dc8" satisfied condition "success or failure"
+Nov 29 07:51:50.408: INFO: Trying to get logs from node worker-266bbc56-f3aa-11e8-ab5c-0a406d6cb422 pod pod-9ffe6409-f3ab-11e8-9124-e6180d057dc8 container test-container: <nil>
+STEP: delete the pod
+Nov 29 07:51:50.419: INFO: Waiting for pod pod-9ffe6409-f3ab-11e8-9124-e6180d057dc8 to disappear
+Nov 29 07:51:50.422: INFO: Pod pod-9ffe6409-f3ab-11e8-9124-e6180d057dc8 no longer exists
+[AfterEach] [sig-storage] EmptyDir volumes
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Nov 29 07:51:50.422: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-emptydir-qhlrt" for this suite.
+Nov 29 07:51:56.429: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Nov 29 07:51:56.446: INFO: namespace: e2e-tests-emptydir-qhlrt, resource: bindings, ignored listing per whitelist
+Nov 29 07:51:56.480: INFO: namespace e2e-tests-emptydir-qhlrt deletion completed in 6.056013977s
+
+• [SLOW TEST:8.110 seconds]
+[sig-storage] EmptyDir volumes
+/workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/empty_dir.go:41
+  should support (root,0666,default) [Conformance]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SSSSSSSSSSS
+------------------------------
+[sig-apps] StatefulSet [k8s.io] Basic StatefulSet functionality [StatefulSetBasic] 
+  Scaling should happen in predictable order and halt if any stateful pod is unhealthy [Conformance]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-apps] StatefulSet
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Nov 29 07:51:56.480: INFO: >>> kubeConfig: /tmp/kubeconfig-385092372
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-apps] StatefulSet
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/statefulset.go:57
+[BeforeEach] [k8s.io] Basic StatefulSet functionality [StatefulSetBasic]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/statefulset.go:72
+STEP: Creating service test in namespace e2e-tests-statefulset-wsqf6
+[It] Scaling should happen in predictable order and halt if any stateful pod is unhealthy [Conformance]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Initializing watcher for selector baz=blah,foo=bar
+STEP: Creating stateful set ss in namespace e2e-tests-statefulset-wsqf6
+STEP: Waiting until all stateful set ss replicas will be running in namespace e2e-tests-statefulset-wsqf6
+Nov 29 07:51:56.528: INFO: Found 0 stateful pods, waiting for 1
+Nov 29 07:52:06.530: INFO: Waiting for pod ss-0 to enter Running - Ready=true, currently Running - Ready=true
+STEP: Confirming that stateful set scale up will halt with unhealthy stateful pod
+Nov 29 07:52:06.532: INFO: Running '/usr/local/bin/kubectl --kubeconfig=/tmp/kubeconfig-385092372 exec --namespace=e2e-tests-statefulset-wsqf6 ss-0 -- /bin/sh -c mv -v /usr/share/nginx/html/index.html /tmp/ || true'
+Nov 29 07:52:06.644: INFO: stderr: ""
+Nov 29 07:52:06.644: INFO: stdout of mv -v /usr/share/nginx/html/index.html /tmp/ || true on ss-0: '/usr/share/nginx/html/index.html' -> '/tmp/index.html'
+
+Nov 29 07:52:06.645: INFO: Waiting for pod ss-0 to enter Running - Ready=false, currently Running - Ready=true
+Nov 29 07:52:16.647: INFO: Waiting for pod ss-0 to enter Running - Ready=false, currently Running - Ready=false
+Nov 29 07:52:16.647: INFO: Waiting for statefulset status.replicas updated to 0
+Nov 29 07:52:16.655: INFO: Verifying statefulset ss doesn't scale past 1 for another 9.999999804s
+Nov 29 07:52:17.657: INFO: Verifying statefulset ss doesn't scale past 1 for another 8.99638905s
+Nov 29 07:52:18.659: INFO: Verifying statefulset ss doesn't scale past 1 for another 7.994406396s
+Nov 29 07:52:19.661: INFO: Verifying statefulset ss doesn't scale past 1 for another 6.992514659s
+Nov 29 07:52:20.663: INFO: Verifying statefulset ss doesn't scale past 1 for another 5.990605449s
+Nov 29 07:52:21.665: INFO: Verifying statefulset ss doesn't scale past 1 for another 4.988612715s
+Nov 29 07:52:22.667: INFO: Verifying statefulset ss doesn't scale past 1 for another 3.986681488s
+Nov 29 07:52:23.669: INFO: Verifying statefulset ss doesn't scale past 1 for another 2.984682213s
+Nov 29 07:52:24.670: INFO: Verifying statefulset ss doesn't scale past 1 for another 1.982803604s
+Nov 29 07:52:25.672: INFO: Verifying statefulset ss doesn't scale past 1 for another 980.975811ms
+STEP: Scaling up stateful set ss to 3 replicas and waiting until all of them will be running in namespace e2e-tests-statefulset-wsqf6
+Nov 29 07:52:26.674: INFO: Running '/usr/local/bin/kubectl --kubeconfig=/tmp/kubeconfig-385092372 exec --namespace=e2e-tests-statefulset-wsqf6 ss-0 -- /bin/sh -c mv -v /tmp/index.html /usr/share/nginx/html/ || true'
+Nov 29 07:52:26.788: INFO: stderr: ""
+Nov 29 07:52:26.788: INFO: stdout of mv -v /tmp/index.html /usr/share/nginx/html/ || true on ss-0: '/tmp/index.html' -> '/usr/share/nginx/html/index.html'
+
+Nov 29 07:52:26.789: INFO: Found 1 stateful pods, waiting for 3
+Nov 29 07:52:36.791: INFO: Waiting for pod ss-0 to enter Running - Ready=true, currently Running - Ready=true
+Nov 29 07:52:36.791: INFO: Waiting for pod ss-1 to enter Running - Ready=true, currently Running - Ready=true
+Nov 29 07:52:36.791: INFO: Waiting for pod ss-2 to enter Running - Ready=true, currently Running - Ready=true
+STEP: Verifying that stateful set ss was scaled up in order
+STEP: Scale down will halt with unhealthy stateful pod
+Nov 29 07:52:36.794: INFO: Running '/usr/local/bin/kubectl --kubeconfig=/tmp/kubeconfig-385092372 exec --namespace=e2e-tests-statefulset-wsqf6 ss-0 -- /bin/sh -c mv -v /usr/share/nginx/html/index.html /tmp/ || true'
+Nov 29 07:52:36.913: INFO: stderr: ""
+Nov 29 07:52:36.913: INFO: stdout of mv -v /usr/share/nginx/html/index.html /tmp/ || true on ss-0: '/usr/share/nginx/html/index.html' -> '/tmp/index.html'
+
+Nov 29 07:52:36.913: INFO: Running '/usr/local/bin/kubectl --kubeconfig=/tmp/kubeconfig-385092372 exec --namespace=e2e-tests-statefulset-wsqf6 ss-1 -- /bin/sh -c mv -v /usr/share/nginx/html/index.html /tmp/ || true'
+Nov 29 07:52:37.045: INFO: stderr: ""
+Nov 29 07:52:37.045: INFO: stdout of mv -v /usr/share/nginx/html/index.html /tmp/ || true on ss-1: '/usr/share/nginx/html/index.html' -> '/tmp/index.html'
+
+Nov 29 07:52:37.045: INFO: Running '/usr/local/bin/kubectl --kubeconfig=/tmp/kubeconfig-385092372 exec --namespace=e2e-tests-statefulset-wsqf6 ss-2 -- /bin/sh -c mv -v /usr/share/nginx/html/index.html /tmp/ || true'
+Nov 29 07:52:37.156: INFO: stderr: ""
+Nov 29 07:52:37.156: INFO: stdout of mv -v /usr/share/nginx/html/index.html /tmp/ || true on ss-2: '/usr/share/nginx/html/index.html' -> '/tmp/index.html'
+
+Nov 29 07:52:37.156: INFO: Waiting for statefulset status.replicas updated to 0
+Nov 29 07:52:37.158: INFO: Waiting for stateful set status.readyReplicas to become 0, currently 3
+Nov 29 07:52:47.161: INFO: Waiting for pod ss-0 to enter Running - Ready=false, currently Running - Ready=false
+Nov 29 07:52:47.161: INFO: Waiting for pod ss-1 to enter Running - Ready=false, currently Running - Ready=false
+Nov 29 07:52:47.161: INFO: Waiting for pod ss-2 to enter Running - Ready=false, currently Running - Ready=false
+Nov 29 07:52:47.167: INFO: Verifying statefulset ss doesn't scale past 3 for another 9.999999757s
+Nov 29 07:52:48.169: INFO: Verifying statefulset ss doesn't scale past 3 for another 8.997791545s
+Nov 29 07:52:49.171: INFO: Verifying statefulset ss doesn't scale past 3 for another 7.995955994s
+Nov 29 07:52:50.173: INFO: Verifying statefulset ss doesn't scale past 3 for another 6.993879905s
+Nov 29 07:52:51.175: INFO: Verifying statefulset ss doesn't scale past 3 for another 5.991951388s
+Nov 29 07:52:52.177: INFO: Verifying statefulset ss doesn't scale past 3 for another 4.989946861s
+Nov 29 07:52:53.179: INFO: Verifying statefulset ss doesn't scale past 3 for another 3.988099731s
+Nov 29 07:52:54.181: INFO: Verifying statefulset ss doesn't scale past 3 for another 2.985985369s
+Nov 29 07:52:55.183: INFO: Verifying statefulset ss doesn't scale past 3 for another 1.984079642s
+Nov 29 07:52:56.185: INFO: Verifying statefulset ss doesn't scale past 3 for another 981.990373ms
+STEP: Scaling down stateful set ss to 0 replicas and waiting until none of pods will run in namespacee2e-tests-statefulset-wsqf6
+Nov 29 07:52:57.187: INFO: Running '/usr/local/bin/kubectl --kubeconfig=/tmp/kubeconfig-385092372 exec --namespace=e2e-tests-statefulset-wsqf6 ss-0 -- /bin/sh -c mv -v /tmp/index.html /usr/share/nginx/html/ || true'
+Nov 29 07:52:57.297: INFO: stderr: ""
+Nov 29 07:52:57.297: INFO: stdout of mv -v /tmp/index.html /usr/share/nginx/html/ || true on ss-0: '/tmp/index.html' -> '/usr/share/nginx/html/index.html'
+
+Nov 29 07:52:57.297: INFO: Running '/usr/local/bin/kubectl --kubeconfig=/tmp/kubeconfig-385092372 exec --namespace=e2e-tests-statefulset-wsqf6 ss-1 -- /bin/sh -c mv -v /tmp/index.html /usr/share/nginx/html/ || true'
+Nov 29 07:52:57.408: INFO: stderr: ""
+Nov 29 07:52:57.408: INFO: stdout of mv -v /tmp/index.html /usr/share/nginx/html/ || true on ss-1: '/tmp/index.html' -> '/usr/share/nginx/html/index.html'
+
+Nov 29 07:52:57.408: INFO: Running '/usr/local/bin/kubectl --kubeconfig=/tmp/kubeconfig-385092372 exec --namespace=e2e-tests-statefulset-wsqf6 ss-2 -- /bin/sh -c mv -v /tmp/index.html /usr/share/nginx/html/ || true'
+Nov 29 07:52:57.529: INFO: stderr: ""
+Nov 29 07:52:57.529: INFO: stdout of mv -v /tmp/index.html /usr/share/nginx/html/ || true on ss-2: '/tmp/index.html' -> '/usr/share/nginx/html/index.html'
+
+Nov 29 07:52:57.529: INFO: Scaling statefulset ss to 0
+STEP: Verifying that stateful set ss was scaled down in reverse order
+[AfterEach] [k8s.io] Basic StatefulSet functionality [StatefulSetBasic]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/statefulset.go:83
+Nov 29 07:53:17.535: INFO: Deleting all statefulset in ns e2e-tests-statefulset-wsqf6
+Nov 29 07:53:17.537: INFO: Scaling statefulset ss to 0
+Nov 29 07:53:17.540: INFO: Waiting for statefulset status.replicas updated to 0
+Nov 29 07:53:17.541: INFO: Deleting statefulset ss
+[AfterEach] [sig-apps] StatefulSet
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Nov 29 07:53:17.548: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-statefulset-wsqf6" for this suite.
+Nov 29 07:53:23.559: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Nov 29 07:53:23.610: INFO: namespace: e2e-tests-statefulset-wsqf6, resource: bindings, ignored listing per whitelist
+Nov 29 07:53:23.613: INFO: namespace e2e-tests-statefulset-wsqf6 deletion completed in 6.062718157s
+
+• [SLOW TEST:87.132 seconds]
+[sig-apps] StatefulSet
+/workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/framework.go:22
+  [k8s.io] Basic StatefulSet functionality [StatefulSetBasic]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:669
+    Scaling should happen in predictable order and halt if any stateful pod is unhealthy [Conformance]
+    /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SSSS
+------------------------------
+[sig-storage] ConfigMap 
+  should be consumable from pods in volume with mappings and Item mode set [Conformance]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-storage] ConfigMap
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Nov 29 07:53:23.613: INFO: >>> kubeConfig: /tmp/kubeconfig-385092372
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should be consumable from pods in volume with mappings and Item mode set [Conformance]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating configMap with name configmap-test-volume-map-d8c3748b-f3ab-11e8-9124-e6180d057dc8
+STEP: Creating a pod to test consume configMaps
+Nov 29 07:53:23.648: INFO: Waiting up to 5m0s for pod "pod-configmaps-d8c3b2a5-f3ab-11e8-9124-e6180d057dc8" in namespace "e2e-tests-configmap-cwtk8" to be "success or failure"
+Nov 29 07:53:23.651: INFO: Pod "pod-configmaps-d8c3b2a5-f3ab-11e8-9124-e6180d057dc8": Phase="Pending", Reason="", readiness=false. Elapsed: 2.637704ms
+Nov 29 07:53:25.652: INFO: Pod "pod-configmaps-d8c3b2a5-f3ab-11e8-9124-e6180d057dc8": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.004127572s
+STEP: Saw pod success
+Nov 29 07:53:25.652: INFO: Pod "pod-configmaps-d8c3b2a5-f3ab-11e8-9124-e6180d057dc8" satisfied condition "success or failure"
+Nov 29 07:53:25.654: INFO: Trying to get logs from node worker-266bbc56-f3aa-11e8-ab5c-0a406d6cb422 pod pod-configmaps-d8c3b2a5-f3ab-11e8-9124-e6180d057dc8 container configmap-volume-test: <nil>
+STEP: delete the pod
+Nov 29 07:53:25.665: INFO: Waiting for pod pod-configmaps-d8c3b2a5-f3ab-11e8-9124-e6180d057dc8 to disappear
+Nov 29 07:53:25.668: INFO: Pod pod-configmaps-d8c3b2a5-f3ab-11e8-9124-e6180d057dc8 no longer exists
+[AfterEach] [sig-storage] ConfigMap
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Nov 29 07:53:25.668: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-configmap-cwtk8" for this suite.
+Nov 29 07:53:31.675: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Nov 29 07:53:31.699: INFO: namespace: e2e-tests-configmap-cwtk8, resource: bindings, ignored listing per whitelist
+Nov 29 07:53:31.726: INFO: namespace e2e-tests-configmap-cwtk8 deletion completed in 6.055634691s
+
+• [SLOW TEST:8.113 seconds]
+[sig-storage] ConfigMap
+/workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/configmap_volume.go:32
+  should be consumable from pods in volume with mappings and Item mode set [Conformance]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SS
+------------------------------
+[k8s.io] Docker Containers 
+  should use the image defaults if command and args are blank  [Conformance]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [k8s.io] Docker Containers
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Nov 29 07:53:31.726: INFO: >>> kubeConfig: /tmp/kubeconfig-385092372
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should use the image defaults if command and args are blank  [Conformance]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating a pod to test use defaults
+Nov 29 07:53:31.756: INFO: Waiting up to 5m0s for pod "client-containers-dd98e554-f3ab-11e8-9124-e6180d057dc8" in namespace "e2e-tests-containers-dfw5x" to be "success or failure"
+Nov 29 07:53:31.758: INFO: Pod "client-containers-dd98e554-f3ab-11e8-9124-e6180d057dc8": Phase="Pending", Reason="", readiness=false. Elapsed: 1.972806ms
+Nov 29 07:53:33.760: INFO: Pod "client-containers-dd98e554-f3ab-11e8-9124-e6180d057dc8": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.003632524s
+STEP: Saw pod success
+Nov 29 07:53:33.760: INFO: Pod "client-containers-dd98e554-f3ab-11e8-9124-e6180d057dc8" satisfied condition "success or failure"
+Nov 29 07:53:33.761: INFO: Trying to get logs from node worker-266bbc56-f3aa-11e8-ab5c-0a406d6cb422 pod client-containers-dd98e554-f3ab-11e8-9124-e6180d057dc8 container test-container: <nil>
+STEP: delete the pod
+Nov 29 07:53:33.772: INFO: Waiting for pod client-containers-dd98e554-f3ab-11e8-9124-e6180d057dc8 to disappear
+Nov 29 07:53:33.775: INFO: Pod client-containers-dd98e554-f3ab-11e8-9124-e6180d057dc8 no longer exists
+[AfterEach] [k8s.io] Docker Containers
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Nov 29 07:53:33.775: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-containers-dfw5x" for this suite.
+Nov 29 07:53:39.785: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Nov 29 07:53:39.807: INFO: namespace: e2e-tests-containers-dfw5x, resource: bindings, ignored listing per whitelist
+Nov 29 07:53:39.841: INFO: namespace e2e-tests-containers-dfw5x deletion completed in 6.064420745s
+
+• [SLOW TEST:8.115 seconds]
+[k8s.io] Docker Containers
+/workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:669
+  should use the image defaults if command and args are blank  [Conformance]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+S
+------------------------------
+[sig-network] Proxy version v1 
+  should proxy logs on node with explicit kubelet port using proxy subresource  [Conformance]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] version v1
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Nov 29 07:53:39.842: INFO: >>> kubeConfig: /tmp/kubeconfig-385092372
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] version v1
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/network/proxy.go:69
+[It] should proxy logs on node with explicit kubelet port using proxy subresource  [Conformance]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+Nov 29 07:53:39.880: INFO: (0) /api/v1/nodes/worker-266bbc56-f3aa-11e8-ab5c-0a406d6cb422:10250/proxy/logs/: <pre>
+<a href="amazon/">amazon/</a>
+<a href="audit/">audit/</a>
+<a href="btmp">btmp</a>
+<a href="... (200; 1.621638ms)
+Nov 29 07:53:39.882: INFO: (1) /api/v1/nodes/worker-266bbc56-f3aa-11e8-ab5c-0a406d6cb422:10250/proxy/logs/: <pre>
+<a href="amazon/">amazon/</a>
+<a href="audit/">audit/</a>
+<a href="btmp">btmp</a>
+<a href="... (200; 1.425562ms)
+Nov 29 07:53:39.883: INFO: (2) /api/v1/nodes/worker-266bbc56-f3aa-11e8-ab5c-0a406d6cb422:10250/proxy/logs/: <pre>
+<a href="amazon/">amazon/</a>
+<a href="audit/">audit/</a>
+<a href="btmp">btmp</a>
+<a href="... (200; 1.323835ms)
+Nov 29 07:53:39.885: INFO: (3) /api/v1/nodes/worker-266bbc56-f3aa-11e8-ab5c-0a406d6cb422:10250/proxy/logs/: <pre>
+<a href="amazon/">amazon/</a>
+<a href="audit/">audit/</a>
+<a href="btmp">btmp</a>
+<a href="... (200; 1.400248ms)
+Nov 29 07:53:39.886: INFO: (4) /api/v1/nodes/worker-266bbc56-f3aa-11e8-ab5c-0a406d6cb422:10250/proxy/logs/: <pre>
+<a href="amazon/">amazon/</a>
+<a href="audit/">audit/</a>
+<a href="btmp">btmp</a>
+<a href="... (200; 1.291326ms)
+Nov 29 07:53:39.887: INFO: (5) /api/v1/nodes/worker-266bbc56-f3aa-11e8-ab5c-0a406d6cb422:10250/proxy/logs/: <pre>
+<a href="amazon/">amazon/</a>
+<a href="audit/">audit/</a>
+<a href="btmp">btmp</a>
+<a href="... (200; 1.298156ms)
+Nov 29 07:53:39.889: INFO: (6) /api/v1/nodes/worker-266bbc56-f3aa-11e8-ab5c-0a406d6cb422:10250/proxy/logs/: <pre>
+<a href="amazon/">amazon/</a>
+<a href="audit/">audit/</a>
+<a href="btmp">btmp</a>
+<a href="... (200; 1.330257ms)
+Nov 29 07:53:39.890: INFO: (7) /api/v1/nodes/worker-266bbc56-f3aa-11e8-ab5c-0a406d6cb422:10250/proxy/logs/: <pre>
+<a href="amazon/">amazon/</a>
+<a href="audit/">audit/</a>
+<a href="btmp">btmp</a>
+<a href="... (200; 1.329197ms)
+Nov 29 07:53:39.891: INFO: (8) /api/v1/nodes/worker-266bbc56-f3aa-11e8-ab5c-0a406d6cb422:10250/proxy/logs/: <pre>
+<a href="amazon/">amazon/</a>
+<a href="audit/">audit/</a>
+<a href="btmp">btmp</a>
+<a href="... (200; 1.274925ms)
+Nov 29 07:53:39.893: INFO: (9) /api/v1/nodes/worker-266bbc56-f3aa-11e8-ab5c-0a406d6cb422:10250/proxy/logs/: <pre>
+<a href="amazon/">amazon/</a>
+<a href="audit/">audit/</a>
+<a href="btmp">btmp</a>
+<a href="... (200; 1.389633ms)
+Nov 29 07:53:39.894: INFO: (10) /api/v1/nodes/worker-266bbc56-f3aa-11e8-ab5c-0a406d6cb422:10250/proxy/logs/: <pre>
+<a href="amazon/">amazon/</a>
+<a href="audit/">audit/</a>
+<a href="btmp">btmp</a>
+<a href="... (200; 1.30174ms)
+Nov 29 07:53:39.895: INFO: (11) /api/v1/nodes/worker-266bbc56-f3aa-11e8-ab5c-0a406d6cb422:10250/proxy/logs/: <pre>
+<a href="amazon/">amazon/</a>
+<a href="audit/">audit/</a>
+<a href="btmp">btmp</a>
+<a href="... (200; 1.396906ms)
+Nov 29 07:53:39.897: INFO: (12) /api/v1/nodes/worker-266bbc56-f3aa-11e8-ab5c-0a406d6cb422:10250/proxy/logs/: <pre>
+<a href="amazon/">amazon/</a>
+<a href="audit/">audit/</a>
+<a href="btmp">btmp</a>
+<a href="... (200; 1.482629ms)
+Nov 29 07:53:39.898: INFO: (13) /api/v1/nodes/worker-266bbc56-f3aa-11e8-ab5c-0a406d6cb422:10250/proxy/logs/: <pre>
+<a href="amazon/">amazon/</a>
+<a href="audit/">audit/</a>
+<a href="btmp">btmp</a>
+<a href="... (200; 1.315367ms)
+Nov 29 07:53:39.900: INFO: (14) /api/v1/nodes/worker-266bbc56-f3aa-11e8-ab5c-0a406d6cb422:10250/proxy/logs/: <pre>
+<a href="amazon/">amazon/</a>
+<a href="audit/">audit/</a>
+<a href="btmp">btmp</a>
+<a href="... (200; 1.447691ms)
+Nov 29 07:53:39.901: INFO: (15) /api/v1/nodes/worker-266bbc56-f3aa-11e8-ab5c-0a406d6cb422:10250/proxy/logs/: <pre>
+<a href="amazon/">amazon/</a>
+<a href="audit/">audit/</a>
+<a href="btmp">btmp</a>
+<a href="... (200; 1.327125ms)
+Nov 29 07:53:39.902: INFO: (16) /api/v1/nodes/worker-266bbc56-f3aa-11e8-ab5c-0a406d6cb422:10250/proxy/logs/: <pre>
+<a href="amazon/">amazon/</a>
+<a href="audit/">audit/</a>
+<a href="btmp">btmp</a>
+<a href="... (200; 1.299188ms)
+Nov 29 07:53:39.904: INFO: (17) /api/v1/nodes/worker-266bbc56-f3aa-11e8-ab5c-0a406d6cb422:10250/proxy/logs/: <pre>
+<a href="amazon/">amazon/</a>
+<a href="audit/">audit/</a>
+<a href="btmp">btmp</a>
+<a href="... (200; 1.320892ms)
+Nov 29 07:53:39.905: INFO: (18) /api/v1/nodes/worker-266bbc56-f3aa-11e8-ab5c-0a406d6cb422:10250/proxy/logs/: <pre>
+<a href="amazon/">amazon/</a>
+<a href="audit/">audit/</a>
+<a href="btmp">btmp</a>
+<a href="... (200; 1.334542ms)
+Nov 29 07:53:39.906: INFO: (19) /api/v1/nodes/worker-266bbc56-f3aa-11e8-ab5c-0a406d6cb422:10250/proxy/logs/: <pre>
+<a href="amazon/">amazon/</a>
+<a href="audit/">audit/</a>
+<a href="btmp">btmp</a>
+<a href="... (200; 1.394807ms)
+[AfterEach] version v1
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Nov 29 07:53:39.907: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-proxy-d95wq" for this suite.
+Nov 29 07:53:45.913: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Nov 29 07:53:45.938: INFO: namespace: e2e-tests-proxy-d95wq, resource: bindings, ignored listing per whitelist
+Nov 29 07:53:45.964: INFO: namespace e2e-tests-proxy-d95wq deletion completed in 6.055737475s
+
+• [SLOW TEST:6.122 seconds]
+[sig-network] Proxy
+/workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/network/framework.go:22
+  version v1
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/network/proxy.go:61
+    should proxy logs on node with explicit kubelet port using proxy subresource  [Conformance]
+    /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SSSSSSSSSS
+------------------------------
+[sig-storage] Projected 
+  should be consumable in multiple volumes in the same pod [Conformance]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Nov 29 07:53:45.964: INFO: >>> kubeConfig: /tmp/kubeconfig-385092372
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:858
+[It] should be consumable in multiple volumes in the same pod [Conformance]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating configMap with name projected-configmap-test-volume-e617c135-f3ab-11e8-9124-e6180d057dc8
+STEP: Creating a pod to test consume configMaps
+Nov 29 07:53:46.016: INFO: Waiting up to 5m0s for pod "pod-projected-configmaps-e617fb4f-f3ab-11e8-9124-e6180d057dc8" in namespace "e2e-tests-projected-d4zjj" to be "success or failure"
+Nov 29 07:53:46.018: INFO: Pod "pod-projected-configmaps-e617fb4f-f3ab-11e8-9124-e6180d057dc8": Phase="Pending", Reason="", readiness=false. Elapsed: 2.66109ms
+Nov 29 07:53:48.020: INFO: Pod "pod-projected-configmaps-e617fb4f-f3ab-11e8-9124-e6180d057dc8": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.004449388s
+STEP: Saw pod success
+Nov 29 07:53:48.020: INFO: Pod "pod-projected-configmaps-e617fb4f-f3ab-11e8-9124-e6180d057dc8" satisfied condition "success or failure"
+Nov 29 07:53:48.021: INFO: Trying to get logs from node worker-266bbc56-f3aa-11e8-ab5c-0a406d6cb422 pod pod-projected-configmaps-e617fb4f-f3ab-11e8-9124-e6180d057dc8 container projected-configmap-volume-test: <nil>
+STEP: delete the pod
+Nov 29 07:53:48.037: INFO: Waiting for pod pod-projected-configmaps-e617fb4f-f3ab-11e8-9124-e6180d057dc8 to disappear
+Nov 29 07:53:48.040: INFO: Pod pod-projected-configmaps-e617fb4f-f3ab-11e8-9124-e6180d057dc8 no longer exists
+[AfterEach] [sig-storage] Projected
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Nov 29 07:53:48.040: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-d4zjj" for this suite.
+Nov 29 07:53:54.047: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Nov 29 07:53:54.084: INFO: namespace: e2e-tests-projected-d4zjj, resource: bindings, ignored listing per whitelist
+Nov 29 07:53:54.100: INFO: namespace e2e-tests-projected-d4zjj deletion completed in 6.058192777s
+
+• [SLOW TEST:8.136 seconds]
+[sig-storage] Projected
+/workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:34
+  should be consumable in multiple volumes in the same pod [Conformance]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SS
+------------------------------
+[sig-apps] StatefulSet [k8s.io] Basic StatefulSet functionality [StatefulSetBasic] 
+  should perform canary updates and phased rolling updates of template modifications [Conformance]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-apps] StatefulSet
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Nov 29 07:53:54.100: INFO: >>> kubeConfig: /tmp/kubeconfig-385092372
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-apps] StatefulSet
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/statefulset.go:57
+[BeforeEach] [k8s.io] Basic StatefulSet functionality [StatefulSetBasic]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/statefulset.go:72
+STEP: Creating service test in namespace e2e-tests-statefulset-286sz
+[It] should perform canary updates and phased rolling updates of template modifications [Conformance]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating a new StaefulSet
+Nov 29 07:53:54.141: INFO: Found 0 stateful pods, waiting for 3
+Nov 29 07:54:04.143: INFO: Waiting for pod ss2-0 to enter Running - Ready=true, currently Running - Ready=true
+Nov 29 07:54:04.144: INFO: Waiting for pod ss2-1 to enter Running - Ready=true, currently Running - Ready=true
+Nov 29 07:54:04.144: INFO: Waiting for pod ss2-2 to enter Running - Ready=true, currently Running - Ready=true
+STEP: Updating stateful set template: update image from k8s.gcr.io/nginx-slim-amd64:0.20 to k8s.gcr.io/nginx-slim-amd64:0.21
+Nov 29 07:54:04.161: INFO: Updating stateful set ss2
+STEP: Creating a new revision
+STEP: Not applying an update when the partition is greater than the number of replicas
+STEP: Performing a canary update
+Nov 29 07:54:14.183: INFO: Updating stateful set ss2
+Nov 29 07:54:14.186: INFO: Waiting for Pod e2e-tests-statefulset-286sz/ss2-2 to have revision ss2-56dd5fb9c4 update revision ss2-76cb68b6ff
+STEP: Restoring Pods to the correct revision when they are deleted
+Nov 29 07:54:24.226: INFO: Found 2 stateful pods, waiting for 3
+Nov 29 07:54:34.228: INFO: Waiting for pod ss2-0 to enter Running - Ready=true, currently Running - Ready=true
+Nov 29 07:54:34.228: INFO: Waiting for pod ss2-1 to enter Running - Ready=true, currently Running - Ready=true
+Nov 29 07:54:34.228: INFO: Waiting for pod ss2-2 to enter Running - Ready=true, currently Running - Ready=true
+STEP: Performing a phased rolling update
+Nov 29 07:54:34.245: INFO: Updating stateful set ss2
+Nov 29 07:54:34.248: INFO: Waiting for Pod e2e-tests-statefulset-286sz/ss2-1 to have revision ss2-56dd5fb9c4 update revision ss2-76cb68b6ff
+Nov 29 07:54:44.265: INFO: Updating stateful set ss2
+Nov 29 07:54:44.268: INFO: Waiting for StatefulSet e2e-tests-statefulset-286sz/ss2 to complete update
+Nov 29 07:54:44.268: INFO: Waiting for Pod e2e-tests-statefulset-286sz/ss2-0 to have revision ss2-56dd5fb9c4 update revision ss2-76cb68b6ff
+[AfterEach] [k8s.io] Basic StatefulSet functionality [StatefulSetBasic]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/statefulset.go:83
+Nov 29 07:54:54.271: INFO: Deleting all statefulset in ns e2e-tests-statefulset-286sz
+Nov 29 07:54:54.272: INFO: Scaling statefulset ss2 to 0
+Nov 29 07:55:14.280: INFO: Waiting for statefulset status.replicas updated to 0
+Nov 29 07:55:14.282: INFO: Deleting statefulset ss2
+[AfterEach] [sig-apps] StatefulSet
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Nov 29 07:55:14.291: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-statefulset-286sz" for this suite.
+Nov 29 07:55:20.299: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Nov 29 07:55:20.343: INFO: namespace: e2e-tests-statefulset-286sz, resource: bindings, ignored listing per whitelist
+Nov 29 07:55:20.356: INFO: namespace e2e-tests-statefulset-286sz deletion completed in 6.062183093s
+
+• [SLOW TEST:86.256 seconds]
+[sig-apps] StatefulSet
+/workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/framework.go:22
+  [k8s.io] Basic StatefulSet functionality [StatefulSetBasic]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:669
+    should perform canary updates and phased rolling updates of template modifications [Conformance]
+    /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+[sig-storage] EmptyDir volumes 
+  volume on default medium should have the correct mode [Conformance]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-storage] EmptyDir volumes
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Nov 29 07:55:20.356: INFO: >>> kubeConfig: /tmp/kubeconfig-385092372
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] volume on default medium should have the correct mode [Conformance]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating a pod to test emptydir volume type on node default medium
+Nov 29 07:55:20.386: INFO: Waiting up to 5m0s for pod "pod-1e588667-f3ac-11e8-9124-e6180d057dc8" in namespace "e2e-tests-emptydir-swk4n" to be "success or failure"
+Nov 29 07:55:20.388: INFO: Pod "pod-1e588667-f3ac-11e8-9124-e6180d057dc8": Phase="Pending", Reason="", readiness=false. Elapsed: 2.086549ms
+Nov 29 07:55:22.390: INFO: Pod "pod-1e588667-f3ac-11e8-9124-e6180d057dc8": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.003762691s
+STEP: Saw pod success
+Nov 29 07:55:22.390: INFO: Pod "pod-1e588667-f3ac-11e8-9124-e6180d057dc8" satisfied condition "success or failure"
+Nov 29 07:55:22.391: INFO: Trying to get logs from node worker-266bbc56-f3aa-11e8-ab5c-0a406d6cb422 pod pod-1e588667-f3ac-11e8-9124-e6180d057dc8 container test-container: <nil>
+STEP: delete the pod
+Nov 29 07:55:22.404: INFO: Waiting for pod pod-1e588667-f3ac-11e8-9124-e6180d057dc8 to disappear
+Nov 29 07:55:22.409: INFO: Pod pod-1e588667-f3ac-11e8-9124-e6180d057dc8 no longer exists
+[AfterEach] [sig-storage] EmptyDir volumes
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Nov 29 07:55:22.409: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-emptydir-swk4n" for this suite.
+Nov 29 07:55:28.416: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Nov 29 07:55:28.439: INFO: namespace: e2e-tests-emptydir-swk4n, resource: bindings, ignored listing per whitelist
+Nov 29 07:55:28.468: INFO: namespace e2e-tests-emptydir-swk4n deletion completed in 6.057661318s
+
+• [SLOW TEST:8.112 seconds]
+[sig-storage] EmptyDir volumes
+/workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/empty_dir.go:41
+  volume on default medium should have the correct mode [Conformance]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SSSS
+------------------------------
+[k8s.io] [sig-node] Pods Extended [k8s.io] Pods Set QOS Class 
+  should be submitted and removed  [Conformance]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [k8s.io] [sig-node] Pods Extended
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Nov 29 07:55:28.468: INFO: >>> kubeConfig: /tmp/kubeconfig-385092372
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [k8s.io] Pods Set QOS Class
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/node/pods.go:199
+[It] should be submitted and removed  [Conformance]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: creating the pod
+STEP: submitting the pod to kubernetes
+STEP: verifying QOS class is set on the pod
+[AfterEach] [k8s.io] [sig-node] Pods Extended
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Nov 29 07:55:28.566: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-pods-gd6s5" for this suite.
+Nov 29 07:55:50.581: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Nov 29 07:55:50.607: INFO: namespace: e2e-tests-pods-gd6s5, resource: bindings, ignored listing per whitelist
+Nov 29 07:55:50.633: INFO: namespace e2e-tests-pods-gd6s5 deletion completed in 22.062690736s
+
+• [SLOW TEST:22.165 seconds]
+[k8s.io] [sig-node] Pods Extended
+/workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:669
+  [k8s.io] Pods Set QOS Class
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:669
+    should be submitted and removed  [Conformance]
+    /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SS
+------------------------------
+[sig-storage] ConfigMap 
+  should be consumable in multiple volumes in the same pod  [Conformance]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-storage] ConfigMap
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Nov 29 07:55:50.633: INFO: >>> kubeConfig: /tmp/kubeconfig-385092372
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should be consumable in multiple volumes in the same pod  [Conformance]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating configMap with name configmap-test-volume-3064924e-f3ac-11e8-9124-e6180d057dc8
+STEP: Creating a pod to test consume configMaps
+Nov 29 07:55:50.665: INFO: Waiting up to 5m0s for pod "pod-configmaps-3064c86a-f3ac-11e8-9124-e6180d057dc8" in namespace "e2e-tests-configmap-qwqg9" to be "success or failure"
+Nov 29 07:55:50.669: INFO: Pod "pod-configmaps-3064c86a-f3ac-11e8-9124-e6180d057dc8": Phase="Pending", Reason="", readiness=false. Elapsed: 3.258057ms
+Nov 29 07:55:52.670: INFO: Pod "pod-configmaps-3064c86a-f3ac-11e8-9124-e6180d057dc8": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.004794s
+STEP: Saw pod success
+Nov 29 07:55:52.670: INFO: Pod "pod-configmaps-3064c86a-f3ac-11e8-9124-e6180d057dc8" satisfied condition "success or failure"
+Nov 29 07:55:52.671: INFO: Trying to get logs from node worker-266bbc56-f3aa-11e8-ab5c-0a406d6cb422 pod pod-configmaps-3064c86a-f3ac-11e8-9124-e6180d057dc8 container configmap-volume-test: <nil>
+STEP: delete the pod
+Nov 29 07:55:52.695: INFO: Waiting for pod pod-configmaps-3064c86a-f3ac-11e8-9124-e6180d057dc8 to disappear
+Nov 29 07:55:52.698: INFO: Pod pod-configmaps-3064c86a-f3ac-11e8-9124-e6180d057dc8 no longer exists
+[AfterEach] [sig-storage] ConfigMap
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Nov 29 07:55:52.698: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-configmap-qwqg9" for this suite.
+Nov 29 07:55:58.708: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Nov 29 07:55:58.736: INFO: namespace: e2e-tests-configmap-qwqg9, resource: bindings, ignored listing per whitelist
+Nov 29 07:55:58.757: INFO: namespace e2e-tests-configmap-qwqg9 deletion completed in 6.057438342s
+
+• [SLOW TEST:8.124 seconds]
+[sig-storage] ConfigMap
+/workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/configmap_volume.go:32
+  should be consumable in multiple volumes in the same pod  [Conformance]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SSSSSSSSS
+------------------------------
+[sig-storage] Downward API volume 
+  should provide container's cpu request  [Conformance]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Nov 29 07:55:58.757: INFO: >>> kubeConfig: /tmp/kubeconfig-385092372
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downwardapi_volume.go:38
+[It] should provide container's cpu request  [Conformance]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating a pod to test downward API volume plugin
+Nov 29 07:55:58.788: INFO: Waiting up to 5m0s for pod "downwardapi-volume-353c316d-f3ac-11e8-9124-e6180d057dc8" in namespace "e2e-tests-downward-api-rrzfr" to be "success or failure"
+Nov 29 07:55:58.796: INFO: Pod "downwardapi-volume-353c316d-f3ac-11e8-9124-e6180d057dc8": Phase="Pending", Reason="", readiness=false. Elapsed: 7.637856ms
+Nov 29 07:56:00.797: INFO: Pod "downwardapi-volume-353c316d-f3ac-11e8-9124-e6180d057dc8": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.009288546s
+STEP: Saw pod success
+Nov 29 07:56:00.798: INFO: Pod "downwardapi-volume-353c316d-f3ac-11e8-9124-e6180d057dc8" satisfied condition "success or failure"
+Nov 29 07:56:00.799: INFO: Trying to get logs from node worker-266bbc56-f3aa-11e8-ab5c-0a406d6cb422 pod downwardapi-volume-353c316d-f3ac-11e8-9124-e6180d057dc8 container client-container: <nil>
+STEP: delete the pod
+Nov 29 07:56:00.812: INFO: Waiting for pod downwardapi-volume-353c316d-f3ac-11e8-9124-e6180d057dc8 to disappear
+Nov 29 07:56:00.815: INFO: Pod downwardapi-volume-353c316d-f3ac-11e8-9124-e6180d057dc8 no longer exists
+[AfterEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Nov 29 07:56:00.815: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-downward-api-rrzfr" for this suite.
+Nov 29 07:56:06.822: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Nov 29 07:56:06.869: INFO: namespace: e2e-tests-downward-api-rrzfr, resource: bindings, ignored listing per whitelist
+Nov 29 07:56:06.876: INFO: namespace e2e-tests-downward-api-rrzfr deletion completed in 6.058895816s
+
+• [SLOW TEST:8.119 seconds]
+[sig-storage] Downward API volume
+/workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downwardapi_volume.go:33
+  should provide container's cpu request  [Conformance]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SSSSS
+------------------------------
+[k8s.io] Variable Expansion 
+  should allow composing env vars into new env vars  [Conformance]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [k8s.io] Variable Expansion
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Nov 29 07:56:06.877: INFO: >>> kubeConfig: /tmp/kubeconfig-385092372
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should allow composing env vars into new env vars  [Conformance]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating a pod to test env composition
+Nov 29 07:56:06.966: INFO: Waiting up to 5m0s for pod "var-expansion-3a1be9f6-f3ac-11e8-9124-e6180d057dc8" in namespace "e2e-tests-var-expansion-knpfx" to be "success or failure"
+Nov 29 07:56:06.969: INFO: Pod "var-expansion-3a1be9f6-f3ac-11e8-9124-e6180d057dc8": Phase="Pending", Reason="", readiness=false. Elapsed: 2.790867ms
+Nov 29 07:56:08.971: INFO: Pod "var-expansion-3a1be9f6-f3ac-11e8-9124-e6180d057dc8": Phase="Pending", Reason="", readiness=false. Elapsed: 2.004560701s
+Nov 29 07:56:10.972: INFO: Pod "var-expansion-3a1be9f6-f3ac-11e8-9124-e6180d057dc8": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.006376976s
+STEP: Saw pod success
+Nov 29 07:56:10.972: INFO: Pod "var-expansion-3a1be9f6-f3ac-11e8-9124-e6180d057dc8" satisfied condition "success or failure"
+Nov 29 07:56:10.974: INFO: Trying to get logs from node worker-266bbc56-f3aa-11e8-ab5c-0a406d6cb422 pod var-expansion-3a1be9f6-f3ac-11e8-9124-e6180d057dc8 container dapi-container: <nil>
+STEP: delete the pod
+Nov 29 07:56:10.984: INFO: Waiting for pod var-expansion-3a1be9f6-f3ac-11e8-9124-e6180d057dc8 to disappear
+Nov 29 07:56:10.986: INFO: Pod var-expansion-3a1be9f6-f3ac-11e8-9124-e6180d057dc8 no longer exists
+[AfterEach] [k8s.io] Variable Expansion
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Nov 29 07:56:10.986: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-var-expansion-knpfx" for this suite.
+Nov 29 07:56:16.994: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Nov 29 07:56:17.045: INFO: namespace: e2e-tests-var-expansion-knpfx, resource: bindings, ignored listing per whitelist
+Nov 29 07:56:17.048: INFO: namespace e2e-tests-var-expansion-knpfx deletion completed in 6.059761613s
+
+• [SLOW TEST:10.172 seconds]
+[k8s.io] Variable Expansion
+/workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:669
+  should allow composing env vars into new env vars  [Conformance]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SSS
+------------------------------
+[k8s.io] [sig-node] PreStop 
+  should call prestop when killing a pod  [Conformance]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [k8s.io] [sig-node] PreStop
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Nov 29 07:56:17.048: INFO: >>> kubeConfig: /tmp/kubeconfig-385092372
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should call prestop when killing a pod  [Conformance]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating server pod server in namespace e2e-tests-prestop-7kfn9
+STEP: Waiting for pods to come up.
+STEP: Creating tester pod tester in namespace e2e-tests-prestop-7kfn9
+STEP: Deleting pre-stop pod
+Nov 29 07:56:30.098: INFO: Saw: {
+	"Hostname": "server",
+	"Sent": null,
+	"Received": {
+		"prestop": 1
+	},
+	"Errors": null,
+	"Log": [
+		"default/nettest has 0 endpoints ([]), which is less than 8 as expected. Waiting for all endpoints to come up.",
+		"default/nettest has 0 endpoints ([]), which is less than 8 as expected. Waiting for all endpoints to come up.",
+		"default/nettest has 0 endpoints ([]), which is less than 8 as expected. Waiting for all endpoints to come up."
+	],
+	"StillContactingPeers": true
+}
+STEP: Deleting the server pod
+[AfterEach] [k8s.io] [sig-node] PreStop
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Nov 29 07:56:30.101: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-prestop-7kfn9" for this suite.
+Nov 29 07:57:08.111: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Nov 29 07:57:08.189: INFO: namespace: e2e-tests-prestop-7kfn9, resource: bindings, ignored listing per whitelist
+Nov 29 07:57:08.189: INFO: namespace e2e-tests-prestop-7kfn9 deletion completed in 38.084190668s
+
+• [SLOW TEST:51.141 seconds]
+[k8s.io] [sig-node] PreStop
+/workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:669
+  should call prestop when killing a pod  [Conformance]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SSS
+------------------------------
+[k8s.io] Pods 
+  should get a host IP  [Conformance]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [k8s.io] Pods
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Nov 29 07:57:08.189: INFO: >>> kubeConfig: /tmp/kubeconfig-385092372
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [k8s.io] Pods
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/pods.go:127
+[It] should get a host IP  [Conformance]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: creating pod
+Nov 29 07:57:12.226: INFO: Pod pod-hostip-5e9ea51b-f3ac-11e8-9124-e6180d057dc8 has hostIP: 10.1.166.73
+[AfterEach] [k8s.io] Pods
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Nov 29 07:57:12.226: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-pods-b56mz" for this suite.
+Nov 29 07:57:34.233: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Nov 29 07:57:34.265: INFO: namespace: e2e-tests-pods-b56mz, resource: bindings, ignored listing per whitelist
+Nov 29 07:57:34.285: INFO: namespace e2e-tests-pods-b56mz deletion completed in 22.057267597s
+
+• [SLOW TEST:26.096 seconds]
+[k8s.io] Pods
+/workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:669
+  should get a host IP  [Conformance]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SSS
+------------------------------
+[sig-storage] EmptyDir volumes 
+  should support (non-root,0644,tmpfs) [Conformance]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-storage] EmptyDir volumes
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Nov 29 07:57:34.286: INFO: >>> kubeConfig: /tmp/kubeconfig-385092372
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should support (non-root,0644,tmpfs) [Conformance]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating a pod to test emptydir 0644 on tmpfs
+Nov 29 07:57:34.316: INFO: Waiting up to 5m0s for pod "pod-6e2c9323-f3ac-11e8-9124-e6180d057dc8" in namespace "e2e-tests-emptydir-fxcqg" to be "success or failure"
+Nov 29 07:57:34.321: INFO: Pod "pod-6e2c9323-f3ac-11e8-9124-e6180d057dc8": Phase="Pending", Reason="", readiness=false. Elapsed: 4.980218ms
+Nov 29 07:57:36.323: INFO: Pod "pod-6e2c9323-f3ac-11e8-9124-e6180d057dc8": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.006609223s
+STEP: Saw pod success
+Nov 29 07:57:36.323: INFO: Pod "pod-6e2c9323-f3ac-11e8-9124-e6180d057dc8" satisfied condition "success or failure"
+Nov 29 07:57:36.324: INFO: Trying to get logs from node worker-266bbc56-f3aa-11e8-ab5c-0a406d6cb422 pod pod-6e2c9323-f3ac-11e8-9124-e6180d057dc8 container test-container: <nil>
+STEP: delete the pod
+Nov 29 07:57:36.335: INFO: Waiting for pod pod-6e2c9323-f3ac-11e8-9124-e6180d057dc8 to disappear
+Nov 29 07:57:36.337: INFO: Pod pod-6e2c9323-f3ac-11e8-9124-e6180d057dc8 no longer exists
+[AfterEach] [sig-storage] EmptyDir volumes
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Nov 29 07:57:36.337: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-emptydir-fxcqg" for this suite.
+Nov 29 07:57:42.346: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Nov 29 07:57:42.392: INFO: namespace: e2e-tests-emptydir-fxcqg, resource: bindings, ignored listing per whitelist
+Nov 29 07:57:42.410: INFO: namespace e2e-tests-emptydir-fxcqg deletion completed in 6.068596276s
+
+• [SLOW TEST:8.124 seconds]
+[sig-storage] EmptyDir volumes
+/workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/empty_dir.go:41
+  should support (non-root,0644,tmpfs) [Conformance]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SSSSS
+------------------------------
+[sig-storage] Projected 
+  updates should be reflected in volume [Conformance]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Nov 29 07:57:42.410: INFO: >>> kubeConfig: /tmp/kubeconfig-385092372
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:858
+[It] updates should be reflected in volume [Conformance]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating projection with configMap that has name projected-configmap-test-upd-7304e806-f3ac-11e8-9124-e6180d057dc8
+STEP: Creating the pod
+STEP: Updating configmap projected-configmap-test-upd-7304e806-f3ac-11e8-9124-e6180d057dc8
+STEP: waiting to observe update in volume
+[AfterEach] [sig-storage] Projected
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Nov 29 07:57:46.465: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-hmpr9" for this suite.
+Nov 29 07:58:08.472: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Nov 29 07:58:08.512: INFO: namespace: e2e-tests-projected-hmpr9, resource: bindings, ignored listing per whitelist
+Nov 29 07:58:08.523: INFO: namespace e2e-tests-projected-hmpr9 deletion completed in 22.055868208s
+
+• [SLOW TEST:26.113 seconds]
+[sig-storage] Projected
+/workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:34
+  updates should be reflected in volume [Conformance]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SSSSSSSSSSSSSS
+------------------------------
+[sig-storage] EmptyDir volumes 
+  should support (non-root,0777,tmpfs) [Conformance]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-storage] EmptyDir volumes
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Nov 29 07:58:08.524: INFO: >>> kubeConfig: /tmp/kubeconfig-385092372
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should support (non-root,0777,tmpfs) [Conformance]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating a pod to test emptydir 0777 on tmpfs
+Nov 29 07:58:08.554: INFO: Waiting up to 5m0s for pod "pod-8294d96e-f3ac-11e8-9124-e6180d057dc8" in namespace "e2e-tests-emptydir-xck66" to be "success or failure"
+Nov 29 07:58:08.558: INFO: Pod "pod-8294d96e-f3ac-11e8-9124-e6180d057dc8": Phase="Pending", Reason="", readiness=false. Elapsed: 3.322119ms
+Nov 29 07:58:10.560: INFO: Pod "pod-8294d96e-f3ac-11e8-9124-e6180d057dc8": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.00521315s
+STEP: Saw pod success
+Nov 29 07:58:10.560: INFO: Pod "pod-8294d96e-f3ac-11e8-9124-e6180d057dc8" satisfied condition "success or failure"
+Nov 29 07:58:10.561: INFO: Trying to get logs from node worker-266bbc56-f3aa-11e8-ab5c-0a406d6cb422 pod pod-8294d96e-f3ac-11e8-9124-e6180d057dc8 container test-container: <nil>
+STEP: delete the pod
+Nov 29 07:58:10.570: INFO: Waiting for pod pod-8294d96e-f3ac-11e8-9124-e6180d057dc8 to disappear
+Nov 29 07:58:10.574: INFO: Pod pod-8294d96e-f3ac-11e8-9124-e6180d057dc8 no longer exists
+[AfterEach] [sig-storage] EmptyDir volumes
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Nov 29 07:58:10.574: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-emptydir-xck66" for this suite.
+Nov 29 07:58:16.582: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Nov 29 07:58:16.605: INFO: namespace: e2e-tests-emptydir-xck66, resource: bindings, ignored listing per whitelist
+Nov 29 07:58:16.632: INFO: namespace e2e-tests-emptydir-xck66 deletion completed in 6.055812425s
+
+• [SLOW TEST:8.108 seconds]
+[sig-storage] EmptyDir volumes
+/workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/empty_dir.go:41
+  should support (non-root,0777,tmpfs) [Conformance]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+S
+------------------------------
+[sig-storage] EmptyDir volumes 
+  should support (root,0777,default) [Conformance]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-storage] EmptyDir volumes
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Nov 29 07:58:16.632: INFO: >>> kubeConfig: /tmp/kubeconfig-385092372
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should support (root,0777,default) [Conformance]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating a pod to test emptydir 0777 on node default medium
+Nov 29 07:58:16.684: INFO: Waiting up to 5m0s for pod "pod-876d5bb0-f3ac-11e8-9124-e6180d057dc8" in namespace "e2e-tests-emptydir-w25mv" to be "success or failure"
+Nov 29 07:58:16.688: INFO: Pod "pod-876d5bb0-f3ac-11e8-9124-e6180d057dc8": Phase="Pending", Reason="", readiness=false. Elapsed: 3.965532ms
+Nov 29 07:58:18.689: INFO: Pod "pod-876d5bb0-f3ac-11e8-9124-e6180d057dc8": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.005510271s
+STEP: Saw pod success
+Nov 29 07:58:18.689: INFO: Pod "pod-876d5bb0-f3ac-11e8-9124-e6180d057dc8" satisfied condition "success or failure"
+Nov 29 07:58:18.690: INFO: Trying to get logs from node worker-266bbc56-f3aa-11e8-ab5c-0a406d6cb422 pod pod-876d5bb0-f3ac-11e8-9124-e6180d057dc8 container test-container: <nil>
+STEP: delete the pod
+Nov 29 07:58:18.701: INFO: Waiting for pod pod-876d5bb0-f3ac-11e8-9124-e6180d057dc8 to disappear
+Nov 29 07:58:18.703: INFO: Pod pod-876d5bb0-f3ac-11e8-9124-e6180d057dc8 no longer exists
+[AfterEach] [sig-storage] EmptyDir volumes
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Nov 29 07:58:18.703: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-emptydir-w25mv" for this suite.
+Nov 29 07:58:24.711: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Nov 29 07:58:24.737: INFO: namespace: e2e-tests-emptydir-w25mv, resource: bindings, ignored listing per whitelist
+Nov 29 07:58:24.764: INFO: namespace e2e-tests-emptydir-w25mv deletion completed in 6.058138964s
+
+• [SLOW TEST:8.132 seconds]
+[sig-storage] EmptyDir volumes
+/workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/empty_dir.go:41
+  should support (root,0777,default) [Conformance]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+S
+------------------------------
+[sig-storage] Secrets 
+  should be consumable from pods in volume with mappings and Item Mode set  [Conformance]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-storage] Secrets
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Nov 29 07:58:24.764: INFO: >>> kubeConfig: /tmp/kubeconfig-385092372
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should be consumable from pods in volume with mappings and Item Mode set  [Conformance]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating secret with name secret-test-map-8c4a827d-f3ac-11e8-9124-e6180d057dc8
+STEP: Creating a pod to test consume secrets
+Nov 29 07:58:24.845: INFO: Waiting up to 5m0s for pod "pod-secrets-8c4abe11-f3ac-11e8-9124-e6180d057dc8" in namespace "e2e-tests-secrets-xcr7w" to be "success or failure"
+Nov 29 07:58:24.847: INFO: Pod "pod-secrets-8c4abe11-f3ac-11e8-9124-e6180d057dc8": Phase="Pending", Reason="", readiness=false. Elapsed: 1.807707ms
+Nov 29 07:58:26.849: INFO: Pod "pod-secrets-8c4abe11-f3ac-11e8-9124-e6180d057dc8": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.003281331s
+STEP: Saw pod success
+Nov 29 07:58:26.849: INFO: Pod "pod-secrets-8c4abe11-f3ac-11e8-9124-e6180d057dc8" satisfied condition "success or failure"
+Nov 29 07:58:26.850: INFO: Trying to get logs from node worker-266bbc56-f3aa-11e8-ab5c-0a406d6cb422 pod pod-secrets-8c4abe11-f3ac-11e8-9124-e6180d057dc8 container secret-volume-test: <nil>
+STEP: delete the pod
+Nov 29 07:58:26.867: INFO: Waiting for pod pod-secrets-8c4abe11-f3ac-11e8-9124-e6180d057dc8 to disappear
+Nov 29 07:58:26.868: INFO: Pod pod-secrets-8c4abe11-f3ac-11e8-9124-e6180d057dc8 no longer exists
+[AfterEach] [sig-storage] Secrets
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Nov 29 07:58:26.868: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-secrets-xcr7w" for this suite.
+Nov 29 07:58:32.876: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Nov 29 07:58:32.899: INFO: namespace: e2e-tests-secrets-xcr7w, resource: bindings, ignored listing per whitelist
+Nov 29 07:58:32.928: INFO: namespace e2e-tests-secrets-xcr7w deletion completed in 6.057651632s
+
+• [SLOW TEST:8.164 seconds]
+[sig-storage] Secrets
+/workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/secrets_volume.go:33
+  should be consumable from pods in volume with mappings and Item Mode set  [Conformance]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+[sig-storage] Projected 
+  should be consumable from pods in volume with defaultMode set [Conformance]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Nov 29 07:58:32.928: INFO: >>> kubeConfig: /tmp/kubeconfig-385092372
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:858
+[It] should be consumable from pods in volume with defaultMode set [Conformance]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating projection with secret that has name projected-secret-test-9128783c-f3ac-11e8-9124-e6180d057dc8
+STEP: Creating a pod to test consume secrets
+Nov 29 07:58:33.022: INFO: Waiting up to 5m0s for pod "pod-projected-secrets-9128b081-f3ac-11e8-9124-e6180d057dc8" in namespace "e2e-tests-projected-vph28" to be "success or failure"
+Nov 29 07:58:33.024: INFO: Pod "pod-projected-secrets-9128b081-f3ac-11e8-9124-e6180d057dc8": Phase="Pending", Reason="", readiness=false. Elapsed: 1.835556ms
+Nov 29 07:58:35.025: INFO: Pod "pod-projected-secrets-9128b081-f3ac-11e8-9124-e6180d057dc8": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.003501155s
+STEP: Saw pod success
+Nov 29 07:58:35.025: INFO: Pod "pod-projected-secrets-9128b081-f3ac-11e8-9124-e6180d057dc8" satisfied condition "success or failure"
+Nov 29 07:58:35.027: INFO: Trying to get logs from node worker-266bbc56-f3aa-11e8-ab5c-0a406d6cb422 pod pod-projected-secrets-9128b081-f3ac-11e8-9124-e6180d057dc8 container projected-secret-volume-test: <nil>
+STEP: delete the pod
+Nov 29 07:58:35.039: INFO: Waiting for pod pod-projected-secrets-9128b081-f3ac-11e8-9124-e6180d057dc8 to disappear
+Nov 29 07:58:35.040: INFO: Pod pod-projected-secrets-9128b081-f3ac-11e8-9124-e6180d057dc8 no longer exists
+[AfterEach] [sig-storage] Projected
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Nov 29 07:58:35.040: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-vph28" for this suite.
+Nov 29 07:58:41.049: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Nov 29 07:58:41.073: INFO: namespace: e2e-tests-projected-vph28, resource: bindings, ignored listing per whitelist
+Nov 29 07:58:41.100: INFO: namespace e2e-tests-projected-vph28 deletion completed in 6.058156964s
+
+• [SLOW TEST:8.173 seconds]
+[sig-storage] Projected
+/workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:34
+  should be consumable from pods in volume with defaultMode set [Conformance]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SSSS
+------------------------------
+[sig-apps] Daemon set [Serial] 
+  should run and stop simple daemon [Conformance]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-apps] Daemon set [Serial]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Nov 29 07:58:41.101: INFO: >>> kubeConfig: /tmp/kubeconfig-385092372
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-apps] Daemon set [Serial]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/daemon_set.go:103
+[It] should run and stop simple daemon [Conformance]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating simple DaemonSet "daemon-set"
+STEP: Check that daemon pods launch on every node of the cluster.
+Nov 29 07:58:41.141: INFO: DaemonSet pods can't tolerate node master-75fc9ea0-f3a7-11e8-90fa-062be367adf0 with taints [{Key:Dedicated Value:Master Effect:NoSchedule TimeAdded:<nil>}], skip checking this node
+Nov 29 07:58:41.143: INFO: Number of nodes with available pods: 0
+Nov 29 07:58:41.143: INFO: Node worker-266bbc56-f3aa-11e8-ab5c-0a406d6cb422 is running more than one daemon pod
+Nov 29 07:58:42.145: INFO: DaemonSet pods can't tolerate node master-75fc9ea0-f3a7-11e8-90fa-062be367adf0 with taints [{Key:Dedicated Value:Master Effect:NoSchedule TimeAdded:<nil>}], skip checking this node
+Nov 29 07:58:42.146: INFO: Number of nodes with available pods: 0
+Nov 29 07:58:42.146: INFO: Node worker-266bbc56-f3aa-11e8-ab5c-0a406d6cb422 is running more than one daemon pod
+Nov 29 07:58:43.145: INFO: DaemonSet pods can't tolerate node master-75fc9ea0-f3a7-11e8-90fa-062be367adf0 with taints [{Key:Dedicated Value:Master Effect:NoSchedule TimeAdded:<nil>}], skip checking this node
+Nov 29 07:58:43.147: INFO: Number of nodes with available pods: 2
+Nov 29 07:58:43.147: INFO: Number of running nodes: 2, number of available pods: 2
+STEP: Stop a daemon pod, check that the daemon pod is revived.
+Nov 29 07:58:43.155: INFO: DaemonSet pods can't tolerate node master-75fc9ea0-f3a7-11e8-90fa-062be367adf0 with taints [{Key:Dedicated Value:Master Effect:NoSchedule TimeAdded:<nil>}], skip checking this node
+Nov 29 07:58:43.157: INFO: Number of nodes with available pods: 1
+Nov 29 07:58:43.157: INFO: Node worker-bdccfcb0-f3a8-11e8-90fa-062be367adf0 is running more than one daemon pod
+Nov 29 07:58:44.159: INFO: DaemonSet pods can't tolerate node master-75fc9ea0-f3a7-11e8-90fa-062be367adf0 with taints [{Key:Dedicated Value:Master Effect:NoSchedule TimeAdded:<nil>}], skip checking this node
+Nov 29 07:58:44.160: INFO: Number of nodes with available pods: 1
+Nov 29 07:58:44.160: INFO: Node worker-bdccfcb0-f3a8-11e8-90fa-062be367adf0 is running more than one daemon pod
+Nov 29 07:58:45.159: INFO: DaemonSet pods can't tolerate node master-75fc9ea0-f3a7-11e8-90fa-062be367adf0 with taints [{Key:Dedicated Value:Master Effect:NoSchedule TimeAdded:<nil>}], skip checking this node
+Nov 29 07:58:45.161: INFO: Number of nodes with available pods: 1
+Nov 29 07:58:45.161: INFO: Node worker-bdccfcb0-f3a8-11e8-90fa-062be367adf0 is running more than one daemon pod
+Nov 29 07:58:46.159: INFO: DaemonSet pods can't tolerate node master-75fc9ea0-f3a7-11e8-90fa-062be367adf0 with taints [{Key:Dedicated Value:Master Effect:NoSchedule TimeAdded:<nil>}], skip checking this node
+Nov 29 07:58:46.160: INFO: Number of nodes with available pods: 1
+Nov 29 07:58:46.161: INFO: Node worker-bdccfcb0-f3a8-11e8-90fa-062be367adf0 is running more than one daemon pod
+Nov 29 07:58:47.159: INFO: DaemonSet pods can't tolerate node master-75fc9ea0-f3a7-11e8-90fa-062be367adf0 with taints [{Key:Dedicated Value:Master Effect:NoSchedule TimeAdded:<nil>}], skip checking this node
+Nov 29 07:58:47.160: INFO: Number of nodes with available pods: 1
+Nov 29 07:58:47.161: INFO: Node worker-bdccfcb0-f3a8-11e8-90fa-062be367adf0 is running more than one daemon pod
+Nov 29 07:58:48.159: INFO: DaemonSet pods can't tolerate node master-75fc9ea0-f3a7-11e8-90fa-062be367adf0 with taints [{Key:Dedicated Value:Master Effect:NoSchedule TimeAdded:<nil>}], skip checking this node
+Nov 29 07:58:48.160: INFO: Number of nodes with available pods: 1
+Nov 29 07:58:48.160: INFO: Node worker-bdccfcb0-f3a8-11e8-90fa-062be367adf0 is running more than one daemon pod
+Nov 29 07:58:49.159: INFO: DaemonSet pods can't tolerate node master-75fc9ea0-f3a7-11e8-90fa-062be367adf0 with taints [{Key:Dedicated Value:Master Effect:NoSchedule TimeAdded:<nil>}], skip checking this node
+Nov 29 07:58:49.161: INFO: Number of nodes with available pods: 1
+Nov 29 07:58:49.161: INFO: Node worker-bdccfcb0-f3a8-11e8-90fa-062be367adf0 is running more than one daemon pod
+Nov 29 07:58:50.159: INFO: DaemonSet pods can't tolerate node master-75fc9ea0-f3a7-11e8-90fa-062be367adf0 with taints [{Key:Dedicated Value:Master Effect:NoSchedule TimeAdded:<nil>}], skip checking this node
+Nov 29 07:58:50.161: INFO: Number of nodes with available pods: 2
+Nov 29 07:58:50.161: INFO: Number of running nodes: 2, number of available pods: 2
+[AfterEach] [sig-apps] Daemon set [Serial]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/daemon_set.go:66
+STEP: Deleting DaemonSet "daemon-set" with reaper
+Nov 29 07:59:01.172: INFO: Number of nodes with available pods: 0
+Nov 29 07:59:01.172: INFO: Number of running nodes: 0, number of available pods: 0
+Nov 29 07:59:01.174: INFO: daemonset: {"kind":"DaemonSetList","apiVersion":"apps/v1","metadata":{"selfLink":"/apis/apps/v1/namespaces/e2e-tests-daemonsets-2bkhm/daemonsets","resourceVersion":"9904"},"items":null}
+
+Nov 29 07:59:01.175: INFO: pods: {"kind":"PodList","apiVersion":"v1","metadata":{"selfLink":"/api/v1/namespaces/e2e-tests-daemonsets-2bkhm/pods","resourceVersion":"9904"},"items":null}
+
+[AfterEach] [sig-apps] Daemon set [Serial]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Nov 29 07:59:01.182: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-daemonsets-2bkhm" for this suite.
+Nov 29 07:59:07.188: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Nov 29 07:59:07.206: INFO: namespace: e2e-tests-daemonsets-2bkhm, resource: bindings, ignored listing per whitelist
+Nov 29 07:59:07.255: INFO: namespace e2e-tests-daemonsets-2bkhm deletion completed in 6.071251199s
+
+• [SLOW TEST:26.154 seconds]
+[sig-apps] Daemon set [Serial]
+/workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/framework.go:22
+  should run and stop simple daemon [Conformance]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SSSSSSSSSS
+------------------------------
+[k8s.io] KubeletManagedEtcHosts 
+  should test kubelet managed /etc/hosts file  [Conformance]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [k8s.io] KubeletManagedEtcHosts
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Nov 29 07:59:07.255: INFO: >>> kubeConfig: /tmp/kubeconfig-385092372
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should test kubelet managed /etc/hosts file  [Conformance]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Setting up the test
+STEP: Creating hostNetwork=false pod
+STEP: Creating hostNetwork=true pod
+STEP: Running the test
+STEP: Verifying /etc/hosts of container is kubelet-managed for pod with hostNetwork=false
+Nov 29 07:59:13.389: INFO: ExecWithOptions {Command:[cat /etc/hosts] Namespace:e2e-tests-e2e-kubelet-etc-hosts-59khz PodName:test-pod ContainerName:busybox-1 Stdin:<nil> CaptureStdout:true CaptureStderr:true PreserveWhitespace:false}
+Nov 29 07:59:13.389: INFO: >>> kubeConfig: /tmp/kubeconfig-385092372
+Nov 29 07:59:13.426: INFO: Exec stderr: ""
+Nov 29 07:59:13.426: INFO: ExecWithOptions {Command:[cat /etc/hosts] Namespace:e2e-tests-e2e-kubelet-etc-hosts-59khz PodName:test-pod ContainerName:busybox-2 Stdin:<nil> CaptureStdout:true CaptureStderr:true PreserveWhitespace:false}
+Nov 29 07:59:13.426: INFO: >>> kubeConfig: /tmp/kubeconfig-385092372
+Nov 29 07:59:13.463: INFO: Exec stderr: ""
+STEP: Verifying /etc/hosts of container is not kubelet-managed since container specifies /etc/hosts mount
+Nov 29 07:59:13.463: INFO: ExecWithOptions {Command:[cat /etc/hosts] Namespace:e2e-tests-e2e-kubelet-etc-hosts-59khz PodName:test-pod ContainerName:busybox-3 Stdin:<nil> CaptureStdout:true CaptureStderr:true PreserveWhitespace:false}
+Nov 29 07:59:13.463: INFO: >>> kubeConfig: /tmp/kubeconfig-385092372
+Nov 29 07:59:13.506: INFO: Exec stderr: ""
+STEP: Verifying /etc/hosts content of container is not kubelet-managed for pod with hostNetwork=true
+Nov 29 07:59:13.507: INFO: ExecWithOptions {Command:[cat /etc/hosts] Namespace:e2e-tests-e2e-kubelet-etc-hosts-59khz PodName:test-host-network-pod ContainerName:busybox-1 Stdin:<nil> CaptureStdout:true CaptureStderr:true PreserveWhitespace:false}
+Nov 29 07:59:13.507: INFO: >>> kubeConfig: /tmp/kubeconfig-385092372
+Nov 29 07:59:13.542: INFO: Exec stderr: ""
+Nov 29 07:59:13.543: INFO: ExecWithOptions {Command:[cat /etc/hosts] Namespace:e2e-tests-e2e-kubelet-etc-hosts-59khz PodName:test-host-network-pod ContainerName:busybox-2 Stdin:<nil> CaptureStdout:true CaptureStderr:true PreserveWhitespace:false}
+Nov 29 07:59:13.543: INFO: >>> kubeConfig: /tmp/kubeconfig-385092372
+Nov 29 07:59:13.578: INFO: Exec stderr: ""
+[AfterEach] [k8s.io] KubeletManagedEtcHosts
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Nov 29 07:59:13.578: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-e2e-kubelet-etc-hosts-59khz" for this suite.
+Nov 29 08:00:05.585: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Nov 29 08:00:05.616: INFO: namespace: e2e-tests-e2e-kubelet-etc-hosts-59khz, resource: bindings, ignored listing per whitelist
+Nov 29 08:00:05.638: INFO: namespace e2e-tests-e2e-kubelet-etc-hosts-59khz deletion completed in 52.057918379s
+
+• [SLOW TEST:58.383 seconds]
+[k8s.io] KubeletManagedEtcHosts
+/workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:669
+  should test kubelet managed /etc/hosts file  [Conformance]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SSSSSS
+------------------------------
+[sig-storage] EmptyDir volumes 
+  should support (non-root,0666,tmpfs) [Conformance]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-storage] EmptyDir volumes
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Nov 29 08:00:05.638: INFO: >>> kubeConfig: /tmp/kubeconfig-385092372
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should support (non-root,0666,tmpfs) [Conformance]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating a pod to test emptydir 0666 on tmpfs
+Nov 29 08:00:05.669: INFO: Waiting up to 5m0s for pod "pod-c8632b8a-f3ac-11e8-9124-e6180d057dc8" in namespace "e2e-tests-emptydir-z24sc" to be "success or failure"
+Nov 29 08:00:05.673: INFO: Pod "pod-c8632b8a-f3ac-11e8-9124-e6180d057dc8": Phase="Pending", Reason="", readiness=false. Elapsed: 4.664339ms
+Nov 29 08:00:07.675: INFO: Pod "pod-c8632b8a-f3ac-11e8-9124-e6180d057dc8": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.006481915s
+STEP: Saw pod success
+Nov 29 08:00:07.675: INFO: Pod "pod-c8632b8a-f3ac-11e8-9124-e6180d057dc8" satisfied condition "success or failure"
+Nov 29 08:00:07.676: INFO: Trying to get logs from node worker-266bbc56-f3aa-11e8-ab5c-0a406d6cb422 pod pod-c8632b8a-f3ac-11e8-9124-e6180d057dc8 container test-container: <nil>
+STEP: delete the pod
+Nov 29 08:00:07.688: INFO: Waiting for pod pod-c8632b8a-f3ac-11e8-9124-e6180d057dc8 to disappear
+Nov 29 08:00:07.690: INFO: Pod pod-c8632b8a-f3ac-11e8-9124-e6180d057dc8 no longer exists
+[AfterEach] [sig-storage] EmptyDir volumes
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Nov 29 08:00:07.690: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-emptydir-z24sc" for this suite.
+Nov 29 08:00:13.698: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Nov 29 08:00:13.733: INFO: namespace: e2e-tests-emptydir-z24sc, resource: bindings, ignored listing per whitelist
+Nov 29 08:00:13.856: INFO: namespace e2e-tests-emptydir-z24sc deletion completed in 6.164285304s
+
+• [SLOW TEST:8.219 seconds]
+[sig-storage] EmptyDir volumes
+/workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/empty_dir.go:41
+  should support (non-root,0666,tmpfs) [Conformance]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SSSSSSSSS
+------------------------------
+[sig-apps] StatefulSet [k8s.io] Basic StatefulSet functionality [StatefulSetBasic] 
+  Burst scaling should run to completion even with unhealthy pods [Conformance]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-apps] StatefulSet
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Nov 29 08:00:13.856: INFO: >>> kubeConfig: /tmp/kubeconfig-385092372
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-apps] StatefulSet
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/statefulset.go:57
+[BeforeEach] [k8s.io] Basic StatefulSet functionality [StatefulSetBasic]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/statefulset.go:72
+STEP: Creating service test in namespace e2e-tests-statefulset-wtqgk
+[It] Burst scaling should run to completion even with unhealthy pods [Conformance]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating stateful set ss in namespace e2e-tests-statefulset-wtqgk
+STEP: Waiting until all stateful set ss replicas will be running in namespace e2e-tests-statefulset-wtqgk
+Nov 29 08:00:13.958: INFO: Found 0 stateful pods, waiting for 1
+Nov 29 08:00:23.960: INFO: Waiting for pod ss-0 to enter Running - Ready=true, currently Running - Ready=true
+STEP: Confirming that stateful set scale up will not halt with unhealthy stateful pod
+Nov 29 08:00:23.961: INFO: Running '/usr/local/bin/kubectl --kubeconfig=/tmp/kubeconfig-385092372 exec --namespace=e2e-tests-statefulset-wtqgk ss-0 -- /bin/sh -c mv -v /usr/share/nginx/html/index.html /tmp/ || true'
+Nov 29 08:00:24.070: INFO: stderr: ""
+Nov 29 08:00:24.070: INFO: stdout of mv -v /usr/share/nginx/html/index.html /tmp/ || true on ss-0: '/usr/share/nginx/html/index.html' -> '/tmp/index.html'
+
+Nov 29 08:00:24.071: INFO: Waiting for pod ss-0 to enter Running - Ready=false, currently Running - Ready=true
+Nov 29 08:00:34.073: INFO: Waiting for pod ss-0 to enter Running - Ready=false, currently Running - Ready=false
+Nov 29 08:00:34.073: INFO: Waiting for statefulset status.replicas updated to 0
+Nov 29 08:00:34.079: INFO: POD   NODE                                         PHASE    GRACE  CONDITIONS
+Nov 29 08:00:34.079: INFO: ss-0  worker-266bbc56-f3aa-11e8-ab5c-0a406d6cb422  Running         [{Initialized True 0001-01-01 00:00:00 +0000 UTC 2018-11-29 08:00:13 +0000 UTC  } {Ready False 0001-01-01 00:00:00 +0000 UTC 2018-11-29 08:00:24 +0000 UTC ContainersNotReady containers with unready status: [nginx]} {ContainersReady False 0001-01-01 00:00:00 +0000 UTC 0001-01-01 00:00:00 +0000 UTC ContainersNotReady containers with unready status: [nginx]} {PodScheduled True 0001-01-01 00:00:00 +0000 UTC 2018-11-29 08:00:13 +0000 UTC  }]
+Nov 29 08:00:34.079: INFO: 
+Nov 29 08:00:34.079: INFO: StatefulSet ss has not reached scale 3, at 1
+Nov 29 08:00:35.081: INFO: Verifying statefulset ss doesn't scale past 3 for another 8.998252426s
+Nov 29 08:00:36.083: INFO: Verifying statefulset ss doesn't scale past 3 for another 7.996599128s
+Nov 29 08:00:37.085: INFO: Verifying statefulset ss doesn't scale past 3 for another 6.994714107s
+Nov 29 08:00:38.087: INFO: Verifying statefulset ss doesn't scale past 3 for another 5.992729769s
+Nov 29 08:00:39.089: INFO: Verifying statefulset ss doesn't scale past 3 for another 4.990489324s
+Nov 29 08:00:40.091: INFO: Verifying statefulset ss doesn't scale past 3 for another 3.98860094s
+Nov 29 08:00:41.093: INFO: Verifying statefulset ss doesn't scale past 3 for another 2.986491546s
+Nov 29 08:00:42.095: INFO: Verifying statefulset ss doesn't scale past 3 for another 1.984695477s
+Nov 29 08:00:43.096: INFO: Verifying statefulset ss doesn't scale past 3 for another 982.708701ms
+STEP: Scaling up stateful set ss to 3 replicas and waiting until all of them will be running in namespace e2e-tests-statefulset-wtqgk
+Nov 29 08:00:44.099: INFO: Running '/usr/local/bin/kubectl --kubeconfig=/tmp/kubeconfig-385092372 exec --namespace=e2e-tests-statefulset-wtqgk ss-0 -- /bin/sh -c mv -v /tmp/index.html /usr/share/nginx/html/ || true'
+Nov 29 08:00:44.208: INFO: stderr: ""
+Nov 29 08:00:44.208: INFO: stdout of mv -v /tmp/index.html /usr/share/nginx/html/ || true on ss-0: '/tmp/index.html' -> '/usr/share/nginx/html/index.html'
+
+Nov 29 08:00:44.208: INFO: Running '/usr/local/bin/kubectl --kubeconfig=/tmp/kubeconfig-385092372 exec --namespace=e2e-tests-statefulset-wtqgk ss-1 -- /bin/sh -c mv -v /tmp/index.html /usr/share/nginx/html/ || true'
+Nov 29 08:00:44.326: INFO: stderr: "mv: cannot stat '/tmp/index.html': No such file or directory\n"
+Nov 29 08:00:44.326: INFO: stdout of mv -v /tmp/index.html /usr/share/nginx/html/ || true on ss-1: 
+Nov 29 08:00:44.326: INFO: Running '/usr/local/bin/kubectl --kubeconfig=/tmp/kubeconfig-385092372 exec --namespace=e2e-tests-statefulset-wtqgk ss-2 -- /bin/sh -c mv -v /tmp/index.html /usr/share/nginx/html/ || true'
+Nov 29 08:00:44.444: INFO: stderr: "mv: cannot stat '/tmp/index.html': No such file or directory\n"
+Nov 29 08:00:44.444: INFO: stdout of mv -v /tmp/index.html /usr/share/nginx/html/ || true on ss-2: 
+Nov 29 08:00:44.446: INFO: Waiting for pod ss-0 to enter Running - Ready=true, currently Running - Ready=false
+Nov 29 08:00:54.448: INFO: Waiting for pod ss-0 to enter Running - Ready=true, currently Running - Ready=true
+Nov 29 08:00:54.448: INFO: Waiting for pod ss-1 to enter Running - Ready=true, currently Running - Ready=true
+Nov 29 08:00:54.448: INFO: Waiting for pod ss-2 to enter Running - Ready=true, currently Running - Ready=true
+STEP: Scale down will not halt with unhealthy stateful pod
+Nov 29 08:00:54.450: INFO: Running '/usr/local/bin/kubectl --kubeconfig=/tmp/kubeconfig-385092372 exec --namespace=e2e-tests-statefulset-wtqgk ss-0 -- /bin/sh -c mv -v /usr/share/nginx/html/index.html /tmp/ || true'
+Nov 29 08:00:54.564: INFO: stderr: ""
+Nov 29 08:00:54.564: INFO: stdout of mv -v /usr/share/nginx/html/index.html /tmp/ || true on ss-0: '/usr/share/nginx/html/index.html' -> '/tmp/index.html'
+
+Nov 29 08:00:54.564: INFO: Running '/usr/local/bin/kubectl --kubeconfig=/tmp/kubeconfig-385092372 exec --namespace=e2e-tests-statefulset-wtqgk ss-1 -- /bin/sh -c mv -v /usr/share/nginx/html/index.html /tmp/ || true'
+Nov 29 08:00:54.677: INFO: stderr: ""
+Nov 29 08:00:54.677: INFO: stdout of mv -v /usr/share/nginx/html/index.html /tmp/ || true on ss-1: '/usr/share/nginx/html/index.html' -> '/tmp/index.html'
+
+Nov 29 08:00:54.677: INFO: Running '/usr/local/bin/kubectl --kubeconfig=/tmp/kubeconfig-385092372 exec --namespace=e2e-tests-statefulset-wtqgk ss-2 -- /bin/sh -c mv -v /usr/share/nginx/html/index.html /tmp/ || true'
+Nov 29 08:00:54.792: INFO: stderr: ""
+Nov 29 08:00:54.792: INFO: stdout of mv -v /usr/share/nginx/html/index.html /tmp/ || true on ss-2: '/usr/share/nginx/html/index.html' -> '/tmp/index.html'
+
+Nov 29 08:00:54.792: INFO: Waiting for statefulset status.replicas updated to 0
+Nov 29 08:00:54.793: INFO: Waiting for stateful set status.readyReplicas to become 0, currently 3
+Nov 29 08:01:04.796: INFO: Waiting for pod ss-0 to enter Running - Ready=false, currently Running - Ready=false
+Nov 29 08:01:04.796: INFO: Waiting for pod ss-1 to enter Running - Ready=false, currently Running - Ready=false
+Nov 29 08:01:04.796: INFO: Waiting for pod ss-2 to enter Running - Ready=false, currently Running - Ready=false
+Nov 29 08:01:04.802: INFO: POD   NODE                                         PHASE    GRACE  CONDITIONS
+Nov 29 08:01:04.802: INFO: ss-0  worker-266bbc56-f3aa-11e8-ab5c-0a406d6cb422  Running         [{Initialized True 0001-01-01 00:00:00 +0000 UTC 2018-11-29 08:00:13 +0000 UTC  } {Ready False 0001-01-01 00:00:00 +0000 UTC 2018-11-29 08:00:54 +0000 UTC ContainersNotReady containers with unready status: [nginx]} {ContainersReady False 0001-01-01 00:00:00 +0000 UTC 0001-01-01 00:00:00 +0000 UTC ContainersNotReady containers with unready status: [nginx]} {PodScheduled True 0001-01-01 00:00:00 +0000 UTC 2018-11-29 08:00:13 +0000 UTC  }]
+Nov 29 08:01:04.803: INFO: ss-1  worker-bdccfcb0-f3a8-11e8-90fa-062be367adf0  Running         [{Initialized True 0001-01-01 00:00:00 +0000 UTC 2018-11-29 08:00:34 +0000 UTC  } {Ready False 0001-01-01 00:00:00 +0000 UTC 2018-11-29 08:00:55 +0000 UTC ContainersNotReady containers with unready status: [nginx]} {ContainersReady False 0001-01-01 00:00:00 +0000 UTC 0001-01-01 00:00:00 +0000 UTC ContainersNotReady containers with unready status: [nginx]} {PodScheduled True 0001-01-01 00:00:00 +0000 UTC 2018-11-29 08:00:34 +0000 UTC  }]
+Nov 29 08:01:04.803: INFO: ss-2  worker-266bbc56-f3aa-11e8-ab5c-0a406d6cb422  Running         [{Initialized True 0001-01-01 00:00:00 +0000 UTC 2018-11-29 08:00:34 +0000 UTC  } {Ready False 0001-01-01 00:00:00 +0000 UTC 2018-11-29 08:00:55 +0000 UTC ContainersNotReady containers with unready status: [nginx]} {ContainersReady False 0001-01-01 00:00:00 +0000 UTC 0001-01-01 00:00:00 +0000 UTC ContainersNotReady containers with unready status: [nginx]} {PodScheduled True 0001-01-01 00:00:00 +0000 UTC 2018-11-29 08:00:34 +0000 UTC  }]
+Nov 29 08:01:04.803: INFO: 
+Nov 29 08:01:04.803: INFO: StatefulSet ss has not reached scale 0, at 3
+Nov 29 08:01:05.805: INFO: POD   NODE                                         PHASE    GRACE  CONDITIONS
+Nov 29 08:01:05.805: INFO: ss-0  worker-266bbc56-f3aa-11e8-ab5c-0a406d6cb422  Running  30s    [{Initialized True 0001-01-01 00:00:00 +0000 UTC 2018-11-29 08:00:13 +0000 UTC  } {Ready False 0001-01-01 00:00:00 +0000 UTC 2018-11-29 08:00:54 +0000 UTC ContainersNotReady containers with unready status: [nginx]} {ContainersReady False 0001-01-01 00:00:00 +0000 UTC 0001-01-01 00:00:00 +0000 UTC ContainersNotReady containers with unready status: [nginx]} {PodScheduled True 0001-01-01 00:00:00 +0000 UTC 2018-11-29 08:00:13 +0000 UTC  }]
+Nov 29 08:01:05.805: INFO: ss-1  worker-bdccfcb0-f3a8-11e8-90fa-062be367adf0  Running  30s    [{Initialized True 0001-01-01 00:00:00 +0000 UTC 2018-11-29 08:00:34 +0000 UTC  } {Ready False 0001-01-01 00:00:00 +0000 UTC 2018-11-29 08:00:55 +0000 UTC ContainersNotReady containers with unready status: [nginx]} {ContainersReady False 0001-01-01 00:00:00 +0000 UTC 0001-01-01 00:00:00 +0000 UTC ContainersNotReady containers with unready status: [nginx]} {PodScheduled True 0001-01-01 00:00:00 +0000 UTC 2018-11-29 08:00:34 +0000 UTC  }]
+Nov 29 08:01:05.805: INFO: ss-2  worker-266bbc56-f3aa-11e8-ab5c-0a406d6cb422  Running  30s    [{Initialized True 0001-01-01 00:00:00 +0000 UTC 2018-11-29 08:00:34 +0000 UTC  } {Ready False 0001-01-01 00:00:00 +0000 UTC 2018-11-29 08:00:55 +0000 UTC ContainersNotReady containers with unready status: [nginx]} {ContainersReady False 0001-01-01 00:00:00 +0000 UTC 0001-01-01 00:00:00 +0000 UTC ContainersNotReady containers with unready status: [nginx]} {PodScheduled True 0001-01-01 00:00:00 +0000 UTC 2018-11-29 08:00:34 +0000 UTC  }]
+Nov 29 08:01:05.805: INFO: 
+Nov 29 08:01:05.805: INFO: StatefulSet ss has not reached scale 0, at 3
+Nov 29 08:01:06.807: INFO: POD   NODE                                         PHASE    GRACE  CONDITIONS
+Nov 29 08:01:06.807: INFO: ss-0  worker-266bbc56-f3aa-11e8-ab5c-0a406d6cb422  Running  30s    [{Initialized True 0001-01-01 00:00:00 +0000 UTC 2018-11-29 08:00:13 +0000 UTC  } {Ready False 0001-01-01 00:00:00 +0000 UTC 2018-11-29 08:00:54 +0000 UTC ContainersNotReady containers with unready status: [nginx]} {ContainersReady False 0001-01-01 00:00:00 +0000 UTC 0001-01-01 00:00:00 +0000 UTC ContainersNotReady containers with unready status: [nginx]} {PodScheduled True 0001-01-01 00:00:00 +0000 UTC 2018-11-29 08:00:13 +0000 UTC  }]
+Nov 29 08:01:06.807: INFO: ss-2  worker-266bbc56-f3aa-11e8-ab5c-0a406d6cb422  Running  30s    [{Initialized True 0001-01-01 00:00:00 +0000 UTC 2018-11-29 08:00:34 +0000 UTC  } {Ready False 0001-01-01 00:00:00 +0000 UTC 2018-11-29 08:00:55 +0000 UTC ContainersNotReady containers with unready status: [nginx]} {ContainersReady False 0001-01-01 00:00:00 +0000 UTC 0001-01-01 00:00:00 +0000 UTC ContainersNotReady containers with unready status: [nginx]} {PodScheduled True 0001-01-01 00:00:00 +0000 UTC 2018-11-29 08:00:34 +0000 UTC  }]
+Nov 29 08:01:06.807: INFO: 
+Nov 29 08:01:06.807: INFO: StatefulSet ss has not reached scale 0, at 2
+Nov 29 08:01:07.809: INFO: POD   NODE                                         PHASE    GRACE  CONDITIONS
+Nov 29 08:01:07.809: INFO: ss-2  worker-266bbc56-f3aa-11e8-ab5c-0a406d6cb422  Pending  30s    [{Initialized True 0001-01-01 00:00:00 +0000 UTC 2018-11-29 08:00:34 +0000 UTC  } {Ready False 0001-01-01 00:00:00 +0000 UTC 2018-11-29 08:00:55 +0000 UTC ContainersNotReady containers with unready status: [nginx]} {ContainersReady False 0001-01-01 00:00:00 +0000 UTC 0001-01-01 00:00:00 +0000 UTC ContainersNotReady containers with unready status: [nginx]} {PodScheduled True 0001-01-01 00:00:00 +0000 UTC 2018-11-29 08:00:34 +0000 UTC  }]
+Nov 29 08:01:07.809: INFO: 
+Nov 29 08:01:07.809: INFO: StatefulSet ss has not reached scale 0, at 1
+Nov 29 08:01:08.811: INFO: POD   NODE                                         PHASE    GRACE  CONDITIONS
+Nov 29 08:01:08.811: INFO: ss-2  worker-266bbc56-f3aa-11e8-ab5c-0a406d6cb422  Pending  30s    [{Initialized True 0001-01-01 00:00:00 +0000 UTC 2018-11-29 08:00:34 +0000 UTC  } {Ready False 0001-01-01 00:00:00 +0000 UTC 2018-11-29 08:00:55 +0000 UTC ContainersNotReady containers with unready status: [nginx]} {ContainersReady False 0001-01-01 00:00:00 +0000 UTC 0001-01-01 00:00:00 +0000 UTC ContainersNotReady containers with unready status: [nginx]} {PodScheduled True 0001-01-01 00:00:00 +0000 UTC 2018-11-29 08:00:34 +0000 UTC  }]
+Nov 29 08:01:08.811: INFO: 
+Nov 29 08:01:08.811: INFO: StatefulSet ss has not reached scale 0, at 1
+Nov 29 08:01:09.813: INFO: POD   NODE                                         PHASE    GRACE  CONDITIONS
+Nov 29 08:01:09.813: INFO: ss-2  worker-266bbc56-f3aa-11e8-ab5c-0a406d6cb422  Pending  30s    [{Initialized True 0001-01-01 00:00:00 +0000 UTC 2018-11-29 08:00:34 +0000 UTC  } {Ready False 0001-01-01 00:00:00 +0000 UTC 2018-11-29 08:00:55 +0000 UTC ContainersNotReady containers with unready status: [nginx]} {ContainersReady False 0001-01-01 00:00:00 +0000 UTC 0001-01-01 00:00:00 +0000 UTC ContainersNotReady containers with unready status: [nginx]} {PodScheduled True 0001-01-01 00:00:00 +0000 UTC 2018-11-29 08:00:34 +0000 UTC  }]
+Nov 29 08:01:09.813: INFO: 
+Nov 29 08:01:09.813: INFO: StatefulSet ss has not reached scale 0, at 1
+Nov 29 08:01:10.815: INFO: POD   NODE                                         PHASE    GRACE  CONDITIONS
+Nov 29 08:01:10.815: INFO: ss-2  worker-266bbc56-f3aa-11e8-ab5c-0a406d6cb422  Pending  30s    [{Initialized True 0001-01-01 00:00:00 +0000 UTC 2018-11-29 08:00:34 +0000 UTC  } {Ready False 0001-01-01 00:00:00 +0000 UTC 2018-11-29 08:00:55 +0000 UTC ContainersNotReady containers with unready status: [nginx]} {ContainersReady False 0001-01-01 00:00:00 +0000 UTC 0001-01-01 00:00:00 +0000 UTC ContainersNotReady containers with unready status: [nginx]} {PodScheduled True 0001-01-01 00:00:00 +0000 UTC 2018-11-29 08:00:34 +0000 UTC  }]
+Nov 29 08:01:10.815: INFO: 
+Nov 29 08:01:10.815: INFO: StatefulSet ss has not reached scale 0, at 1
+Nov 29 08:01:11.817: INFO: Verifying statefulset ss doesn't scale past 0 for another 2.984570425s
+Nov 29 08:01:12.818: INFO: Verifying statefulset ss doesn't scale past 0 for another 1.982821071s
+Nov 29 08:01:13.824: INFO: Verifying statefulset ss doesn't scale past 0 for another 981.263788ms
+STEP: Scaling down stateful set ss to 0 replicas and waiting until none of pods will run in namespacee2e-tests-statefulset-wtqgk
+Nov 29 08:01:14.825: INFO: Scaling statefulset ss to 0
+Nov 29 08:01:14.829: INFO: Waiting for statefulset status.replicas updated to 0
+[AfterEach] [k8s.io] Basic StatefulSet functionality [StatefulSetBasic]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/statefulset.go:83
+Nov 29 08:01:14.830: INFO: Deleting all statefulset in ns e2e-tests-statefulset-wtqgk
+Nov 29 08:01:14.832: INFO: Scaling statefulset ss to 0
+Nov 29 08:01:14.835: INFO: Waiting for statefulset status.replicas updated to 0
+Nov 29 08:01:14.836: INFO: Deleting statefulset ss
+[AfterEach] [sig-apps] StatefulSet
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Nov 29 08:01:14.844: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-statefulset-wtqgk" for this suite.
+Nov 29 08:01:20.852: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Nov 29 08:01:20.868: INFO: namespace: e2e-tests-statefulset-wtqgk, resource: bindings, ignored listing per whitelist
+Nov 29 08:01:20.905: INFO: namespace e2e-tests-statefulset-wtqgk deletion completed in 6.05790532s
+
+• [SLOW TEST:67.049 seconds]
+[sig-apps] StatefulSet
+/workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/framework.go:22
+  [k8s.io] Basic StatefulSet functionality [StatefulSetBasic]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:669
+    Burst scaling should run to completion even with unhealthy pods [Conformance]
+    /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+S
+------------------------------
+[sig-storage] Downward API volume 
+  should provide node allocatable (memory) as default memory limit if the limit is not set  [Conformance]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Nov 29 08:01:20.905: INFO: >>> kubeConfig: /tmp/kubeconfig-385092372
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downwardapi_volume.go:38
+[It] should provide node allocatable (memory) as default memory limit if the limit is not set  [Conformance]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating a pod to test downward API volume plugin
+Nov 29 08:01:20.939: INFO: Waiting up to 5m0s for pod "downwardapi-volume-f54081dd-f3ac-11e8-9124-e6180d057dc8" in namespace "e2e-tests-downward-api-gmpgm" to be "success or failure"
+Nov 29 08:01:20.947: INFO: Pod "downwardapi-volume-f54081dd-f3ac-11e8-9124-e6180d057dc8": Phase="Pending", Reason="", readiness=false. Elapsed: 8.004361ms
+Nov 29 08:01:22.948: INFO: Pod "downwardapi-volume-f54081dd-f3ac-11e8-9124-e6180d057dc8": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.009383426s
+STEP: Saw pod success
+Nov 29 08:01:22.948: INFO: Pod "downwardapi-volume-f54081dd-f3ac-11e8-9124-e6180d057dc8" satisfied condition "success or failure"
+Nov 29 08:01:22.950: INFO: Trying to get logs from node worker-266bbc56-f3aa-11e8-ab5c-0a406d6cb422 pod downwardapi-volume-f54081dd-f3ac-11e8-9124-e6180d057dc8 container client-container: <nil>
+STEP: delete the pod
+Nov 29 08:01:22.962: INFO: Waiting for pod downwardapi-volume-f54081dd-f3ac-11e8-9124-e6180d057dc8 to disappear
+Nov 29 08:01:22.964: INFO: Pod downwardapi-volume-f54081dd-f3ac-11e8-9124-e6180d057dc8 no longer exists
+[AfterEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Nov 29 08:01:22.964: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-downward-api-gmpgm" for this suite.
+Nov 29 08:01:28.972: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Nov 29 08:01:29.005: INFO: namespace: e2e-tests-downward-api-gmpgm, resource: bindings, ignored listing per whitelist
+Nov 29 08:01:29.023: INFO: namespace e2e-tests-downward-api-gmpgm deletion completed in 6.055894533s
+
+• [SLOW TEST:8.117 seconds]
+[sig-storage] Downward API volume
+/workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downwardapi_volume.go:33
+  should provide node allocatable (memory) as default memory limit if the limit is not set  [Conformance]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+[sig-storage] Downward API volume 
+  should provide container's cpu limit  [Conformance]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Nov 29 08:01:29.023: INFO: >>> kubeConfig: /tmp/kubeconfig-385092372
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downwardapi_volume.go:38
+[It] should provide container's cpu limit  [Conformance]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating a pod to test downward API volume plugin
+Nov 29 08:01:29.058: INFO: Waiting up to 5m0s for pod "downwardapi-volume-fa16b825-f3ac-11e8-9124-e6180d057dc8" in namespace "e2e-tests-downward-api-dqdzr" to be "success or failure"
+Nov 29 08:01:29.064: INFO: Pod "downwardapi-volume-fa16b825-f3ac-11e8-9124-e6180d057dc8": Phase="Pending", Reason="", readiness=false. Elapsed: 5.212347ms
+Nov 29 08:01:31.065: INFO: Pod "downwardapi-volume-fa16b825-f3ac-11e8-9124-e6180d057dc8": Phase="Pending", Reason="", readiness=false. Elapsed: 2.007032864s
+Nov 29 08:01:33.067: INFO: Pod "downwardapi-volume-fa16b825-f3ac-11e8-9124-e6180d057dc8": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.008563167s
+STEP: Saw pod success
+Nov 29 08:01:33.067: INFO: Pod "downwardapi-volume-fa16b825-f3ac-11e8-9124-e6180d057dc8" satisfied condition "success or failure"
+Nov 29 08:01:33.068: INFO: Trying to get logs from node worker-266bbc56-f3aa-11e8-ab5c-0a406d6cb422 pod downwardapi-volume-fa16b825-f3ac-11e8-9124-e6180d057dc8 container client-container: <nil>
+STEP: delete the pod
+Nov 29 08:01:33.081: INFO: Waiting for pod downwardapi-volume-fa16b825-f3ac-11e8-9124-e6180d057dc8 to disappear
+Nov 29 08:01:33.083: INFO: Pod downwardapi-volume-fa16b825-f3ac-11e8-9124-e6180d057dc8 no longer exists
+[AfterEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Nov 29 08:01:33.083: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-downward-api-dqdzr" for this suite.
+Nov 29 08:01:39.092: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Nov 29 08:01:39.131: INFO: namespace: e2e-tests-downward-api-dqdzr, resource: bindings, ignored listing per whitelist
+Nov 29 08:01:39.144: INFO: namespace e2e-tests-downward-api-dqdzr deletion completed in 6.05721783s
+
+• [SLOW TEST:10.121 seconds]
+[sig-storage] Downward API volume
+/workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downwardapi_volume.go:33
+  should provide container's cpu limit  [Conformance]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SSSS
+------------------------------
+[sig-network] Proxy version v1 
+  should proxy logs on node using proxy subresource  [Conformance]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] version v1
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Nov 29 08:01:39.144: INFO: >>> kubeConfig: /tmp/kubeconfig-385092372
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] version v1
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/network/proxy.go:69
+[It] should proxy logs on node using proxy subresource  [Conformance]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+Nov 29 08:01:39.176: INFO: (0) /api/v1/nodes/worker-266bbc56-f3aa-11e8-ab5c-0a406d6cb422/proxy/logs/: <pre>
+<a href="amazon/">amazon/</a>
+<a href="audit/">audit/</a>
+<a href="btmp">btmp</a>
+<a href="... (200; 1.574701ms)
+Nov 29 08:01:39.177: INFO: (1) /api/v1/nodes/worker-266bbc56-f3aa-11e8-ab5c-0a406d6cb422/proxy/logs/: <pre>
+<a href="amazon/">amazon/</a>
+<a href="audit/">audit/</a>
+<a href="btmp">btmp</a>
+<a href="... (200; 1.39887ms)
+Nov 29 08:01:39.179: INFO: (2) /api/v1/nodes/worker-266bbc56-f3aa-11e8-ab5c-0a406d6cb422/proxy/logs/: <pre>
+<a href="amazon/">amazon/</a>
+<a href="audit/">audit/</a>
+<a href="btmp">btmp</a>
+<a href="... (200; 1.654691ms)
+Nov 29 08:01:39.180: INFO: (3) /api/v1/nodes/worker-266bbc56-f3aa-11e8-ab5c-0a406d6cb422/proxy/logs/: <pre>
+<a href="amazon/">amazon/</a>
+<a href="audit/">audit/</a>
+<a href="btmp">btmp</a>
+<a href="... (200; 1.303348ms)
+Nov 29 08:01:39.181: INFO: (4) /api/v1/nodes/worker-266bbc56-f3aa-11e8-ab5c-0a406d6cb422/proxy/logs/: <pre>
+<a href="amazon/">amazon/</a>
+<a href="audit/">audit/</a>
+<a href="btmp">btmp</a>
+<a href="... (200; 1.329075ms)
+Nov 29 08:01:39.183: INFO: (5) /api/v1/nodes/worker-266bbc56-f3aa-11e8-ab5c-0a406d6cb422/proxy/logs/: <pre>
+<a href="amazon/">amazon/</a>
+<a href="audit/">audit/</a>
+<a href="btmp">btmp</a>
+<a href="... (200; 1.31189ms)
+Nov 29 08:01:39.185: INFO: (6) /api/v1/nodes/worker-266bbc56-f3aa-11e8-ab5c-0a406d6cb422/proxy/logs/: <pre>
+<a href="amazon/">amazon/</a>
+<a href="audit/">audit/</a>
+<a href="btmp">btmp</a>
+<a href="... (200; 1.803799ms)
+Nov 29 08:01:39.188: INFO: (7) /api/v1/nodes/worker-266bbc56-f3aa-11e8-ab5c-0a406d6cb422/proxy/logs/: <pre>
+<a href="amazon/">amazon/</a>
+<a href="audit/">audit/</a>
+<a href="btmp">btmp</a>
+<a href="... (200; 3.08919ms)
+Nov 29 08:01:39.189: INFO: (8) /api/v1/nodes/worker-266bbc56-f3aa-11e8-ab5c-0a406d6cb422/proxy/logs/: <pre>
+<a href="amazon/">amazon/</a>
+<a href="audit/">audit/</a>
+<a href="btmp">btmp</a>
+<a href="... (200; 1.388436ms)
+Nov 29 08:01:39.190: INFO: (9) /api/v1/nodes/worker-266bbc56-f3aa-11e8-ab5c-0a406d6cb422/proxy/logs/: <pre>
+<a href="amazon/">amazon/</a>
+<a href="audit/">audit/</a>
+<a href="btmp">btmp</a>
+<a href="... (200; 1.278963ms)
+Nov 29 08:01:39.192: INFO: (10) /api/v1/nodes/worker-266bbc56-f3aa-11e8-ab5c-0a406d6cb422/proxy/logs/: <pre>
+<a href="amazon/">amazon/</a>
+<a href="audit/">audit/</a>
+<a href="btmp">btmp</a>
+<a href="... (200; 1.260979ms)
+Nov 29 08:01:39.193: INFO: (11) /api/v1/nodes/worker-266bbc56-f3aa-11e8-ab5c-0a406d6cb422/proxy/logs/: <pre>
+<a href="amazon/">amazon/</a>
+<a href="audit/">audit/</a>
+<a href="btmp">btmp</a>
+<a href="... (200; 1.307293ms)
+Nov 29 08:01:39.194: INFO: (12) /api/v1/nodes/worker-266bbc56-f3aa-11e8-ab5c-0a406d6cb422/proxy/logs/: <pre>
+<a href="amazon/">amazon/</a>
+<a href="audit/">audit/</a>
+<a href="btmp">btmp</a>
+<a href="... (200; 1.322158ms)
+Nov 29 08:01:39.196: INFO: (13) /api/v1/nodes/worker-266bbc56-f3aa-11e8-ab5c-0a406d6cb422/proxy/logs/: <pre>
+<a href="amazon/">amazon/</a>
+<a href="audit/">audit/</a>
+<a href="btmp">btmp</a>
+<a href="... (200; 1.282789ms)
+Nov 29 08:01:39.197: INFO: (14) /api/v1/nodes/worker-266bbc56-f3aa-11e8-ab5c-0a406d6cb422/proxy/logs/: <pre>
+<a href="amazon/">amazon/</a>
+<a href="audit/">audit/</a>
+<a href="btmp">btmp</a>
+<a href="... (200; 1.353191ms)
+Nov 29 08:01:39.198: INFO: (15) /api/v1/nodes/worker-266bbc56-f3aa-11e8-ab5c-0a406d6cb422/proxy/logs/: <pre>
+<a href="amazon/">amazon/</a>
+<a href="audit/">audit/</a>
+<a href="btmp">btmp</a>
+<a href="... (200; 1.271321ms)
+Nov 29 08:01:39.200: INFO: (16) /api/v1/nodes/worker-266bbc56-f3aa-11e8-ab5c-0a406d6cb422/proxy/logs/: <pre>
+<a href="amazon/">amazon/</a>
+<a href="audit/">audit/</a>
+<a href="btmp">btmp</a>
+<a href="... (200; 1.389167ms)
+Nov 29 08:01:39.201: INFO: (17) /api/v1/nodes/worker-266bbc56-f3aa-11e8-ab5c-0a406d6cb422/proxy/logs/: <pre>
+<a href="amazon/">amazon/</a>
+<a href="audit/">audit/</a>
+<a href="btmp">btmp</a>
+<a href="... (200; 1.339596ms)
+Nov 29 08:01:39.202: INFO: (18) /api/v1/nodes/worker-266bbc56-f3aa-11e8-ab5c-0a406d6cb422/proxy/logs/: <pre>
+<a href="amazon/">amazon/</a>
+<a href="audit/">audit/</a>
+<a href="btmp">btmp</a>
+<a href="... (200; 1.26913ms)
+Nov 29 08:01:39.204: INFO: (19) /api/v1/nodes/worker-266bbc56-f3aa-11e8-ab5c-0a406d6cb422/proxy/logs/: <pre>
+<a href="amazon/">amazon/</a>
+<a href="audit/">audit/</a>
+<a href="btmp">btmp</a>
+<a href="... (200; 1.337495ms)
+[AfterEach] version v1
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Nov 29 08:01:39.204: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-proxy-pq2l2" for this suite.
+Nov 29 08:01:45.209: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Nov 29 08:01:45.231: INFO: namespace: e2e-tests-proxy-pq2l2, resource: bindings, ignored listing per whitelist
+Nov 29 08:01:45.263: INFO: namespace e2e-tests-proxy-pq2l2 deletion completed in 6.057450473s
+
+• [SLOW TEST:6.119 seconds]
+[sig-network] Proxy
+/workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/network/framework.go:22
+  version v1
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/network/proxy.go:61
+    should proxy logs on node using proxy subresource  [Conformance]
+    /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+S
+------------------------------
+[sig-network] Services 
+  should serve a basic endpoint from pods  [Conformance]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-network] Services
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Nov 29 08:01:45.263: INFO: >>> kubeConfig: /tmp/kubeconfig-385092372
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-network] Services
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/network/service.go:53
+[It] should serve a basic endpoint from pods  [Conformance]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: creating service endpoint-test2 in namespace e2e-tests-services-4jmjq
+STEP: waiting up to 1m0s for service endpoint-test2 in namespace e2e-tests-services-4jmjq to expose endpoints map[]
+Nov 29 08:01:45.299: INFO: successfully validated that service endpoint-test2 in namespace e2e-tests-services-4jmjq exposes endpoints map[] (1.464807ms elapsed)
+STEP: Creating pod pod1 in namespace e2e-tests-services-4jmjq
+STEP: waiting up to 1m0s for service endpoint-test2 in namespace e2e-tests-services-4jmjq to expose endpoints map[pod1:[80]]
+Nov 29 08:01:46.318: INFO: successfully validated that service endpoint-test2 in namespace e2e-tests-services-4jmjq exposes endpoints map[pod1:[80]] (1.010683264s elapsed)
+STEP: Creating pod pod2 in namespace e2e-tests-services-4jmjq
+STEP: waiting up to 1m0s for service endpoint-test2 in namespace e2e-tests-services-4jmjq to expose endpoints map[pod1:[80] pod2:[80]]
+Nov 29 08:01:48.339: INFO: successfully validated that service endpoint-test2 in namespace e2e-tests-services-4jmjq exposes endpoints map[pod1:[80] pod2:[80]] (2.018167827s elapsed)
+STEP: Deleting pod pod1 in namespace e2e-tests-services-4jmjq
+STEP: waiting up to 1m0s for service endpoint-test2 in namespace e2e-tests-services-4jmjq to expose endpoints map[pod2:[80]]
+Nov 29 08:01:48.351: INFO: successfully validated that service endpoint-test2 in namespace e2e-tests-services-4jmjq exposes endpoints map[pod2:[80]] (10.583426ms elapsed)
+STEP: Deleting pod pod2 in namespace e2e-tests-services-4jmjq
+STEP: waiting up to 1m0s for service endpoint-test2 in namespace e2e-tests-services-4jmjq to expose endpoints map[]
+Nov 29 08:01:48.361: INFO: successfully validated that service endpoint-test2 in namespace e2e-tests-services-4jmjq exposes endpoints map[] (1.829401ms elapsed)
+[AfterEach] [sig-network] Services
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Nov 29 08:01:48.372: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-services-4jmjq" for this suite.
+Nov 29 08:02:10.385: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Nov 29 08:02:10.441: INFO: namespace: e2e-tests-services-4jmjq, resource: bindings, ignored listing per whitelist
+Nov 29 08:02:10.444: INFO: namespace e2e-tests-services-4jmjq deletion completed in 22.070911084s
+[AfterEach] [sig-network] Services
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/network/service.go:58
+
+• [SLOW TEST:25.182 seconds]
+[sig-network] Services
+/workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/network/framework.go:22
+  should serve a basic endpoint from pods  [Conformance]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+[sig-api-machinery] Secrets 
+  should be consumable via the environment  [Conformance]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-api-machinery] Secrets
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Nov 29 08:02:10.444: INFO: >>> kubeConfig: /tmp/kubeconfig-385092372
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should be consumable via the environment  [Conformance]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: creating secret e2e-tests-secrets-mksv9/secret-test-12cf0c66-f3ad-11e8-9124-e6180d057dc8
+STEP: Creating a pod to test consume secrets
+Nov 29 08:02:10.530: INFO: Waiting up to 5m0s for pod "pod-configmaps-12cf8242-f3ad-11e8-9124-e6180d057dc8" in namespace "e2e-tests-secrets-mksv9" to be "success or failure"
+Nov 29 08:02:10.537: INFO: Pod "pod-configmaps-12cf8242-f3ad-11e8-9124-e6180d057dc8": Phase="Pending", Reason="", readiness=false. Elapsed: 6.231465ms
+Nov 29 08:02:12.538: INFO: Pod "pod-configmaps-12cf8242-f3ad-11e8-9124-e6180d057dc8": Phase="Pending", Reason="", readiness=false. Elapsed: 2.00792263s
+Nov 29 08:02:14.540: INFO: Pod "pod-configmaps-12cf8242-f3ad-11e8-9124-e6180d057dc8": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.009607344s
+STEP: Saw pod success
+Nov 29 08:02:14.540: INFO: Pod "pod-configmaps-12cf8242-f3ad-11e8-9124-e6180d057dc8" satisfied condition "success or failure"
+Nov 29 08:02:14.541: INFO: Trying to get logs from node worker-266bbc56-f3aa-11e8-ab5c-0a406d6cb422 pod pod-configmaps-12cf8242-f3ad-11e8-9124-e6180d057dc8 container env-test: <nil>
+STEP: delete the pod
+Nov 29 08:02:14.552: INFO: Waiting for pod pod-configmaps-12cf8242-f3ad-11e8-9124-e6180d057dc8 to disappear
+Nov 29 08:02:14.558: INFO: Pod pod-configmaps-12cf8242-f3ad-11e8-9124-e6180d057dc8 no longer exists
+[AfterEach] [sig-api-machinery] Secrets
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Nov 29 08:02:14.558: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-secrets-mksv9" for this suite.
+Nov 29 08:02:20.565: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Nov 29 08:02:20.590: INFO: namespace: e2e-tests-secrets-mksv9, resource: bindings, ignored listing per whitelist
+Nov 29 08:02:20.634: INFO: namespace e2e-tests-secrets-mksv9 deletion completed in 6.074513766s
+
+• [SLOW TEST:10.190 seconds]
+[sig-api-machinery] Secrets
+/workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/secrets.go:30
+  should be consumable via the environment  [Conformance]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SSSSSSSSSS
+------------------------------
+[sig-storage] Projected 
+  should provide container's cpu limit [Conformance]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Nov 29 08:02:20.634: INFO: >>> kubeConfig: /tmp/kubeconfig-385092372
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:858
+[It] should provide container's cpu limit [Conformance]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating a pod to test downward API volume plugin
+Nov 29 08:02:20.733: INFO: Waiting up to 5m0s for pod "downwardapi-volume-18e3cbee-f3ad-11e8-9124-e6180d057dc8" in namespace "e2e-tests-projected-4gxsw" to be "success or failure"
+Nov 29 08:02:20.738: INFO: Pod "downwardapi-volume-18e3cbee-f3ad-11e8-9124-e6180d057dc8": Phase="Pending", Reason="", readiness=false. Elapsed: 4.079153ms
+Nov 29 08:02:22.739: INFO: Pod "downwardapi-volume-18e3cbee-f3ad-11e8-9124-e6180d057dc8": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.005759135s
+STEP: Saw pod success
+Nov 29 08:02:22.739: INFO: Pod "downwardapi-volume-18e3cbee-f3ad-11e8-9124-e6180d057dc8" satisfied condition "success or failure"
+Nov 29 08:02:22.740: INFO: Trying to get logs from node worker-266bbc56-f3aa-11e8-ab5c-0a406d6cb422 pod downwardapi-volume-18e3cbee-f3ad-11e8-9124-e6180d057dc8 container client-container: <nil>
+STEP: delete the pod
+Nov 29 08:02:22.757: INFO: Waiting for pod downwardapi-volume-18e3cbee-f3ad-11e8-9124-e6180d057dc8 to disappear
+Nov 29 08:02:22.760: INFO: Pod downwardapi-volume-18e3cbee-f3ad-11e8-9124-e6180d057dc8 no longer exists
+[AfterEach] [sig-storage] Projected
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Nov 29 08:02:22.760: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-4gxsw" for this suite.
+Nov 29 08:02:28.769: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Nov 29 08:02:28.787: INFO: namespace: e2e-tests-projected-4gxsw, resource: bindings, ignored listing per whitelist
+Nov 29 08:02:28.821: INFO: namespace e2e-tests-projected-4gxsw deletion completed in 6.059100126s
+
+• [SLOW TEST:8.187 seconds]
+[sig-storage] Projected
+/workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:34
+  should provide container's cpu limit [Conformance]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SSSS
+------------------------------
+[sig-network] Proxy version v1 
+  should proxy through a service and a pod  [Conformance]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] version v1
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Nov 29 08:02:28.821: INFO: >>> kubeConfig: /tmp/kubeconfig-385092372
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] version v1
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/network/proxy.go:69
+[It] should proxy through a service and a pod  [Conformance]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: starting an echo server on multiple ports
+STEP: creating replication controller proxy-service-n5sdh in namespace e2e-tests-proxy-7lwtm
+I1129 08:02:28.916093      13 runners.go:175] Created replication controller with name: proxy-service-n5sdh, namespace: e2e-tests-proxy-7lwtm, replica count: 1
+I1129 08:02:29.966473      13 runners.go:175] proxy-service-n5sdh Pods: 1 out of 1 created, 0 running, 1 pending, 0 waiting, 0 inactive, 0 terminating, 0 unknown, 0 runningButNotReady 
+I1129 08:02:30.966603      13 runners.go:175] proxy-service-n5sdh Pods: 1 out of 1 created, 0 running, 1 pending, 0 waiting, 0 inactive, 0 terminating, 0 unknown, 0 runningButNotReady 
+I1129 08:02:31.966765      13 runners.go:175] proxy-service-n5sdh Pods: 1 out of 1 created, 0 running, 0 pending, 0 waiting, 0 inactive, 0 terminating, 0 unknown, 1 runningButNotReady 
+I1129 08:02:32.966892      13 runners.go:175] proxy-service-n5sdh Pods: 1 out of 1 created, 0 running, 0 pending, 0 waiting, 0 inactive, 0 terminating, 0 unknown, 1 runningButNotReady 
+I1129 08:02:33.967018      13 runners.go:175] proxy-service-n5sdh Pods: 1 out of 1 created, 0 running, 0 pending, 0 waiting, 0 inactive, 0 terminating, 0 unknown, 1 runningButNotReady 
+I1129 08:02:34.967144      13 runners.go:175] proxy-service-n5sdh Pods: 1 out of 1 created, 0 running, 0 pending, 0 waiting, 0 inactive, 0 terminating, 0 unknown, 1 runningButNotReady 
+I1129 08:02:35.967273      13 runners.go:175] proxy-service-n5sdh Pods: 1 out of 1 created, 0 running, 0 pending, 0 waiting, 0 inactive, 0 terminating, 0 unknown, 1 runningButNotReady 
+I1129 08:02:36.967402      13 runners.go:175] proxy-service-n5sdh Pods: 1 out of 1 created, 0 running, 0 pending, 0 waiting, 0 inactive, 0 terminating, 0 unknown, 1 runningButNotReady 
+I1129 08:02:37.967531      13 runners.go:175] proxy-service-n5sdh Pods: 1 out of 1 created, 0 running, 0 pending, 0 waiting, 0 inactive, 0 terminating, 0 unknown, 1 runningButNotReady 
+I1129 08:02:38.967726      13 runners.go:175] proxy-service-n5sdh Pods: 1 out of 1 created, 0 running, 0 pending, 0 waiting, 0 inactive, 0 terminating, 0 unknown, 1 runningButNotReady 
+I1129 08:02:39.967856      13 runners.go:175] proxy-service-n5sdh Pods: 1 out of 1 created, 1 running, 0 pending, 0 waiting, 0 inactive, 0 terminating, 0 unknown, 0 runningButNotReady 
+Nov 29 08:02:39.969: INFO: setup took 11.069228432s, starting test cases
+STEP: running 16 cases, 20 attempts per case, 320 total attempts
+Nov 29 08:02:39.979: INFO: (0) /api/v1/namespaces/e2e-tests-proxy-7lwtm/services/http:proxy-service-n5sdh:portname1/proxy/: foo (200; 9.759462ms)
+Nov 29 08:02:39.979: INFO: (0) /api/v1/namespaces/e2e-tests-proxy-7lwtm/pods/proxy-service-n5sdh-r7dnw:160/proxy/: foo (200; 9.678871ms)
+Nov 29 08:02:39.979: INFO: (0) /api/v1/namespaces/e2e-tests-proxy-7lwtm/pods/http:proxy-service-n5sdh-r7dnw:160/proxy/: foo (200; 9.276056ms)
+Nov 29 08:02:39.979: INFO: (0) /api/v1/namespaces/e2e-tests-proxy-7lwtm/services/proxy-service-n5sdh:portname2/proxy/: bar (200; 9.914403ms)
+Nov 29 08:02:39.979: INFO: (0) /api/v1/namespaces/e2e-tests-proxy-7lwtm/services/proxy-service-n5sdh:portname1/proxy/: foo (200; 9.669532ms)
+Nov 29 08:02:39.979: INFO: (0) /api/v1/namespaces/e2e-tests-proxy-7lwtm/pods/http:proxy-service-n5sdh-r7dnw:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-7lwtm/pods/http:proxy-service-n5sdh-r7dnw:1080/proxy/... (200; 9.836795ms)
+Nov 29 08:02:39.979: INFO: (0) /api/v1/namespaces/e2e-tests-proxy-7lwtm/pods/proxy-service-n5sdh-r7dnw:162/proxy/: bar (200; 9.646063ms)
+Nov 29 08:02:39.979: INFO: (0) /api/v1/namespaces/e2e-tests-proxy-7lwtm/pods/http:proxy-service-n5sdh-r7dnw:162/proxy/: bar (200; 9.636295ms)
+Nov 29 08:02:39.979: INFO: (0) /api/v1/namespaces/e2e-tests-proxy-7lwtm/pods/proxy-service-n5sdh-r7dnw:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-7lwtm/pods/proxy-service-n5sdh-r7dnw:1080/proxy/rewri... (200; 9.469232ms)
+Nov 29 08:02:39.979: INFO: (0) /api/v1/namespaces/e2e-tests-proxy-7lwtm/pods/https:proxy-service-n5sdh-r7dnw:462/proxy/: tls qux (200; 10.358063ms)
+Nov 29 08:02:39.980: INFO: (0) /api/v1/namespaces/e2e-tests-proxy-7lwtm/pods/proxy-service-n5sdh-r7dnw/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-7lwtm/pods/proxy-service-n5sdh-r7dnw/proxy/rewriteme"... (200; 10.617606ms)
+Nov 29 08:02:39.983: INFO: (0) /api/v1/namespaces/e2e-tests-proxy-7lwtm/services/http:proxy-service-n5sdh:portname2/proxy/: bar (200; 12.948403ms)
+Nov 29 08:02:39.985: INFO: (0) /api/v1/namespaces/e2e-tests-proxy-7lwtm/services/https:proxy-service-n5sdh:tlsportname2/proxy/: tls qux (200; 15.421045ms)
+Nov 29 08:02:39.985: INFO: (0) /api/v1/namespaces/e2e-tests-proxy-7lwtm/pods/https:proxy-service-n5sdh-r7dnw:460/proxy/: tls baz (200; 15.988643ms)
+Nov 29 08:02:39.985: INFO: (0) /api/v1/namespaces/e2e-tests-proxy-7lwtm/pods/https:proxy-service-n5sdh-r7dnw:443/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-7lwtm/pods/https:proxy-service-n5sdh-r7dnw:443/proxy/... (200; 15.860148ms)
+Nov 29 08:02:39.987: INFO: (0) /api/v1/namespaces/e2e-tests-proxy-7lwtm/services/https:proxy-service-n5sdh:tlsportname1/proxy/: tls baz (200; 17.562611ms)
+Nov 29 08:02:39.992: INFO: (1) /api/v1/namespaces/e2e-tests-proxy-7lwtm/pods/http:proxy-service-n5sdh-r7dnw:162/proxy/: bar (200; 4.074559ms)
+Nov 29 08:02:39.994: INFO: (1) /api/v1/namespaces/e2e-tests-proxy-7lwtm/pods/proxy-service-n5sdh-r7dnw:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-7lwtm/pods/proxy-service-n5sdh-r7dnw:1080/proxy/rewri... (200; 6.65693ms)
+Nov 29 08:02:39.995: INFO: (1) /api/v1/namespaces/e2e-tests-proxy-7lwtm/pods/http:proxy-service-n5sdh-r7dnw:160/proxy/: foo (200; 6.815769ms)
+Nov 29 08:02:39.995: INFO: (1) /api/v1/namespaces/e2e-tests-proxy-7lwtm/services/https:proxy-service-n5sdh:tlsportname2/proxy/: tls qux (200; 7.963919ms)
+Nov 29 08:02:39.996: INFO: (1) /api/v1/namespaces/e2e-tests-proxy-7lwtm/pods/https:proxy-service-n5sdh-r7dnw:443/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-7lwtm/pods/https:proxy-service-n5sdh-r7dnw:443/proxy/... (200; 8.167447ms)
+Nov 29 08:02:39.996: INFO: (1) /api/v1/namespaces/e2e-tests-proxy-7lwtm/pods/https:proxy-service-n5sdh-r7dnw:462/proxy/: tls qux (200; 8.30743ms)
+Nov 29 08:02:39.996: INFO: (1) /api/v1/namespaces/e2e-tests-proxy-7lwtm/services/http:proxy-service-n5sdh:portname2/proxy/: bar (200; 8.318281ms)
+Nov 29 08:02:39.996: INFO: (1) /api/v1/namespaces/e2e-tests-proxy-7lwtm/pods/proxy-service-n5sdh-r7dnw:160/proxy/: foo (200; 8.537459ms)
+Nov 29 08:02:39.996: INFO: (1) /api/v1/namespaces/e2e-tests-proxy-7lwtm/services/http:proxy-service-n5sdh:portname1/proxy/: foo (200; 8.688837ms)
+Nov 29 08:02:39.996: INFO: (1) /api/v1/namespaces/e2e-tests-proxy-7lwtm/pods/proxy-service-n5sdh-r7dnw/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-7lwtm/pods/proxy-service-n5sdh-r7dnw/proxy/rewriteme"... (200; 8.642557ms)
+Nov 29 08:02:39.996: INFO: (1) /api/v1/namespaces/e2e-tests-proxy-7lwtm/pods/http:proxy-service-n5sdh-r7dnw:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-7lwtm/pods/http:proxy-service-n5sdh-r7dnw:1080/proxy/... (200; 8.735643ms)
+Nov 29 08:02:39.996: INFO: (1) /api/v1/namespaces/e2e-tests-proxy-7lwtm/pods/proxy-service-n5sdh-r7dnw:162/proxy/: bar (200; 8.606888ms)
+Nov 29 08:02:39.996: INFO: (1) /api/v1/namespaces/e2e-tests-proxy-7lwtm/services/proxy-service-n5sdh:portname2/proxy/: bar (200; 9.035233ms)
+Nov 29 08:02:39.996: INFO: (1) /api/v1/namespaces/e2e-tests-proxy-7lwtm/pods/https:proxy-service-n5sdh-r7dnw:460/proxy/: tls baz (200; 8.851279ms)
+Nov 29 08:02:39.996: INFO: (1) /api/v1/namespaces/e2e-tests-proxy-7lwtm/services/proxy-service-n5sdh:portname1/proxy/: foo (200; 8.90347ms)
+Nov 29 08:02:39.997: INFO: (1) /api/v1/namespaces/e2e-tests-proxy-7lwtm/services/https:proxy-service-n5sdh:tlsportname1/proxy/: tls baz (200; 9.104409ms)
+Nov 29 08:02:40.003: INFO: (2) /api/v1/namespaces/e2e-tests-proxy-7lwtm/pods/http:proxy-service-n5sdh-r7dnw:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-7lwtm/pods/http:proxy-service-n5sdh-r7dnw:1080/proxy/... (200; 5.589829ms)
+Nov 29 08:02:40.003: INFO: (2) /api/v1/namespaces/e2e-tests-proxy-7lwtm/pods/https:proxy-service-n5sdh-r7dnw:460/proxy/: tls baz (200; 6.059915ms)
+Nov 29 08:02:40.003: INFO: (2) /api/v1/namespaces/e2e-tests-proxy-7lwtm/pods/https:proxy-service-n5sdh-r7dnw:462/proxy/: tls qux (200; 6.159397ms)
+Nov 29 08:02:40.003: INFO: (2) /api/v1/namespaces/e2e-tests-proxy-7lwtm/pods/proxy-service-n5sdh-r7dnw:160/proxy/: foo (200; 6.407018ms)
+Nov 29 08:02:40.004: INFO: (2) /api/v1/namespaces/e2e-tests-proxy-7lwtm/pods/proxy-service-n5sdh-r7dnw/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-7lwtm/pods/proxy-service-n5sdh-r7dnw/proxy/rewriteme"... (200; 6.312459ms)
+Nov 29 08:02:40.004: INFO: (2) /api/v1/namespaces/e2e-tests-proxy-7lwtm/pods/https:proxy-service-n5sdh-r7dnw:443/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-7lwtm/pods/https:proxy-service-n5sdh-r7dnw:443/proxy/... (200; 6.793839ms)
+Nov 29 08:02:40.004: INFO: (2) /api/v1/namespaces/e2e-tests-proxy-7lwtm/pods/proxy-service-n5sdh-r7dnw:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-7lwtm/pods/proxy-service-n5sdh-r7dnw:1080/proxy/rewri... (200; 6.768959ms)
+Nov 29 08:02:40.004: INFO: (2) /api/v1/namespaces/e2e-tests-proxy-7lwtm/pods/http:proxy-service-n5sdh-r7dnw:162/proxy/: bar (200; 6.823925ms)
+Nov 29 08:02:40.004: INFO: (2) /api/v1/namespaces/e2e-tests-proxy-7lwtm/pods/proxy-service-n5sdh-r7dnw:162/proxy/: bar (200; 6.971157ms)
+Nov 29 08:02:40.004: INFO: (2) /api/v1/namespaces/e2e-tests-proxy-7lwtm/pods/http:proxy-service-n5sdh-r7dnw:160/proxy/: foo (200; 6.902486ms)
+Nov 29 08:02:40.006: INFO: (2) /api/v1/namespaces/e2e-tests-proxy-7lwtm/services/proxy-service-n5sdh:portname2/proxy/: bar (200; 8.608817ms)
+Nov 29 08:02:40.006: INFO: (2) /api/v1/namespaces/e2e-tests-proxy-7lwtm/services/proxy-service-n5sdh:portname1/proxy/: foo (200; 8.540055ms)
+Nov 29 08:02:40.006: INFO: (2) /api/v1/namespaces/e2e-tests-proxy-7lwtm/services/https:proxy-service-n5sdh:tlsportname1/proxy/: tls baz (200; 8.444914ms)
+Nov 29 08:02:40.006: INFO: (2) /api/v1/namespaces/e2e-tests-proxy-7lwtm/services/http:proxy-service-n5sdh:portname1/proxy/: foo (200; 8.864319ms)
+Nov 29 08:02:40.006: INFO: (2) /api/v1/namespaces/e2e-tests-proxy-7lwtm/services/http:proxy-service-n5sdh:portname2/proxy/: bar (200; 8.806922ms)
+Nov 29 08:02:40.006: INFO: (2) /api/v1/namespaces/e2e-tests-proxy-7lwtm/services/https:proxy-service-n5sdh:tlsportname2/proxy/: tls qux (200; 8.911925ms)
+Nov 29 08:02:40.013: INFO: (3) /api/v1/namespaces/e2e-tests-proxy-7lwtm/pods/http:proxy-service-n5sdh-r7dnw:162/proxy/: bar (200; 5.917459ms)
+Nov 29 08:02:40.013: INFO: (3) /api/v1/namespaces/e2e-tests-proxy-7lwtm/pods/http:proxy-service-n5sdh-r7dnw:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-7lwtm/pods/http:proxy-service-n5sdh-r7dnw:1080/proxy/... (200; 6.559974ms)
+Nov 29 08:02:40.013: INFO: (3) /api/v1/namespaces/e2e-tests-proxy-7lwtm/pods/https:proxy-service-n5sdh-r7dnw:462/proxy/: tls qux (200; 6.149307ms)
+Nov 29 08:02:40.013: INFO: (3) /api/v1/namespaces/e2e-tests-proxy-7lwtm/pods/proxy-service-n5sdh-r7dnw:162/proxy/: bar (200; 6.355255ms)
+Nov 29 08:02:40.013: INFO: (3) /api/v1/namespaces/e2e-tests-proxy-7lwtm/pods/proxy-service-n5sdh-r7dnw:160/proxy/: foo (200; 6.703221ms)
+Nov 29 08:02:40.013: INFO: (3) /api/v1/namespaces/e2e-tests-proxy-7lwtm/pods/http:proxy-service-n5sdh-r7dnw:160/proxy/: foo (200; 6.389178ms)
+Nov 29 08:02:40.013: INFO: (3) /api/v1/namespaces/e2e-tests-proxy-7lwtm/pods/proxy-service-n5sdh-r7dnw/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-7lwtm/pods/proxy-service-n5sdh-r7dnw/proxy/rewriteme"... (200; 6.575471ms)
+Nov 29 08:02:40.013: INFO: (3) /api/v1/namespaces/e2e-tests-proxy-7lwtm/pods/https:proxy-service-n5sdh-r7dnw:443/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-7lwtm/pods/https:proxy-service-n5sdh-r7dnw:443/proxy/... (200; 6.729668ms)
+Nov 29 08:02:40.013: INFO: (3) /api/v1/namespaces/e2e-tests-proxy-7lwtm/pods/https:proxy-service-n5sdh-r7dnw:460/proxy/: tls baz (200; 6.944476ms)
+Nov 29 08:02:40.015: INFO: (3) /api/v1/namespaces/e2e-tests-proxy-7lwtm/services/https:proxy-service-n5sdh:tlsportname2/proxy/: tls qux (200; 8.503421ms)
+Nov 29 08:02:40.015: INFO: (3) /api/v1/namespaces/e2e-tests-proxy-7lwtm/services/proxy-service-n5sdh:portname1/proxy/: foo (200; 8.555434ms)
+Nov 29 08:02:40.015: INFO: (3) /api/v1/namespaces/e2e-tests-proxy-7lwtm/services/proxy-service-n5sdh:portname2/proxy/: bar (200; 8.742874ms)
+Nov 29 08:02:40.015: INFO: (3) /api/v1/namespaces/e2e-tests-proxy-7lwtm/pods/proxy-service-n5sdh-r7dnw:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-7lwtm/pods/proxy-service-n5sdh-r7dnw:1080/proxy/rewri... (200; 8.493412ms)
+Nov 29 08:02:40.015: INFO: (3) /api/v1/namespaces/e2e-tests-proxy-7lwtm/services/http:proxy-service-n5sdh:portname1/proxy/: foo (200; 8.469868ms)
+Nov 29 08:02:40.015: INFO: (3) /api/v1/namespaces/e2e-tests-proxy-7lwtm/services/http:proxy-service-n5sdh:portname2/proxy/: bar (200; 8.657678ms)
+Nov 29 08:02:40.016: INFO: (3) /api/v1/namespaces/e2e-tests-proxy-7lwtm/services/https:proxy-service-n5sdh:tlsportname1/proxy/: tls baz (200; 8.759264ms)
+Nov 29 08:02:40.020: INFO: (4) /api/v1/namespaces/e2e-tests-proxy-7lwtm/pods/http:proxy-service-n5sdh-r7dnw:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-7lwtm/pods/http:proxy-service-n5sdh-r7dnw:1080/proxy/... (200; 4.726363ms)
+Nov 29 08:02:40.021: INFO: (4) /api/v1/namespaces/e2e-tests-proxy-7lwtm/pods/proxy-service-n5sdh-r7dnw/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-7lwtm/pods/proxy-service-n5sdh-r7dnw/proxy/rewriteme"... (200; 5.302451ms)
+Nov 29 08:02:40.022: INFO: (4) /api/v1/namespaces/e2e-tests-proxy-7lwtm/pods/https:proxy-service-n5sdh-r7dnw:460/proxy/: tls baz (200; 5.891999ms)
+Nov 29 08:02:40.022: INFO: (4) /api/v1/namespaces/e2e-tests-proxy-7lwtm/pods/http:proxy-service-n5sdh-r7dnw:162/proxy/: bar (200; 5.680227ms)
+Nov 29 08:02:40.022: INFO: (4) /api/v1/namespaces/e2e-tests-proxy-7lwtm/pods/https:proxy-service-n5sdh-r7dnw:443/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-7lwtm/pods/https:proxy-service-n5sdh-r7dnw:443/proxy/... (200; 5.764781ms)
+Nov 29 08:02:40.022: INFO: (4) /api/v1/namespaces/e2e-tests-proxy-7lwtm/pods/proxy-service-n5sdh-r7dnw:162/proxy/: bar (200; 5.749072ms)
+Nov 29 08:02:40.022: INFO: (4) /api/v1/namespaces/e2e-tests-proxy-7lwtm/services/http:proxy-service-n5sdh:portname1/proxy/: foo (200; 6.389775ms)
+Nov 29 08:02:40.022: INFO: (4) /api/v1/namespaces/e2e-tests-proxy-7lwtm/pods/proxy-service-n5sdh-r7dnw:160/proxy/: foo (200; 6.33995ms)
+Nov 29 08:02:40.022: INFO: (4) /api/v1/namespaces/e2e-tests-proxy-7lwtm/services/proxy-service-n5sdh:portname2/proxy/: bar (200; 6.456645ms)
+Nov 29 08:02:40.022: INFO: (4) /api/v1/namespaces/e2e-tests-proxy-7lwtm/services/https:proxy-service-n5sdh:tlsportname2/proxy/: tls qux (200; 6.650675ms)
+Nov 29 08:02:40.024: INFO: (4) /api/v1/namespaces/e2e-tests-proxy-7lwtm/pods/proxy-service-n5sdh-r7dnw:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-7lwtm/pods/proxy-service-n5sdh-r7dnw:1080/proxy/rewri... (200; 7.451178ms)
+Nov 29 08:02:40.024: INFO: (4) /api/v1/namespaces/e2e-tests-proxy-7lwtm/pods/http:proxy-service-n5sdh-r7dnw:160/proxy/: foo (200; 7.697374ms)
+Nov 29 08:02:40.025: INFO: (4) /api/v1/namespaces/e2e-tests-proxy-7lwtm/services/https:proxy-service-n5sdh:tlsportname1/proxy/: tls baz (200; 8.97878ms)
+Nov 29 08:02:40.025: INFO: (4) /api/v1/namespaces/e2e-tests-proxy-7lwtm/pods/https:proxy-service-n5sdh-r7dnw:462/proxy/: tls qux (200; 9.121723ms)
+Nov 29 08:02:40.026: INFO: (4) /api/v1/namespaces/e2e-tests-proxy-7lwtm/services/http:proxy-service-n5sdh:portname2/proxy/: bar (200; 9.784058ms)
+Nov 29 08:02:40.026: INFO: (4) /api/v1/namespaces/e2e-tests-proxy-7lwtm/services/proxy-service-n5sdh:portname1/proxy/: foo (200; 9.745988ms)
+Nov 29 08:02:40.035: INFO: (5) /api/v1/namespaces/e2e-tests-proxy-7lwtm/pods/proxy-service-n5sdh-r7dnw/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-7lwtm/pods/proxy-service-n5sdh-r7dnw/proxy/rewriteme"... (200; 8.426047ms)
+Nov 29 08:02:40.035: INFO: (5) /api/v1/namespaces/e2e-tests-proxy-7lwtm/pods/http:proxy-service-n5sdh-r7dnw:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-7lwtm/pods/http:proxy-service-n5sdh-r7dnw:1080/proxy/... (200; 8.535231ms)
+Nov 29 08:02:40.035: INFO: (5) /api/v1/namespaces/e2e-tests-proxy-7lwtm/pods/https:proxy-service-n5sdh-r7dnw:462/proxy/: tls qux (200; 8.907827ms)
+Nov 29 08:02:40.035: INFO: (5) /api/v1/namespaces/e2e-tests-proxy-7lwtm/services/https:proxy-service-n5sdh:tlsportname1/proxy/: tls baz (200; 9.054796ms)
+Nov 29 08:02:40.036: INFO: (5) /api/v1/namespaces/e2e-tests-proxy-7lwtm/pods/proxy-service-n5sdh-r7dnw:162/proxy/: bar (200; 9.404265ms)
+Nov 29 08:02:40.036: INFO: (5) /api/v1/namespaces/e2e-tests-proxy-7lwtm/pods/http:proxy-service-n5sdh-r7dnw:160/proxy/: foo (200; 9.194259ms)
+Nov 29 08:02:40.036: INFO: (5) /api/v1/namespaces/e2e-tests-proxy-7lwtm/pods/https:proxy-service-n5sdh-r7dnw:460/proxy/: tls baz (200; 9.143923ms)
+Nov 29 08:02:40.036: INFO: (5) /api/v1/namespaces/e2e-tests-proxy-7lwtm/pods/proxy-service-n5sdh-r7dnw:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-7lwtm/pods/proxy-service-n5sdh-r7dnw:1080/proxy/rewri... (200; 9.383689ms)
+Nov 29 08:02:40.036: INFO: (5) /api/v1/namespaces/e2e-tests-proxy-7lwtm/pods/https:proxy-service-n5sdh-r7dnw:443/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-7lwtm/pods/https:proxy-service-n5sdh-r7dnw:443/proxy/... (200; 9.086012ms)
+Nov 29 08:02:40.036: INFO: (5) /api/v1/namespaces/e2e-tests-proxy-7lwtm/pods/http:proxy-service-n5sdh-r7dnw:162/proxy/: bar (200; 9.769203ms)
+Nov 29 08:02:40.036: INFO: (5) /api/v1/namespaces/e2e-tests-proxy-7lwtm/services/http:proxy-service-n5sdh:portname1/proxy/: foo (200; 9.493336ms)
+Nov 29 08:02:40.036: INFO: (5) /api/v1/namespaces/e2e-tests-proxy-7lwtm/services/https:proxy-service-n5sdh:tlsportname2/proxy/: tls qux (200; 9.466177ms)
+Nov 29 08:02:40.036: INFO: (5) /api/v1/namespaces/e2e-tests-proxy-7lwtm/services/proxy-service-n5sdh:portname1/proxy/: foo (200; 9.856586ms)
+Nov 29 08:02:40.036: INFO: (5) /api/v1/namespaces/e2e-tests-proxy-7lwtm/services/proxy-service-n5sdh:portname2/proxy/: bar (200; 9.367905ms)
+Nov 29 08:02:40.036: INFO: (5) /api/v1/namespaces/e2e-tests-proxy-7lwtm/services/http:proxy-service-n5sdh:portname2/proxy/: bar (200; 10.19209ms)
+Nov 29 08:02:40.036: INFO: (5) /api/v1/namespaces/e2e-tests-proxy-7lwtm/pods/proxy-service-n5sdh-r7dnw:160/proxy/: foo (200; 9.670063ms)
+Nov 29 08:02:40.041: INFO: (6) /api/v1/namespaces/e2e-tests-proxy-7lwtm/services/https:proxy-service-n5sdh:tlsportname2/proxy/: tls qux (200; 5.149353ms)
+Nov 29 08:02:40.042: INFO: (6) /api/v1/namespaces/e2e-tests-proxy-7lwtm/pods/http:proxy-service-n5sdh-r7dnw:160/proxy/: foo (200; 5.105606ms)
+Nov 29 08:02:40.043: INFO: (6) /api/v1/namespaces/e2e-tests-proxy-7lwtm/pods/https:proxy-service-n5sdh-r7dnw:443/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-7lwtm/pods/https:proxy-service-n5sdh-r7dnw:443/proxy/... (200; 5.948749ms)
+Nov 29 08:02:40.043: INFO: (6) /api/v1/namespaces/e2e-tests-proxy-7lwtm/pods/proxy-service-n5sdh-r7dnw:162/proxy/: bar (200; 6.079474ms)
+Nov 29 08:02:40.043: INFO: (6) /api/v1/namespaces/e2e-tests-proxy-7lwtm/pods/http:proxy-service-n5sdh-r7dnw:162/proxy/: bar (200; 6.3019ms)
+Nov 29 08:02:40.044: INFO: (6) /api/v1/namespaces/e2e-tests-proxy-7lwtm/pods/proxy-service-n5sdh-r7dnw:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-7lwtm/pods/proxy-service-n5sdh-r7dnw:1080/proxy/rewri... (200; 6.913006ms)
+Nov 29 08:02:40.044: INFO: (6) /api/v1/namespaces/e2e-tests-proxy-7lwtm/services/proxy-service-n5sdh:portname2/proxy/: bar (200; 7.35446ms)
+Nov 29 08:02:40.044: INFO: (6) /api/v1/namespaces/e2e-tests-proxy-7lwtm/services/proxy-service-n5sdh:portname1/proxy/: foo (200; 7.632035ms)
+Nov 29 08:02:40.044: INFO: (6) /api/v1/namespaces/e2e-tests-proxy-7lwtm/services/https:proxy-service-n5sdh:tlsportname1/proxy/: tls baz (200; 7.858828ms)
+Nov 29 08:02:40.044: INFO: (6) /api/v1/namespaces/e2e-tests-proxy-7lwtm/pods/https:proxy-service-n5sdh-r7dnw:462/proxy/: tls qux (200; 7.691386ms)
+Nov 29 08:02:40.045: INFO: (6) /api/v1/namespaces/e2e-tests-proxy-7lwtm/services/http:proxy-service-n5sdh:portname2/proxy/: bar (200; 7.871801ms)
+Nov 29 08:02:40.045: INFO: (6) /api/v1/namespaces/e2e-tests-proxy-7lwtm/services/http:proxy-service-n5sdh:portname1/proxy/: foo (200; 8.209127ms)
+Nov 29 08:02:40.046: INFO: (6) /api/v1/namespaces/e2e-tests-proxy-7lwtm/pods/http:proxy-service-n5sdh-r7dnw:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-7lwtm/pods/http:proxy-service-n5sdh-r7dnw:1080/proxy/... (200; 9.613526ms)
+Nov 29 08:02:40.046: INFO: (6) /api/v1/namespaces/e2e-tests-proxy-7lwtm/pods/proxy-service-n5sdh-r7dnw:160/proxy/: foo (200; 9.703202ms)
+Nov 29 08:02:40.046: INFO: (6) /api/v1/namespaces/e2e-tests-proxy-7lwtm/pods/https:proxy-service-n5sdh-r7dnw:460/proxy/: tls baz (200; 9.887079ms)
+Nov 29 08:02:40.046: INFO: (6) /api/v1/namespaces/e2e-tests-proxy-7lwtm/pods/proxy-service-n5sdh-r7dnw/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-7lwtm/pods/proxy-service-n5sdh-r7dnw/proxy/rewriteme"... (200; 9.966501ms)
+Nov 29 08:02:40.051: INFO: (7) /api/v1/namespaces/e2e-tests-proxy-7lwtm/pods/https:proxy-service-n5sdh-r7dnw:462/proxy/: tls qux (200; 3.728263ms)
+Nov 29 08:02:40.051: INFO: (7) /api/v1/namespaces/e2e-tests-proxy-7lwtm/pods/http:proxy-service-n5sdh-r7dnw:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-7lwtm/pods/http:proxy-service-n5sdh-r7dnw:1080/proxy/... (200; 3.973162ms)
+Nov 29 08:02:40.051: INFO: (7) /api/v1/namespaces/e2e-tests-proxy-7lwtm/pods/https:proxy-service-n5sdh-r7dnw:460/proxy/: tls baz (200; 4.306821ms)
+Nov 29 08:02:40.052: INFO: (7) /api/v1/namespaces/e2e-tests-proxy-7lwtm/services/proxy-service-n5sdh:portname2/proxy/: bar (200; 4.85745ms)
+Nov 29 08:02:40.052: INFO: (7) /api/v1/namespaces/e2e-tests-proxy-7lwtm/pods/proxy-service-n5sdh-r7dnw:160/proxy/: foo (200; 5.015114ms)
+Nov 29 08:02:40.052: INFO: (7) /api/v1/namespaces/e2e-tests-proxy-7lwtm/services/http:proxy-service-n5sdh:portname1/proxy/: foo (200; 5.343464ms)
+Nov 29 08:02:40.052: INFO: (7) /api/v1/namespaces/e2e-tests-proxy-7lwtm/pods/proxy-service-n5sdh-r7dnw/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-7lwtm/pods/proxy-service-n5sdh-r7dnw/proxy/rewriteme"... (200; 5.327361ms)
+Nov 29 08:02:40.053: INFO: (7) /api/v1/namespaces/e2e-tests-proxy-7lwtm/pods/https:proxy-service-n5sdh-r7dnw:443/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-7lwtm/pods/https:proxy-service-n5sdh-r7dnw:443/proxy/... (200; 5.471278ms)
+Nov 29 08:02:40.055: INFO: (7) /api/v1/namespaces/e2e-tests-proxy-7lwtm/services/https:proxy-service-n5sdh:tlsportname2/proxy/: tls qux (200; 8.088007ms)
+Nov 29 08:02:40.055: INFO: (7) /api/v1/namespaces/e2e-tests-proxy-7lwtm/pods/proxy-service-n5sdh-r7dnw:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-7lwtm/pods/proxy-service-n5sdh-r7dnw:1080/proxy/rewri... (200; 8.477967ms)
+Nov 29 08:02:40.056: INFO: (7) /api/v1/namespaces/e2e-tests-proxy-7lwtm/services/https:proxy-service-n5sdh:tlsportname1/proxy/: tls baz (200; 8.833703ms)
+Nov 29 08:02:40.056: INFO: (7) /api/v1/namespaces/e2e-tests-proxy-7lwtm/pods/http:proxy-service-n5sdh-r7dnw:162/proxy/: bar (200; 9.025379ms)
+Nov 29 08:02:40.056: INFO: (7) /api/v1/namespaces/e2e-tests-proxy-7lwtm/services/proxy-service-n5sdh:portname1/proxy/: foo (200; 8.846884ms)
+Nov 29 08:02:40.056: INFO: (7) /api/v1/namespaces/e2e-tests-proxy-7lwtm/pods/http:proxy-service-n5sdh-r7dnw:160/proxy/: foo (200; 9.162287ms)
+Nov 29 08:02:40.056: INFO: (7) /api/v1/namespaces/e2e-tests-proxy-7lwtm/pods/proxy-service-n5sdh-r7dnw:162/proxy/: bar (200; 9.356826ms)
+Nov 29 08:02:40.056: INFO: (7) /api/v1/namespaces/e2e-tests-proxy-7lwtm/services/http:proxy-service-n5sdh:portname2/proxy/: bar (200; 9.389014ms)
+Nov 29 08:02:40.061: INFO: (8) /api/v1/namespaces/e2e-tests-proxy-7lwtm/pods/http:proxy-service-n5sdh-r7dnw:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-7lwtm/pods/http:proxy-service-n5sdh-r7dnw:1080/proxy/... (200; 5.175879ms)
+Nov 29 08:02:40.062: INFO: (8) /api/v1/namespaces/e2e-tests-proxy-7lwtm/services/proxy-service-n5sdh:portname2/proxy/: bar (200; 5.54403ms)
+Nov 29 08:02:40.063: INFO: (8) /api/v1/namespaces/e2e-tests-proxy-7lwtm/pods/proxy-service-n5sdh-r7dnw:162/proxy/: bar (200; 6.439385ms)
+Nov 29 08:02:40.064: INFO: (8) /api/v1/namespaces/e2e-tests-proxy-7lwtm/pods/http:proxy-service-n5sdh-r7dnw:160/proxy/: foo (200; 6.980896ms)
+Nov 29 08:02:40.064: INFO: (8) /api/v1/namespaces/e2e-tests-proxy-7lwtm/services/https:proxy-service-n5sdh:tlsportname1/proxy/: tls baz (200; 7.651052ms)
+Nov 29 08:02:40.065: INFO: (8) /api/v1/namespaces/e2e-tests-proxy-7lwtm/services/https:proxy-service-n5sdh:tlsportname2/proxy/: tls qux (200; 8.280712ms)
+Nov 29 08:02:40.065: INFO: (8) /api/v1/namespaces/e2e-tests-proxy-7lwtm/pods/https:proxy-service-n5sdh-r7dnw:462/proxy/: tls qux (200; 7.821145ms)
+Nov 29 08:02:40.065: INFO: (8) /api/v1/namespaces/e2e-tests-proxy-7lwtm/services/http:proxy-service-n5sdh:portname2/proxy/: bar (200; 8.38434ms)
+Nov 29 08:02:40.065: INFO: (8) /api/v1/namespaces/e2e-tests-proxy-7lwtm/services/proxy-service-n5sdh:portname1/proxy/: foo (200; 8.616ms)
+Nov 29 08:02:40.065: INFO: (8) /api/v1/namespaces/e2e-tests-proxy-7lwtm/pods/https:proxy-service-n5sdh-r7dnw:443/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-7lwtm/pods/https:proxy-service-n5sdh-r7dnw:443/proxy/... (200; 8.947923ms)
+Nov 29 08:02:40.065: INFO: (8) /api/v1/namespaces/e2e-tests-proxy-7lwtm/pods/https:proxy-service-n5sdh-r7dnw:460/proxy/: tls baz (200; 8.78514ms)
+Nov 29 08:02:40.065: INFO: (8) /api/v1/namespaces/e2e-tests-proxy-7lwtm/pods/proxy-service-n5sdh-r7dnw/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-7lwtm/pods/proxy-service-n5sdh-r7dnw/proxy/rewriteme"... (200; 9.122019ms)
+Nov 29 08:02:40.065: INFO: (8) /api/v1/namespaces/e2e-tests-proxy-7lwtm/pods/proxy-service-n5sdh-r7dnw:160/proxy/: foo (200; 9.038773ms)
+Nov 29 08:02:40.066: INFO: (8) /api/v1/namespaces/e2e-tests-proxy-7lwtm/pods/proxy-service-n5sdh-r7dnw:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-7lwtm/pods/proxy-service-n5sdh-r7dnw:1080/proxy/rewri... (200; 8.948931ms)
+Nov 29 08:02:40.066: INFO: (8) /api/v1/namespaces/e2e-tests-proxy-7lwtm/pods/http:proxy-service-n5sdh-r7dnw:162/proxy/: bar (200; 9.053157ms)
+Nov 29 08:02:40.066: INFO: (8) /api/v1/namespaces/e2e-tests-proxy-7lwtm/services/http:proxy-service-n5sdh:portname1/proxy/: foo (200; 8.989983ms)
+Nov 29 08:02:40.069: INFO: (9) /api/v1/namespaces/e2e-tests-proxy-7lwtm/pods/proxy-service-n5sdh-r7dnw:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-7lwtm/pods/proxy-service-n5sdh-r7dnw:1080/proxy/rewri... (200; 3.271642ms)
+Nov 29 08:02:40.069: INFO: (9) /api/v1/namespaces/e2e-tests-proxy-7lwtm/pods/proxy-service-n5sdh-r7dnw:160/proxy/: foo (200; 3.198583ms)
+Nov 29 08:02:40.070: INFO: (9) /api/v1/namespaces/e2e-tests-proxy-7lwtm/pods/http:proxy-service-n5sdh-r7dnw:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-7lwtm/pods/http:proxy-service-n5sdh-r7dnw:1080/proxy/... (200; 3.763931ms)
+Nov 29 08:02:40.070: INFO: (9) /api/v1/namespaces/e2e-tests-proxy-7lwtm/pods/https:proxy-service-n5sdh-r7dnw:460/proxy/: tls baz (200; 3.952673ms)
+Nov 29 08:02:40.070: INFO: (9) /api/v1/namespaces/e2e-tests-proxy-7lwtm/pods/https:proxy-service-n5sdh-r7dnw:443/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-7lwtm/pods/https:proxy-service-n5sdh-r7dnw:443/proxy/... (200; 4.226867ms)
+Nov 29 08:02:40.070: INFO: (9) /api/v1/namespaces/e2e-tests-proxy-7lwtm/services/http:proxy-service-n5sdh:portname1/proxy/: foo (200; 4.433806ms)
+Nov 29 08:02:40.074: INFO: (9) /api/v1/namespaces/e2e-tests-proxy-7lwtm/services/proxy-service-n5sdh:portname2/proxy/: bar (200; 7.768318ms)
+Nov 29 08:02:40.075: INFO: (9) /api/v1/namespaces/e2e-tests-proxy-7lwtm/pods/http:proxy-service-n5sdh-r7dnw:160/proxy/: foo (200; 8.389048ms)
+Nov 29 08:02:40.075: INFO: (9) /api/v1/namespaces/e2e-tests-proxy-7lwtm/pods/proxy-service-n5sdh-r7dnw/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-7lwtm/pods/proxy-service-n5sdh-r7dnw/proxy/rewriteme"... (200; 8.573042ms)
+Nov 29 08:02:40.075: INFO: (9) /api/v1/namespaces/e2e-tests-proxy-7lwtm/pods/http:proxy-service-n5sdh-r7dnw:162/proxy/: bar (200; 8.499289ms)
+Nov 29 08:02:40.075: INFO: (9) /api/v1/namespaces/e2e-tests-proxy-7lwtm/pods/https:proxy-service-n5sdh-r7dnw:462/proxy/: tls qux (200; 8.59551ms)
+Nov 29 08:02:40.075: INFO: (9) /api/v1/namespaces/e2e-tests-proxy-7lwtm/pods/proxy-service-n5sdh-r7dnw:162/proxy/: bar (200; 9.13885ms)
+Nov 29 08:02:40.076: INFO: (9) /api/v1/namespaces/e2e-tests-proxy-7lwtm/services/http:proxy-service-n5sdh:portname2/proxy/: bar (200; 9.158923ms)
+Nov 29 08:02:40.076: INFO: (9) /api/v1/namespaces/e2e-tests-proxy-7lwtm/services/https:proxy-service-n5sdh:tlsportname2/proxy/: tls qux (200; 9.451712ms)
+Nov 29 08:02:40.076: INFO: (9) /api/v1/namespaces/e2e-tests-proxy-7lwtm/services/proxy-service-n5sdh:portname1/proxy/: foo (200; 9.426649ms)
+Nov 29 08:02:40.076: INFO: (9) /api/v1/namespaces/e2e-tests-proxy-7lwtm/services/https:proxy-service-n5sdh:tlsportname1/proxy/: tls baz (200; 9.26157ms)
+Nov 29 08:02:40.079: INFO: (10) /api/v1/namespaces/e2e-tests-proxy-7lwtm/pods/proxy-service-n5sdh-r7dnw:162/proxy/: bar (200; 3.179269ms)
+Nov 29 08:02:40.079: INFO: (10) /api/v1/namespaces/e2e-tests-proxy-7lwtm/pods/proxy-service-n5sdh-r7dnw:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-7lwtm/pods/proxy-service-n5sdh-r7dnw:1080/proxy/rewri... (200; 3.245681ms)
+Nov 29 08:02:40.079: INFO: (10) /api/v1/namespaces/e2e-tests-proxy-7lwtm/pods/http:proxy-service-n5sdh-r7dnw:162/proxy/: bar (200; 3.426758ms)
+Nov 29 08:02:40.079: INFO: (10) /api/v1/namespaces/e2e-tests-proxy-7lwtm/pods/https:proxy-service-n5sdh-r7dnw:460/proxy/: tls baz (200; 3.428032ms)
+Nov 29 08:02:40.084: INFO: (10) /api/v1/namespaces/e2e-tests-proxy-7lwtm/services/http:proxy-service-n5sdh:portname1/proxy/: foo (200; 7.735645ms)
+Nov 29 08:02:40.084: INFO: (10) /api/v1/namespaces/e2e-tests-proxy-7lwtm/services/https:proxy-service-n5sdh:tlsportname2/proxy/: tls qux (200; 8.180989ms)
+Nov 29 08:02:40.084: INFO: (10) /api/v1/namespaces/e2e-tests-proxy-7lwtm/pods/http:proxy-service-n5sdh-r7dnw:160/proxy/: foo (200; 8.039299ms)
+Nov 29 08:02:40.084: INFO: (10) /api/v1/namespaces/e2e-tests-proxy-7lwtm/pods/https:proxy-service-n5sdh-r7dnw:443/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-7lwtm/pods/https:proxy-service-n5sdh-r7dnw:443/proxy/... (200; 8.140961ms)
+Nov 29 08:02:40.084: INFO: (10) /api/v1/namespaces/e2e-tests-proxy-7lwtm/services/http:proxy-service-n5sdh:portname2/proxy/: bar (200; 8.153485ms)
+Nov 29 08:02:40.085: INFO: (10) /api/v1/namespaces/e2e-tests-proxy-7lwtm/services/proxy-service-n5sdh:portname1/proxy/: foo (200; 8.712428ms)
+Nov 29 08:02:40.085: INFO: (10) /api/v1/namespaces/e2e-tests-proxy-7lwtm/pods/http:proxy-service-n5sdh-r7dnw:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-7lwtm/pods/http:proxy-service-n5sdh-r7dnw:1080/proxy/... (200; 8.525946ms)
+Nov 29 08:02:40.085: INFO: (10) /api/v1/namespaces/e2e-tests-proxy-7lwtm/services/proxy-service-n5sdh:portname2/proxy/: bar (200; 8.812958ms)
+Nov 29 08:02:40.085: INFO: (10) /api/v1/namespaces/e2e-tests-proxy-7lwtm/pods/proxy-service-n5sdh-r7dnw/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-7lwtm/pods/proxy-service-n5sdh-r7dnw/proxy/rewriteme"... (200; 9.147839ms)
+Nov 29 08:02:40.085: INFO: (10) /api/v1/namespaces/e2e-tests-proxy-7lwtm/pods/https:proxy-service-n5sdh-r7dnw:462/proxy/: tls qux (200; 9.098761ms)
+Nov 29 08:02:40.085: INFO: (10) /api/v1/namespaces/e2e-tests-proxy-7lwtm/pods/proxy-service-n5sdh-r7dnw:160/proxy/: foo (200; 9.249493ms)
+Nov 29 08:02:40.086: INFO: (10) /api/v1/namespaces/e2e-tests-proxy-7lwtm/services/https:proxy-service-n5sdh:tlsportname1/proxy/: tls baz (200; 9.613444ms)
+Nov 29 08:02:40.093: INFO: (11) /api/v1/namespaces/e2e-tests-proxy-7lwtm/pods/http:proxy-service-n5sdh-r7dnw:162/proxy/: bar (200; 7.199795ms)
+Nov 29 08:02:40.094: INFO: (11) /api/v1/namespaces/e2e-tests-proxy-7lwtm/pods/https:proxy-service-n5sdh-r7dnw:462/proxy/: tls qux (200; 7.639417ms)
+Nov 29 08:02:40.094: INFO: (11) /api/v1/namespaces/e2e-tests-proxy-7lwtm/pods/https:proxy-service-n5sdh-r7dnw:443/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-7lwtm/pods/https:proxy-service-n5sdh-r7dnw:443/proxy/... (200; 8.014323ms)
+Nov 29 08:02:40.094: INFO: (11) /api/v1/namespaces/e2e-tests-proxy-7lwtm/pods/http:proxy-service-n5sdh-r7dnw:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-7lwtm/pods/http:proxy-service-n5sdh-r7dnw:1080/proxy/... (200; 8.181955ms)
+Nov 29 08:02:40.095: INFO: (11) /api/v1/namespaces/e2e-tests-proxy-7lwtm/pods/proxy-service-n5sdh-r7dnw:160/proxy/: foo (200; 8.253049ms)
+Nov 29 08:02:40.095: INFO: (11) /api/v1/namespaces/e2e-tests-proxy-7lwtm/services/http:proxy-service-n5sdh:portname2/proxy/: bar (200; 8.491973ms)
+Nov 29 08:02:40.096: INFO: (11) /api/v1/namespaces/e2e-tests-proxy-7lwtm/services/https:proxy-service-n5sdh:tlsportname2/proxy/: tls qux (200; 9.420864ms)
+Nov 29 08:02:40.096: INFO: (11) /api/v1/namespaces/e2e-tests-proxy-7lwtm/services/https:proxy-service-n5sdh:tlsportname1/proxy/: tls baz (200; 9.477212ms)
+Nov 29 08:02:40.096: INFO: (11) /api/v1/namespaces/e2e-tests-proxy-7lwtm/pods/https:proxy-service-n5sdh-r7dnw:460/proxy/: tls baz (200; 9.271294ms)
+Nov 29 08:02:40.096: INFO: (11) /api/v1/namespaces/e2e-tests-proxy-7lwtm/pods/proxy-service-n5sdh-r7dnw:162/proxy/: bar (200; 9.445596ms)
+Nov 29 08:02:40.096: INFO: (11) /api/v1/namespaces/e2e-tests-proxy-7lwtm/pods/proxy-service-n5sdh-r7dnw:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-7lwtm/pods/proxy-service-n5sdh-r7dnw:1080/proxy/rewri... (200; 9.488721ms)
+Nov 29 08:02:40.096: INFO: (11) /api/v1/namespaces/e2e-tests-proxy-7lwtm/pods/http:proxy-service-n5sdh-r7dnw:160/proxy/: foo (200; 9.6369ms)
+Nov 29 08:02:40.096: INFO: (11) /api/v1/namespaces/e2e-tests-proxy-7lwtm/pods/proxy-service-n5sdh-r7dnw/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-7lwtm/pods/proxy-service-n5sdh-r7dnw/proxy/rewriteme"... (200; 9.889245ms)
+Nov 29 08:02:40.096: INFO: (11) /api/v1/namespaces/e2e-tests-proxy-7lwtm/services/proxy-service-n5sdh:portname2/proxy/: bar (200; 10.116376ms)
+Nov 29 08:02:40.096: INFO: (11) /api/v1/namespaces/e2e-tests-proxy-7lwtm/services/http:proxy-service-n5sdh:portname1/proxy/: foo (200; 9.732308ms)
+Nov 29 08:02:40.096: INFO: (11) /api/v1/namespaces/e2e-tests-proxy-7lwtm/services/proxy-service-n5sdh:portname1/proxy/: foo (200; 9.997355ms)
+Nov 29 08:02:40.099: INFO: (12) /api/v1/namespaces/e2e-tests-proxy-7lwtm/pods/proxy-service-n5sdh-r7dnw:162/proxy/: bar (200; 2.165111ms)
+Nov 29 08:02:40.099: INFO: (12) /api/v1/namespaces/e2e-tests-proxy-7lwtm/pods/https:proxy-service-n5sdh-r7dnw:460/proxy/: tls baz (200; 2.468246ms)
+Nov 29 08:02:40.099: INFO: (12) /api/v1/namespaces/e2e-tests-proxy-7lwtm/pods/http:proxy-service-n5sdh-r7dnw:162/proxy/: bar (200; 2.481859ms)
+Nov 29 08:02:40.103: INFO: (12) /api/v1/namespaces/e2e-tests-proxy-7lwtm/pods/proxy-service-n5sdh-r7dnw:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-7lwtm/pods/proxy-service-n5sdh-r7dnw:1080/proxy/rewri... (200; 6.024998ms)
+Nov 29 08:02:40.103: INFO: (12) /api/v1/namespaces/e2e-tests-proxy-7lwtm/pods/https:proxy-service-n5sdh-r7dnw:462/proxy/: tls qux (200; 5.968568ms)
+Nov 29 08:02:40.103: INFO: (12) /api/v1/namespaces/e2e-tests-proxy-7lwtm/pods/https:proxy-service-n5sdh-r7dnw:443/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-7lwtm/pods/https:proxy-service-n5sdh-r7dnw:443/proxy/... (200; 6.234629ms)
+Nov 29 08:02:40.103: INFO: (12) /api/v1/namespaces/e2e-tests-proxy-7lwtm/pods/proxy-service-n5sdh-r7dnw:160/proxy/: foo (200; 6.336698ms)
+Nov 29 08:02:40.103: INFO: (12) /api/v1/namespaces/e2e-tests-proxy-7lwtm/services/proxy-service-n5sdh:portname2/proxy/: bar (200; 6.572538ms)
+Nov 29 08:02:40.103: INFO: (12) /api/v1/namespaces/e2e-tests-proxy-7lwtm/pods/proxy-service-n5sdh-r7dnw/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-7lwtm/pods/proxy-service-n5sdh-r7dnw/proxy/rewriteme"... (200; 6.509906ms)
+Nov 29 08:02:40.103: INFO: (12) /api/v1/namespaces/e2e-tests-proxy-7lwtm/pods/http:proxy-service-n5sdh-r7dnw:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-7lwtm/pods/http:proxy-service-n5sdh-r7dnw:1080/proxy/... (200; 6.531995ms)
+Nov 29 08:02:40.104: INFO: (12) /api/v1/namespaces/e2e-tests-proxy-7lwtm/pods/http:proxy-service-n5sdh-r7dnw:160/proxy/: foo (200; 7.166809ms)
+Nov 29 08:02:40.105: INFO: (12) /api/v1/namespaces/e2e-tests-proxy-7lwtm/services/https:proxy-service-n5sdh:tlsportname1/proxy/: tls baz (200; 7.883107ms)
+Nov 29 08:02:40.105: INFO: (12) /api/v1/namespaces/e2e-tests-proxy-7lwtm/services/https:proxy-service-n5sdh:tlsportname2/proxy/: tls qux (200; 8.904429ms)
+Nov 29 08:02:40.105: INFO: (12) /api/v1/namespaces/e2e-tests-proxy-7lwtm/services/http:proxy-service-n5sdh:portname2/proxy/: bar (200; 8.895549ms)
+Nov 29 08:02:40.106: INFO: (12) /api/v1/namespaces/e2e-tests-proxy-7lwtm/services/proxy-service-n5sdh:portname1/proxy/: foo (200; 8.757075ms)
+Nov 29 08:02:40.106: INFO: (12) /api/v1/namespaces/e2e-tests-proxy-7lwtm/services/http:proxy-service-n5sdh:portname1/proxy/: foo (200; 8.790911ms)
+Nov 29 08:02:40.111: INFO: (13) /api/v1/namespaces/e2e-tests-proxy-7lwtm/pods/proxy-service-n5sdh-r7dnw/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-7lwtm/pods/proxy-service-n5sdh-r7dnw/proxy/rewriteme"... (200; 5.314088ms)
+Nov 29 08:02:40.112: INFO: (13) /api/v1/namespaces/e2e-tests-proxy-7lwtm/pods/proxy-service-n5sdh-r7dnw:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-7lwtm/pods/proxy-service-n5sdh-r7dnw:1080/proxy/rewri... (200; 5.23538ms)
+Nov 29 08:02:40.112: INFO: (13) /api/v1/namespaces/e2e-tests-proxy-7lwtm/pods/https:proxy-service-n5sdh-r7dnw:462/proxy/: tls qux (200; 5.497089ms)
+Nov 29 08:02:40.112: INFO: (13) /api/v1/namespaces/e2e-tests-proxy-7lwtm/pods/http:proxy-service-n5sdh-r7dnw:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-7lwtm/pods/http:proxy-service-n5sdh-r7dnw:1080/proxy/... (200; 6.030201ms)
+Nov 29 08:02:40.112: INFO: (13) /api/v1/namespaces/e2e-tests-proxy-7lwtm/pods/http:proxy-service-n5sdh-r7dnw:162/proxy/: bar (200; 5.690187ms)
+Nov 29 08:02:40.114: INFO: (13) /api/v1/namespaces/e2e-tests-proxy-7lwtm/pods/https:proxy-service-n5sdh-r7dnw:443/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-7lwtm/pods/https:proxy-service-n5sdh-r7dnw:443/proxy/... (200; 8.020828ms)
+Nov 29 08:02:40.114: INFO: (13) /api/v1/namespaces/e2e-tests-proxy-7lwtm/pods/proxy-service-n5sdh-r7dnw:160/proxy/: foo (200; 8.234649ms)
+Nov 29 08:02:40.114: INFO: (13) /api/v1/namespaces/e2e-tests-proxy-7lwtm/pods/proxy-service-n5sdh-r7dnw:162/proxy/: bar (200; 8.371803ms)
+Nov 29 08:02:40.114: INFO: (13) /api/v1/namespaces/e2e-tests-proxy-7lwtm/services/proxy-service-n5sdh:portname2/proxy/: bar (200; 8.17456ms)
+Nov 29 08:02:40.114: INFO: (13) /api/v1/namespaces/e2e-tests-proxy-7lwtm/services/https:proxy-service-n5sdh:tlsportname2/proxy/: tls qux (200; 8.144683ms)
+Nov 29 08:02:40.114: INFO: (13) /api/v1/namespaces/e2e-tests-proxy-7lwtm/services/http:proxy-service-n5sdh:portname1/proxy/: foo (200; 7.768123ms)
+Nov 29 08:02:40.114: INFO: (13) /api/v1/namespaces/e2e-tests-proxy-7lwtm/pods/http:proxy-service-n5sdh-r7dnw:160/proxy/: foo (200; 7.959679ms)
+Nov 29 08:02:40.114: INFO: (13) /api/v1/namespaces/e2e-tests-proxy-7lwtm/services/https:proxy-service-n5sdh:tlsportname1/proxy/: tls baz (200; 7.838777ms)
+Nov 29 08:02:40.114: INFO: (13) /api/v1/namespaces/e2e-tests-proxy-7lwtm/pods/https:proxy-service-n5sdh-r7dnw:460/proxy/: tls baz (200; 7.764499ms)
+Nov 29 08:02:40.114: INFO: (13) /api/v1/namespaces/e2e-tests-proxy-7lwtm/services/http:proxy-service-n5sdh:portname2/proxy/: bar (200; 8.090525ms)
+Nov 29 08:02:40.114: INFO: (13) /api/v1/namespaces/e2e-tests-proxy-7lwtm/services/proxy-service-n5sdh:portname1/proxy/: foo (200; 8.140841ms)
+Nov 29 08:02:40.116: INFO: (14) /api/v1/namespaces/e2e-tests-proxy-7lwtm/pods/https:proxy-service-n5sdh-r7dnw:443/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-7lwtm/pods/https:proxy-service-n5sdh-r7dnw:443/proxy/... (200; 1.691009ms)
+Nov 29 08:02:40.120: INFO: (14) /api/v1/namespaces/e2e-tests-proxy-7lwtm/services/proxy-service-n5sdh:portname1/proxy/: foo (200; 5.533119ms)
+Nov 29 08:02:40.120: INFO: (14) /api/v1/namespaces/e2e-tests-proxy-7lwtm/pods/proxy-service-n5sdh-r7dnw:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-7lwtm/pods/proxy-service-n5sdh-r7dnw:1080/proxy/rewri... (200; 5.497433ms)
+Nov 29 08:02:40.122: INFO: (14) /api/v1/namespaces/e2e-tests-proxy-7lwtm/pods/http:proxy-service-n5sdh-r7dnw:160/proxy/: foo (200; 7.69728ms)
+Nov 29 08:02:40.122: INFO: (14) /api/v1/namespaces/e2e-tests-proxy-7lwtm/services/http:proxy-service-n5sdh:portname1/proxy/: foo (200; 7.803583ms)
+Nov 29 08:02:40.123: INFO: (14) /api/v1/namespaces/e2e-tests-proxy-7lwtm/pods/https:proxy-service-n5sdh-r7dnw:462/proxy/: tls qux (200; 8.693845ms)
+Nov 29 08:02:40.123: INFO: (14) /api/v1/namespaces/e2e-tests-proxy-7lwtm/pods/proxy-service-n5sdh-r7dnw/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-7lwtm/pods/proxy-service-n5sdh-r7dnw/proxy/rewriteme"... (200; 8.485908ms)
+Nov 29 08:02:40.123: INFO: (14) /api/v1/namespaces/e2e-tests-proxy-7lwtm/pods/http:proxy-service-n5sdh-r7dnw:162/proxy/: bar (200; 8.911795ms)
+Nov 29 08:02:40.123: INFO: (14) /api/v1/namespaces/e2e-tests-proxy-7lwtm/pods/proxy-service-n5sdh-r7dnw:162/proxy/: bar (200; 9.015406ms)
+Nov 29 08:02:40.124: INFO: (14) /api/v1/namespaces/e2e-tests-proxy-7lwtm/services/http:proxy-service-n5sdh:portname2/proxy/: bar (200; 9.221142ms)
+Nov 29 08:02:40.124: INFO: (14) /api/v1/namespaces/e2e-tests-proxy-7lwtm/pods/https:proxy-service-n5sdh-r7dnw:460/proxy/: tls baz (200; 9.004231ms)
+Nov 29 08:02:40.124: INFO: (14) /api/v1/namespaces/e2e-tests-proxy-7lwtm/services/https:proxy-service-n5sdh:tlsportname1/proxy/: tls baz (200; 9.600565ms)
+Nov 29 08:02:40.124: INFO: (14) /api/v1/namespaces/e2e-tests-proxy-7lwtm/pods/proxy-service-n5sdh-r7dnw:160/proxy/: foo (200; 9.25412ms)
+Nov 29 08:02:40.124: INFO: (14) /api/v1/namespaces/e2e-tests-proxy-7lwtm/pods/http:proxy-service-n5sdh-r7dnw:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-7lwtm/pods/http:proxy-service-n5sdh-r7dnw:1080/proxy/... (200; 9.57901ms)
+Nov 29 08:02:40.125: INFO: (14) /api/v1/namespaces/e2e-tests-proxy-7lwtm/services/proxy-service-n5sdh:portname2/proxy/: bar (200; 9.855257ms)
+Nov 29 08:02:40.125: INFO: (14) /api/v1/namespaces/e2e-tests-proxy-7lwtm/services/https:proxy-service-n5sdh:tlsportname2/proxy/: tls qux (200; 9.911412ms)
+Nov 29 08:02:40.129: INFO: (15) /api/v1/namespaces/e2e-tests-proxy-7lwtm/pods/http:proxy-service-n5sdh-r7dnw:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-7lwtm/pods/http:proxy-service-n5sdh-r7dnw:1080/proxy/... (200; 4.3341ms)
+Nov 29 08:02:40.129: INFO: (15) /api/v1/namespaces/e2e-tests-proxy-7lwtm/pods/https:proxy-service-n5sdh-r7dnw:460/proxy/: tls baz (200; 4.58182ms)
+Nov 29 08:02:40.129: INFO: (15) /api/v1/namespaces/e2e-tests-proxy-7lwtm/pods/proxy-service-n5sdh-r7dnw:160/proxy/: foo (200; 4.583396ms)
+Nov 29 08:02:40.129: INFO: (15) /api/v1/namespaces/e2e-tests-proxy-7lwtm/pods/proxy-service-n5sdh-r7dnw/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-7lwtm/pods/proxy-service-n5sdh-r7dnw/proxy/rewriteme"... (200; 4.509679ms)
+Nov 29 08:02:40.130: INFO: (15) /api/v1/namespaces/e2e-tests-proxy-7lwtm/pods/https:proxy-service-n5sdh-r7dnw:443/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-7lwtm/pods/https:proxy-service-n5sdh-r7dnw:443/proxy/... (200; 4.765895ms)
+Nov 29 08:02:40.137: INFO: (15) /api/v1/namespaces/e2e-tests-proxy-7lwtm/services/http:proxy-service-n5sdh:portname2/proxy/: bar (200; 12.208709ms)
+Nov 29 08:02:40.140: INFO: (15) /api/v1/namespaces/e2e-tests-proxy-7lwtm/services/https:proxy-service-n5sdh:tlsportname2/proxy/: tls qux (200; 15.170374ms)
+Nov 29 08:02:40.140: INFO: (15) /api/v1/namespaces/e2e-tests-proxy-7lwtm/services/proxy-service-n5sdh:portname2/proxy/: bar (200; 15.319312ms)
+Nov 29 08:02:40.141: INFO: (15) /api/v1/namespaces/e2e-tests-proxy-7lwtm/pods/https:proxy-service-n5sdh-r7dnw:462/proxy/: tls qux (200; 15.586015ms)
+Nov 29 08:02:40.141: INFO: (15) /api/v1/namespaces/e2e-tests-proxy-7lwtm/pods/http:proxy-service-n5sdh-r7dnw:160/proxy/: foo (200; 15.755423ms)
+Nov 29 08:02:40.141: INFO: (15) /api/v1/namespaces/e2e-tests-proxy-7lwtm/pods/http:proxy-service-n5sdh-r7dnw:162/proxy/: bar (200; 15.89505ms)
+Nov 29 08:02:40.141: INFO: (15) /api/v1/namespaces/e2e-tests-proxy-7lwtm/pods/proxy-service-n5sdh-r7dnw:162/proxy/: bar (200; 16.05657ms)
+Nov 29 08:02:40.141: INFO: (15) /api/v1/namespaces/e2e-tests-proxy-7lwtm/services/proxy-service-n5sdh:portname1/proxy/: foo (200; 16.417505ms)
+Nov 29 08:02:40.142: INFO: (15) /api/v1/namespaces/e2e-tests-proxy-7lwtm/pods/proxy-service-n5sdh-r7dnw:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-7lwtm/pods/proxy-service-n5sdh-r7dnw:1080/proxy/rewri... (200; 16.343702ms)
+Nov 29 08:02:40.146: INFO: (15) /api/v1/namespaces/e2e-tests-proxy-7lwtm/services/http:proxy-service-n5sdh:portname1/proxy/: foo (200; 20.566443ms)
+Nov 29 08:02:40.146: INFO: (15) /api/v1/namespaces/e2e-tests-proxy-7lwtm/services/https:proxy-service-n5sdh:tlsportname1/proxy/: tls baz (200; 21.012262ms)
+Nov 29 08:02:40.153: INFO: (16) /api/v1/namespaces/e2e-tests-proxy-7lwtm/pods/https:proxy-service-n5sdh-r7dnw:443/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-7lwtm/pods/https:proxy-service-n5sdh-r7dnw:443/proxy/... (200; 6.432563ms)
+Nov 29 08:02:40.153: INFO: (16) /api/v1/namespaces/e2e-tests-proxy-7lwtm/pods/http:proxy-service-n5sdh-r7dnw:162/proxy/: bar (200; 7.051186ms)
+Nov 29 08:02:40.156: INFO: (16) /api/v1/namespaces/e2e-tests-proxy-7lwtm/pods/proxy-service-n5sdh-r7dnw/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-7lwtm/pods/proxy-service-n5sdh-r7dnw/proxy/rewriteme"... (200; 9.137505ms)
+Nov 29 08:02:40.156: INFO: (16) /api/v1/namespaces/e2e-tests-proxy-7lwtm/pods/http:proxy-service-n5sdh-r7dnw:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-7lwtm/pods/http:proxy-service-n5sdh-r7dnw:1080/proxy/... (200; 9.691521ms)
+Nov 29 08:02:40.156: INFO: (16) /api/v1/namespaces/e2e-tests-proxy-7lwtm/pods/proxy-service-n5sdh-r7dnw:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-7lwtm/pods/proxy-service-n5sdh-r7dnw:1080/proxy/rewri... (200; 9.647047ms)
+Nov 29 08:02:40.157: INFO: (16) /api/v1/namespaces/e2e-tests-proxy-7lwtm/pods/proxy-service-n5sdh-r7dnw:160/proxy/: foo (200; 10.04407ms)
+Nov 29 08:02:40.157: INFO: (16) /api/v1/namespaces/e2e-tests-proxy-7lwtm/pods/https:proxy-service-n5sdh-r7dnw:462/proxy/: tls qux (200; 9.899383ms)
+Nov 29 08:02:40.157: INFO: (16) /api/v1/namespaces/e2e-tests-proxy-7lwtm/pods/http:proxy-service-n5sdh-r7dnw:160/proxy/: foo (200; 10.15489ms)
+Nov 29 08:02:40.157: INFO: (16) /api/v1/namespaces/e2e-tests-proxy-7lwtm/services/http:proxy-service-n5sdh:portname2/proxy/: bar (200; 10.017945ms)
+Nov 29 08:02:40.157: INFO: (16) /api/v1/namespaces/e2e-tests-proxy-7lwtm/services/proxy-service-n5sdh:portname2/proxy/: bar (200; 10.390401ms)
+Nov 29 08:02:40.157: INFO: (16) /api/v1/namespaces/e2e-tests-proxy-7lwtm/pods/proxy-service-n5sdh-r7dnw:162/proxy/: bar (200; 10.372843ms)
+Nov 29 08:02:40.157: INFO: (16) /api/v1/namespaces/e2e-tests-proxy-7lwtm/services/proxy-service-n5sdh:portname1/proxy/: foo (200; 10.378036ms)
+Nov 29 08:02:40.157: INFO: (16) /api/v1/namespaces/e2e-tests-proxy-7lwtm/services/https:proxy-service-n5sdh:tlsportname2/proxy/: tls qux (200; 10.725861ms)
+Nov 29 08:02:40.158: INFO: (16) /api/v1/namespaces/e2e-tests-proxy-7lwtm/services/https:proxy-service-n5sdh:tlsportname1/proxy/: tls baz (200; 11.49365ms)
+Nov 29 08:02:40.159: INFO: (16) /api/v1/namespaces/e2e-tests-proxy-7lwtm/pods/https:proxy-service-n5sdh-r7dnw:460/proxy/: tls baz (200; 11.585563ms)
+Nov 29 08:02:40.159: INFO: (16) /api/v1/namespaces/e2e-tests-proxy-7lwtm/services/http:proxy-service-n5sdh:portname1/proxy/: foo (200; 12.368336ms)
+Nov 29 08:02:40.164: INFO: (17) /api/v1/namespaces/e2e-tests-proxy-7lwtm/services/proxy-service-n5sdh:portname2/proxy/: bar (200; 5.185666ms)
+Nov 29 08:02:40.165: INFO: (17) /api/v1/namespaces/e2e-tests-proxy-7lwtm/pods/https:proxy-service-n5sdh-r7dnw:443/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-7lwtm/pods/https:proxy-service-n5sdh-r7dnw:443/proxy/... (200; 6.416679ms)
+Nov 29 08:02:40.166: INFO: (17) /api/v1/namespaces/e2e-tests-proxy-7lwtm/pods/http:proxy-service-n5sdh-r7dnw:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-7lwtm/pods/http:proxy-service-n5sdh-r7dnw:1080/proxy/... (200; 7.238048ms)
+Nov 29 08:02:40.167: INFO: (17) /api/v1/namespaces/e2e-tests-proxy-7lwtm/services/https:proxy-service-n5sdh:tlsportname2/proxy/: tls qux (200; 7.612742ms)
+Nov 29 08:02:40.167: INFO: (17) /api/v1/namespaces/e2e-tests-proxy-7lwtm/pods/proxy-service-n5sdh-r7dnw:160/proxy/: foo (200; 7.535ms)
+Nov 29 08:02:40.167: INFO: (17) /api/v1/namespaces/e2e-tests-proxy-7lwtm/services/http:proxy-service-n5sdh:portname1/proxy/: foo (200; 8.144136ms)
+Nov 29 08:02:40.167: INFO: (17) /api/v1/namespaces/e2e-tests-proxy-7lwtm/pods/https:proxy-service-n5sdh-r7dnw:462/proxy/: tls qux (200; 8.290901ms)
+Nov 29 08:02:40.167: INFO: (17) /api/v1/namespaces/e2e-tests-proxy-7lwtm/pods/http:proxy-service-n5sdh-r7dnw:162/proxy/: bar (200; 8.041484ms)
+Nov 29 08:02:40.167: INFO: (17) /api/v1/namespaces/e2e-tests-proxy-7lwtm/pods/https:proxy-service-n5sdh-r7dnw:460/proxy/: tls baz (200; 8.308853ms)
+Nov 29 08:02:40.167: INFO: (17) /api/v1/namespaces/e2e-tests-proxy-7lwtm/pods/http:proxy-service-n5sdh-r7dnw:160/proxy/: foo (200; 7.995701ms)
+Nov 29 08:02:40.168: INFO: (17) /api/v1/namespaces/e2e-tests-proxy-7lwtm/pods/proxy-service-n5sdh-r7dnw/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-7lwtm/pods/proxy-service-n5sdh-r7dnw/proxy/rewriteme"... (200; 8.577451ms)
+Nov 29 08:02:40.168: INFO: (17) /api/v1/namespaces/e2e-tests-proxy-7lwtm/services/proxy-service-n5sdh:portname1/proxy/: foo (200; 8.980383ms)
+Nov 29 08:02:40.168: INFO: (17) /api/v1/namespaces/e2e-tests-proxy-7lwtm/pods/proxy-service-n5sdh-r7dnw:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-7lwtm/pods/proxy-service-n5sdh-r7dnw:1080/proxy/rewri... (200; 8.915267ms)
+Nov 29 08:02:40.168: INFO: (17) /api/v1/namespaces/e2e-tests-proxy-7lwtm/pods/proxy-service-n5sdh-r7dnw:162/proxy/: bar (200; 9.170364ms)
+Nov 29 08:02:40.168: INFO: (17) /api/v1/namespaces/e2e-tests-proxy-7lwtm/services/http:proxy-service-n5sdh:portname2/proxy/: bar (200; 9.117615ms)
+Nov 29 08:02:40.168: INFO: (17) /api/v1/namespaces/e2e-tests-proxy-7lwtm/services/https:proxy-service-n5sdh:tlsportname1/proxy/: tls baz (200; 9.230207ms)
+Nov 29 08:02:40.171: INFO: (18) /api/v1/namespaces/e2e-tests-proxy-7lwtm/pods/proxy-service-n5sdh-r7dnw:162/proxy/: bar (200; 3.053397ms)
+Nov 29 08:02:40.172: INFO: (18) /api/v1/namespaces/e2e-tests-proxy-7lwtm/pods/http:proxy-service-n5sdh-r7dnw:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-7lwtm/pods/http:proxy-service-n5sdh-r7dnw:1080/proxy/... (200; 3.047832ms)
+Nov 29 08:02:40.172: INFO: (18) /api/v1/namespaces/e2e-tests-proxy-7lwtm/pods/proxy-service-n5sdh-r7dnw/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-7lwtm/pods/proxy-service-n5sdh-r7dnw/proxy/rewriteme"... (200; 3.235901ms)
+Nov 29 08:02:40.176: INFO: (18) /api/v1/namespaces/e2e-tests-proxy-7lwtm/pods/https:proxy-service-n5sdh-r7dnw:460/proxy/: tls baz (200; 7.729096ms)
+Nov 29 08:02:40.177: INFO: (18) /api/v1/namespaces/e2e-tests-proxy-7lwtm/pods/proxy-service-n5sdh-r7dnw:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-7lwtm/pods/proxy-service-n5sdh-r7dnw:1080/proxy/rewri... (200; 7.861053ms)
+Nov 29 08:02:40.177: INFO: (18) /api/v1/namespaces/e2e-tests-proxy-7lwtm/pods/http:proxy-service-n5sdh-r7dnw:160/proxy/: foo (200; 7.675523ms)
+Nov 29 08:02:40.177: INFO: (18) /api/v1/namespaces/e2e-tests-proxy-7lwtm/pods/https:proxy-service-n5sdh-r7dnw:443/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-7lwtm/pods/https:proxy-service-n5sdh-r7dnw:443/proxy/... (200; 7.971124ms)
+Nov 29 08:02:40.177: INFO: (18) /api/v1/namespaces/e2e-tests-proxy-7lwtm/services/https:proxy-service-n5sdh:tlsportname2/proxy/: tls qux (200; 8.159147ms)
+Nov 29 08:02:40.177: INFO: (18) /api/v1/namespaces/e2e-tests-proxy-7lwtm/pods/http:proxy-service-n5sdh-r7dnw:162/proxy/: bar (200; 7.86935ms)
+Nov 29 08:02:40.177: INFO: (18) /api/v1/namespaces/e2e-tests-proxy-7lwtm/pods/https:proxy-service-n5sdh-r7dnw:462/proxy/: tls qux (200; 7.770608ms)
+Nov 29 08:02:40.177: INFO: (18) /api/v1/namespaces/e2e-tests-proxy-7lwtm/services/proxy-service-n5sdh:portname2/proxy/: bar (200; 8.262379ms)
+Nov 29 08:02:40.177: INFO: (18) /api/v1/namespaces/e2e-tests-proxy-7lwtm/pods/proxy-service-n5sdh-r7dnw:160/proxy/: foo (200; 8.791684ms)
+Nov 29 08:02:40.178: INFO: (18) /api/v1/namespaces/e2e-tests-proxy-7lwtm/services/proxy-service-n5sdh:portname1/proxy/: foo (200; 9.147495ms)
+Nov 29 08:02:40.178: INFO: (18) /api/v1/namespaces/e2e-tests-proxy-7lwtm/services/http:proxy-service-n5sdh:portname1/proxy/: foo (200; 9.07754ms)
+Nov 29 08:02:40.178: INFO: (18) /api/v1/namespaces/e2e-tests-proxy-7lwtm/services/http:proxy-service-n5sdh:portname2/proxy/: bar (200; 9.258065ms)
+Nov 29 08:02:40.178: INFO: (18) /api/v1/namespaces/e2e-tests-proxy-7lwtm/services/https:proxy-service-n5sdh:tlsportname1/proxy/: tls baz (200; 9.235181ms)
+Nov 29 08:02:40.180: INFO: (19) /api/v1/namespaces/e2e-tests-proxy-7lwtm/pods/proxy-service-n5sdh-r7dnw:162/proxy/: bar (200; 1.922373ms)
+Nov 29 08:02:40.180: INFO: (19) /api/v1/namespaces/e2e-tests-proxy-7lwtm/pods/proxy-service-n5sdh-r7dnw:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-7lwtm/pods/proxy-service-n5sdh-r7dnw:1080/proxy/rewri... (200; 2.011651ms)
+Nov 29 08:02:40.184: INFO: (19) /api/v1/namespaces/e2e-tests-proxy-7lwtm/pods/proxy-service-n5sdh-r7dnw/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-7lwtm/pods/proxy-service-n5sdh-r7dnw/proxy/rewriteme"... (200; 5.45656ms)
+Nov 29 08:02:40.184: INFO: (19) /api/v1/namespaces/e2e-tests-proxy-7lwtm/pods/http:proxy-service-n5sdh-r7dnw:1080/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-7lwtm/pods/http:proxy-service-n5sdh-r7dnw:1080/proxy/... (200; 5.752915ms)
+Nov 29 08:02:40.184: INFO: (19) /api/v1/namespaces/e2e-tests-proxy-7lwtm/pods/http:proxy-service-n5sdh-r7dnw:160/proxy/: foo (200; 5.584594ms)
+Nov 29 08:02:40.184: INFO: (19) /api/v1/namespaces/e2e-tests-proxy-7lwtm/pods/https:proxy-service-n5sdh-r7dnw:460/proxy/: tls baz (200; 5.637249ms)
+Nov 29 08:02:40.184: INFO: (19) /api/v1/namespaces/e2e-tests-proxy-7lwtm/pods/https:proxy-service-n5sdh-r7dnw:462/proxy/: tls qux (200; 5.998904ms)
+Nov 29 08:02:40.186: INFO: (19) /api/v1/namespaces/e2e-tests-proxy-7lwtm/pods/proxy-service-n5sdh-r7dnw:160/proxy/: foo (200; 8.098915ms)
+Nov 29 08:02:40.187: INFO: (19) /api/v1/namespaces/e2e-tests-proxy-7lwtm/pods/https:proxy-service-n5sdh-r7dnw:443/proxy/: <a href="/api/v1/namespaces/e2e-tests-proxy-7lwtm/pods/https:proxy-service-n5sdh-r7dnw:443/proxy/... (200; 8.286632ms)
+Nov 29 08:02:40.187: INFO: (19) /api/v1/namespaces/e2e-tests-proxy-7lwtm/services/https:proxy-service-n5sdh:tlsportname1/proxy/: tls baz (200; 8.168622ms)
+Nov 29 08:02:40.187: INFO: (19) /api/v1/namespaces/e2e-tests-proxy-7lwtm/services/proxy-service-n5sdh:portname2/proxy/: bar (200; 8.329577ms)
+Nov 29 08:02:40.187: INFO: (19) /api/v1/namespaces/e2e-tests-proxy-7lwtm/services/http:proxy-service-n5sdh:portname2/proxy/: bar (200; 8.144624ms)
+Nov 29 08:02:40.187: INFO: (19) /api/v1/namespaces/e2e-tests-proxy-7lwtm/services/http:proxy-service-n5sdh:portname1/proxy/: foo (200; 8.457171ms)
+Nov 29 08:02:40.188: INFO: (19) /api/v1/namespaces/e2e-tests-proxy-7lwtm/pods/http:proxy-service-n5sdh-r7dnw:162/proxy/: bar (200; 9.55589ms)
+Nov 29 08:02:40.189: INFO: (19) /api/v1/namespaces/e2e-tests-proxy-7lwtm/services/proxy-service-n5sdh:portname1/proxy/: foo (200; 10.192387ms)
+Nov 29 08:02:40.189: INFO: (19) /api/v1/namespaces/e2e-tests-proxy-7lwtm/services/https:proxy-service-n5sdh:tlsportname2/proxy/: tls qux (200; 10.728467ms)
+STEP: deleting { ReplicationController} proxy-service-n5sdh in namespace e2e-tests-proxy-7lwtm
+Nov 29 08:02:41.258: INFO: Deleting { ReplicationController} proxy-service-n5sdh took: 1.017348953s
+Nov 29 08:02:41.258: INFO: Terminating { ReplicationController} proxy-service-n5sdh pods took: 22.45µs
+Nov 29 08:02:50.958: INFO: Garbage collecting { ReplicationController} proxy-service-n5sdh pods took: 10.717488166s
+[AfterEach] version v1
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Nov 29 08:02:50.958: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-proxy-7lwtm" for this suite.
+Nov 29 08:02:56.965: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Nov 29 08:02:57.015: INFO: namespace: e2e-tests-proxy-7lwtm, resource: bindings, ignored listing per whitelist
+Nov 29 08:02:57.018: INFO: namespace e2e-tests-proxy-7lwtm deletion completed in 6.057888558s
+
+• [SLOW TEST:28.197 seconds]
+[sig-network] Proxy
+/workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/network/framework.go:22
+  version v1
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/network/proxy.go:61
+    should proxy through a service and a pod  [Conformance]
+    /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SSSSSS
+------------------------------
+[k8s.io] Probing container 
+  should be restarted with a /healthz http liveness probe  [Conformance]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [k8s.io] Probing container
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Nov 29 08:02:57.018: INFO: >>> kubeConfig: /tmp/kubeconfig-385092372
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [k8s.io] Probing container
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/container_probe.go:48
+[It] should be restarted with a /healthz http liveness probe  [Conformance]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating pod liveness-http in namespace e2e-tests-container-probe-lwc9q
+Nov 29 08:02:59.053: INFO: Started pod liveness-http in namespace e2e-tests-container-probe-lwc9q
+STEP: checking the pod's current state and verifying that restartCount is present
+Nov 29 08:02:59.054: INFO: Initial restart count of pod liveness-http is 0
+Nov 29 08:03:23.076: INFO: Restart count of pod e2e-tests-container-probe-lwc9q/liveness-http is now 1 (24.021985796s elapsed)
+STEP: deleting the pod
+[AfterEach] [k8s.io] Probing container
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Nov 29 08:03:23.085: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-container-probe-lwc9q" for this suite.
+Nov 29 08:03:29.094: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Nov 29 08:03:29.142: INFO: namespace: e2e-tests-container-probe-lwc9q, resource: bindings, ignored listing per whitelist
+Nov 29 08:03:29.147: INFO: namespace e2e-tests-container-probe-lwc9q deletion completed in 6.057458535s
+
+• [SLOW TEST:32.129 seconds]
+[k8s.io] Probing container
+/workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:669
+  should be restarted with a /healthz http liveness probe  [Conformance]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SSSSSSSSSSS
+------------------------------
+[sig-storage] Projected 
+  should be consumable in multiple volumes in a pod [Conformance]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Nov 29 08:03:29.147: INFO: >>> kubeConfig: /tmp/kubeconfig-385092372
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:858
+[It] should be consumable in multiple volumes in a pod [Conformance]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating secret with name projected-secret-test-41b03b92-f3ad-11e8-9124-e6180d057dc8
+STEP: Creating a pod to test consume secrets
+Nov 29 08:03:29.180: INFO: Waiting up to 5m0s for pod "pod-projected-secrets-41b0765c-f3ad-11e8-9124-e6180d057dc8" in namespace "e2e-tests-projected-nmthf" to be "success or failure"
+Nov 29 08:03:29.186: INFO: Pod "pod-projected-secrets-41b0765c-f3ad-11e8-9124-e6180d057dc8": Phase="Pending", Reason="", readiness=false. Elapsed: 6.269913ms
+Nov 29 08:03:31.188: INFO: Pod "pod-projected-secrets-41b0765c-f3ad-11e8-9124-e6180d057dc8": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.007980298s
+STEP: Saw pod success
+Nov 29 08:03:31.188: INFO: Pod "pod-projected-secrets-41b0765c-f3ad-11e8-9124-e6180d057dc8" satisfied condition "success or failure"
+Nov 29 08:03:31.189: INFO: Trying to get logs from node worker-266bbc56-f3aa-11e8-ab5c-0a406d6cb422 pod pod-projected-secrets-41b0765c-f3ad-11e8-9124-e6180d057dc8 container secret-volume-test: <nil>
+STEP: delete the pod
+Nov 29 08:03:31.202: INFO: Waiting for pod pod-projected-secrets-41b0765c-f3ad-11e8-9124-e6180d057dc8 to disappear
+Nov 29 08:03:31.203: INFO: Pod pod-projected-secrets-41b0765c-f3ad-11e8-9124-e6180d057dc8 no longer exists
+[AfterEach] [sig-storage] Projected
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Nov 29 08:03:31.203: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-nmthf" for this suite.
+Nov 29 08:03:37.211: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Nov 29 08:03:37.264: INFO: namespace: e2e-tests-projected-nmthf, resource: bindings, ignored listing per whitelist
+Nov 29 08:03:37.267: INFO: namespace e2e-tests-projected-nmthf deletion completed in 6.061923172s
+
+• [SLOW TEST:8.120 seconds]
+[sig-storage] Projected
+/workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:34
+  should be consumable in multiple volumes in a pod [Conformance]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SSSSSSSSSSSSSSS
+------------------------------
+[sig-network] Networking Granular Checks: Pods 
+  should function for intra-pod communication: http  [Conformance]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-network] Networking
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Nov 29 08:03:37.267: INFO: >>> kubeConfig: /tmp/kubeconfig-385092372
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should function for intra-pod communication: http  [Conformance]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Performing setup for networking test in namespace e2e-tests-pod-network-test-qzktf
+STEP: creating a selector
+STEP: Creating the service pods in kubernetes
+Nov 29 08:03:37.299: INFO: Waiting up to 10m0s for all (but 0) nodes to be schedulable
+STEP: Creating test pods
+Nov 29 08:03:59.357: INFO: ExecWithOptions {Command:[/bin/sh -c curl -g -q -s 'http://10.2.2.74:8080/dial?request=hostName&protocol=http&host=10.2.1.59&port=8080&tries=1'] Namespace:e2e-tests-pod-network-test-qzktf PodName:host-test-container-pod ContainerName:hostexec Stdin:<nil> CaptureStdout:true CaptureStderr:true PreserveWhitespace:false}
+Nov 29 08:03:59.357: INFO: >>> kubeConfig: /tmp/kubeconfig-385092372
+Nov 29 08:03:59.399: INFO: Waiting for endpoints: map[]
+Nov 29 08:03:59.400: INFO: ExecWithOptions {Command:[/bin/sh -c curl -g -q -s 'http://10.2.2.74:8080/dial?request=hostName&protocol=http&host=10.2.2.73&port=8080&tries=1'] Namespace:e2e-tests-pod-network-test-qzktf PodName:host-test-container-pod ContainerName:hostexec Stdin:<nil> CaptureStdout:true CaptureStderr:true PreserveWhitespace:false}
+Nov 29 08:03:59.400: INFO: >>> kubeConfig: /tmp/kubeconfig-385092372
+Nov 29 08:03:59.436: INFO: Waiting for endpoints: map[]
+[AfterEach] [sig-network] Networking
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Nov 29 08:03:59.436: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-pod-network-test-qzktf" for this suite.
+Nov 29 08:04:21.443: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Nov 29 08:04:21.459: INFO: namespace: e2e-tests-pod-network-test-qzktf, resource: bindings, ignored listing per whitelist
+Nov 29 08:04:21.496: INFO: namespace e2e-tests-pod-network-test-qzktf deletion completed in 22.057614952s
+
+• [SLOW TEST:44.228 seconds]
+[sig-network] Networking
+/workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/networking.go:25
+  Granular Checks: Pods
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/networking.go:28
+    should function for intra-pod communication: http  [Conformance]
+    /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SSS
+------------------------------
+[sig-storage] Projected 
+  should be consumable from pods in volume as non-root [Conformance]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Nov 29 08:04:21.496: INFO: >>> kubeConfig: /tmp/kubeconfig-385092372
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:858
+[It] should be consumable from pods in volume as non-root [Conformance]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating configMap with name projected-configmap-test-volume-60eb45ea-f3ad-11e8-9124-e6180d057dc8
+STEP: Creating a pod to test consume configMaps
+Nov 29 08:04:21.577: INFO: Waiting up to 5m0s for pod "pod-projected-configmaps-60eb7fbc-f3ad-11e8-9124-e6180d057dc8" in namespace "e2e-tests-projected-wx26c" to be "success or failure"
+Nov 29 08:04:21.579: INFO: Pod "pod-projected-configmaps-60eb7fbc-f3ad-11e8-9124-e6180d057dc8": Phase="Pending", Reason="", readiness=false. Elapsed: 2.763569ms
+Nov 29 08:04:23.581: INFO: Pod "pod-projected-configmaps-60eb7fbc-f3ad-11e8-9124-e6180d057dc8": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.004309869s
+STEP: Saw pod success
+Nov 29 08:04:23.581: INFO: Pod "pod-projected-configmaps-60eb7fbc-f3ad-11e8-9124-e6180d057dc8" satisfied condition "success or failure"
+Nov 29 08:04:23.582: INFO: Trying to get logs from node worker-266bbc56-f3aa-11e8-ab5c-0a406d6cb422 pod pod-projected-configmaps-60eb7fbc-f3ad-11e8-9124-e6180d057dc8 container projected-configmap-volume-test: <nil>
+STEP: delete the pod
+Nov 29 08:04:23.597: INFO: Waiting for pod pod-projected-configmaps-60eb7fbc-f3ad-11e8-9124-e6180d057dc8 to disappear
+Nov 29 08:04:23.598: INFO: Pod pod-projected-configmaps-60eb7fbc-f3ad-11e8-9124-e6180d057dc8 no longer exists
+[AfterEach] [sig-storage] Projected
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Nov 29 08:04:23.598: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-wx26c" for this suite.
+Nov 29 08:04:29.604: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Nov 29 08:04:29.627: INFO: namespace: e2e-tests-projected-wx26c, resource: bindings, ignored listing per whitelist
+Nov 29 08:04:29.654: INFO: namespace e2e-tests-projected-wx26c deletion completed in 6.054053718s
+
+• [SLOW TEST:8.158 seconds]
+[sig-storage] Projected
+/workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:34
+  should be consumable from pods in volume as non-root [Conformance]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SSSSSSS
+------------------------------
+[sig-storage] Projected 
+  should be consumable from pods in volume as non-root with defaultMode and fsGroup set [Conformance]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Nov 29 08:04:29.654: INFO: >>> kubeConfig: /tmp/kubeconfig-385092372
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:858
+[It] should be consumable from pods in volume as non-root with defaultMode and fsGroup set [Conformance]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating projection with secret that has name projected-secret-test-65c876ee-f3ad-11e8-9124-e6180d057dc8
+STEP: Creating a pod to test consume secrets
+Nov 29 08:04:29.736: INFO: Waiting up to 5m0s for pod "pod-projected-secrets-65c8ab13-f3ad-11e8-9124-e6180d057dc8" in namespace "e2e-tests-projected-45zcg" to be "success or failure"
+Nov 29 08:04:29.739: INFO: Pod "pod-projected-secrets-65c8ab13-f3ad-11e8-9124-e6180d057dc8": Phase="Pending", Reason="", readiness=false. Elapsed: 3.078423ms
+Nov 29 08:04:31.741: INFO: Pod "pod-projected-secrets-65c8ab13-f3ad-11e8-9124-e6180d057dc8": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.00471616s
+STEP: Saw pod success
+Nov 29 08:04:31.741: INFO: Pod "pod-projected-secrets-65c8ab13-f3ad-11e8-9124-e6180d057dc8" satisfied condition "success or failure"
+Nov 29 08:04:31.742: INFO: Trying to get logs from node worker-266bbc56-f3aa-11e8-ab5c-0a406d6cb422 pod pod-projected-secrets-65c8ab13-f3ad-11e8-9124-e6180d057dc8 container projected-secret-volume-test: <nil>
+STEP: delete the pod
+Nov 29 08:04:31.754: INFO: Waiting for pod pod-projected-secrets-65c8ab13-f3ad-11e8-9124-e6180d057dc8 to disappear
+Nov 29 08:04:31.758: INFO: Pod pod-projected-secrets-65c8ab13-f3ad-11e8-9124-e6180d057dc8 no longer exists
+[AfterEach] [sig-storage] Projected
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Nov 29 08:04:31.758: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-45zcg" for this suite.
+Nov 29 08:04:37.766: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Nov 29 08:04:37.798: INFO: namespace: e2e-tests-projected-45zcg, resource: bindings, ignored listing per whitelist
+Nov 29 08:04:37.817: INFO: namespace e2e-tests-projected-45zcg deletion completed in 6.057767374s
+
+• [SLOW TEST:8.163 seconds]
+[sig-storage] Projected
+/workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:34
+  should be consumable from pods in volume as non-root with defaultMode and fsGroup set [Conformance]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SSSS
+------------------------------
+[sig-storage] Secrets 
+  should be consumable from pods in volume with mappings  [Conformance]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-storage] Secrets
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Nov 29 08:04:37.818: INFO: >>> kubeConfig: /tmp/kubeconfig-385092372
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should be consumable from pods in volume with mappings  [Conformance]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating secret with name secret-test-map-6a9e9189-f3ad-11e8-9124-e6180d057dc8
+STEP: Creating a pod to test consume secrets
+Nov 29 08:04:37.851: INFO: Waiting up to 5m0s for pod "pod-secrets-6a9ecbaf-f3ad-11e8-9124-e6180d057dc8" in namespace "e2e-tests-secrets-jg7jg" to be "success or failure"
+Nov 29 08:04:37.854: INFO: Pod "pod-secrets-6a9ecbaf-f3ad-11e8-9124-e6180d057dc8": Phase="Pending", Reason="", readiness=false. Elapsed: 2.993623ms
+Nov 29 08:04:39.856: INFO: Pod "pod-secrets-6a9ecbaf-f3ad-11e8-9124-e6180d057dc8": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.004868188s
+STEP: Saw pod success
+Nov 29 08:04:39.856: INFO: Pod "pod-secrets-6a9ecbaf-f3ad-11e8-9124-e6180d057dc8" satisfied condition "success or failure"
+Nov 29 08:04:39.857: INFO: Trying to get logs from node worker-266bbc56-f3aa-11e8-ab5c-0a406d6cb422 pod pod-secrets-6a9ecbaf-f3ad-11e8-9124-e6180d057dc8 container secret-volume-test: <nil>
+STEP: delete the pod
+Nov 29 08:04:39.872: INFO: Waiting for pod pod-secrets-6a9ecbaf-f3ad-11e8-9124-e6180d057dc8 to disappear
+Nov 29 08:04:39.874: INFO: Pod pod-secrets-6a9ecbaf-f3ad-11e8-9124-e6180d057dc8 no longer exists
+[AfterEach] [sig-storage] Secrets
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Nov 29 08:04:39.874: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-secrets-jg7jg" for this suite.
+Nov 29 08:04:45.882: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Nov 29 08:04:45.905: INFO: namespace: e2e-tests-secrets-jg7jg, resource: bindings, ignored listing per whitelist
+Nov 29 08:04:45.932: INFO: namespace e2e-tests-secrets-jg7jg deletion completed in 6.055823456s
+
+• [SLOW TEST:8.115 seconds]
+[sig-storage] Secrets
+/workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/secrets_volume.go:33
+  should be consumable from pods in volume with mappings  [Conformance]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SSSSSSSSSSSSSSSSSSSSSS
+------------------------------
+[sig-api-machinery] Garbage collector 
+  should not be blocked by dependency circle [Conformance]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-api-machinery] Garbage collector
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Nov 29 08:04:45.932: INFO: >>> kubeConfig: /tmp/kubeconfig-385092372
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should not be blocked by dependency circle [Conformance]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+Nov 29 08:04:46.035: INFO: pod1.ObjectMeta.OwnerReferences=[]v1.OwnerReference{v1.OwnerReference{APIVersion:"v1", Kind:"Pod", Name:"pod3", UID:"6f7defaa-f3ad-11e8-9c33-06ce02f7f1c8", Controller:(*bool)(0xc421ae35fe), BlockOwnerDeletion:(*bool)(0xc421ae35ff)}}
+Nov 29 08:04:46.045: INFO: pod2.ObjectMeta.OwnerReferences=[]v1.OwnerReference{v1.OwnerReference{APIVersion:"v1", Kind:"Pod", Name:"pod1", UID:"6f7cc859-f3ad-11e8-9c33-06ce02f7f1c8", Controller:(*bool)(0xc421ae3a06), BlockOwnerDeletion:(*bool)(0xc421ae3a07)}}
+Nov 29 08:04:46.049: INFO: pod3.ObjectMeta.OwnerReferences=[]v1.OwnerReference{v1.OwnerReference{APIVersion:"v1", Kind:"Pod", Name:"pod2", UID:"6f7d84fc-f3ad-11e8-9c33-06ce02f7f1c8", Controller:(*bool)(0xc421ae3e0e), BlockOwnerDeletion:(*bool)(0xc421ae3e0f)}}
+[AfterEach] [sig-api-machinery] Garbage collector
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Nov 29 08:04:51.056: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-gc-v6vqw" for this suite.
+Nov 29 08:04:57.065: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Nov 29 08:04:57.090: INFO: namespace: e2e-tests-gc-v6vqw, resource: bindings, ignored listing per whitelist
+Nov 29 08:04:57.121: INFO: namespace e2e-tests-gc-v6vqw deletion completed in 6.062422331s
+
+• [SLOW TEST:11.188 seconds]
+[sig-api-machinery] Garbage collector
+/workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apimachinery/framework.go:22
+  should not be blocked by dependency circle [Conformance]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SSSSSSSSSSSSSSS
+------------------------------
+[sig-apps] Daemon set [Serial] 
+  should run and stop complex daemon [Conformance]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-apps] Daemon set [Serial]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Nov 29 08:04:57.121: INFO: >>> kubeConfig: /tmp/kubeconfig-385092372
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-apps] Daemon set [Serial]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/daemon_set.go:103
+[It] should run and stop complex daemon [Conformance]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+Nov 29 08:04:57.204: INFO: Creating daemon "daemon-set" with a node selector
+STEP: Initially, daemon pods should not be running on any nodes.
+Nov 29 08:04:57.209: INFO: Number of nodes with available pods: 0
+Nov 29 08:04:57.209: INFO: Number of running nodes: 0, number of available pods: 0
+STEP: Change node label to blue, check that daemon pod is launched.
+Nov 29 08:04:57.221: INFO: Number of nodes with available pods: 0
+Nov 29 08:04:57.221: INFO: Node worker-266bbc56-f3aa-11e8-ab5c-0a406d6cb422 is running more than one daemon pod
+Nov 29 08:04:58.223: INFO: Number of nodes with available pods: 0
+Nov 29 08:04:58.223: INFO: Node worker-266bbc56-f3aa-11e8-ab5c-0a406d6cb422 is running more than one daemon pod
+Nov 29 08:04:59.223: INFO: Number of nodes with available pods: 1
+Nov 29 08:04:59.223: INFO: Number of running nodes: 1, number of available pods: 1
+STEP: Update the node label to green, and wait for daemons to be unscheduled
+Nov 29 08:04:59.234: INFO: Number of nodes with available pods: 1
+Nov 29 08:04:59.234: INFO: Number of running nodes: 0, number of available pods: 1
+Nov 29 08:05:00.236: INFO: Number of nodes with available pods: 0
+Nov 29 08:05:00.236: INFO: Number of running nodes: 0, number of available pods: 0
+STEP: Update DaemonSet node selector to green, and change its update strategy to RollingUpdate
+Nov 29 08:05:00.241: INFO: Number of nodes with available pods: 0
+Nov 29 08:05:00.241: INFO: Node worker-266bbc56-f3aa-11e8-ab5c-0a406d6cb422 is running more than one daemon pod
+Nov 29 08:05:01.243: INFO: Number of nodes with available pods: 0
+Nov 29 08:05:01.243: INFO: Node worker-266bbc56-f3aa-11e8-ab5c-0a406d6cb422 is running more than one daemon pod
+Nov 29 08:05:02.243: INFO: Number of nodes with available pods: 0
+Nov 29 08:05:02.243: INFO: Node worker-266bbc56-f3aa-11e8-ab5c-0a406d6cb422 is running more than one daemon pod
+Nov 29 08:05:03.243: INFO: Number of nodes with available pods: 0
+Nov 29 08:05:03.243: INFO: Node worker-266bbc56-f3aa-11e8-ab5c-0a406d6cb422 is running more than one daemon pod
+Nov 29 08:05:04.243: INFO: Number of nodes with available pods: 0
+Nov 29 08:05:04.243: INFO: Node worker-266bbc56-f3aa-11e8-ab5c-0a406d6cb422 is running more than one daemon pod
+Nov 29 08:05:05.243: INFO: Number of nodes with available pods: 0
+Nov 29 08:05:05.243: INFO: Node worker-266bbc56-f3aa-11e8-ab5c-0a406d6cb422 is running more than one daemon pod
+Nov 29 08:05:06.243: INFO: Number of nodes with available pods: 0
+Nov 29 08:05:06.243: INFO: Node worker-266bbc56-f3aa-11e8-ab5c-0a406d6cb422 is running more than one daemon pod
+Nov 29 08:05:07.243: INFO: Number of nodes with available pods: 0
+Nov 29 08:05:07.243: INFO: Node worker-266bbc56-f3aa-11e8-ab5c-0a406d6cb422 is running more than one daemon pod
+Nov 29 08:05:08.243: INFO: Number of nodes with available pods: 0
+Nov 29 08:05:08.243: INFO: Node worker-266bbc56-f3aa-11e8-ab5c-0a406d6cb422 is running more than one daemon pod
+Nov 29 08:05:09.243: INFO: Number of nodes with available pods: 0
+Nov 29 08:05:09.243: INFO: Node worker-266bbc56-f3aa-11e8-ab5c-0a406d6cb422 is running more than one daemon pod
+Nov 29 08:05:10.243: INFO: Number of nodes with available pods: 0
+Nov 29 08:05:10.243: INFO: Node worker-266bbc56-f3aa-11e8-ab5c-0a406d6cb422 is running more than one daemon pod
+Nov 29 08:05:11.243: INFO: Number of nodes with available pods: 0
+Nov 29 08:05:11.243: INFO: Node worker-266bbc56-f3aa-11e8-ab5c-0a406d6cb422 is running more than one daemon pod
+Nov 29 08:05:12.242: INFO: Number of nodes with available pods: 1
+Nov 29 08:05:12.242: INFO: Number of running nodes: 1, number of available pods: 1
+[AfterEach] [sig-apps] Daemon set [Serial]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/daemon_set.go:66
+STEP: Deleting DaemonSet "daemon-set" with reaper
+Nov 29 08:05:15.262: INFO: Number of nodes with available pods: 0
+Nov 29 08:05:15.262: INFO: Number of running nodes: 0, number of available pods: 0
+Nov 29 08:05:15.263: INFO: daemonset: {"kind":"DaemonSetList","apiVersion":"apps/v1","metadata":{"selfLink":"/apis/apps/v1/namespaces/e2e-tests-daemonsets-f5qqt/daemonsets","resourceVersion":"11832"},"items":null}
+
+Nov 29 08:05:15.267: INFO: pods: {"kind":"PodList","apiVersion":"v1","metadata":{"selfLink":"/api/v1/namespaces/e2e-tests-daemonsets-f5qqt/pods","resourceVersion":"11832"},"items":null}
+
+[AfterEach] [sig-apps] Daemon set [Serial]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Nov 29 08:05:15.281: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-daemonsets-f5qqt" for this suite.
+Nov 29 08:05:21.288: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Nov 29 08:05:21.330: INFO: namespace: e2e-tests-daemonsets-f5qqt, resource: bindings, ignored listing per whitelist
+Nov 29 08:05:21.346: INFO: namespace e2e-tests-daemonsets-f5qqt deletion completed in 6.063571819s
+
+• [SLOW TEST:24.225 seconds]
+[sig-apps] Daemon set [Serial]
+/workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/framework.go:22
+  should run and stop complex daemon [Conformance]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SSSSSS
+------------------------------
+[k8s.io] Probing container 
+  should be restarted with a exec "cat /tmp/health" liveness probe [Conformance]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [k8s.io] Probing container
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Nov 29 08:05:21.346: INFO: >>> kubeConfig: /tmp/kubeconfig-385092372
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [k8s.io] Probing container
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/container_probe.go:48
+[It] should be restarted with a exec "cat /tmp/health" liveness probe [Conformance]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating pod liveness-exec in namespace e2e-tests-container-probe-pkwv6
+Nov 29 08:05:25.395: INFO: Started pod liveness-exec in namespace e2e-tests-container-probe-pkwv6
+STEP: checking the pod's current state and verifying that restartCount is present
+Nov 29 08:05:25.396: INFO: Initial restart count of pod liveness-exec is 0
+Nov 29 08:06:17.444: INFO: Restart count of pod e2e-tests-container-probe-pkwv6/liveness-exec is now 1 (52.048520619s elapsed)
+STEP: deleting the pod
+[AfterEach] [k8s.io] Probing container
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Nov 29 08:06:17.455: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-container-probe-pkwv6" for this suite.
+Nov 29 08:06:23.463: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Nov 29 08:06:23.506: INFO: namespace: e2e-tests-container-probe-pkwv6, resource: bindings, ignored listing per whitelist
+Nov 29 08:06:23.525: INFO: namespace e2e-tests-container-probe-pkwv6 deletion completed in 6.067423002s
+
+• [SLOW TEST:62.179 seconds]
+[k8s.io] Probing container
+/workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:669
+  should be restarted with a exec "cat /tmp/health" liveness probe [Conformance]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+S
+------------------------------
+[sig-storage] Projected 
+  optional updates should be reflected in volume [Conformance]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Nov 29 08:06:23.525: INFO: >>> kubeConfig: /tmp/kubeconfig-385092372
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:858
+[It] optional updates should be reflected in volume [Conformance]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating secret with name s-test-opt-del-a9a06ee3-f3ad-11e8-9124-e6180d057dc8
+STEP: Creating secret with name s-test-opt-upd-a9a06f14-f3ad-11e8-9124-e6180d057dc8
+STEP: Creating the pod
+STEP: Deleting secret s-test-opt-del-a9a06ee3-f3ad-11e8-9124-e6180d057dc8
+STEP: Updating secret s-test-opt-upd-a9a06f14-f3ad-11e8-9124-e6180d057dc8
+STEP: Creating secret with name s-test-opt-create-a9a06f24-f3ad-11e8-9124-e6180d057dc8
+STEP: waiting to observe update in volume
+[AfterEach] [sig-storage] Projected
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Nov 29 08:06:29.604: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-w7wgj" for this suite.
+Nov 29 08:06:51.611: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Nov 29 08:06:51.654: INFO: namespace: e2e-tests-projected-w7wgj, resource: bindings, ignored listing per whitelist
+Nov 29 08:06:51.665: INFO: namespace e2e-tests-projected-w7wgj deletion completed in 22.05889431s
+
+• [SLOW TEST:28.140 seconds]
+[sig-storage] Projected
+/workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:34
+  optional updates should be reflected in volume [Conformance]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SS
+------------------------------
+[k8s.io] Docker Containers 
+  should be able to override the image's default command (docker entrypoint)  [Conformance]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [k8s.io] Docker Containers
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Nov 29 08:06:51.665: INFO: >>> kubeConfig: /tmp/kubeconfig-385092372
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should be able to override the image's default command (docker entrypoint)  [Conformance]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating a pod to test override command
+Nov 29 08:06:51.695: INFO: Waiting up to 5m0s for pod "client-containers-ba65eff1-f3ad-11e8-9124-e6180d057dc8" in namespace "e2e-tests-containers-gc2xx" to be "success or failure"
+Nov 29 08:06:51.698: INFO: Pod "client-containers-ba65eff1-f3ad-11e8-9124-e6180d057dc8": Phase="Pending", Reason="", readiness=false. Elapsed: 2.981231ms
+Nov 29 08:06:53.700: INFO: Pod "client-containers-ba65eff1-f3ad-11e8-9124-e6180d057dc8": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.004724991s
+STEP: Saw pod success
+Nov 29 08:06:53.700: INFO: Pod "client-containers-ba65eff1-f3ad-11e8-9124-e6180d057dc8" satisfied condition "success or failure"
+Nov 29 08:06:53.701: INFO: Trying to get logs from node worker-266bbc56-f3aa-11e8-ab5c-0a406d6cb422 pod client-containers-ba65eff1-f3ad-11e8-9124-e6180d057dc8 container test-container: <nil>
+STEP: delete the pod
+Nov 29 08:06:53.777: INFO: Waiting for pod client-containers-ba65eff1-f3ad-11e8-9124-e6180d057dc8 to disappear
+Nov 29 08:06:53.778: INFO: Pod client-containers-ba65eff1-f3ad-11e8-9124-e6180d057dc8 no longer exists
+[AfterEach] [k8s.io] Docker Containers
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Nov 29 08:06:53.778: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-containers-gc2xx" for this suite.
+Nov 29 08:06:59.785: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Nov 29 08:06:59.820: INFO: namespace: e2e-tests-containers-gc2xx, resource: bindings, ignored listing per whitelist
+Nov 29 08:06:59.836: INFO: namespace e2e-tests-containers-gc2xx deletion completed in 6.055459584s
+
+• [SLOW TEST:8.171 seconds]
+[k8s.io] Docker Containers
+/workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:669
+  should be able to override the image's default command (docker entrypoint)  [Conformance]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+S
+------------------------------
+[sig-storage] Projected 
+  should provide node allocatable (memory) as default memory limit if the limit is not set [Conformance]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Nov 29 08:06:59.836: INFO: >>> kubeConfig: /tmp/kubeconfig-385092372
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:858
+[It] should provide node allocatable (memory) as default memory limit if the limit is not set [Conformance]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating a pod to test downward API volume plugin
+Nov 29 08:06:59.868: INFO: Waiting up to 5m0s for pod "downwardapi-volume-bf44d836-f3ad-11e8-9124-e6180d057dc8" in namespace "e2e-tests-projected-72ft9" to be "success or failure"
+Nov 29 08:06:59.872: INFO: Pod "downwardapi-volume-bf44d836-f3ad-11e8-9124-e6180d057dc8": Phase="Pending", Reason="", readiness=false. Elapsed: 4.798539ms
+Nov 29 08:07:01.876: INFO: Pod "downwardapi-volume-bf44d836-f3ad-11e8-9124-e6180d057dc8": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.00787322s
+STEP: Saw pod success
+Nov 29 08:07:01.876: INFO: Pod "downwardapi-volume-bf44d836-f3ad-11e8-9124-e6180d057dc8" satisfied condition "success or failure"
+Nov 29 08:07:01.878: INFO: Trying to get logs from node worker-266bbc56-f3aa-11e8-ab5c-0a406d6cb422 pod downwardapi-volume-bf44d836-f3ad-11e8-9124-e6180d057dc8 container client-container: <nil>
+STEP: delete the pod
+Nov 29 08:07:01.895: INFO: Waiting for pod downwardapi-volume-bf44d836-f3ad-11e8-9124-e6180d057dc8 to disappear
+Nov 29 08:07:01.896: INFO: Pod downwardapi-volume-bf44d836-f3ad-11e8-9124-e6180d057dc8 no longer exists
+[AfterEach] [sig-storage] Projected
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Nov 29 08:07:01.896: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-72ft9" for this suite.
+Nov 29 08:07:07.902: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Nov 29 08:07:07.945: INFO: namespace: e2e-tests-projected-72ft9, resource: bindings, ignored listing per whitelist
+Nov 29 08:07:07.953: INFO: namespace e2e-tests-projected-72ft9 deletion completed in 6.055382155s
+
+• [SLOW TEST:8.118 seconds]
+[sig-storage] Projected
+/workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:34
+  should provide node allocatable (memory) as default memory limit if the limit is not set [Conformance]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+[sig-storage] Secrets 
+  should be consumable from pods in volume  [Conformance]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-storage] Secrets
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Nov 29 08:07:07.953: INFO: >>> kubeConfig: /tmp/kubeconfig-385092372
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should be consumable from pods in volume  [Conformance]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating secret with name secret-test-c41b8194-f3ad-11e8-9124-e6180d057dc8
+STEP: Creating a pod to test consume secrets
+Nov 29 08:07:07.990: INFO: Waiting up to 5m0s for pod "pod-secrets-c41bbd8a-f3ad-11e8-9124-e6180d057dc8" in namespace "e2e-tests-secrets-6x4ts" to be "success or failure"
+Nov 29 08:07:07.995: INFO: Pod "pod-secrets-c41bbd8a-f3ad-11e8-9124-e6180d057dc8": Phase="Pending", Reason="", readiness=false. Elapsed: 4.361189ms
+Nov 29 08:07:09.997: INFO: Pod "pod-secrets-c41bbd8a-f3ad-11e8-9124-e6180d057dc8": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.00641577s
+STEP: Saw pod success
+Nov 29 08:07:09.997: INFO: Pod "pod-secrets-c41bbd8a-f3ad-11e8-9124-e6180d057dc8" satisfied condition "success or failure"
+Nov 29 08:07:09.998: INFO: Trying to get logs from node worker-266bbc56-f3aa-11e8-ab5c-0a406d6cb422 pod pod-secrets-c41bbd8a-f3ad-11e8-9124-e6180d057dc8 container secret-volume-test: <nil>
+STEP: delete the pod
+Nov 29 08:07:10.017: INFO: Waiting for pod pod-secrets-c41bbd8a-f3ad-11e8-9124-e6180d057dc8 to disappear
+Nov 29 08:07:10.018: INFO: Pod pod-secrets-c41bbd8a-f3ad-11e8-9124-e6180d057dc8 no longer exists
+[AfterEach] [sig-storage] Secrets
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Nov 29 08:07:10.018: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-secrets-6x4ts" for this suite.
+Nov 29 08:07:16.026: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Nov 29 08:07:16.063: INFO: namespace: e2e-tests-secrets-6x4ts, resource: bindings, ignored listing per whitelist
+Nov 29 08:07:16.076: INFO: namespace e2e-tests-secrets-6x4ts deletion completed in 6.05679058s
+
+• [SLOW TEST:8.123 seconds]
+[sig-storage] Secrets
+/workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/secrets_volume.go:33
+  should be consumable from pods in volume  [Conformance]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SSS
+------------------------------
+[sig-api-machinery] Downward API 
+  should provide default limits.cpu/memory from node allocatable  [Conformance]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-api-machinery] Downward API
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Nov 29 08:07:16.077: INFO: >>> kubeConfig: /tmp/kubeconfig-385092372
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should provide default limits.cpu/memory from node allocatable  [Conformance]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating a pod to test downward api env vars
+Nov 29 08:07:16.186: INFO: Waiting up to 5m0s for pod "downward-api-c8feb76c-f3ad-11e8-9124-e6180d057dc8" in namespace "e2e-tests-downward-api-llwfw" to be "success or failure"
+Nov 29 08:07:16.190: INFO: Pod "downward-api-c8feb76c-f3ad-11e8-9124-e6180d057dc8": Phase="Pending", Reason="", readiness=false. Elapsed: 3.35969ms
+Nov 29 08:07:18.191: INFO: Pod "downward-api-c8feb76c-f3ad-11e8-9124-e6180d057dc8": Phase="Pending", Reason="", readiness=false. Elapsed: 2.005157398s
+Nov 29 08:07:20.193: INFO: Pod "downward-api-c8feb76c-f3ad-11e8-9124-e6180d057dc8": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.0069949s
+STEP: Saw pod success
+Nov 29 08:07:20.193: INFO: Pod "downward-api-c8feb76c-f3ad-11e8-9124-e6180d057dc8" satisfied condition "success or failure"
+Nov 29 08:07:20.195: INFO: Trying to get logs from node worker-266bbc56-f3aa-11e8-ab5c-0a406d6cb422 pod downward-api-c8feb76c-f3ad-11e8-9124-e6180d057dc8 container dapi-container: <nil>
+STEP: delete the pod
+Nov 29 08:07:20.208: INFO: Waiting for pod downward-api-c8feb76c-f3ad-11e8-9124-e6180d057dc8 to disappear
+Nov 29 08:07:20.215: INFO: Pod downward-api-c8feb76c-f3ad-11e8-9124-e6180d057dc8 no longer exists
+[AfterEach] [sig-api-machinery] Downward API
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Nov 29 08:07:20.216: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-downward-api-llwfw" for this suite.
+Nov 29 08:07:26.222: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Nov 29 08:07:26.245: INFO: namespace: e2e-tests-downward-api-llwfw, resource: bindings, ignored listing per whitelist
+Nov 29 08:07:26.273: INFO: namespace e2e-tests-downward-api-llwfw deletion completed in 6.055665208s
+
+• [SLOW TEST:10.196 seconds]
+[sig-api-machinery] Downward API
+/workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downward_api.go:37
+  should provide default limits.cpu/memory from node allocatable  [Conformance]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SSSSSS
+------------------------------
+[sig-storage] Projected 
+  should set DefaultMode on files [Conformance]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Nov 29 08:07:26.273: INFO: >>> kubeConfig: /tmp/kubeconfig-385092372
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:858
+[It] should set DefaultMode on files [Conformance]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating a pod to test downward API volume plugin
+Nov 29 08:07:26.304: INFO: Waiting up to 5m0s for pod "downwardapi-volume-cf06da2d-f3ad-11e8-9124-e6180d057dc8" in namespace "e2e-tests-projected-trslh" to be "success or failure"
+Nov 29 08:07:26.308: INFO: Pod "downwardapi-volume-cf06da2d-f3ad-11e8-9124-e6180d057dc8": Phase="Pending", Reason="", readiness=false. Elapsed: 3.145107ms
+Nov 29 08:07:28.309: INFO: Pod "downwardapi-volume-cf06da2d-f3ad-11e8-9124-e6180d057dc8": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.004918395s
+STEP: Saw pod success
+Nov 29 08:07:28.309: INFO: Pod "downwardapi-volume-cf06da2d-f3ad-11e8-9124-e6180d057dc8" satisfied condition "success or failure"
+Nov 29 08:07:28.311: INFO: Trying to get logs from node worker-266bbc56-f3aa-11e8-ab5c-0a406d6cb422 pod downwardapi-volume-cf06da2d-f3ad-11e8-9124-e6180d057dc8 container client-container: <nil>
+STEP: delete the pod
+Nov 29 08:07:28.323: INFO: Waiting for pod downwardapi-volume-cf06da2d-f3ad-11e8-9124-e6180d057dc8 to disappear
+Nov 29 08:07:28.324: INFO: Pod downwardapi-volume-cf06da2d-f3ad-11e8-9124-e6180d057dc8 no longer exists
+[AfterEach] [sig-storage] Projected
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Nov 29 08:07:28.324: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-trslh" for this suite.
+Nov 29 08:07:34.332: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Nov 29 08:07:34.363: INFO: namespace: e2e-tests-projected-trslh, resource: bindings, ignored listing per whitelist
+Nov 29 08:07:34.385: INFO: namespace e2e-tests-projected-trslh deletion completed in 6.057793202s
+
+• [SLOW TEST:8.112 seconds]
+[sig-storage] Projected
+/workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:34
+  should set DefaultMode on files [Conformance]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+S
+------------------------------
+[sig-apps] ReplicationController 
+  should serve a basic image on each replica with a public image  [Conformance]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-apps] ReplicationController
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Nov 29 08:07:34.385: INFO: >>> kubeConfig: /tmp/kubeconfig-385092372
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should serve a basic image on each replica with a public image  [Conformance]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating replication controller my-hostname-basic-d3e4986f-f3ad-11e8-9124-e6180d057dc8
+Nov 29 08:07:34.469: INFO: Pod name my-hostname-basic-d3e4986f-f3ad-11e8-9124-e6180d057dc8: Found 0 pods out of 1
+Nov 29 08:07:39.471: INFO: Pod name my-hostname-basic-d3e4986f-f3ad-11e8-9124-e6180d057dc8: Found 1 pods out of 1
+Nov 29 08:07:39.471: INFO: Ensuring all pods for ReplicationController "my-hostname-basic-d3e4986f-f3ad-11e8-9124-e6180d057dc8" are running
+Nov 29 08:07:39.472: INFO: Pod "my-hostname-basic-d3e4986f-f3ad-11e8-9124-e6180d057dc8-jhf4q" is running (conditions: [{Type:Initialized Status:True LastProbeTime:0001-01-01 00:00:00 +0000 UTC LastTransitionTime:2018-11-29 08:07:34 +0000 UTC Reason: Message:} {Type:Ready Status:True LastProbeTime:0001-01-01 00:00:00 +0000 UTC LastTransitionTime:2018-11-29 08:07:35 +0000 UTC Reason: Message:} {Type:ContainersReady Status:True LastProbeTime:0001-01-01 00:00:00 +0000 UTC LastTransitionTime:0001-01-01 00:00:00 +0000 UTC Reason: Message:} {Type:PodScheduled Status:True LastProbeTime:0001-01-01 00:00:00 +0000 UTC LastTransitionTime:2018-11-29 08:07:34 +0000 UTC Reason: Message:}])
+Nov 29 08:07:39.472: INFO: Trying to dial the pod
+Nov 29 08:07:44.477: INFO: Controller my-hostname-basic-d3e4986f-f3ad-11e8-9124-e6180d057dc8: Got expected result from replica 1 [my-hostname-basic-d3e4986f-f3ad-11e8-9124-e6180d057dc8-jhf4q]: "my-hostname-basic-d3e4986f-f3ad-11e8-9124-e6180d057dc8-jhf4q", 1 of 1 required successes so far
+[AfterEach] [sig-apps] ReplicationController
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Nov 29 08:07:44.477: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-replication-controller-vjm7t" for this suite.
+Nov 29 08:07:50.484: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Nov 29 08:07:50.533: INFO: namespace: e2e-tests-replication-controller-vjm7t, resource: bindings, ignored listing per whitelist
+Nov 29 08:07:50.537: INFO: namespace e2e-tests-replication-controller-vjm7t deletion completed in 6.058559773s
+
+• [SLOW TEST:16.153 seconds]
+[sig-apps] ReplicationController
+/workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/framework.go:22
+  should serve a basic image on each replica with a public image  [Conformance]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SSSSS
+------------------------------
+[sig-api-machinery] Downward API 
+  should provide host IP as an env var  [Conformance]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-api-machinery] Downward API
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Nov 29 08:07:50.538: INFO: >>> kubeConfig: /tmp/kubeconfig-385092372
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should provide host IP as an env var  [Conformance]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating a pod to test downward api env vars
+Nov 29 08:07:50.569: INFO: Waiting up to 5m0s for pod "downward-api-dd7d601f-f3ad-11e8-9124-e6180d057dc8" in namespace "e2e-tests-downward-api-5tq6c" to be "success or failure"
+Nov 29 08:07:50.573: INFO: Pod "downward-api-dd7d601f-f3ad-11e8-9124-e6180d057dc8": Phase="Pending", Reason="", readiness=false. Elapsed: 4.026982ms
+Nov 29 08:07:52.575: INFO: Pod "downward-api-dd7d601f-f3ad-11e8-9124-e6180d057dc8": Phase="Pending", Reason="", readiness=false. Elapsed: 2.005859455s
+Nov 29 08:07:54.577: INFO: Pod "downward-api-dd7d601f-f3ad-11e8-9124-e6180d057dc8": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.007554746s
+STEP: Saw pod success
+Nov 29 08:07:54.577: INFO: Pod "downward-api-dd7d601f-f3ad-11e8-9124-e6180d057dc8" satisfied condition "success or failure"
+Nov 29 08:07:54.578: INFO: Trying to get logs from node worker-266bbc56-f3aa-11e8-ab5c-0a406d6cb422 pod downward-api-dd7d601f-f3ad-11e8-9124-e6180d057dc8 container dapi-container: <nil>
+STEP: delete the pod
+Nov 29 08:07:54.601: INFO: Waiting for pod downward-api-dd7d601f-f3ad-11e8-9124-e6180d057dc8 to disappear
+Nov 29 08:07:54.605: INFO: Pod downward-api-dd7d601f-f3ad-11e8-9124-e6180d057dc8 no longer exists
+[AfterEach] [sig-api-machinery] Downward API
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Nov 29 08:07:54.605: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-downward-api-5tq6c" for this suite.
+Nov 29 08:08:00.611: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Nov 29 08:08:00.628: INFO: namespace: e2e-tests-downward-api-5tq6c, resource: bindings, ignored listing per whitelist
+Nov 29 08:08:00.673: INFO: namespace e2e-tests-downward-api-5tq6c deletion completed in 6.067335013s
+
+• [SLOW TEST:10.136 seconds]
+[sig-api-machinery] Downward API
+/workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downward_api.go:37
+  should provide host IP as an env var  [Conformance]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SS
+------------------------------
+[sig-storage] EmptyDir volumes 
+  volume on tmpfs should have the correct mode [Conformance]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-storage] EmptyDir volumes
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Nov 29 08:08:00.674: INFO: >>> kubeConfig: /tmp/kubeconfig-385092372
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] volume on tmpfs should have the correct mode [Conformance]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating a pod to test emptydir volume type on tmpfs
+Nov 29 08:08:00.705: INFO: Waiting up to 5m0s for pod "pod-e387ea46-f3ad-11e8-9124-e6180d057dc8" in namespace "e2e-tests-emptydir-m4lnj" to be "success or failure"
+Nov 29 08:08:00.711: INFO: Pod "pod-e387ea46-f3ad-11e8-9124-e6180d057dc8": Phase="Pending", Reason="", readiness=false. Elapsed: 6.543992ms
+Nov 29 08:08:02.713: INFO: Pod "pod-e387ea46-f3ad-11e8-9124-e6180d057dc8": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.008282154s
+STEP: Saw pod success
+Nov 29 08:08:02.713: INFO: Pod "pod-e387ea46-f3ad-11e8-9124-e6180d057dc8" satisfied condition "success or failure"
+Nov 29 08:08:02.714: INFO: Trying to get logs from node worker-266bbc56-f3aa-11e8-ab5c-0a406d6cb422 pod pod-e387ea46-f3ad-11e8-9124-e6180d057dc8 container test-container: <nil>
+STEP: delete the pod
+Nov 29 08:08:02.726: INFO: Waiting for pod pod-e387ea46-f3ad-11e8-9124-e6180d057dc8 to disappear
+Nov 29 08:08:02.732: INFO: Pod pod-e387ea46-f3ad-11e8-9124-e6180d057dc8 no longer exists
+[AfterEach] [sig-storage] EmptyDir volumes
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Nov 29 08:08:02.732: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-emptydir-m4lnj" for this suite.
+Nov 29 08:08:08.741: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Nov 29 08:08:08.760: INFO: namespace: e2e-tests-emptydir-m4lnj, resource: bindings, ignored listing per whitelist
+Nov 29 08:08:08.795: INFO: namespace e2e-tests-emptydir-m4lnj deletion completed in 6.060158692s
+
+• [SLOW TEST:8.122 seconds]
+[sig-storage] EmptyDir volumes
+/workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/empty_dir.go:41
+  volume on tmpfs should have the correct mode [Conformance]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SSSSSSS
+------------------------------
+[sig-storage] Projected 
+  optional updates should be reflected in volume [Conformance]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Nov 29 08:08:08.796: INFO: >>> kubeConfig: /tmp/kubeconfig-385092372
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:858
+[It] optional updates should be reflected in volume [Conformance]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating configMap with name cm-test-opt-del-e85f65b7-f3ad-11e8-9124-e6180d057dc8
+STEP: Creating configMap with name cm-test-opt-upd-e85f65e0-f3ad-11e8-9124-e6180d057dc8
+STEP: Creating the pod
+STEP: Deleting configmap cm-test-opt-del-e85f65b7-f3ad-11e8-9124-e6180d057dc8
+STEP: Updating configmap cm-test-opt-upd-e85f65e0-f3ad-11e8-9124-e6180d057dc8
+STEP: Creating configMap with name cm-test-opt-create-e85f65f0-f3ad-11e8-9124-e6180d057dc8
+STEP: waiting to observe update in volume
+[AfterEach] [sig-storage] Projected
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Nov 29 08:08:12.869: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-9p7s9" for this suite.
+Nov 29 08:08:34.876: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Nov 29 08:08:34.913: INFO: namespace: e2e-tests-projected-9p7s9, resource: bindings, ignored listing per whitelist
+Nov 29 08:08:34.929: INFO: namespace e2e-tests-projected-9p7s9 deletion completed in 22.058695387s
+
+• [SLOW TEST:26.133 seconds]
+[sig-storage] Projected
+/workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:34
+  optional updates should be reflected in volume [Conformance]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SSSSSSSSSSSSS
+------------------------------
+[sig-api-machinery] Garbage collector 
+  should orphan pods created by rc if delete options say so [Conformance]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-api-machinery] Garbage collector
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Nov 29 08:08:34.929: INFO: >>> kubeConfig: /tmp/kubeconfig-385092372
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should orphan pods created by rc if delete options say so [Conformance]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: create the rc
+STEP: delete the rc
+STEP: wait for the rc to be deleted
+STEP: wait for 30 seconds to see if the garbage collector mistakenly deletes the pods
+STEP: Gathering metrics
+W1129 08:09:15.042973      13 metrics_grabber.go:81] Master node is not registered. Grabbing metrics from Scheduler, ControllerManager and ClusterAutoscaler is disabled.
+Nov 29 08:09:15.043: INFO: For apiserver_request_count:
+For apiserver_request_latencies_summary:
+For etcd_helper_cache_entry_count:
+For etcd_helper_cache_hit_count:
+For etcd_helper_cache_miss_count:
+For etcd_request_cache_add_latencies_summary:
+For etcd_request_cache_get_latencies_summary:
+For etcd_request_latencies_summary:
+For garbage_collector_attempt_to_delete_queue_latency:
+For garbage_collector_attempt_to_delete_work_duration:
+For garbage_collector_attempt_to_orphan_queue_latency:
+For garbage_collector_attempt_to_orphan_work_duration:
+For garbage_collector_dirty_processing_latency_microseconds:
+For garbage_collector_event_processing_latency_microseconds:
+For garbage_collector_graph_changes_queue_latency:
+For garbage_collector_graph_changes_work_duration:
+For garbage_collector_orphan_processing_latency_microseconds:
+For namespace_queue_latency:
+For namespace_queue_latency_sum:
+For namespace_queue_latency_count:
+For namespace_retries:
+For namespace_work_duration:
+For namespace_work_duration_sum:
+For namespace_work_duration_count:
+For function_duration_seconds:
+For errors_total:
+For evicted_pods_total:
+
+[AfterEach] [sig-api-machinery] Garbage collector
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Nov 29 08:09:15.043: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-gc-zqcg8" for this suite.
+Nov 29 08:09:21.049: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Nov 29 08:09:21.085: INFO: namespace: e2e-tests-gc-zqcg8, resource: bindings, ignored listing per whitelist
+Nov 29 08:09:21.102: INFO: namespace e2e-tests-gc-zqcg8 deletion completed in 6.057710341s
+
+• [SLOW TEST:46.173 seconds]
+[sig-api-machinery] Garbage collector
+/workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apimachinery/framework.go:22
+  should orphan pods created by rc if delete options say so [Conformance]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SS
+------------------------------
+[sig-scheduling] SchedulerPredicates [Serial] 
+  validates that NodeSelector is respected if matching  [Conformance]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-scheduling] SchedulerPredicates [Serial]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Nov 29 08:09:21.102: INFO: >>> kubeConfig: /tmp/kubeconfig-385092372
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-scheduling] SchedulerPredicates [Serial]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/scheduling/predicates.go:78
+Nov 29 08:09:21.130: INFO: Waiting up to 1m0s for all nodes to be ready
+Nov 29 08:10:21.138: INFO: Waiting for terminating namespaces to be deleted...
+Nov 29 08:10:21.141: INFO: Waiting up to 5m0s for all pods (need at least 0) in namespace 'kube-system' to be running and ready
+Nov 29 08:10:21.143: INFO: 0 / 0 pods in namespace 'kube-system' are running and ready (0 seconds elapsed)
+Nov 29 08:10:21.143: INFO: expected 0 pod replicas in namespace 'kube-system', 0 are Running and Ready.
+Nov 29 08:10:21.144: INFO: Waiting for pods to enter Success, but no pods in "kube-system" match label map[name:e2e-image-puller]
+Nov 29 08:10:21.144: INFO: 
+Logging pods the kubelet thinks is on node worker-266bbc56-f3aa-11e8-ab5c-0a406d6cb422 before test
+Nov 29 08:10:21.147: INFO: canal-node-test15434755641-11-5-1-vg9lg from vke-system started at 2018-11-29 07:43:31 +0000 UTC (3 container statuses recorded)
+Nov 29 08:10:21.147: INFO: 	Container calico-node ready: true, restart count 0
+Nov 29 08:10:21.147: INFO: 	Container flannel ready: true, restart count 0
+Nov 29 08:10:21.147: INFO: 	Container install-calico-cni ready: true, restart count 0
+Nov 29 08:10:21.147: INFO: 
+Logging pods the kubelet thinks is on node worker-bdccfcb0-f3a8-11e8-90fa-062be367adf0 before test
+Nov 29 08:10:21.149: INFO: canal-node-test15434755641-11-5-1-dtcp7 from vke-system started at 2018-11-29 07:33:18 +0000 UTC (3 container statuses recorded)
+Nov 29 08:10:21.149: INFO: 	Container calico-node ready: true, restart count 0
+Nov 29 08:10:21.149: INFO: 	Container flannel ready: true, restart count 0
+Nov 29 08:10:21.149: INFO: 	Container install-calico-cni ready: true, restart count 0
+Nov 29 08:10:21.149: INFO: sonobuoy from sonobuoy started at 2018-11-29 07:33:28 +0000 UTC (1 container statuses recorded)
+Nov 29 08:10:21.149: INFO: 	Container kube-sonobuoy ready: true, restart count 0
+Nov 29 08:10:21.149: INFO: sonobuoy-e2e-job from sonobuoy started at 2018-11-29 07:33:40 +0000 UTC (2 container statuses recorded)
+Nov 29 08:10:21.149: INFO: 	Container e2e ready: true, restart count 0
+Nov 29 08:10:21.149: INFO: 	Container sonobuoy-worker ready: true, restart count 0
+[It] validates that NodeSelector is respected if matching  [Conformance]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Trying to launch a pod without a label to get a node which can launch it.
+STEP: Explicitly delete pod here to free the resource it takes.
+STEP: Trying to apply a random label on the found node.
+STEP: verifying the node has the label kubernetes.io/e2e-38723a90-f3ae-11e8-9124-e6180d057dc8 42
+STEP: Trying to relaunch the pod, now with labels.
+STEP: removing the label kubernetes.io/e2e-38723a90-f3ae-11e8-9124-e6180d057dc8 off the node worker-266bbc56-f3aa-11e8-ab5c-0a406d6cb422
+STEP: verifying the node doesn't have the label kubernetes.io/e2e-38723a90-f3ae-11e8-9124-e6180d057dc8
+[AfterEach] [sig-scheduling] SchedulerPredicates [Serial]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Nov 29 08:10:25.196: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-sched-pred-wlj58" for this suite.
+Nov 29 08:10:47.203: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Nov 29 08:10:47.219: INFO: namespace: e2e-tests-sched-pred-wlj58, resource: bindings, ignored listing per whitelist
+Nov 29 08:10:47.259: INFO: namespace e2e-tests-sched-pred-wlj58 deletion completed in 22.060960754s
+[AfterEach] [sig-scheduling] SchedulerPredicates [Serial]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/scheduling/predicates.go:69
+
+• [SLOW TEST:86.157 seconds]
+[sig-scheduling] SchedulerPredicates [Serial]
+/workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/scheduling/framework.go:22
+  validates that NodeSelector is respected if matching  [Conformance]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SS
+------------------------------
+[sig-api-machinery] Garbage collector 
+  should orphan RS created by deployment when deleteOptions.PropagationPolicy is Orphan [Conformance]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-api-machinery] Garbage collector
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Nov 29 08:10:47.259: INFO: >>> kubeConfig: /tmp/kubeconfig-385092372
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should orphan RS created by deployment when deleteOptions.PropagationPolicy is Orphan [Conformance]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: create the deployment
+STEP: Wait for the Deployment to create new ReplicaSet
+STEP: delete the deployment
+STEP: wait for 2 Minute to see if the garbage collector mistakenly deletes the rs
+STEP: expected 0 Deploymentss, got 1 Deployments
+STEP: Gathering metrics
+W1129 08:10:52.358654      13 metrics_grabber.go:81] Master node is not registered. Grabbing metrics from Scheduler, ControllerManager and ClusterAutoscaler is disabled.
+Nov 29 08:10:52.358: INFO: For apiserver_request_count:
+For apiserver_request_latencies_summary:
+For etcd_helper_cache_entry_count:
+For etcd_helper_cache_hit_count:
+For etcd_helper_cache_miss_count:
+For etcd_request_cache_add_latencies_summary:
+For etcd_request_cache_get_latencies_summary:
+For etcd_request_latencies_summary:
+For garbage_collector_attempt_to_delete_queue_latency:
+For garbage_collector_attempt_to_delete_work_duration:
+For garbage_collector_attempt_to_orphan_queue_latency:
+For garbage_collector_attempt_to_orphan_work_duration:
+For garbage_collector_dirty_processing_latency_microseconds:
+For garbage_collector_event_processing_latency_microseconds:
+For garbage_collector_graph_changes_queue_latency:
+For garbage_collector_graph_changes_work_duration:
+For garbage_collector_orphan_processing_latency_microseconds:
+For namespace_queue_latency:
+For namespace_queue_latency_sum:
+For namespace_queue_latency_count:
+For namespace_retries:
+For namespace_work_duration:
+For namespace_work_duration_sum:
+For namespace_work_duration_count:
+For function_duration_seconds:
+For errors_total:
+For evicted_pods_total:
+
+[AfterEach] [sig-api-machinery] Garbage collector
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Nov 29 08:10:52.358: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-gc-xkffd" for this suite.
+Nov 29 08:10:58.365: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Nov 29 08:10:58.398: INFO: namespace: e2e-tests-gc-xkffd, resource: bindings, ignored listing per whitelist
+Nov 29 08:10:58.421: INFO: namespace e2e-tests-gc-xkffd deletion completed in 6.059935376s
+
+• [SLOW TEST:11.162 seconds]
+[sig-api-machinery] Garbage collector
+/workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apimachinery/framework.go:22
+  should orphan RS created by deployment when deleteOptions.PropagationPolicy is Orphan [Conformance]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+S
+------------------------------
+[sig-storage] ConfigMap 
+  updates should be reflected in volume  [Conformance]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-storage] ConfigMap
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Nov 29 08:10:58.421: INFO: >>> kubeConfig: /tmp/kubeconfig-385092372
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] updates should be reflected in volume  [Conformance]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating configMap with name configmap-test-upd-4d7b2474-f3ae-11e8-9124-e6180d057dc8
+STEP: Creating the pod
+STEP: Updating configmap configmap-test-upd-4d7b2474-f3ae-11e8-9124-e6180d057dc8
+STEP: waiting to observe update in volume
+[AfterEach] [sig-storage] ConfigMap
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Nov 29 08:11:02.488: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-configmap-5ptb4" for this suite.
+Nov 29 08:11:24.495: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Nov 29 08:11:24.562: INFO: namespace: e2e-tests-configmap-5ptb4, resource: bindings, ignored listing per whitelist
+Nov 29 08:11:24.573: INFO: namespace e2e-tests-configmap-5ptb4 deletion completed in 22.083810875s
+
+• [SLOW TEST:26.153 seconds]
+[sig-storage] ConfigMap
+/workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/configmap_volume.go:32
+  updates should be reflected in volume  [Conformance]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SSSSSSSSSSSSSS
+------------------------------
+[sig-storage] Projected 
+  should update annotations on modification [Conformance]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Nov 29 08:11:24.573: INFO: >>> kubeConfig: /tmp/kubeconfig-385092372
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:858
+[It] should update annotations on modification [Conformance]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating the pod
+Nov 29 08:11:27.145: INFO: Successfully updated pod "annotationupdate5d130e5a-f3ae-11e8-9124-e6180d057dc8"
+[AfterEach] [sig-storage] Projected
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Nov 29 08:11:29.153: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-lnzbd" for this suite.
+Nov 29 08:11:51.159: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Nov 29 08:11:51.204: INFO: namespace: e2e-tests-projected-lnzbd, resource: bindings, ignored listing per whitelist
+Nov 29 08:11:51.212: INFO: namespace e2e-tests-projected-lnzbd deletion completed in 22.05718919s
+
+• [SLOW TEST:26.638 seconds]
+[sig-storage] Projected
+/workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:34
+  should update annotations on modification [Conformance]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SSS
+------------------------------
+[sig-storage] Projected 
+  should be consumable from pods in volume with mappings [Conformance]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Nov 29 08:11:51.212: INFO: >>> kubeConfig: /tmp/kubeconfig-385092372
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:858
+[It] should be consumable from pods in volume with mappings [Conformance]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating configMap with name projected-configmap-test-volume-map-6cf8db79-f3ae-11e8-9124-e6180d057dc8
+STEP: Creating a pod to test consume configMaps
+Nov 29 08:11:51.295: INFO: Waiting up to 5m0s for pod "pod-projected-configmaps-6cf918f4-f3ae-11e8-9124-e6180d057dc8" in namespace "e2e-tests-projected-jqdkx" to be "success or failure"
+Nov 29 08:11:51.303: INFO: Pod "pod-projected-configmaps-6cf918f4-f3ae-11e8-9124-e6180d057dc8": Phase="Pending", Reason="", readiness=false. Elapsed: 7.975184ms
+Nov 29 08:11:53.304: INFO: Pod "pod-projected-configmaps-6cf918f4-f3ae-11e8-9124-e6180d057dc8": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.009647679s
+STEP: Saw pod success
+Nov 29 08:11:53.304: INFO: Pod "pod-projected-configmaps-6cf918f4-f3ae-11e8-9124-e6180d057dc8" satisfied condition "success or failure"
+Nov 29 08:11:53.305: INFO: Trying to get logs from node worker-266bbc56-f3aa-11e8-ab5c-0a406d6cb422 pod pod-projected-configmaps-6cf918f4-f3ae-11e8-9124-e6180d057dc8 container projected-configmap-volume-test: <nil>
+STEP: delete the pod
+Nov 29 08:11:53.318: INFO: Waiting for pod pod-projected-configmaps-6cf918f4-f3ae-11e8-9124-e6180d057dc8 to disappear
+Nov 29 08:11:53.320: INFO: Pod pod-projected-configmaps-6cf918f4-f3ae-11e8-9124-e6180d057dc8 no longer exists
+[AfterEach] [sig-storage] Projected
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Nov 29 08:11:53.320: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-jqdkx" for this suite.
+Nov 29 08:11:59.327: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Nov 29 08:11:59.358: INFO: namespace: e2e-tests-projected-jqdkx, resource: bindings, ignored listing per whitelist
+Nov 29 08:11:59.383: INFO: namespace e2e-tests-projected-jqdkx deletion completed in 6.060957816s
+
+• [SLOW TEST:8.171 seconds]
+[sig-storage] Projected
+/workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:34
+  should be consumable from pods in volume with mappings [Conformance]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SSSSSSS
+------------------------------
+[sig-storage] Secrets 
+  should be consumable from pods in volume with defaultMode set  [Conformance]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-storage] Secrets
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Nov 29 08:11:59.383: INFO: >>> kubeConfig: /tmp/kubeconfig-385092372
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should be consumable from pods in volume with defaultMode set  [Conformance]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating secret with name secret-test-71d1f05d-f3ae-11e8-9124-e6180d057dc8
+STEP: Creating a pod to test consume secrets
+Nov 29 08:11:59.431: INFO: Waiting up to 5m0s for pod "pod-secrets-71d23964-f3ae-11e8-9124-e6180d057dc8" in namespace "e2e-tests-secrets-fz7mn" to be "success or failure"
+Nov 29 08:11:59.433: INFO: Pod "pod-secrets-71d23964-f3ae-11e8-9124-e6180d057dc8": Phase="Pending", Reason="", readiness=false. Elapsed: 1.545746ms
+Nov 29 08:12:01.434: INFO: Pod "pod-secrets-71d23964-f3ae-11e8-9124-e6180d057dc8": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.003393484s
+STEP: Saw pod success
+Nov 29 08:12:01.434: INFO: Pod "pod-secrets-71d23964-f3ae-11e8-9124-e6180d057dc8" satisfied condition "success or failure"
+Nov 29 08:12:01.436: INFO: Trying to get logs from node worker-266bbc56-f3aa-11e8-ab5c-0a406d6cb422 pod pod-secrets-71d23964-f3ae-11e8-9124-e6180d057dc8 container secret-volume-test: <nil>
+STEP: delete the pod
+Nov 29 08:12:01.447: INFO: Waiting for pod pod-secrets-71d23964-f3ae-11e8-9124-e6180d057dc8 to disappear
+Nov 29 08:12:01.449: INFO: Pod pod-secrets-71d23964-f3ae-11e8-9124-e6180d057dc8 no longer exists
+[AfterEach] [sig-storage] Secrets
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Nov 29 08:12:01.449: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-secrets-fz7mn" for this suite.
+Nov 29 08:12:07.457: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Nov 29 08:12:07.500: INFO: namespace: e2e-tests-secrets-fz7mn, resource: bindings, ignored listing per whitelist
+Nov 29 08:12:07.511: INFO: namespace e2e-tests-secrets-fz7mn deletion completed in 6.059366463s
+
+• [SLOW TEST:8.128 seconds]
+[sig-storage] Secrets
+/workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/secrets_volume.go:33
+  should be consumable from pods in volume with defaultMode set  [Conformance]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SSS
+------------------------------
+[sig-api-machinery] Secrets 
+  should be consumable from pods in env vars  [Conformance]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-api-machinery] Secrets
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Nov 29 08:12:07.511: INFO: >>> kubeConfig: /tmp/kubeconfig-385092372
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should be consumable from pods in env vars  [Conformance]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating secret with name secret-test-76a8414b-f3ae-11e8-9124-e6180d057dc8
+STEP: Creating a pod to test consume secrets
+Nov 29 08:12:07.545: INFO: Waiting up to 5m0s for pod "pod-secrets-76a88214-f3ae-11e8-9124-e6180d057dc8" in namespace "e2e-tests-secrets-kxmq2" to be "success or failure"
+Nov 29 08:12:07.552: INFO: Pod "pod-secrets-76a88214-f3ae-11e8-9124-e6180d057dc8": Phase="Pending", Reason="", readiness=false. Elapsed: 7.08624ms
+Nov 29 08:12:09.553: INFO: Pod "pod-secrets-76a88214-f3ae-11e8-9124-e6180d057dc8": Phase="Pending", Reason="", readiness=false. Elapsed: 2.008578729s
+Nov 29 08:12:11.555: INFO: Pod "pod-secrets-76a88214-f3ae-11e8-9124-e6180d057dc8": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.00998234s
+STEP: Saw pod success
+Nov 29 08:12:11.555: INFO: Pod "pod-secrets-76a88214-f3ae-11e8-9124-e6180d057dc8" satisfied condition "success or failure"
+Nov 29 08:12:11.556: INFO: Trying to get logs from node worker-266bbc56-f3aa-11e8-ab5c-0a406d6cb422 pod pod-secrets-76a88214-f3ae-11e8-9124-e6180d057dc8 container secret-env-test: <nil>
+STEP: delete the pod
+Nov 29 08:12:11.568: INFO: Waiting for pod pod-secrets-76a88214-f3ae-11e8-9124-e6180d057dc8 to disappear
+Nov 29 08:12:11.569: INFO: Pod pod-secrets-76a88214-f3ae-11e8-9124-e6180d057dc8 no longer exists
+[AfterEach] [sig-api-machinery] Secrets
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Nov 29 08:12:11.569: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-secrets-kxmq2" for this suite.
+Nov 29 08:12:17.579: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Nov 29 08:12:17.608: INFO: namespace: e2e-tests-secrets-kxmq2, resource: bindings, ignored listing per whitelist
+Nov 29 08:12:17.631: INFO: namespace e2e-tests-secrets-kxmq2 deletion completed in 6.059967858s
+
+• [SLOW TEST:10.120 seconds]
+[sig-api-machinery] Secrets
+/workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/secrets.go:30
+  should be consumable from pods in env vars  [Conformance]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+[sig-storage] EmptyDir volumes 
+  should support (root,0644,tmpfs) [Conformance]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-storage] EmptyDir volumes
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Nov 29 08:12:17.631: INFO: >>> kubeConfig: /tmp/kubeconfig-385092372
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should support (root,0644,tmpfs) [Conformance]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating a pod to test emptydir 0644 on tmpfs
+Nov 29 08:12:17.719: INFO: Waiting up to 5m0s for pod "pod-7cb875c0-f3ae-11e8-9124-e6180d057dc8" in namespace "e2e-tests-emptydir-rv7l8" to be "success or failure"
+Nov 29 08:12:17.721: INFO: Pod "pod-7cb875c0-f3ae-11e8-9124-e6180d057dc8": Phase="Pending", Reason="", readiness=false. Elapsed: 2.552421ms
+Nov 29 08:12:19.723: INFO: Pod "pod-7cb875c0-f3ae-11e8-9124-e6180d057dc8": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.004030836s
+STEP: Saw pod success
+Nov 29 08:12:19.723: INFO: Pod "pod-7cb875c0-f3ae-11e8-9124-e6180d057dc8" satisfied condition "success or failure"
+Nov 29 08:12:19.724: INFO: Trying to get logs from node worker-266bbc56-f3aa-11e8-ab5c-0a406d6cb422 pod pod-7cb875c0-f3ae-11e8-9124-e6180d057dc8 container test-container: <nil>
+STEP: delete the pod
+Nov 29 08:12:19.739: INFO: Waiting for pod pod-7cb875c0-f3ae-11e8-9124-e6180d057dc8 to disappear
+Nov 29 08:12:19.741: INFO: Pod pod-7cb875c0-f3ae-11e8-9124-e6180d057dc8 no longer exists
+[AfterEach] [sig-storage] EmptyDir volumes
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Nov 29 08:12:19.741: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-emptydir-rv7l8" for this suite.
+Nov 29 08:12:25.747: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Nov 29 08:12:25.792: INFO: namespace: e2e-tests-emptydir-rv7l8, resource: bindings, ignored listing per whitelist
+Nov 29 08:12:25.797: INFO: namespace e2e-tests-emptydir-rv7l8 deletion completed in 6.054537397s
+
+• [SLOW TEST:8.165 seconds]
+[sig-storage] EmptyDir volumes
+/workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/empty_dir.go:41
+  should support (root,0644,tmpfs) [Conformance]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SSSSSSSSSSSSSSSSSSSSSSSSS
+------------------------------
+[sig-apps] ReplicaSet 
+  should serve a basic image on each replica with a public image  [Conformance]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-apps] ReplicaSet
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Nov 29 08:12:25.797: INFO: >>> kubeConfig: /tmp/kubeconfig-385092372
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should serve a basic image on each replica with a public image  [Conformance]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+Nov 29 08:12:25.825: INFO: Creating ReplicaSet my-hostname-basic-818e767a-f3ae-11e8-9124-e6180d057dc8
+Nov 29 08:12:25.830: INFO: Pod name my-hostname-basic-818e767a-f3ae-11e8-9124-e6180d057dc8: Found 0 pods out of 1
+Nov 29 08:12:30.832: INFO: Pod name my-hostname-basic-818e767a-f3ae-11e8-9124-e6180d057dc8: Found 1 pods out of 1
+Nov 29 08:12:30.832: INFO: Ensuring a pod for ReplicaSet "my-hostname-basic-818e767a-f3ae-11e8-9124-e6180d057dc8" is running
+Nov 29 08:12:30.833: INFO: Pod "my-hostname-basic-818e767a-f3ae-11e8-9124-e6180d057dc8-9x9w4" is running (conditions: [{Type:Initialized Status:True LastProbeTime:0001-01-01 00:00:00 +0000 UTC LastTransitionTime:2018-11-29 08:12:25 +0000 UTC Reason: Message:} {Type:Ready Status:True LastProbeTime:0001-01-01 00:00:00 +0000 UTC LastTransitionTime:2018-11-29 08:12:27 +0000 UTC Reason: Message:} {Type:ContainersReady Status:True LastProbeTime:0001-01-01 00:00:00 +0000 UTC LastTransitionTime:0001-01-01 00:00:00 +0000 UTC Reason: Message:} {Type:PodScheduled Status:True LastProbeTime:0001-01-01 00:00:00 +0000 UTC LastTransitionTime:2018-11-29 08:12:25 +0000 UTC Reason: Message:}])
+Nov 29 08:12:30.833: INFO: Trying to dial the pod
+Nov 29 08:12:35.839: INFO: Controller my-hostname-basic-818e767a-f3ae-11e8-9124-e6180d057dc8: Got expected result from replica 1 [my-hostname-basic-818e767a-f3ae-11e8-9124-e6180d057dc8-9x9w4]: "my-hostname-basic-818e767a-f3ae-11e8-9124-e6180d057dc8-9x9w4", 1 of 1 required successes so far
+[AfterEach] [sig-apps] ReplicaSet
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Nov 29 08:12:35.839: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-replicaset-r66r6" for this suite.
+Nov 29 08:12:41.845: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Nov 29 08:12:41.885: INFO: namespace: e2e-tests-replicaset-r66r6, resource: bindings, ignored listing per whitelist
+Nov 29 08:12:41.902: INFO: namespace e2e-tests-replicaset-r66r6 deletion completed in 6.061704658s
+
+• [SLOW TEST:16.105 seconds]
+[sig-apps] ReplicaSet
+/workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/framework.go:22
+  should serve a basic image on each replica with a public image  [Conformance]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SS
+------------------------------
+[k8s.io] Variable Expansion 
+  should allow substituting values in a container's command  [Conformance]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [k8s.io] Variable Expansion
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Nov 29 08:12:41.902: INFO: >>> kubeConfig: /tmp/kubeconfig-385092372
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should allow substituting values in a container's command  [Conformance]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating a pod to test substitution in container's command
+Nov 29 08:12:41.933: INFO: Waiting up to 5m0s for pod "var-expansion-8b27e96f-f3ae-11e8-9124-e6180d057dc8" in namespace "e2e-tests-var-expansion-cflv4" to be "success or failure"
+Nov 29 08:12:41.935: INFO: Pod "var-expansion-8b27e96f-f3ae-11e8-9124-e6180d057dc8": Phase="Pending", Reason="", readiness=false. Elapsed: 2.080078ms
+Nov 29 08:12:43.937: INFO: Pod "var-expansion-8b27e96f-f3ae-11e8-9124-e6180d057dc8": Phase="Pending", Reason="", readiness=false. Elapsed: 2.003757383s
+Nov 29 08:12:45.939: INFO: Pod "var-expansion-8b27e96f-f3ae-11e8-9124-e6180d057dc8": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.005520605s
+STEP: Saw pod success
+Nov 29 08:12:45.939: INFO: Pod "var-expansion-8b27e96f-f3ae-11e8-9124-e6180d057dc8" satisfied condition "success or failure"
+Nov 29 08:12:45.940: INFO: Trying to get logs from node worker-266bbc56-f3aa-11e8-ab5c-0a406d6cb422 pod var-expansion-8b27e96f-f3ae-11e8-9124-e6180d057dc8 container dapi-container: <nil>
+STEP: delete the pod
+Nov 29 08:12:45.953: INFO: Waiting for pod var-expansion-8b27e96f-f3ae-11e8-9124-e6180d057dc8 to disappear
+Nov 29 08:12:45.955: INFO: Pod var-expansion-8b27e96f-f3ae-11e8-9124-e6180d057dc8 no longer exists
+[AfterEach] [k8s.io] Variable Expansion
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Nov 29 08:12:45.955: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-var-expansion-cflv4" for this suite.
+Nov 29 08:12:51.962: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Nov 29 08:12:52.018: INFO: namespace: e2e-tests-var-expansion-cflv4, resource: bindings, ignored listing per whitelist
+Nov 29 08:12:52.025: INFO: namespace e2e-tests-var-expansion-cflv4 deletion completed in 6.067438508s
+
+• [SLOW TEST:10.123 seconds]
+[k8s.io] Variable Expansion
+/workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:669
+  should allow substituting values in a container's command  [Conformance]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+[sig-storage] Projected 
+  should project all components that make up the projection API [Projection] [Conformance]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Nov 29 08:12:52.025: INFO: >>> kubeConfig: /tmp/kubeconfig-385092372
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:858
+[It] should project all components that make up the projection API [Projection] [Conformance]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating configMap with name configmap-projected-all-test-volume-9130bacc-f3ae-11e8-9124-e6180d057dc8
+STEP: Creating secret with name secret-projected-all-test-volume-9130bab6-f3ae-11e8-9124-e6180d057dc8
+STEP: Creating a pod to test Check all projections for projected volume plugin
+Nov 29 08:12:52.060: INFO: Waiting up to 5m0s for pod "projected-volume-9130ba8a-f3ae-11e8-9124-e6180d057dc8" in namespace "e2e-tests-projected-m59s4" to be "success or failure"
+Nov 29 08:12:52.063: INFO: Pod "projected-volume-9130ba8a-f3ae-11e8-9124-e6180d057dc8": Phase="Pending", Reason="", readiness=false. Elapsed: 2.823361ms
+Nov 29 08:12:54.064: INFO: Pod "projected-volume-9130ba8a-f3ae-11e8-9124-e6180d057dc8": Phase="Pending", Reason="", readiness=false. Elapsed: 2.004340232s
+Nov 29 08:12:56.066: INFO: Pod "projected-volume-9130ba8a-f3ae-11e8-9124-e6180d057dc8": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.006083407s
+STEP: Saw pod success
+Nov 29 08:12:56.066: INFO: Pod "projected-volume-9130ba8a-f3ae-11e8-9124-e6180d057dc8" satisfied condition "success or failure"
+Nov 29 08:12:56.067: INFO: Trying to get logs from node worker-266bbc56-f3aa-11e8-ab5c-0a406d6cb422 pod projected-volume-9130ba8a-f3ae-11e8-9124-e6180d057dc8 container projected-all-volume-test: <nil>
+STEP: delete the pod
+Nov 29 08:12:56.082: INFO: Waiting for pod projected-volume-9130ba8a-f3ae-11e8-9124-e6180d057dc8 to disappear
+Nov 29 08:12:56.089: INFO: Pod projected-volume-9130ba8a-f3ae-11e8-9124-e6180d057dc8 no longer exists
+[AfterEach] [sig-storage] Projected
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Nov 29 08:12:56.089: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-m59s4" for this suite.
+Nov 29 08:13:02.112: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Nov 29 08:13:02.164: INFO: namespace: e2e-tests-projected-m59s4, resource: bindings, ignored listing per whitelist
+Nov 29 08:13:02.175: INFO: namespace e2e-tests-projected-m59s4 deletion completed in 6.079108959s
+
+• [SLOW TEST:10.150 seconds]
+[sig-storage] Projected
+/workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:34
+  should project all components that make up the projection API [Projection] [Conformance]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+[sig-storage] Projected 
+  should update labels on modification [Conformance]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Nov 29 08:13:02.175: INFO: >>> kubeConfig: /tmp/kubeconfig-385092372
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:858
+[It] should update labels on modification [Conformance]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating the pod
+Nov 29 08:13:04.723: INFO: Successfully updated pod "labelsupdate973d3d26-f3ae-11e8-9124-e6180d057dc8"
+[AfterEach] [sig-storage] Projected
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Nov 29 08:13:06.734: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-754p5" for this suite.
+Nov 29 08:13:28.742: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Nov 29 08:13:28.777: INFO: namespace: e2e-tests-projected-754p5, resource: bindings, ignored listing per whitelist
+Nov 29 08:13:28.795: INFO: namespace e2e-tests-projected-754p5 deletion completed in 22.05871578s
+
+• [SLOW TEST:26.620 seconds]
+[sig-storage] Projected
+/workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:34
+  should update labels on modification [Conformance]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SSSSSSSSS
+------------------------------
+[sig-storage] Downward API volume 
+  should update annotations on modification  [Conformance]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Nov 29 08:13:28.795: INFO: >>> kubeConfig: /tmp/kubeconfig-385092372
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downwardapi_volume.go:38
+[It] should update annotations on modification  [Conformance]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating the pod
+Nov 29 08:13:33.340: INFO: Successfully updated pod "annotationupdatea71b0b4f-f3ae-11e8-9124-e6180d057dc8"
+[AfterEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Nov 29 08:13:35.352: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-downward-api-d6ph7" for this suite.
+Nov 29 08:13:57.359: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Nov 29 08:13:57.384: INFO: namespace: e2e-tests-downward-api-d6ph7, resource: bindings, ignored listing per whitelist
+Nov 29 08:13:57.414: INFO: namespace e2e-tests-downward-api-d6ph7 deletion completed in 22.059196286s
+
+• [SLOW TEST:28.619 seconds]
+[sig-storage] Downward API volume
+/workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downwardapi_volume.go:33
+  should update annotations on modification  [Conformance]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SSSS
+------------------------------
+[sig-storage] Downward API volume 
+  should update labels on modification  [Conformance]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Nov 29 08:13:57.414: INFO: >>> kubeConfig: /tmp/kubeconfig-385092372
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downwardapi_volume.go:38
+[It] should update labels on modification  [Conformance]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating the pod
+Nov 29 08:14:00.016: INFO: Successfully updated pod "labelsupdateb831c04b-f3ae-11e8-9124-e6180d057dc8"
+[AfterEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Nov 29 08:14:04.030: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-downward-api-kq6kn" for this suite.
+Nov 29 08:14:26.037: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Nov 29 08:14:26.085: INFO: namespace: e2e-tests-downward-api-kq6kn, resource: bindings, ignored listing per whitelist
+Nov 29 08:14:26.090: INFO: namespace e2e-tests-downward-api-kq6kn deletion completed in 22.057988896s
+
+• [SLOW TEST:28.676 seconds]
+[sig-storage] Downward API volume
+/workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downwardapi_volume.go:33
+  should update labels on modification  [Conformance]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SSSSSSSSSSS
+------------------------------
+[k8s.io] Probing container 
+  should be restarted with a docker exec liveness probe with timeout  [Conformance]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [k8s.io] Probing container
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Nov 29 08:14:26.090: INFO: >>> kubeConfig: /tmp/kubeconfig-385092372
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [k8s.io] Probing container
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/container_probe.go:48
+[It] should be restarted with a docker exec liveness probe with timeout  [Conformance]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+Nov 29 08:14:26.118: INFO: The default exec handler, dockertools.NativeExecHandler, does not support timeouts due to a limitation in the Docker Remote API
+[AfterEach] [k8s.io] Probing container
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Nov 29 08:14:26.119: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-container-probe-ttv79" for this suite.
+Nov 29 08:14:32.125: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Nov 29 08:14:32.169: INFO: namespace: e2e-tests-container-probe-ttv79, resource: bindings, ignored listing per whitelist
+Nov 29 08:14:32.175: INFO: namespace e2e-tests-container-probe-ttv79 deletion completed in 6.054524291s
+
+S [SKIPPING] [6.085 seconds]
+[k8s.io] Probing container
+/workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:669
+  should be restarted with a docker exec liveness probe with timeout  [Conformance] [It]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+
+  Nov 29 08:14:26.118: The default exec handler, dockertools.NativeExecHandler, does not support timeouts due to a limitation in the Docker Remote API
+
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/util.go:299
+------------------------------
+SSSSS
+------------------------------
+[sig-apps] Daemon set [Serial] 
+  should rollback without unnecessary restarts [Conformance]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-apps] Daemon set [Serial]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Nov 29 08:14:32.175: INFO: >>> kubeConfig: /tmp/kubeconfig-385092372
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-apps] Daemon set [Serial]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/daemon_set.go:103
+[It] should rollback without unnecessary restarts [Conformance]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+Nov 29 08:14:32.207: INFO: Requires at least 2 nodes (not -1)
+[AfterEach] [sig-apps] Daemon set [Serial]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/daemon_set.go:66
+Nov 29 08:14:32.212: INFO: daemonset: {"kind":"DaemonSetList","apiVersion":"apps/v1","metadata":{"selfLink":"/apis/apps/v1/namespaces/e2e-tests-daemonsets-bnw2f/daemonsets","resourceVersion":"14531"},"items":null}
+
+Nov 29 08:14:32.213: INFO: pods: {"kind":"PodList","apiVersion":"v1","metadata":{"selfLink":"/api/v1/namespaces/e2e-tests-daemonsets-bnw2f/pods","resourceVersion":"14531"},"items":null}
+
+[AfterEach] [sig-apps] Daemon set [Serial]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Nov 29 08:14:32.218: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-daemonsets-bnw2f" for this suite.
+Nov 29 08:14:38.225: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Nov 29 08:14:38.276: INFO: namespace: e2e-tests-daemonsets-bnw2f, resource: bindings, ignored listing per whitelist
+Nov 29 08:14:38.284: INFO: namespace e2e-tests-daemonsets-bnw2f deletion completed in 6.06437533s
+
+S [SKIPPING] [6.109 seconds]
+[sig-apps] Daemon set [Serial]
+/workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/framework.go:22
+  should rollback without unnecessary restarts [Conformance] [It]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+
+  Nov 29 08:14:32.207: Requires at least 2 nodes (not -1)
+
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/util.go:299
+------------------------------
+SSSSSSSSSSSS
+------------------------------
+[sig-storage] EmptyDir volumes 
+  should support (root,0666,tmpfs) [Conformance]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-storage] EmptyDir volumes
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Nov 29 08:14:38.284: INFO: >>> kubeConfig: /tmp/kubeconfig-385092372
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should support (root,0666,tmpfs) [Conformance]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating a pod to test emptydir 0666 on tmpfs
+Nov 29 08:14:38.365: INFO: Waiting up to 5m0s for pod "pod-d08e0022-f3ae-11e8-9124-e6180d057dc8" in namespace "e2e-tests-emptydir-k2k2w" to be "success or failure"
+Nov 29 08:14:38.367: INFO: Pod "pod-d08e0022-f3ae-11e8-9124-e6180d057dc8": Phase="Pending", Reason="", readiness=false. Elapsed: 2.503621ms
+Nov 29 08:14:40.369: INFO: Pod "pod-d08e0022-f3ae-11e8-9124-e6180d057dc8": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.004050216s
+STEP: Saw pod success
+Nov 29 08:14:40.369: INFO: Pod "pod-d08e0022-f3ae-11e8-9124-e6180d057dc8" satisfied condition "success or failure"
+Nov 29 08:14:40.370: INFO: Trying to get logs from node worker-266bbc56-f3aa-11e8-ab5c-0a406d6cb422 pod pod-d08e0022-f3ae-11e8-9124-e6180d057dc8 container test-container: <nil>
+STEP: delete the pod
+Nov 29 08:14:40.389: INFO: Waiting for pod pod-d08e0022-f3ae-11e8-9124-e6180d057dc8 to disappear
+Nov 29 08:14:40.396: INFO: Pod pod-d08e0022-f3ae-11e8-9124-e6180d057dc8 no longer exists
+[AfterEach] [sig-storage] EmptyDir volumes
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Nov 29 08:14:40.396: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-emptydir-k2k2w" for this suite.
+Nov 29 08:14:46.403: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Nov 29 08:14:46.446: INFO: namespace: e2e-tests-emptydir-k2k2w, resource: bindings, ignored listing per whitelist
+Nov 29 08:14:46.456: INFO: namespace e2e-tests-emptydir-k2k2w deletion completed in 6.058142335s
+
+• [SLOW TEST:8.171 seconds]
+[sig-storage] EmptyDir volumes
+/workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/empty_dir.go:41
+  should support (root,0666,tmpfs) [Conformance]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SSSSSSSSSSSSSSS
+------------------------------
+[sig-auth] ServiceAccounts 
+  should allow opting out of API token automount  [Conformance]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-auth] ServiceAccounts
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Nov 29 08:14:46.456: INFO: >>> kubeConfig: /tmp/kubeconfig-385092372
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should allow opting out of API token automount  [Conformance]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: getting the auto-created API token
+Nov 29 08:14:46.995: INFO: created pod pod-service-account-defaultsa
+Nov 29 08:14:46.995: INFO: pod pod-service-account-defaultsa service account token volume mount: true
+Nov 29 08:14:47.003: INFO: created pod pod-service-account-mountsa
+Nov 29 08:14:47.003: INFO: pod pod-service-account-mountsa service account token volume mount: true
+Nov 29 08:14:47.006: INFO: created pod pod-service-account-nomountsa
+Nov 29 08:14:47.006: INFO: pod pod-service-account-nomountsa service account token volume mount: false
+Nov 29 08:14:47.017: INFO: created pod pod-service-account-defaultsa-mountspec
+Nov 29 08:14:47.017: INFO: pod pod-service-account-defaultsa-mountspec service account token volume mount: true
+Nov 29 08:14:47.025: INFO: created pod pod-service-account-mountsa-mountspec
+Nov 29 08:14:47.025: INFO: pod pod-service-account-mountsa-mountspec service account token volume mount: true
+Nov 29 08:14:47.037: INFO: created pod pod-service-account-nomountsa-mountspec
+Nov 29 08:14:47.037: INFO: pod pod-service-account-nomountsa-mountspec service account token volume mount: true
+Nov 29 08:14:47.042: INFO: created pod pod-service-account-defaultsa-nomountspec
+Nov 29 08:14:47.042: INFO: pod pod-service-account-defaultsa-nomountspec service account token volume mount: false
+Nov 29 08:14:47.047: INFO: created pod pod-service-account-mountsa-nomountspec
+Nov 29 08:14:47.047: INFO: pod pod-service-account-mountsa-nomountspec service account token volume mount: false
+Nov 29 08:14:47.054: INFO: created pod pod-service-account-nomountsa-nomountspec
+Nov 29 08:14:47.054: INFO: pod pod-service-account-nomountsa-nomountspec service account token volume mount: false
+[AfterEach] [sig-auth] ServiceAccounts
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Nov 29 08:14:47.054: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-svcaccounts-rsj64" for this suite.
+Nov 29 08:14:53.079: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Nov 29 08:14:53.097: INFO: namespace: e2e-tests-svcaccounts-rsj64, resource: bindings, ignored listing per whitelist
+Nov 29 08:14:53.131: INFO: namespace e2e-tests-svcaccounts-rsj64 deletion completed in 6.067839465s
+
+• [SLOW TEST:6.675 seconds]
+[sig-auth] ServiceAccounts
+/workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/auth/framework.go:22
+  should allow opting out of API token automount  [Conformance]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SSSSSSSSSSS
+------------------------------
+[sig-storage] Projected 
+  should be consumable from pods in volume [Conformance]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Nov 29 08:14:53.131: INFO: >>> kubeConfig: /tmp/kubeconfig-385092372
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:858
+[It] should be consumable from pods in volume [Conformance]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating configMap with name projected-configmap-test-volume-d9604670-f3ae-11e8-9124-e6180d057dc8
+STEP: Creating a pod to test consume configMaps
+Nov 29 08:14:53.167: INFO: Waiting up to 5m0s for pod "pod-projected-configmaps-d96080e2-f3ae-11e8-9124-e6180d057dc8" in namespace "e2e-tests-projected-dhxp2" to be "success or failure"
+Nov 29 08:14:53.170: INFO: Pod "pod-projected-configmaps-d96080e2-f3ae-11e8-9124-e6180d057dc8": Phase="Pending", Reason="", readiness=false. Elapsed: 2.988196ms
+Nov 29 08:14:55.172: INFO: Pod "pod-projected-configmaps-d96080e2-f3ae-11e8-9124-e6180d057dc8": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.00479798s
+STEP: Saw pod success
+Nov 29 08:14:55.172: INFO: Pod "pod-projected-configmaps-d96080e2-f3ae-11e8-9124-e6180d057dc8" satisfied condition "success or failure"
+Nov 29 08:14:55.173: INFO: Trying to get logs from node worker-266bbc56-f3aa-11e8-ab5c-0a406d6cb422 pod pod-projected-configmaps-d96080e2-f3ae-11e8-9124-e6180d057dc8 container projected-configmap-volume-test: <nil>
+STEP: delete the pod
+Nov 29 08:14:55.184: INFO: Waiting for pod pod-projected-configmaps-d96080e2-f3ae-11e8-9124-e6180d057dc8 to disappear
+Nov 29 08:14:55.188: INFO: Pod pod-projected-configmaps-d96080e2-f3ae-11e8-9124-e6180d057dc8 no longer exists
+[AfterEach] [sig-storage] Projected
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Nov 29 08:14:55.188: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-dhxp2" for this suite.
+Nov 29 08:15:01.195: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Nov 29 08:15:01.225: INFO: namespace: e2e-tests-projected-dhxp2, resource: bindings, ignored listing per whitelist
+Nov 29 08:15:01.245: INFO: namespace e2e-tests-projected-dhxp2 deletion completed in 6.055592498s
+
+• [SLOW TEST:8.114 seconds]
+[sig-storage] Projected
+/workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:34
+  should be consumable from pods in volume [Conformance]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SSSSSSSSS
+------------------------------
+[sig-apps] StatefulSet [k8s.io] Basic StatefulSet functionality [StatefulSetBasic] 
+  Should recreate evicted statefulset [Conformance]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-apps] StatefulSet
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Nov 29 08:15:01.245: INFO: >>> kubeConfig: /tmp/kubeconfig-385092372
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-apps] StatefulSet
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/statefulset.go:57
+[BeforeEach] [k8s.io] Basic StatefulSet functionality [StatefulSetBasic]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/statefulset.go:72
+STEP: Creating service test in namespace e2e-tests-statefulset-zt28j
+[It] Should recreate evicted statefulset [Conformance]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Looking for a node to schedule stateful set and pod
+STEP: Creating pod with conflicting port in namespace e2e-tests-statefulset-zt28j
+STEP: Creating statefulset with conflicting port in namespace e2e-tests-statefulset-zt28j
+STEP: Waiting until pod test-pod will start running in namespace e2e-tests-statefulset-zt28j
+STEP: Waiting until stateful pod ss-0 will be recreated and deleted at least once in namespace e2e-tests-statefulset-zt28j
+Nov 29 08:15:05.354: INFO: Observed stateful pod in namespace: e2e-tests-statefulset-zt28j, name: ss-0, uid: e068b2df-f3ae-11e8-9c33-06ce02f7f1c8, status phase: Pending. Waiting for statefulset controller to delete.
+Nov 29 08:15:06.144: INFO: Observed stateful pod in namespace: e2e-tests-statefulset-zt28j, name: ss-0, uid: e068b2df-f3ae-11e8-9c33-06ce02f7f1c8, status phase: Failed. Waiting for statefulset controller to delete.
+Nov 29 08:15:06.148: INFO: Observed stateful pod in namespace: e2e-tests-statefulset-zt28j, name: ss-0, uid: e068b2df-f3ae-11e8-9c33-06ce02f7f1c8, status phase: Failed. Waiting for statefulset controller to delete.
+Nov 29 08:15:06.152: INFO: Observed delete event for stateful pod ss-0 in namespace e2e-tests-statefulset-zt28j
+STEP: Removing pod with conflicting port in namespace e2e-tests-statefulset-zt28j
+STEP: Waiting when stateful pod ss-0 will be recreated in namespace e2e-tests-statefulset-zt28j and will be in running state
+[AfterEach] [k8s.io] Basic StatefulSet functionality [StatefulSetBasic]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/statefulset.go:83
+Nov 29 08:15:10.172: INFO: Deleting all statefulset in ns e2e-tests-statefulset-zt28j
+Nov 29 08:15:10.173: INFO: Scaling statefulset ss to 0
+Nov 29 08:15:30.187: INFO: Waiting for statefulset status.replicas updated to 0
+Nov 29 08:15:30.188: INFO: Deleting statefulset ss
+[AfterEach] [sig-apps] StatefulSet
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Nov 29 08:15:30.195: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-statefulset-zt28j" for this suite.
+Nov 29 08:15:36.202: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Nov 29 08:15:36.259: INFO: namespace: e2e-tests-statefulset-zt28j, resource: bindings, ignored listing per whitelist
+Nov 29 08:15:36.259: INFO: namespace e2e-tests-statefulset-zt28j deletion completed in 6.062706281s
+
+• [SLOW TEST:35.014 seconds]
+[sig-apps] StatefulSet
+/workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/framework.go:22
+  [k8s.io] Basic StatefulSet functionality [StatefulSetBasic]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:669
+    Should recreate evicted statefulset [Conformance]
+    /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SSSSSSSSSSSSSSSSSSSSSS
+------------------------------
+[sig-storage] Secrets 
+  should be consumable from pods in volume as non-root with defaultMode and fsGroup set  [Conformance]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-storage] Secrets
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Nov 29 08:15:36.260: INFO: >>> kubeConfig: /tmp/kubeconfig-385092372
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should be consumable from pods in volume as non-root with defaultMode and fsGroup set  [Conformance]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating secret with name secret-test-f31c97c9-f3ae-11e8-9124-e6180d057dc8
+STEP: Creating a pod to test consume secrets
+Nov 29 08:15:36.350: INFO: Waiting up to 5m0s for pod "pod-secrets-f31d2ae9-f3ae-11e8-9124-e6180d057dc8" in namespace "e2e-tests-secrets-dnllc" to be "success or failure"
+Nov 29 08:15:36.354: INFO: Pod "pod-secrets-f31d2ae9-f3ae-11e8-9124-e6180d057dc8": Phase="Pending", Reason="", readiness=false. Elapsed: 3.165252ms
+Nov 29 08:15:38.355: INFO: Pod "pod-secrets-f31d2ae9-f3ae-11e8-9124-e6180d057dc8": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.004430754s
+STEP: Saw pod success
+Nov 29 08:15:38.355: INFO: Pod "pod-secrets-f31d2ae9-f3ae-11e8-9124-e6180d057dc8" satisfied condition "success or failure"
+Nov 29 08:15:38.360: INFO: Trying to get logs from node worker-266bbc56-f3aa-11e8-ab5c-0a406d6cb422 pod pod-secrets-f31d2ae9-f3ae-11e8-9124-e6180d057dc8 container secret-volume-test: <nil>
+STEP: delete the pod
+Nov 29 08:15:38.379: INFO: Waiting for pod pod-secrets-f31d2ae9-f3ae-11e8-9124-e6180d057dc8 to disappear
+Nov 29 08:15:38.381: INFO: Pod pod-secrets-f31d2ae9-f3ae-11e8-9124-e6180d057dc8 no longer exists
+[AfterEach] [sig-storage] Secrets
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Nov 29 08:15:38.381: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-secrets-dnllc" for this suite.
+Nov 29 08:15:44.387: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Nov 29 08:15:44.427: INFO: namespace: e2e-tests-secrets-dnllc, resource: bindings, ignored listing per whitelist
+Nov 29 08:15:44.451: INFO: namespace e2e-tests-secrets-dnllc deletion completed in 6.068533959s
+
+• [SLOW TEST:8.191 seconds]
+[sig-storage] Secrets
+/workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/secrets_volume.go:33
+  should be consumable from pods in volume as non-root with defaultMode and fsGroup set  [Conformance]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+[sig-storage] ConfigMap 
+  should be consumable from pods in volume with defaultMode set  [Conformance]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-storage] ConfigMap
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Nov 29 08:15:44.451: INFO: >>> kubeConfig: /tmp/kubeconfig-385092372
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should be consumable from pods in volume with defaultMode set  [Conformance]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating configMap with name configmap-test-volume-f7f6b6e5-f3ae-11e8-9124-e6180d057dc8
+STEP: Creating a pod to test consume configMaps
+Nov 29 08:15:44.484: INFO: Waiting up to 5m0s for pod "pod-configmaps-f7f7086c-f3ae-11e8-9124-e6180d057dc8" in namespace "e2e-tests-configmap-rz6xg" to be "success or failure"
+Nov 29 08:15:44.489: INFO: Pod "pod-configmaps-f7f7086c-f3ae-11e8-9124-e6180d057dc8": Phase="Pending", Reason="", readiness=false. Elapsed: 4.338337ms
+Nov 29 08:15:46.490: INFO: Pod "pod-configmaps-f7f7086c-f3ae-11e8-9124-e6180d057dc8": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.006170388s
+STEP: Saw pod success
+Nov 29 08:15:46.490: INFO: Pod "pod-configmaps-f7f7086c-f3ae-11e8-9124-e6180d057dc8" satisfied condition "success or failure"
+Nov 29 08:15:46.492: INFO: Trying to get logs from node worker-266bbc56-f3aa-11e8-ab5c-0a406d6cb422 pod pod-configmaps-f7f7086c-f3ae-11e8-9124-e6180d057dc8 container configmap-volume-test: <nil>
+STEP: delete the pod
+Nov 29 08:15:46.664: INFO: Waiting for pod pod-configmaps-f7f7086c-f3ae-11e8-9124-e6180d057dc8 to disappear
+Nov 29 08:15:46.667: INFO: Pod pod-configmaps-f7f7086c-f3ae-11e8-9124-e6180d057dc8 no longer exists
+[AfterEach] [sig-storage] ConfigMap
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Nov 29 08:15:46.668: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-configmap-rz6xg" for this suite.
+Nov 29 08:15:52.675: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Nov 29 08:15:52.711: INFO: namespace: e2e-tests-configmap-rz6xg, resource: bindings, ignored listing per whitelist
+Nov 29 08:15:52.728: INFO: namespace e2e-tests-configmap-rz6xg deletion completed in 6.058054608s
+
+• [SLOW TEST:8.277 seconds]
+[sig-storage] ConfigMap
+/workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/configmap_volume.go:32
+  should be consumable from pods in volume with defaultMode set  [Conformance]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SSS
+------------------------------
+[sig-network] Networking Granular Checks: Pods 
+  should function for intra-pod communication: udp  [Conformance]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-network] Networking
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Nov 29 08:15:52.728: INFO: >>> kubeConfig: /tmp/kubeconfig-385092372
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should function for intra-pod communication: udp  [Conformance]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Performing setup for networking test in namespace e2e-tests-pod-network-test-qzgls
+STEP: creating a selector
+STEP: Creating the service pods in kubernetes
+Nov 29 08:15:52.756: INFO: Waiting up to 10m0s for all (but 0) nodes to be schedulable
+STEP: Creating test pods
+Nov 29 08:16:10.807: INFO: ExecWithOptions {Command:[/bin/sh -c curl -g -q -s 'http://10.2.2.125:8080/dial?request=hostName&protocol=udp&host=10.2.1.68&port=8081&tries=1'] Namespace:e2e-tests-pod-network-test-qzgls PodName:host-test-container-pod ContainerName:hostexec Stdin:<nil> CaptureStdout:true CaptureStderr:true PreserveWhitespace:false}
+Nov 29 08:16:10.807: INFO: >>> kubeConfig: /tmp/kubeconfig-385092372
+Nov 29 08:16:10.843: INFO: Waiting for endpoints: map[]
+Nov 29 08:16:10.844: INFO: ExecWithOptions {Command:[/bin/sh -c curl -g -q -s 'http://10.2.2.125:8080/dial?request=hostName&protocol=udp&host=10.2.2.124&port=8081&tries=1'] Namespace:e2e-tests-pod-network-test-qzgls PodName:host-test-container-pod ContainerName:hostexec Stdin:<nil> CaptureStdout:true CaptureStderr:true PreserveWhitespace:false}
+Nov 29 08:16:10.844: INFO: >>> kubeConfig: /tmp/kubeconfig-385092372
+Nov 29 08:16:10.883: INFO: Waiting for endpoints: map[]
+[AfterEach] [sig-network] Networking
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Nov 29 08:16:10.883: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-pod-network-test-qzgls" for this suite.
+Nov 29 08:16:32.889: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Nov 29 08:16:32.935: INFO: namespace: e2e-tests-pod-network-test-qzgls, resource: bindings, ignored listing per whitelist
+Nov 29 08:16:32.943: INFO: namespace e2e-tests-pod-network-test-qzgls deletion completed in 22.058043483s
+
+• [SLOW TEST:40.215 seconds]
+[sig-network] Networking
+/workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/networking.go:25
+  Granular Checks: Pods
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/networking.go:28
+    should function for intra-pod communication: udp  [Conformance]
+    /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SS
+------------------------------
+[sig-storage] Projected 
+  should be consumable from pods in volume with defaultMode set [Conformance]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Nov 29 08:16:32.943: INFO: >>> kubeConfig: /tmp/kubeconfig-385092372
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:858
+[It] should be consumable from pods in volume with defaultMode set [Conformance]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating configMap with name projected-configmap-test-volume-14ddcbca-f3af-11e8-9124-e6180d057dc8
+STEP: Creating a pod to test consume configMaps
+Nov 29 08:16:32.974: INFO: Waiting up to 5m0s for pod "pod-projected-configmaps-14de05a2-f3af-11e8-9124-e6180d057dc8" in namespace "e2e-tests-projected-jggpt" to be "success or failure"
+Nov 29 08:16:32.980: INFO: Pod "pod-projected-configmaps-14de05a2-f3af-11e8-9124-e6180d057dc8": Phase="Pending", Reason="", readiness=false. Elapsed: 5.897202ms
+Nov 29 08:16:34.982: INFO: Pod "pod-projected-configmaps-14de05a2-f3af-11e8-9124-e6180d057dc8": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.007808846s
+STEP: Saw pod success
+Nov 29 08:16:34.982: INFO: Pod "pod-projected-configmaps-14de05a2-f3af-11e8-9124-e6180d057dc8" satisfied condition "success or failure"
+Nov 29 08:16:34.983: INFO: Trying to get logs from node worker-266bbc56-f3aa-11e8-ab5c-0a406d6cb422 pod pod-projected-configmaps-14de05a2-f3af-11e8-9124-e6180d057dc8 container projected-configmap-volume-test: <nil>
+STEP: delete the pod
+Nov 29 08:16:35.002: INFO: Waiting for pod pod-projected-configmaps-14de05a2-f3af-11e8-9124-e6180d057dc8 to disappear
+Nov 29 08:16:35.007: INFO: Pod pod-projected-configmaps-14de05a2-f3af-11e8-9124-e6180d057dc8 no longer exists
+[AfterEach] [sig-storage] Projected
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Nov 29 08:16:35.007: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-jggpt" for this suite.
+Nov 29 08:16:41.014: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Nov 29 08:16:41.035: INFO: namespace: e2e-tests-projected-jggpt, resource: bindings, ignored listing per whitelist
+Nov 29 08:16:41.067: INFO: namespace e2e-tests-projected-jggpt deletion completed in 6.057673874s
+
+• [SLOW TEST:8.124 seconds]
+[sig-storage] Projected
+/workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:34
+  should be consumable from pods in volume with defaultMode set [Conformance]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SS
+------------------------------
+[sig-api-machinery] CustomResourceDefinition resources Simple CustomResourceDefinition 
+  creating/deleting custom resource definition objects works  [Conformance]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-api-machinery] CustomResourceDefinition resources
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Nov 29 08:16:41.067: INFO: >>> kubeConfig: /tmp/kubeconfig-385092372
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] creating/deleting custom resource definition objects works  [Conformance]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+Nov 29 08:16:41.146: INFO: >>> kubeConfig: /tmp/kubeconfig-385092372
+[AfterEach] [sig-api-machinery] CustomResourceDefinition resources
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Nov 29 08:16:42.174: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-custom-resource-definition-r2gsf" for this suite.
+Nov 29 08:16:48.181: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Nov 29 08:16:48.215: INFO: namespace: e2e-tests-custom-resource-definition-r2gsf, resource: bindings, ignored listing per whitelist
+Nov 29 08:16:48.236: INFO: namespace e2e-tests-custom-resource-definition-r2gsf deletion completed in 6.060583978s
+
+• [SLOW TEST:7.169 seconds]
+[sig-api-machinery] CustomResourceDefinition resources
+/workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apimachinery/framework.go:22
+  Simple CustomResourceDefinition
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apimachinery/custom_resource_definition.go:35
+    creating/deleting custom resource definition objects works  [Conformance]
+    /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+S
+------------------------------
+[sig-apps] Daemon set [Serial] 
+  should retry creating failed daemon pods [Conformance]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-apps] Daemon set [Serial]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Nov 29 08:16:48.236: INFO: >>> kubeConfig: /tmp/kubeconfig-385092372
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-apps] Daemon set [Serial]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/daemon_set.go:103
+[It] should retry creating failed daemon pods [Conformance]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating a simple DaemonSet "daemon-set"
+STEP: Check that daemon pods launch on every node of the cluster.
+Nov 29 08:16:48.336: INFO: DaemonSet pods can't tolerate node master-75fc9ea0-f3a7-11e8-90fa-062be367adf0 with taints [{Key:Dedicated Value:Master Effect:NoSchedule TimeAdded:<nil>}], skip checking this node
+Nov 29 08:16:48.338: INFO: Number of nodes with available pods: 0
+Nov 29 08:16:48.338: INFO: Node worker-266bbc56-f3aa-11e8-ab5c-0a406d6cb422 is running more than one daemon pod
+Nov 29 08:16:49.340: INFO: DaemonSet pods can't tolerate node master-75fc9ea0-f3a7-11e8-90fa-062be367adf0 with taints [{Key:Dedicated Value:Master Effect:NoSchedule TimeAdded:<nil>}], skip checking this node
+Nov 29 08:16:49.341: INFO: Number of nodes with available pods: 1
+Nov 29 08:16:49.341: INFO: Node worker-bdccfcb0-f3a8-11e8-90fa-062be367adf0 is running more than one daemon pod
+Nov 29 08:16:50.340: INFO: DaemonSet pods can't tolerate node master-75fc9ea0-f3a7-11e8-90fa-062be367adf0 with taints [{Key:Dedicated Value:Master Effect:NoSchedule TimeAdded:<nil>}], skip checking this node
+Nov 29 08:16:50.341: INFO: Number of nodes with available pods: 2
+Nov 29 08:16:50.341: INFO: Number of running nodes: 2, number of available pods: 2
+STEP: Set a daemon pod's phase to 'Failed', check that the daemon pod is revived.
+Nov 29 08:16:50.348: INFO: DaemonSet pods can't tolerate node master-75fc9ea0-f3a7-11e8-90fa-062be367adf0 with taints [{Key:Dedicated Value:Master Effect:NoSchedule TimeAdded:<nil>}], skip checking this node
+Nov 29 08:16:50.358: INFO: Number of nodes with available pods: 2
+Nov 29 08:16:50.358: INFO: Number of running nodes: 2, number of available pods: 2
+STEP: Wait for the failed daemon pod to be completely deleted.
+[AfterEach] [sig-apps] Daemon set [Serial]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/daemon_set.go:66
+STEP: Deleting DaemonSet "daemon-set" with reaper
+Nov 29 08:16:59.397: INFO: Number of nodes with available pods: 0
+Nov 29 08:16:59.397: INFO: Number of running nodes: 0, number of available pods: 0
+Nov 29 08:16:59.399: INFO: daemonset: {"kind":"DaemonSetList","apiVersion":"apps/v1","metadata":{"selfLink":"/apis/apps/v1/namespaces/e2e-tests-daemonsets-hwfsd/daemonsets","resourceVersion":"15497"},"items":null}
+
+Nov 29 08:16:59.400: INFO: pods: {"kind":"PodList","apiVersion":"v1","metadata":{"selfLink":"/api/v1/namespaces/e2e-tests-daemonsets-hwfsd/pods","resourceVersion":"15497"},"items":null}
+
+[AfterEach] [sig-apps] Daemon set [Serial]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Nov 29 08:16:59.406: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-daemonsets-hwfsd" for this suite.
+Nov 29 08:17:05.416: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Nov 29 08:17:05.439: INFO: namespace: e2e-tests-daemonsets-hwfsd, resource: bindings, ignored listing per whitelist
+Nov 29 08:17:05.472: INFO: namespace e2e-tests-daemonsets-hwfsd deletion completed in 6.064373994s
+
+• [SLOW TEST:17.235 seconds]
+[sig-apps] Daemon set [Serial]
+/workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/apps/framework.go:22
+  should retry creating failed daemon pods [Conformance]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SS
+------------------------------
+[k8s.io] Variable Expansion 
+  should allow substituting values in a container's args  [Conformance]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [k8s.io] Variable Expansion
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Nov 29 08:17:05.472: INFO: >>> kubeConfig: /tmp/kubeconfig-385092372
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should allow substituting values in a container's args  [Conformance]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating a pod to test substitution in container's args
+Nov 29 08:17:05.502: INFO: Waiting up to 5m0s for pod "var-expansion-284172aa-f3af-11e8-9124-e6180d057dc8" in namespace "e2e-tests-var-expansion-2hq6l" to be "success or failure"
+Nov 29 08:17:05.505: INFO: Pod "var-expansion-284172aa-f3af-11e8-9124-e6180d057dc8": Phase="Pending", Reason="", readiness=false. Elapsed: 2.776327ms
+Nov 29 08:17:07.507: INFO: Pod "var-expansion-284172aa-f3af-11e8-9124-e6180d057dc8": Phase="Pending", Reason="", readiness=false. Elapsed: 2.004494165s
+Nov 29 08:17:09.509: INFO: Pod "var-expansion-284172aa-f3af-11e8-9124-e6180d057dc8": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.006281124s
+STEP: Saw pod success
+Nov 29 08:17:09.509: INFO: Pod "var-expansion-284172aa-f3af-11e8-9124-e6180d057dc8" satisfied condition "success or failure"
+Nov 29 08:17:09.510: INFO: Trying to get logs from node worker-266bbc56-f3aa-11e8-ab5c-0a406d6cb422 pod var-expansion-284172aa-f3af-11e8-9124-e6180d057dc8 container dapi-container: <nil>
+STEP: delete the pod
+Nov 29 08:17:09.522: INFO: Waiting for pod var-expansion-284172aa-f3af-11e8-9124-e6180d057dc8 to disappear
+Nov 29 08:17:09.527: INFO: Pod var-expansion-284172aa-f3af-11e8-9124-e6180d057dc8 no longer exists
+[AfterEach] [k8s.io] Variable Expansion
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Nov 29 08:17:09.527: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-var-expansion-2hq6l" for this suite.
+Nov 29 08:17:15.534: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Nov 29 08:17:15.584: INFO: namespace: e2e-tests-var-expansion-2hq6l, resource: bindings, ignored listing per whitelist
+Nov 29 08:17:15.591: INFO: namespace e2e-tests-var-expansion-2hq6l deletion completed in 6.062533808s
+
+• [SLOW TEST:10.120 seconds]
+[k8s.io] Variable Expansion
+/workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:669
+  should allow substituting values in a container's args  [Conformance]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SSSSSSSS
+------------------------------
+[sig-storage] Secrets 
+  optional updates should be reflected in volume  [Conformance]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-storage] Secrets
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Nov 29 08:17:15.591: INFO: >>> kubeConfig: /tmp/kubeconfig-385092372
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] optional updates should be reflected in volume  [Conformance]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating secret with name s-test-opt-del-2e49bad9-f3af-11e8-9124-e6180d057dc8
+STEP: Creating secret with name s-test-opt-upd-2e49bb08-f3af-11e8-9124-e6180d057dc8
+STEP: Creating the pod
+STEP: Deleting secret s-test-opt-del-2e49bad9-f3af-11e8-9124-e6180d057dc8
+STEP: Updating secret s-test-opt-upd-2e49bb08-f3af-11e8-9124-e6180d057dc8
+STEP: Creating secret with name s-test-opt-create-2e49bb1b-f3af-11e8-9124-e6180d057dc8
+STEP: waiting to observe update in volume
+[AfterEach] [sig-storage] Secrets
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Nov 29 08:17:21.670: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-secrets-nd47r" for this suite.
+Nov 29 08:17:43.677: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Nov 29 08:17:43.695: INFO: namespace: e2e-tests-secrets-nd47r, resource: bindings, ignored listing per whitelist
+Nov 29 08:17:43.728: INFO: namespace e2e-tests-secrets-nd47r deletion completed in 22.056402121s
+
+• [SLOW TEST:28.137 seconds]
+[sig-storage] Secrets
+/workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/secrets_volume.go:33
+  optional updates should be reflected in volume  [Conformance]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+[sig-storage] HostPath 
+  should give a volume the correct mode [Conformance]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-storage] HostPath
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Nov 29 08:17:43.728: INFO: >>> kubeConfig: /tmp/kubeconfig-385092372
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] HostPath
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/host_path.go:37
+[It] should give a volume the correct mode [Conformance]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating a pod to test hostPath mode
+Nov 29 08:17:43.810: INFO: Waiting up to 5m0s for pod "pod-host-path-test" in namespace "e2e-tests-hostpath-zqqm8" to be "success or failure"
+Nov 29 08:17:43.817: INFO: Pod "pod-host-path-test": Phase="Pending", Reason="", readiness=false. Elapsed: 6.218518ms
+Nov 29 08:17:45.818: INFO: Pod "pod-host-path-test": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.007780238s
+STEP: Saw pod success
+Nov 29 08:17:45.818: INFO: Pod "pod-host-path-test" satisfied condition "success or failure"
+Nov 29 08:17:45.819: INFO: Trying to get logs from node worker-266bbc56-f3aa-11e8-ab5c-0a406d6cb422 pod pod-host-path-test container test-container-1: <nil>
+STEP: delete the pod
+Nov 29 08:17:45.835: INFO: Waiting for pod pod-host-path-test to disappear
+Nov 29 08:17:45.836: INFO: Pod pod-host-path-test no longer exists
+[AfterEach] [sig-storage] HostPath
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Nov 29 08:17:45.836: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-hostpath-zqqm8" for this suite.
+Nov 29 08:17:51.843: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Nov 29 08:17:51.889: INFO: namespace: e2e-tests-hostpath-zqqm8, resource: bindings, ignored listing per whitelist
+Nov 29 08:17:51.895: INFO: namespace e2e-tests-hostpath-zqqm8 deletion completed in 6.057509605s
+
+• [SLOW TEST:8.167 seconds]
+[sig-storage] HostPath
+/workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/host_path.go:34
+  should give a volume the correct mode [Conformance]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SSSS
+------------------------------
+[sig-storage] EmptyDir volumes 
+  should support (root,0644,default) [Conformance]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-storage] EmptyDir volumes
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Nov 29 08:17:51.895: INFO: >>> kubeConfig: /tmp/kubeconfig-385092372
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should support (root,0644,default) [Conformance]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating a pod to test emptydir 0644 on node default medium
+Nov 29 08:17:51.927: INFO: Waiting up to 5m0s for pod "pod-43ed5ae1-f3af-11e8-9124-e6180d057dc8" in namespace "e2e-tests-emptydir-dx9cg" to be "success or failure"
+Nov 29 08:17:51.931: INFO: Pod "pod-43ed5ae1-f3af-11e8-9124-e6180d057dc8": Phase="Pending", Reason="", readiness=false. Elapsed: 3.543322ms
+Nov 29 08:17:53.933: INFO: Pod "pod-43ed5ae1-f3af-11e8-9124-e6180d057dc8": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.005264122s
+STEP: Saw pod success
+Nov 29 08:17:53.933: INFO: Pod "pod-43ed5ae1-f3af-11e8-9124-e6180d057dc8" satisfied condition "success or failure"
+Nov 29 08:17:53.934: INFO: Trying to get logs from node worker-266bbc56-f3aa-11e8-ab5c-0a406d6cb422 pod pod-43ed5ae1-f3af-11e8-9124-e6180d057dc8 container test-container: <nil>
+STEP: delete the pod
+Nov 29 08:17:53.945: INFO: Waiting for pod pod-43ed5ae1-f3af-11e8-9124-e6180d057dc8 to disappear
+Nov 29 08:17:53.948: INFO: Pod pod-43ed5ae1-f3af-11e8-9124-e6180d057dc8 no longer exists
+[AfterEach] [sig-storage] EmptyDir volumes
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Nov 29 08:17:53.948: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-emptydir-dx9cg" for this suite.
+Nov 29 08:17:59.956: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Nov 29 08:17:59.999: INFO: namespace: e2e-tests-emptydir-dx9cg, resource: bindings, ignored listing per whitelist
+Nov 29 08:18:00.010: INFO: namespace e2e-tests-emptydir-dx9cg deletion completed in 6.059964632s
+
+• [SLOW TEST:8.115 seconds]
+[sig-storage] EmptyDir volumes
+/workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/empty_dir.go:41
+  should support (root,0644,default) [Conformance]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SSSSS
+------------------------------
+[sig-storage] Projected 
+  should provide container's memory request [Conformance]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Nov 29 08:18:00.010: INFO: >>> kubeConfig: /tmp/kubeconfig-385092372
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:858
+[It] should provide container's memory request [Conformance]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating a pod to test downward API volume plugin
+Nov 29 08:18:00.101: INFO: Waiting up to 5m0s for pod "downwardapi-volume-48cc891b-f3af-11e8-9124-e6180d057dc8" in namespace "e2e-tests-projected-vzmrn" to be "success or failure"
+Nov 29 08:18:00.108: INFO: Pod "downwardapi-volume-48cc891b-f3af-11e8-9124-e6180d057dc8": Phase="Pending", Reason="", readiness=false. Elapsed: 6.931701ms
+Nov 29 08:18:02.110: INFO: Pod "downwardapi-volume-48cc891b-f3af-11e8-9124-e6180d057dc8": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.008702713s
+STEP: Saw pod success
+Nov 29 08:18:02.110: INFO: Pod "downwardapi-volume-48cc891b-f3af-11e8-9124-e6180d057dc8" satisfied condition "success or failure"
+Nov 29 08:18:02.111: INFO: Trying to get logs from node worker-266bbc56-f3aa-11e8-ab5c-0a406d6cb422 pod downwardapi-volume-48cc891b-f3af-11e8-9124-e6180d057dc8 container client-container: <nil>
+STEP: delete the pod
+Nov 29 08:18:02.126: INFO: Waiting for pod downwardapi-volume-48cc891b-f3af-11e8-9124-e6180d057dc8 to disappear
+Nov 29 08:18:02.129: INFO: Pod downwardapi-volume-48cc891b-f3af-11e8-9124-e6180d057dc8 no longer exists
+[AfterEach] [sig-storage] Projected
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Nov 29 08:18:02.129: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-vzmrn" for this suite.
+Nov 29 08:18:08.137: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Nov 29 08:18:08.261: INFO: namespace: e2e-tests-projected-vzmrn, resource: bindings, ignored listing per whitelist
+Nov 29 08:18:08.270: INFO: namespace e2e-tests-projected-vzmrn deletion completed in 6.138425057s
+
+• [SLOW TEST:8.260 seconds]
+[sig-storage] Projected
+/workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:34
+  should provide container's memory request [Conformance]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SS
+------------------------------
+[sig-storage] ConfigMap 
+  optional updates should be reflected in volume  [Conformance]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-storage] ConfigMap
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Nov 29 08:18:08.270: INFO: >>> kubeConfig: /tmp/kubeconfig-385092372
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] optional updates should be reflected in volume  [Conformance]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating configMap with name cm-test-opt-del-4dafeb78-f3af-11e8-9124-e6180d057dc8
+STEP: Creating configMap with name cm-test-opt-upd-4dafeba8-f3af-11e8-9124-e6180d057dc8
+STEP: Creating the pod
+STEP: Deleting configmap cm-test-opt-del-4dafeb78-f3af-11e8-9124-e6180d057dc8
+STEP: Updating configmap cm-test-opt-upd-4dafeba8-f3af-11e8-9124-e6180d057dc8
+STEP: Creating configMap with name cm-test-opt-create-4dafebb7-f3af-11e8-9124-e6180d057dc8
+STEP: waiting to observe update in volume
+[AfterEach] [sig-storage] ConfigMap
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Nov 29 08:18:12.343: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-configmap-qkrvc" for this suite.
+Nov 29 08:18:34.351: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Nov 29 08:18:34.402: INFO: namespace: e2e-tests-configmap-qkrvc, resource: bindings, ignored listing per whitelist
+Nov 29 08:18:34.404: INFO: namespace e2e-tests-configmap-qkrvc deletion completed in 22.058737571s
+
+• [SLOW TEST:26.133 seconds]
+[sig-storage] ConfigMap
+/workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/configmap_volume.go:32
+  optional updates should be reflected in volume  [Conformance]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SSSSS
+------------------------------
+[sig-storage] Projected 
+  should provide container's memory limit [Conformance]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Nov 29 08:18:34.404: INFO: >>> kubeConfig: /tmp/kubeconfig-385092372
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Projected
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:858
+[It] should provide container's memory limit [Conformance]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating a pod to test downward API volume plugin
+Nov 29 08:18:34.438: INFO: Waiting up to 5m0s for pod "downwardapi-volume-5d43efb4-f3af-11e8-9124-e6180d057dc8" in namespace "e2e-tests-projected-frfgv" to be "success or failure"
+Nov 29 08:18:34.441: INFO: Pod "downwardapi-volume-5d43efb4-f3af-11e8-9124-e6180d057dc8": Phase="Pending", Reason="", readiness=false. Elapsed: 3.071617ms
+Nov 29 08:18:36.443: INFO: Pod "downwardapi-volume-5d43efb4-f3af-11e8-9124-e6180d057dc8": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.004590618s
+STEP: Saw pod success
+Nov 29 08:18:36.443: INFO: Pod "downwardapi-volume-5d43efb4-f3af-11e8-9124-e6180d057dc8" satisfied condition "success or failure"
+Nov 29 08:18:36.444: INFO: Trying to get logs from node worker-266bbc56-f3aa-11e8-ab5c-0a406d6cb422 pod downwardapi-volume-5d43efb4-f3af-11e8-9124-e6180d057dc8 container client-container: <nil>
+STEP: delete the pod
+Nov 29 08:18:36.461: INFO: Waiting for pod downwardapi-volume-5d43efb4-f3af-11e8-9124-e6180d057dc8 to disappear
+Nov 29 08:18:36.463: INFO: Pod downwardapi-volume-5d43efb4-f3af-11e8-9124-e6180d057dc8 no longer exists
+[AfterEach] [sig-storage] Projected
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Nov 29 08:18:36.463: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-projected-frfgv" for this suite.
+Nov 29 08:18:42.469: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Nov 29 08:18:42.482: INFO: namespace: e2e-tests-projected-frfgv, resource: bindings, ignored listing per whitelist
+Nov 29 08:18:42.520: INFO: namespace e2e-tests-projected-frfgv deletion completed in 6.0556128s
+
+• [SLOW TEST:8.116 seconds]
+[sig-storage] Projected
+/workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/projected.go:34
+  should provide container's memory limit [Conformance]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SSSSSSSSSSSSSSSSSSSSSSS
+------------------------------
+[sig-auth] ServiceAccounts 
+  should mount an API token into pods  [Conformance]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-auth] ServiceAccounts
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Nov 29 08:18:42.520: INFO: >>> kubeConfig: /tmp/kubeconfig-385092372
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should mount an API token into pods  [Conformance]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: getting the auto-created API token
+STEP: Creating a pod to test consume service account token
+Nov 29 08:18:43.054: INFO: Waiting up to 5m0s for pod "pod-service-account-626698c4-f3af-11e8-9124-e6180d057dc8-6hxpc" in namespace "e2e-tests-svcaccounts-27pkq" to be "success or failure"
+Nov 29 08:18:43.059: INFO: Pod "pod-service-account-626698c4-f3af-11e8-9124-e6180d057dc8-6hxpc": Phase="Pending", Reason="", readiness=false. Elapsed: 4.973424ms
+Nov 29 08:18:45.061: INFO: Pod "pod-service-account-626698c4-f3af-11e8-9124-e6180d057dc8-6hxpc": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.006654264s
+STEP: Saw pod success
+Nov 29 08:18:45.061: INFO: Pod "pod-service-account-626698c4-f3af-11e8-9124-e6180d057dc8-6hxpc" satisfied condition "success or failure"
+Nov 29 08:18:45.062: INFO: Trying to get logs from node worker-266bbc56-f3aa-11e8-ab5c-0a406d6cb422 pod pod-service-account-626698c4-f3af-11e8-9124-e6180d057dc8-6hxpc container token-test: <nil>
+STEP: delete the pod
+Nov 29 08:18:45.080: INFO: Waiting for pod pod-service-account-626698c4-f3af-11e8-9124-e6180d057dc8-6hxpc to disappear
+Nov 29 08:18:45.082: INFO: Pod pod-service-account-626698c4-f3af-11e8-9124-e6180d057dc8-6hxpc no longer exists
+STEP: Creating a pod to test consume service account root CA
+Nov 29 08:18:45.083: INFO: Waiting up to 5m0s for pod "pod-service-account-626698c4-f3af-11e8-9124-e6180d057dc8-24kdq" in namespace "e2e-tests-svcaccounts-27pkq" to be "success or failure"
+Nov 29 08:18:45.091: INFO: Pod "pod-service-account-626698c4-f3af-11e8-9124-e6180d057dc8-24kdq": Phase="Pending", Reason="", readiness=false. Elapsed: 8.248744ms
+Nov 29 08:18:47.093: INFO: Pod "pod-service-account-626698c4-f3af-11e8-9124-e6180d057dc8-24kdq": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.009814658s
+STEP: Saw pod success
+Nov 29 08:18:47.093: INFO: Pod "pod-service-account-626698c4-f3af-11e8-9124-e6180d057dc8-24kdq" satisfied condition "success or failure"
+Nov 29 08:18:47.094: INFO: Trying to get logs from node worker-266bbc56-f3aa-11e8-ab5c-0a406d6cb422 pod pod-service-account-626698c4-f3af-11e8-9124-e6180d057dc8-24kdq container root-ca-test: <nil>
+STEP: delete the pod
+Nov 29 08:18:47.111: INFO: Waiting for pod pod-service-account-626698c4-f3af-11e8-9124-e6180d057dc8-24kdq to disappear
+Nov 29 08:18:47.112: INFO: Pod pod-service-account-626698c4-f3af-11e8-9124-e6180d057dc8-24kdq no longer exists
+STEP: Creating a pod to test consume service account namespace
+Nov 29 08:18:47.120: INFO: Waiting up to 5m0s for pod "pod-service-account-626698c4-f3af-11e8-9124-e6180d057dc8-7vvhn" in namespace "e2e-tests-svcaccounts-27pkq" to be "success or failure"
+Nov 29 08:18:47.123: INFO: Pod "pod-service-account-626698c4-f3af-11e8-9124-e6180d057dc8-7vvhn": Phase="Pending", Reason="", readiness=false. Elapsed: 3.701109ms
+Nov 29 08:18:49.125: INFO: Pod "pod-service-account-626698c4-f3af-11e8-9124-e6180d057dc8-7vvhn": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.005180418s
+STEP: Saw pod success
+Nov 29 08:18:49.125: INFO: Pod "pod-service-account-626698c4-f3af-11e8-9124-e6180d057dc8-7vvhn" satisfied condition "success or failure"
+Nov 29 08:18:49.126: INFO: Trying to get logs from node worker-266bbc56-f3aa-11e8-ab5c-0a406d6cb422 pod pod-service-account-626698c4-f3af-11e8-9124-e6180d057dc8-7vvhn container namespace-test: <nil>
+STEP: delete the pod
+Nov 29 08:18:49.139: INFO: Waiting for pod pod-service-account-626698c4-f3af-11e8-9124-e6180d057dc8-7vvhn to disappear
+Nov 29 08:18:49.142: INFO: Pod pod-service-account-626698c4-f3af-11e8-9124-e6180d057dc8-7vvhn no longer exists
+[AfterEach] [sig-auth] ServiceAccounts
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Nov 29 08:18:49.142: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-svcaccounts-27pkq" for this suite.
+Nov 29 08:18:55.152: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Nov 29 08:18:55.186: INFO: namespace: e2e-tests-svcaccounts-27pkq, resource: bindings, ignored listing per whitelist
+Nov 29 08:18:55.206: INFO: namespace e2e-tests-svcaccounts-27pkq deletion completed in 6.061287439s
+
+• [SLOW TEST:12.685 seconds]
+[sig-auth] ServiceAccounts
+/workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/auth/framework.go:22
+  should mount an API token into pods  [Conformance]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SS
+------------------------------
+[k8s.io] Probing container 
+  with readiness probe should not be ready before initial delay and never restart  [Conformance]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [k8s.io] Probing container
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Nov 29 08:18:55.206: INFO: >>> kubeConfig: /tmp/kubeconfig-385092372
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [k8s.io] Probing container
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/container_probe.go:48
+[It] with readiness probe should not be ready before initial delay and never restart  [Conformance]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+Nov 29 08:19:21.296: INFO: Container started at 2018-11-29 08:18:56 +0000 UTC, pod became ready at 2018-11-29 08:19:19 +0000 UTC
+[AfterEach] [k8s.io] Probing container
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Nov 29 08:19:21.296: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-container-probe-dkpt2" for this suite.
+Nov 29 08:19:43.303: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Nov 29 08:19:43.327: INFO: namespace: e2e-tests-container-probe-dkpt2, resource: bindings, ignored listing per whitelist
+Nov 29 08:19:43.361: INFO: namespace e2e-tests-container-probe-dkpt2 deletion completed in 22.062884341s
+
+• [SLOW TEST:48.155 seconds]
+[k8s.io] Probing container
+/workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:669
+  with readiness probe should not be ready before initial delay and never restart  [Conformance]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SSSSSSSSSSSSSSSSSS
+------------------------------
+[sig-network] Service endpoints latency 
+  should not be very high  [Conformance]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-network] Service endpoints latency
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Nov 29 08:19:43.361: INFO: >>> kubeConfig: /tmp/kubeconfig-385092372
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should not be very high  [Conformance]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: creating replication controller svc-latency-rc in namespace e2e-tests-svc-latency-xz6df
+I1129 08:19:43.393709      13 runners.go:175] Created replication controller with name: svc-latency-rc, namespace: e2e-tests-svc-latency-xz6df, replica count: 1
+I1129 08:19:44.444052      13 runners.go:175] svc-latency-rc Pods: 1 out of 1 created, 1 running, 0 pending, 0 waiting, 0 inactive, 0 terminating, 0 unknown, 0 runningButNotReady 
+Nov 29 08:19:44.556: INFO: Created: latency-svc-7w2mb
+Nov 29 08:19:44.556: INFO: Got endpoints: latency-svc-7w2mb [12.334796ms]
+Nov 29 08:19:44.569: INFO: Created: latency-svc-995k7
+Nov 29 08:19:44.569: INFO: Created: latency-svc-6twhz
+Nov 29 08:19:44.575: INFO: Got endpoints: latency-svc-6twhz [18.614697ms]
+Nov 29 08:19:44.575: INFO: Got endpoints: latency-svc-995k7 [18.47018ms]
+Nov 29 08:19:44.588: INFO: Created: latency-svc-zdhw8
+Nov 29 08:19:44.588: INFO: Got endpoints: latency-svc-zdhw8 [31.238945ms]
+Nov 29 08:19:44.588: INFO: Created: latency-svc-zx9m9
+Nov 29 08:19:44.588: INFO: Created: latency-svc-g8wtw
+Nov 29 08:19:44.596: INFO: Got endpoints: latency-svc-g8wtw [37.701013ms]
+Nov 29 08:19:44.596: INFO: Got endpoints: latency-svc-zx9m9 [38.830788ms]
+Nov 29 08:19:44.599: INFO: Created: latency-svc-8jlxj
+Nov 29 08:19:44.602: INFO: Created: latency-svc-dp85b
+Nov 29 08:19:44.613: INFO: Created: latency-svc-knwrk
+Nov 29 08:19:44.613: INFO: Got endpoints: latency-svc-dp85b [55.619211ms]
+Nov 29 08:19:44.613: INFO: Got endpoints: latency-svc-8jlxj [55.832215ms]
+Nov 29 08:19:44.613: INFO: Created: latency-svc-brlmn
+Nov 29 08:19:44.618: INFO: Created: latency-svc-bz5wb
+Nov 29 08:19:44.621: INFO: Got endpoints: latency-svc-brlmn [62.509679ms]
+Nov 29 08:19:44.621: INFO: Got endpoints: latency-svc-knwrk [62.89267ms]
+Nov 29 08:19:44.629: INFO: Created: latency-svc-8knq4
+Nov 29 08:19:44.631: INFO: Got endpoints: latency-svc-bz5wb [73.679359ms]
+Nov 29 08:19:44.634: INFO: Got endpoints: latency-svc-8knq4 [75.063831ms]
+Nov 29 08:19:44.641: INFO: Created: latency-svc-z9klw
+Nov 29 08:19:44.641: INFO: Got endpoints: latency-svc-z9klw [82.071739ms]
+Nov 29 08:19:44.643: INFO: Created: latency-svc-p242s
+Nov 29 08:19:44.646: INFO: Created: latency-svc-26cx4
+Nov 29 08:19:44.653: INFO: Created: latency-svc-h5kdp
+Nov 29 08:19:44.658: INFO: Got endpoints: latency-svc-h5kdp [98.374857ms]
+Nov 29 08:19:44.658: INFO: Got endpoints: latency-svc-p242s [97.318031ms]
+Nov 29 08:19:44.659: INFO: Created: latency-svc-qsxgd
+Nov 29 08:19:44.663: INFO: Got endpoints: latency-svc-qsxgd [87.726077ms]
+Nov 29 08:19:44.663: INFO: Got endpoints: latency-svc-26cx4 [101.676231ms]
+Nov 29 08:19:44.666: INFO: Created: latency-svc-hdr9c
+Nov 29 08:19:44.673: INFO: Got endpoints: latency-svc-hdr9c [95.98091ms]
+Nov 29 08:19:44.674: INFO: Created: latency-svc-j2mwn
+Nov 29 08:19:44.676: INFO: Created: latency-svc-fbwjp
+Nov 29 08:19:44.679: INFO: Got endpoints: latency-svc-fbwjp [82.558037ms]
+Nov 29 08:19:44.682: INFO: Created: latency-svc-8v56p
+Nov 29 08:19:44.692: INFO: Got endpoints: latency-svc-8v56p [96.066831ms]
+Nov 29 08:19:44.692: INFO: Got endpoints: latency-svc-j2mwn [104.473359ms]
+Nov 29 08:19:44.693: INFO: Created: latency-svc-4x8zc
+Nov 29 08:19:44.708: INFO: Created: latency-svc-b47zk
+Nov 29 08:19:44.708: INFO: Created: latency-svc-4rm8k
+Nov 29 08:19:44.708: INFO: Created: latency-svc-7m79c
+Nov 29 08:19:44.708: INFO: Got endpoints: latency-svc-4x8zc [94.439202ms]
+Nov 29 08:19:44.711: INFO: Got endpoints: latency-svc-b47zk [97.849036ms]
+Nov 29 08:19:44.719: INFO: Created: latency-svc-kdqr4
+Nov 29 08:19:44.719: INFO: Created: latency-svc-c7dsq
+Nov 29 08:19:44.723: INFO: Got endpoints: latency-svc-4rm8k [30.448511ms]
+Nov 29 08:19:44.728: INFO: Created: latency-svc-whwlt
+Nov 29 08:19:44.729: INFO: Got endpoints: latency-svc-7m79c [108.621125ms]
+Nov 29 08:19:44.733: INFO: Created: latency-svc-mp977
+Nov 29 08:19:44.744: INFO: Created: latency-svc-5bt92
+Nov 29 08:19:44.747: INFO: Got endpoints: latency-svc-c7dsq [125.707889ms]
+Nov 29 08:19:44.749: INFO: Created: latency-svc-8m8g7
+Nov 29 08:19:44.757: INFO: Got endpoints: latency-svc-5bt92 [99.480771ms]
+Nov 29 08:19:44.757: INFO: Got endpoints: latency-svc-mp977 [116.713798ms]
+Nov 29 08:19:44.758: INFO: Got endpoints: latency-svc-whwlt [123.962559ms]
+Nov 29 08:19:44.758: INFO: Got endpoints: latency-svc-kdqr4 [127.003644ms]
+Nov 29 08:19:44.762: INFO: Got endpoints: latency-svc-8m8g7 [103.541512ms]
+Nov 29 08:19:44.764: INFO: Created: latency-svc-58whp
+Nov 29 08:19:44.765: INFO: Got endpoints: latency-svc-58whp [102.307966ms]
+Nov 29 08:19:44.771: INFO: Created: latency-svc-s7j7d
+Nov 29 08:19:44.774: INFO: Created: latency-svc-j8qnw
+Nov 29 08:19:44.775: INFO: Got endpoints: latency-svc-s7j7d [112.108223ms]
+Nov 29 08:19:44.775: INFO: Created: latency-svc-q6fm6
+Nov 29 08:19:44.780: INFO: Got endpoints: latency-svc-j8qnw [107.608892ms]
+Nov 29 08:19:44.781: INFO: Created: latency-svc-d2bvx
+Nov 29 08:19:44.785: INFO: Created: latency-svc-dw7c9
+Nov 29 08:19:44.791: INFO: Created: latency-svc-rf9fb
+Nov 29 08:19:44.794: INFO: Created: latency-svc-g2zdr
+Nov 29 08:19:44.798: INFO: Created: latency-svc-4ccfg
+Nov 29 08:19:44.803: INFO: Created: latency-svc-99kg9
+Nov 29 08:19:44.804: INFO: Got endpoints: latency-svc-q6fm6 [125.019315ms]
+Nov 29 08:19:44.808: INFO: Created: latency-svc-2gn9t
+Nov 29 08:19:44.813: INFO: Created: latency-svc-ggvgn
+Nov 29 08:19:44.816: INFO: Created: latency-svc-bd5b2
+Nov 29 08:19:44.819: INFO: Created: latency-svc-jtqth
+Nov 29 08:19:44.821: INFO: Created: latency-svc-vqflm
+Nov 29 08:19:44.826: INFO: Created: latency-svc-jqncd
+Nov 29 08:19:44.829: INFO: Created: latency-svc-qv2kb
+Nov 29 08:19:44.833: INFO: Created: latency-svc-779pb
+Nov 29 08:19:44.836: INFO: Created: latency-svc-fj5cb
+Nov 29 08:19:44.853: INFO: Got endpoints: latency-svc-d2bvx [161.127809ms]
+Nov 29 08:19:44.861: INFO: Created: latency-svc-hhgj7
+Nov 29 08:19:44.901: INFO: Got endpoints: latency-svc-dw7c9 [193.471913ms]
+Nov 29 08:19:44.905: INFO: Created: latency-svc-69tjw
+Nov 29 08:19:44.952: INFO: Got endpoints: latency-svc-rf9fb [240.707194ms]
+Nov 29 08:19:44.959: INFO: Created: latency-svc-9dgrg
+Nov 29 08:19:45.001: INFO: Got endpoints: latency-svc-g2zdr [278.412047ms]
+Nov 29 08:19:45.005: INFO: Created: latency-svc-2l52l
+Nov 29 08:19:45.052: INFO: Got endpoints: latency-svc-4ccfg [322.186854ms]
+Nov 29 08:19:45.056: INFO: Created: latency-svc-77p6p
+Nov 29 08:19:45.102: INFO: Got endpoints: latency-svc-99kg9 [355.225652ms]
+Nov 29 08:19:45.106: INFO: Created: latency-svc-46lxc
+Nov 29 08:19:45.151: INFO: Got endpoints: latency-svc-2gn9t [393.940667ms]
+Nov 29 08:19:45.156: INFO: Created: latency-svc-q6ddt
+Nov 29 08:19:45.201: INFO: Got endpoints: latency-svc-ggvgn [443.346255ms]
+Nov 29 08:19:45.204: INFO: Created: latency-svc-md8jx
+Nov 29 08:19:45.252: INFO: Got endpoints: latency-svc-bd5b2 [494.527556ms]
+Nov 29 08:19:45.256: INFO: Created: latency-svc-gs867
+Nov 29 08:19:45.302: INFO: Got endpoints: latency-svc-jtqth [544.725863ms]
+Nov 29 08:19:45.307: INFO: Created: latency-svc-xfvj6
+Nov 29 08:19:45.352: INFO: Got endpoints: latency-svc-vqflm [590.555558ms]
+Nov 29 08:19:45.357: INFO: Created: latency-svc-s5jpt
+Nov 29 08:19:45.401: INFO: Got endpoints: latency-svc-jqncd [636.227102ms]
+Nov 29 08:19:45.405: INFO: Created: latency-svc-qp4ss
+Nov 29 08:19:45.452: INFO: Got endpoints: latency-svc-qv2kb [676.758462ms]
+Nov 29 08:19:45.458: INFO: Created: latency-svc-dlth5
+Nov 29 08:19:45.502: INFO: Got endpoints: latency-svc-779pb [721.819225ms]
+Nov 29 08:19:45.508: INFO: Created: latency-svc-hrl62
+Nov 29 08:19:45.551: INFO: Got endpoints: latency-svc-fj5cb [747.70374ms]
+Nov 29 08:19:45.557: INFO: Created: latency-svc-xwsbd
+Nov 29 08:19:45.602: INFO: Got endpoints: latency-svc-hhgj7 [748.360596ms]
+Nov 29 08:19:45.608: INFO: Created: latency-svc-7wpgs
+Nov 29 08:19:45.651: INFO: Got endpoints: latency-svc-69tjw [749.631343ms]
+Nov 29 08:19:45.657: INFO: Created: latency-svc-4sw47
+Nov 29 08:19:45.702: INFO: Got endpoints: latency-svc-9dgrg [749.555524ms]
+Nov 29 08:19:45.706: INFO: Created: latency-svc-wnffc
+Nov 29 08:19:45.751: INFO: Got endpoints: latency-svc-2l52l [749.771091ms]
+Nov 29 08:19:45.755: INFO: Created: latency-svc-nshwp
+Nov 29 08:19:45.801: INFO: Got endpoints: latency-svc-77p6p [749.815567ms]
+Nov 29 08:19:45.805: INFO: Created: latency-svc-s7x5c
+Nov 29 08:19:45.852: INFO: Got endpoints: latency-svc-46lxc [749.660714ms]
+Nov 29 08:19:45.855: INFO: Created: latency-svc-xbzpr
+Nov 29 08:19:45.901: INFO: Got endpoints: latency-svc-q6ddt [749.75263ms]
+Nov 29 08:19:45.905: INFO: Created: latency-svc-8rsc9
+Nov 29 08:19:45.952: INFO: Got endpoints: latency-svc-md8jx [750.714251ms]
+Nov 29 08:19:45.957: INFO: Created: latency-svc-sb9d5
+Nov 29 08:19:46.002: INFO: Got endpoints: latency-svc-gs867 [749.587769ms]
+Nov 29 08:19:46.006: INFO: Created: latency-svc-nxvh7
+Nov 29 08:19:46.051: INFO: Got endpoints: latency-svc-xfvj6 [748.912034ms]
+Nov 29 08:19:46.055: INFO: Created: latency-svc-t9thf
+Nov 29 08:19:46.102: INFO: Got endpoints: latency-svc-s5jpt [749.908697ms]
+Nov 29 08:19:46.107: INFO: Created: latency-svc-q2g5t
+Nov 29 08:19:46.152: INFO: Got endpoints: latency-svc-qp4ss [750.174717ms]
+Nov 29 08:19:46.156: INFO: Created: latency-svc-np94c
+Nov 29 08:19:46.202: INFO: Got endpoints: latency-svc-dlth5 [749.831148ms]
+Nov 29 08:19:46.211: INFO: Created: latency-svc-n4c96
+Nov 29 08:19:46.252: INFO: Got endpoints: latency-svc-hrl62 [749.766472ms]
+Nov 29 08:19:46.256: INFO: Created: latency-svc-49wkc
+Nov 29 08:19:46.301: INFO: Got endpoints: latency-svc-xwsbd [749.954771ms]
+Nov 29 08:19:46.306: INFO: Created: latency-svc-c67ng
+Nov 29 08:19:46.351: INFO: Got endpoints: latency-svc-7wpgs [749.004297ms]
+Nov 29 08:19:46.355: INFO: Created: latency-svc-4nbz8
+Nov 29 08:19:46.401: INFO: Got endpoints: latency-svc-4sw47 [750.272423ms]
+Nov 29 08:19:46.406: INFO: Created: latency-svc-5jvs2
+Nov 29 08:19:46.452: INFO: Got endpoints: latency-svc-wnffc [749.967171ms]
+Nov 29 08:19:46.456: INFO: Created: latency-svc-kxjkm
+Nov 29 08:19:46.502: INFO: Got endpoints: latency-svc-nshwp [750.398608ms]
+Nov 29 08:19:46.505: INFO: Created: latency-svc-d7mbz
+Nov 29 08:19:46.551: INFO: Got endpoints: latency-svc-s7x5c [750.063378ms]
+Nov 29 08:19:46.557: INFO: Created: latency-svc-nw9gt
+Nov 29 08:19:46.602: INFO: Got endpoints: latency-svc-xbzpr [750.174601ms]
+Nov 29 08:19:46.606: INFO: Created: latency-svc-lgrjj
+Nov 29 08:19:46.651: INFO: Got endpoints: latency-svc-8rsc9 [750.032479ms]
+Nov 29 08:19:46.655: INFO: Created: latency-svc-ldk29
+Nov 29 08:19:46.701: INFO: Got endpoints: latency-svc-sb9d5 [749.06421ms]
+Nov 29 08:19:46.705: INFO: Created: latency-svc-8p7x8
+Nov 29 08:19:46.752: INFO: Got endpoints: latency-svc-nxvh7 [750.326403ms]
+Nov 29 08:19:46.756: INFO: Created: latency-svc-5kkxc
+Nov 29 08:19:46.802: INFO: Got endpoints: latency-svc-t9thf [750.781608ms]
+Nov 29 08:19:46.807: INFO: Created: latency-svc-t2r2t
+Nov 29 08:19:46.853: INFO: Got endpoints: latency-svc-q2g5t [750.943618ms]
+Nov 29 08:19:46.858: INFO: Created: latency-svc-nd9nt
+Nov 29 08:19:46.902: INFO: Got endpoints: latency-svc-np94c [750.293869ms]
+Nov 29 08:19:46.908: INFO: Created: latency-svc-xmtr7
+Nov 29 08:19:46.952: INFO: Got endpoints: latency-svc-n4c96 [750.401083ms]
+Nov 29 08:19:46.956: INFO: Created: latency-svc-kzld7
+Nov 29 08:19:47.002: INFO: Got endpoints: latency-svc-49wkc [750.039276ms]
+Nov 29 08:19:47.006: INFO: Created: latency-svc-g8f4k
+Nov 29 08:19:47.052: INFO: Got endpoints: latency-svc-c67ng [750.142674ms]
+Nov 29 08:19:47.055: INFO: Created: latency-svc-mfdln
+Nov 29 08:19:47.102: INFO: Got endpoints: latency-svc-4nbz8 [750.818402ms]
+Nov 29 08:19:47.105: INFO: Created: latency-svc-hz5vx
+Nov 29 08:19:47.152: INFO: Got endpoints: latency-svc-5jvs2 [750.692361ms]
+Nov 29 08:19:47.157: INFO: Created: latency-svc-mz85p
+Nov 29 08:19:47.202: INFO: Got endpoints: latency-svc-kxjkm [750.534138ms]
+Nov 29 08:19:47.208: INFO: Created: latency-svc-lqnrg
+Nov 29 08:19:47.252: INFO: Got endpoints: latency-svc-d7mbz [750.438123ms]
+Nov 29 08:19:47.256: INFO: Created: latency-svc-4642s
+Nov 29 08:19:47.301: INFO: Got endpoints: latency-svc-nw9gt [749.429405ms]
+Nov 29 08:19:47.305: INFO: Created: latency-svc-55797
+Nov 29 08:19:47.352: INFO: Got endpoints: latency-svc-lgrjj [750.460306ms]
+Nov 29 08:19:47.358: INFO: Created: latency-svc-p84rk
+Nov 29 08:19:47.403: INFO: Got endpoints: latency-svc-ldk29 [751.963561ms]
+Nov 29 08:19:47.408: INFO: Created: latency-svc-7gfhc
+Nov 29 08:19:47.453: INFO: Got endpoints: latency-svc-8p7x8 [752.401245ms]
+Nov 29 08:19:47.458: INFO: Created: latency-svc-rglfh
+Nov 29 08:19:47.503: INFO: Got endpoints: latency-svc-5kkxc [750.473592ms]
+Nov 29 08:19:47.513: INFO: Created: latency-svc-hgn79
+Nov 29 08:19:47.552: INFO: Got endpoints: latency-svc-t2r2t [749.833063ms]
+Nov 29 08:19:47.557: INFO: Created: latency-svc-dk2wz
+Nov 29 08:19:47.601: INFO: Got endpoints: latency-svc-nd9nt [748.261373ms]
+Nov 29 08:19:47.607: INFO: Created: latency-svc-98srj
+Nov 29 08:19:47.652: INFO: Got endpoints: latency-svc-xmtr7 [750.263197ms]
+Nov 29 08:19:47.658: INFO: Created: latency-svc-skd4b
+Nov 29 08:19:47.702: INFO: Got endpoints: latency-svc-kzld7 [750.144128ms]
+Nov 29 08:19:47.708: INFO: Created: latency-svc-d8f2g
+Nov 29 08:19:47.752: INFO: Got endpoints: latency-svc-g8f4k [750.288609ms]
+Nov 29 08:19:47.758: INFO: Created: latency-svc-pxb8b
+Nov 29 08:19:47.801: INFO: Got endpoints: latency-svc-mfdln [749.32194ms]
+Nov 29 08:19:47.804: INFO: Created: latency-svc-4vswh
+Nov 29 08:19:47.852: INFO: Got endpoints: latency-svc-hz5vx [749.944537ms]
+Nov 29 08:19:47.855: INFO: Created: latency-svc-7n764
+Nov 29 08:19:47.901: INFO: Got endpoints: latency-svc-mz85p [749.098623ms]
+Nov 29 08:19:47.906: INFO: Created: latency-svc-t75m2
+Nov 29 08:19:47.956: INFO: Got endpoints: latency-svc-lqnrg [753.872071ms]
+Nov 29 08:19:47.960: INFO: Created: latency-svc-fb6ld
+Nov 29 08:19:48.002: INFO: Got endpoints: latency-svc-4642s [749.587551ms]
+Nov 29 08:19:48.006: INFO: Created: latency-svc-vpvqr
+Nov 29 08:19:48.052: INFO: Got endpoints: latency-svc-55797 [750.81735ms]
+Nov 29 08:19:48.057: INFO: Created: latency-svc-gkxmt
+Nov 29 08:19:48.101: INFO: Got endpoints: latency-svc-p84rk [749.079388ms]
+Nov 29 08:19:48.107: INFO: Created: latency-svc-trnzb
+Nov 29 08:19:48.152: INFO: Got endpoints: latency-svc-7gfhc [748.602058ms]
+Nov 29 08:19:48.157: INFO: Created: latency-svc-fnrlq
+Nov 29 08:19:48.201: INFO: Got endpoints: latency-svc-rglfh [748.008823ms]
+Nov 29 08:19:48.205: INFO: Created: latency-svc-42xjx
+Nov 29 08:19:48.252: INFO: Got endpoints: latency-svc-hgn79 [749.722739ms]
+Nov 29 08:19:48.258: INFO: Created: latency-svc-9kjcc
+Nov 29 08:19:48.302: INFO: Got endpoints: latency-svc-dk2wz [750.436032ms]
+Nov 29 08:19:48.307: INFO: Created: latency-svc-rxns6
+Nov 29 08:19:48.352: INFO: Got endpoints: latency-svc-98srj [750.149601ms]
+Nov 29 08:19:48.359: INFO: Created: latency-svc-drtmn
+Nov 29 08:19:48.401: INFO: Got endpoints: latency-svc-skd4b [749.18056ms]
+Nov 29 08:19:48.405: INFO: Created: latency-svc-8mfzt
+Nov 29 08:19:48.451: INFO: Got endpoints: latency-svc-d8f2g [748.725218ms]
+Nov 29 08:19:48.454: INFO: Created: latency-svc-zv2tn
+Nov 29 08:19:48.502: INFO: Got endpoints: latency-svc-pxb8b [749.423823ms]
+Nov 29 08:19:48.504: INFO: Created: latency-svc-jftv2
+Nov 29 08:19:48.552: INFO: Got endpoints: latency-svc-4vswh [750.802026ms]
+Nov 29 08:19:48.555: INFO: Created: latency-svc-trcf8
+Nov 29 08:19:48.601: INFO: Got endpoints: latency-svc-7n764 [749.333209ms]
+Nov 29 08:19:48.606: INFO: Created: latency-svc-cl5xx
+Nov 29 08:19:48.651: INFO: Got endpoints: latency-svc-t75m2 [750.044449ms]
+Nov 29 08:19:48.654: INFO: Created: latency-svc-6m8vw
+Nov 29 08:19:48.701: INFO: Got endpoints: latency-svc-fb6ld [744.849521ms]
+Nov 29 08:19:48.705: INFO: Created: latency-svc-kflww
+Nov 29 08:19:48.752: INFO: Got endpoints: latency-svc-vpvqr [749.709519ms]
+Nov 29 08:19:48.754: INFO: Created: latency-svc-565qc
+Nov 29 08:19:48.801: INFO: Got endpoints: latency-svc-gkxmt [749.00862ms]
+Nov 29 08:19:48.805: INFO: Created: latency-svc-29w7q
+Nov 29 08:19:48.851: INFO: Got endpoints: latency-svc-trnzb [749.936569ms]
+Nov 29 08:19:48.855: INFO: Created: latency-svc-s4mkk
+Nov 29 08:19:48.901: INFO: Got endpoints: latency-svc-fnrlq [749.605199ms]
+Nov 29 08:19:48.905: INFO: Created: latency-svc-t5bgp
+Nov 29 08:19:48.952: INFO: Got endpoints: latency-svc-42xjx [750.065977ms]
+Nov 29 08:19:48.955: INFO: Created: latency-svc-tw549
+Nov 29 08:19:49.001: INFO: Got endpoints: latency-svc-9kjcc [748.774636ms]
+Nov 29 08:19:49.004: INFO: Created: latency-svc-lbwns
+Nov 29 08:19:49.051: INFO: Got endpoints: latency-svc-rxns6 [748.890938ms]
+Nov 29 08:19:49.055: INFO: Created: latency-svc-8lttj
+Nov 29 08:19:49.101: INFO: Got endpoints: latency-svc-drtmn [749.694533ms]
+Nov 29 08:19:49.104: INFO: Created: latency-svc-7plbj
+Nov 29 08:19:49.151: INFO: Got endpoints: latency-svc-8mfzt [749.732762ms]
+Nov 29 08:19:49.156: INFO: Created: latency-svc-77jnm
+Nov 29 08:19:49.201: INFO: Got endpoints: latency-svc-zv2tn [750.107232ms]
+Nov 29 08:19:49.204: INFO: Created: latency-svc-f8zxz
+Nov 29 08:19:49.252: INFO: Got endpoints: latency-svc-jftv2 [750.533472ms]
+Nov 29 08:19:49.257: INFO: Created: latency-svc-wsp29
+Nov 29 08:19:49.302: INFO: Got endpoints: latency-svc-trcf8 [750.066379ms]
+Nov 29 08:19:49.307: INFO: Created: latency-svc-995n7
+Nov 29 08:19:49.351: INFO: Got endpoints: latency-svc-cl5xx [750.236056ms]
+Nov 29 08:19:49.354: INFO: Created: latency-svc-wfwtp
+Nov 29 08:19:49.402: INFO: Got endpoints: latency-svc-6m8vw [750.994463ms]
+Nov 29 08:19:49.407: INFO: Created: latency-svc-twdc6
+Nov 29 08:19:49.451: INFO: Got endpoints: latency-svc-kflww [750.077734ms]
+Nov 29 08:19:49.456: INFO: Created: latency-svc-xhdvk
+Nov 29 08:19:49.501: INFO: Got endpoints: latency-svc-565qc [749.207234ms]
+Nov 29 08:19:49.506: INFO: Created: latency-svc-bszd2
+Nov 29 08:19:49.552: INFO: Got endpoints: latency-svc-29w7q [751.039324ms]
+Nov 29 08:19:49.555: INFO: Created: latency-svc-nfkhk
+Nov 29 08:19:49.601: INFO: Got endpoints: latency-svc-s4mkk [749.684098ms]
+Nov 29 08:19:49.605: INFO: Created: latency-svc-gp8sn
+Nov 29 08:19:49.653: INFO: Got endpoints: latency-svc-t5bgp [751.084373ms]
+Nov 29 08:19:49.657: INFO: Created: latency-svc-tpt75
+Nov 29 08:19:49.702: INFO: Got endpoints: latency-svc-tw549 [750.092365ms]
+Nov 29 08:19:49.706: INFO: Created: latency-svc-vmk58
+Nov 29 08:19:49.753: INFO: Got endpoints: latency-svc-lbwns [751.80253ms]
+Nov 29 08:19:49.758: INFO: Created: latency-svc-ktkdz
+Nov 29 08:19:49.802: INFO: Got endpoints: latency-svc-8lttj [750.451907ms]
+Nov 29 08:19:49.806: INFO: Created: latency-svc-rjx77
+Nov 29 08:19:49.852: INFO: Got endpoints: latency-svc-7plbj [750.748691ms]
+Nov 29 08:19:49.858: INFO: Created: latency-svc-kpmhp
+Nov 29 08:19:49.903: INFO: Got endpoints: latency-svc-77jnm [751.429023ms]
+Nov 29 08:19:49.907: INFO: Created: latency-svc-r8wfh
+Nov 29 08:19:49.952: INFO: Got endpoints: latency-svc-f8zxz [750.681721ms]
+Nov 29 08:19:49.956: INFO: Created: latency-svc-krbmj
+Nov 29 08:19:50.001: INFO: Got endpoints: latency-svc-wsp29 [748.66ms]
+Nov 29 08:19:50.005: INFO: Created: latency-svc-r4qwm
+Nov 29 08:19:50.052: INFO: Got endpoints: latency-svc-995n7 [749.861519ms]
+Nov 29 08:19:50.056: INFO: Created: latency-svc-m6rhh
+Nov 29 08:19:50.102: INFO: Got endpoints: latency-svc-wfwtp [750.92318ms]
+Nov 29 08:19:50.108: INFO: Created: latency-svc-mxdxl
+Nov 29 08:19:50.152: INFO: Got endpoints: latency-svc-twdc6 [749.730887ms]
+Nov 29 08:19:50.156: INFO: Created: latency-svc-qjvvd
+Nov 29 08:19:50.202: INFO: Got endpoints: latency-svc-xhdvk [750.472908ms]
+Nov 29 08:19:50.207: INFO: Created: latency-svc-lxj49
+Nov 29 08:19:50.252: INFO: Got endpoints: latency-svc-bszd2 [750.967377ms]
+Nov 29 08:19:50.257: INFO: Created: latency-svc-q8ttp
+Nov 29 08:19:50.303: INFO: Got endpoints: latency-svc-nfkhk [751.121258ms]
+Nov 29 08:19:50.307: INFO: Created: latency-svc-p6njq
+Nov 29 08:19:50.352: INFO: Got endpoints: latency-svc-gp8sn [750.78456ms]
+Nov 29 08:19:50.356: INFO: Created: latency-svc-6zf5s
+Nov 29 08:19:50.402: INFO: Got endpoints: latency-svc-tpt75 [749.021686ms]
+Nov 29 08:19:50.407: INFO: Created: latency-svc-x27jn
+Nov 29 08:19:50.452: INFO: Got endpoints: latency-svc-vmk58 [750.012226ms]
+Nov 29 08:19:50.457: INFO: Created: latency-svc-pz9pn
+Nov 29 08:19:50.502: INFO: Got endpoints: latency-svc-ktkdz [748.556259ms]
+Nov 29 08:19:50.506: INFO: Created: latency-svc-hj758
+Nov 29 08:19:50.553: INFO: Got endpoints: latency-svc-rjx77 [750.697021ms]
+Nov 29 08:19:50.558: INFO: Created: latency-svc-2t8bd
+Nov 29 08:19:50.602: INFO: Got endpoints: latency-svc-kpmhp [749.41701ms]
+Nov 29 08:19:50.606: INFO: Created: latency-svc-bfd2g
+Nov 29 08:19:50.651: INFO: Got endpoints: latency-svc-r8wfh [748.53803ms]
+Nov 29 08:19:50.656: INFO: Created: latency-svc-cws56
+Nov 29 08:19:50.702: INFO: Got endpoints: latency-svc-krbmj [749.877836ms]
+Nov 29 08:19:50.707: INFO: Created: latency-svc-f9svv
+Nov 29 08:19:50.751: INFO: Got endpoints: latency-svc-r4qwm [750.40761ms]
+Nov 29 08:19:50.755: INFO: Created: latency-svc-xrmbv
+Nov 29 08:19:50.802: INFO: Got endpoints: latency-svc-m6rhh [750.336725ms]
+Nov 29 08:19:50.808: INFO: Created: latency-svc-xjkjd
+Nov 29 08:19:50.851: INFO: Got endpoints: latency-svc-mxdxl [748.974314ms]
+Nov 29 08:19:50.856: INFO: Created: latency-svc-k9dsd
+Nov 29 08:19:50.902: INFO: Got endpoints: latency-svc-qjvvd [749.750264ms]
+Nov 29 08:19:50.907: INFO: Created: latency-svc-8wfp5
+Nov 29 08:19:50.952: INFO: Got endpoints: latency-svc-lxj49 [749.910581ms]
+Nov 29 08:19:50.957: INFO: Created: latency-svc-488lf
+Nov 29 08:19:51.002: INFO: Got endpoints: latency-svc-q8ttp [749.771239ms]
+Nov 29 08:19:51.007: INFO: Created: latency-svc-79fcm
+Nov 29 08:19:51.052: INFO: Got endpoints: latency-svc-p6njq [749.185512ms]
+Nov 29 08:19:51.056: INFO: Created: latency-svc-7zvdv
+Nov 29 08:19:51.102: INFO: Got endpoints: latency-svc-6zf5s [749.808978ms]
+Nov 29 08:19:51.105: INFO: Created: latency-svc-jcxm9
+Nov 29 08:19:51.152: INFO: Got endpoints: latency-svc-x27jn [749.818169ms]
+Nov 29 08:19:51.157: INFO: Created: latency-svc-srx4p
+Nov 29 08:19:51.202: INFO: Got endpoints: latency-svc-pz9pn [750.25872ms]
+Nov 29 08:19:51.207: INFO: Created: latency-svc-8wff9
+Nov 29 08:19:51.252: INFO: Got endpoints: latency-svc-hj758 [750.040069ms]
+Nov 29 08:19:51.256: INFO: Created: latency-svc-dbdnz
+Nov 29 08:19:51.303: INFO: Got endpoints: latency-svc-2t8bd [750.491763ms]
+Nov 29 08:19:51.308: INFO: Created: latency-svc-b2wq8
+Nov 29 08:19:51.351: INFO: Got endpoints: latency-svc-bfd2g [749.762985ms]
+Nov 29 08:19:51.355: INFO: Created: latency-svc-nxw2p
+Nov 29 08:19:51.401: INFO: Got endpoints: latency-svc-cws56 [750.109208ms]
+Nov 29 08:19:51.407: INFO: Created: latency-svc-zscgf
+Nov 29 08:19:51.453: INFO: Got endpoints: latency-svc-f9svv [751.053315ms]
+Nov 29 08:19:51.457: INFO: Created: latency-svc-z8mmq
+Nov 29 08:19:51.502: INFO: Got endpoints: latency-svc-xrmbv [750.450723ms]
+Nov 29 08:19:51.506: INFO: Created: latency-svc-ltqqg
+Nov 29 08:19:51.552: INFO: Got endpoints: latency-svc-xjkjd [749.49462ms]
+Nov 29 08:19:51.557: INFO: Created: latency-svc-t6rv9
+Nov 29 08:19:51.602: INFO: Got endpoints: latency-svc-k9dsd [750.357936ms]
+Nov 29 08:19:51.606: INFO: Created: latency-svc-rtftd
+Nov 29 08:19:51.651: INFO: Got endpoints: latency-svc-8wfp5 [749.552339ms]
+Nov 29 08:19:51.657: INFO: Created: latency-svc-ksw9p
+Nov 29 08:19:51.702: INFO: Got endpoints: latency-svc-488lf [750.317559ms]
+Nov 29 08:19:51.707: INFO: Created: latency-svc-7trsv
+Nov 29 08:19:51.751: INFO: Got endpoints: latency-svc-79fcm [749.796106ms]
+Nov 29 08:19:51.756: INFO: Created: latency-svc-5cqxp
+Nov 29 08:19:51.802: INFO: Got endpoints: latency-svc-7zvdv [749.576469ms]
+Nov 29 08:19:51.807: INFO: Created: latency-svc-vtjx5
+Nov 29 08:19:51.853: INFO: Got endpoints: latency-svc-jcxm9 [750.698504ms]
+Nov 29 08:19:51.858: INFO: Created: latency-svc-6g88f
+Nov 29 08:19:51.901: INFO: Got endpoints: latency-svc-srx4p [749.384725ms]
+Nov 29 08:19:51.905: INFO: Created: latency-svc-p5cf7
+Nov 29 08:19:51.952: INFO: Got endpoints: latency-svc-8wff9 [750.12065ms]
+Nov 29 08:19:51.956: INFO: Created: latency-svc-svv87
+Nov 29 08:19:52.005: INFO: Got endpoints: latency-svc-dbdnz [753.269598ms]
+Nov 29 08:19:52.011: INFO: Created: latency-svc-hbcw2
+Nov 29 08:19:52.052: INFO: Got endpoints: latency-svc-b2wq8 [748.637778ms]
+Nov 29 08:19:52.056: INFO: Created: latency-svc-f6kls
+Nov 29 08:19:52.102: INFO: Got endpoints: latency-svc-nxw2p [750.446193ms]
+Nov 29 08:19:52.106: INFO: Created: latency-svc-rkwqv
+Nov 29 08:19:52.151: INFO: Got endpoints: latency-svc-zscgf [750.009447ms]
+Nov 29 08:19:52.156: INFO: Created: latency-svc-psp5l
+Nov 29 08:19:52.202: INFO: Got endpoints: latency-svc-z8mmq [749.040929ms]
+Nov 29 08:19:52.207: INFO: Created: latency-svc-8n7jv
+Nov 29 08:19:52.252: INFO: Got endpoints: latency-svc-ltqqg [750.241169ms]
+Nov 29 08:19:52.256: INFO: Created: latency-svc-txqp7
+Nov 29 08:19:52.302: INFO: Got endpoints: latency-svc-t6rv9 [750.1745ms]
+Nov 29 08:19:52.307: INFO: Created: latency-svc-2zpds
+Nov 29 08:19:52.352: INFO: Got endpoints: latency-svc-rtftd [750.247284ms]
+Nov 29 08:19:52.358: INFO: Created: latency-svc-sc9xs
+Nov 29 08:19:52.403: INFO: Got endpoints: latency-svc-ksw9p [751.255626ms]
+Nov 29 08:19:52.452: INFO: Got endpoints: latency-svc-7trsv [750.009875ms]
+Nov 29 08:19:52.502: INFO: Got endpoints: latency-svc-5cqxp [750.992021ms]
+Nov 29 08:19:52.552: INFO: Got endpoints: latency-svc-vtjx5 [750.215382ms]
+Nov 29 08:19:52.603: INFO: Got endpoints: latency-svc-6g88f [750.181009ms]
+Nov 29 08:19:52.652: INFO: Got endpoints: latency-svc-p5cf7 [750.989796ms]
+Nov 29 08:19:52.702: INFO: Got endpoints: latency-svc-svv87 [749.279166ms]
+Nov 29 08:19:52.751: INFO: Got endpoints: latency-svc-hbcw2 [746.052078ms]
+Nov 29 08:19:52.801: INFO: Got endpoints: latency-svc-f6kls [749.204428ms]
+Nov 29 08:19:52.851: INFO: Got endpoints: latency-svc-rkwqv [749.313212ms]
+Nov 29 08:19:52.901: INFO: Got endpoints: latency-svc-psp5l [749.167985ms]
+Nov 29 08:19:52.952: INFO: Got endpoints: latency-svc-8n7jv [749.940554ms]
+Nov 29 08:19:53.002: INFO: Got endpoints: latency-svc-txqp7 [749.629625ms]
+Nov 29 08:19:53.051: INFO: Got endpoints: latency-svc-2zpds [749.276566ms]
+Nov 29 08:19:53.101: INFO: Got endpoints: latency-svc-sc9xs [749.050023ms]
+Nov 29 08:19:53.101: INFO: Latencies: [18.47018ms 18.614697ms 30.448511ms 31.238945ms 37.701013ms 38.830788ms 55.619211ms 55.832215ms 62.509679ms 62.89267ms 73.679359ms 75.063831ms 82.071739ms 82.558037ms 87.726077ms 94.439202ms 95.98091ms 96.066831ms 97.318031ms 97.849036ms 98.374857ms 99.480771ms 101.676231ms 102.307966ms 103.541512ms 104.473359ms 107.608892ms 108.621125ms 112.108223ms 116.713798ms 123.962559ms 125.019315ms 125.707889ms 127.003644ms 161.127809ms 193.471913ms 240.707194ms 278.412047ms 322.186854ms 355.225652ms 393.940667ms 443.346255ms 494.527556ms 544.725863ms 590.555558ms 636.227102ms 676.758462ms 721.819225ms 744.849521ms 746.052078ms 747.70374ms 748.008823ms 748.261373ms 748.360596ms 748.53803ms 748.556259ms 748.602058ms 748.637778ms 748.66ms 748.725218ms 748.774636ms 748.890938ms 748.912034ms 748.974314ms 749.004297ms 749.00862ms 749.021686ms 749.040929ms 749.050023ms 749.06421ms 749.079388ms 749.098623ms 749.167985ms 749.18056ms 749.185512ms 749.204428ms 749.207234ms 749.276566ms 749.279166ms 749.313212ms 749.32194ms 749.333209ms 749.384725ms 749.41701ms 749.423823ms 749.429405ms 749.49462ms 749.552339ms 749.555524ms 749.576469ms 749.587551ms 749.587769ms 749.605199ms 749.629625ms 749.631343ms 749.660714ms 749.684098ms 749.694533ms 749.709519ms 749.722739ms 749.730887ms 749.732762ms 749.750264ms 749.75263ms 749.762985ms 749.766472ms 749.771091ms 749.771239ms 749.796106ms 749.808978ms 749.815567ms 749.818169ms 749.831148ms 749.833063ms 749.861519ms 749.877836ms 749.908697ms 749.910581ms 749.936569ms 749.940554ms 749.944537ms 749.954771ms 749.967171ms 750.009447ms 750.009875ms 750.012226ms 750.032479ms 750.039276ms 750.040069ms 750.044449ms 750.063378ms 750.065977ms 750.066379ms 750.077734ms 750.092365ms 750.107232ms 750.109208ms 750.12065ms 750.142674ms 750.144128ms 750.149601ms 750.1745ms 750.174601ms 750.174717ms 750.181009ms 750.215382ms 750.236056ms 750.241169ms 750.247284ms 750.25872ms 750.263197ms 750.272423ms 750.288609ms 750.293869ms 750.317559ms 750.326403ms 750.336725ms 750.357936ms 750.398608ms 750.401083ms 750.40761ms 750.436032ms 750.438123ms 750.446193ms 750.450723ms 750.451907ms 750.460306ms 750.472908ms 750.473592ms 750.491763ms 750.533472ms 750.534138ms 750.681721ms 750.692361ms 750.697021ms 750.698504ms 750.714251ms 750.748691ms 750.781608ms 750.78456ms 750.802026ms 750.81735ms 750.818402ms 750.92318ms 750.943618ms 750.967377ms 750.989796ms 750.992021ms 750.994463ms 751.039324ms 751.053315ms 751.084373ms 751.121258ms 751.255626ms 751.429023ms 751.80253ms 751.963561ms 752.401245ms 753.269598ms 753.872071ms]
+Nov 29 08:19:53.101: INFO: 50 %ile: 749.730887ms
+Nov 29 08:19:53.101: INFO: 90 %ile: 750.802026ms
+Nov 29 08:19:53.101: INFO: 99 %ile: 753.269598ms
+Nov 29 08:19:53.101: INFO: Total sample count: 200
+[AfterEach] [sig-network] Service endpoints latency
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Nov 29 08:19:53.101: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-svc-latency-xz6df" for this suite.
+Nov 29 08:20:13.109: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Nov 29 08:20:13.154: INFO: namespace: e2e-tests-svc-latency-xz6df, resource: bindings, ignored listing per whitelist
+Nov 29 08:20:13.159: INFO: namespace e2e-tests-svc-latency-xz6df deletion completed in 20.055798481s
+
+• [SLOW TEST:29.798 seconds]
+[sig-network] Service endpoints latency
+/workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/network/framework.go:22
+  should not be very high  [Conformance]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SSSS
+------------------------------
+[sig-api-machinery] Downward API 
+  should provide pod name, namespace and IP address as env vars  [Conformance]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-api-machinery] Downward API
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Nov 29 08:20:13.160: INFO: >>> kubeConfig: /tmp/kubeconfig-385092372
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[It] should provide pod name, namespace and IP address as env vars  [Conformance]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating a pod to test downward api env vars
+Nov 29 08:20:13.190: INFO: Waiting up to 5m0s for pod "downward-api-982048aa-f3af-11e8-9124-e6180d057dc8" in namespace "e2e-tests-downward-api-pjgdd" to be "success or failure"
+Nov 29 08:20:13.194: INFO: Pod "downward-api-982048aa-f3af-11e8-9124-e6180d057dc8": Phase="Pending", Reason="", readiness=false. Elapsed: 3.850321ms
+Nov 29 08:20:15.196: INFO: Pod "downward-api-982048aa-f3af-11e8-9124-e6180d057dc8": Phase="Pending", Reason="", readiness=false. Elapsed: 2.005644722s
+Nov 29 08:20:17.198: INFO: Pod "downward-api-982048aa-f3af-11e8-9124-e6180d057dc8": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.007489966s
+STEP: Saw pod success
+Nov 29 08:20:17.198: INFO: Pod "downward-api-982048aa-f3af-11e8-9124-e6180d057dc8" satisfied condition "success or failure"
+Nov 29 08:20:17.199: INFO: Trying to get logs from node worker-266bbc56-f3aa-11e8-ab5c-0a406d6cb422 pod downward-api-982048aa-f3af-11e8-9124-e6180d057dc8 container dapi-container: <nil>
+STEP: delete the pod
+Nov 29 08:20:17.211: INFO: Waiting for pod downward-api-982048aa-f3af-11e8-9124-e6180d057dc8 to disappear
+Nov 29 08:20:17.213: INFO: Pod downward-api-982048aa-f3af-11e8-9124-e6180d057dc8 no longer exists
+[AfterEach] [sig-api-machinery] Downward API
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Nov 29 08:20:17.213: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-downward-api-pjgdd" for this suite.
+Nov 29 08:20:23.221: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Nov 29 08:20:23.260: INFO: namespace: e2e-tests-downward-api-pjgdd, resource: bindings, ignored listing per whitelist
+Nov 29 08:20:23.280: INFO: namespace e2e-tests-downward-api-pjgdd deletion completed in 6.064705543s
+
+• [SLOW TEST:10.121 seconds]
+[sig-api-machinery] Downward API
+/workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downward_api.go:37
+  should provide pod name, namespace and IP address as env vars  [Conformance]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+[k8s.io] Probing container 
+  with readiness probe that fails should never be ready and never restart  [Conformance]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [k8s.io] Probing container
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Nov 29 08:20:23.280: INFO: >>> kubeConfig: /tmp/kubeconfig-385092372
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [k8s.io] Probing container
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/container_probe.go:48
+[It] with readiness probe that fails should never be ready and never restart  [Conformance]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[AfterEach] [k8s.io] Probing container
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Nov 29 08:21:23.313: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-container-probe-q58f4" for this suite.
+Nov 29 08:21:45.320: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Nov 29 08:21:45.367: INFO: namespace: e2e-tests-container-probe-q58f4, resource: bindings, ignored listing per whitelist
+Nov 29 08:21:45.379: INFO: namespace e2e-tests-container-probe-q58f4 deletion completed in 22.064405699s
+
+• [SLOW TEST:82.099 seconds]
+[k8s.io] Probing container
+/workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:669
+  with readiness probe that fails should never be ready and never restart  [Conformance]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SSSSS
+------------------------------
+[sig-network] Services 
+  should provide secure master service  [Conformance]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-network] Services
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Nov 29 08:21:45.379: INFO: >>> kubeConfig: /tmp/kubeconfig-385092372
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-network] Services
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/network/service.go:53
+[It] should provide secure master service  [Conformance]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[AfterEach] [sig-network] Services
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Nov 29 08:21:45.419: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-services-4x8sl" for this suite.
+Nov 29 08:21:51.430: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Nov 29 08:21:51.462: INFO: namespace: e2e-tests-services-4x8sl, resource: bindings, ignored listing per whitelist
+Nov 29 08:21:51.482: INFO: namespace e2e-tests-services-4x8sl deletion completed in 6.059669017s
+[AfterEach] [sig-network] Services
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/network/service.go:58
+
+• [SLOW TEST:6.103 seconds]
+[sig-network] Services
+/workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/network/framework.go:22
+  should provide secure master service  [Conformance]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SSS
+------------------------------
+[k8s.io] Probing container 
+  should *not* be restarted with a exec "cat /tmp/health" liveness probe [Conformance]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [k8s.io] Probing container
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Nov 29 08:21:51.482: INFO: >>> kubeConfig: /tmp/kubeconfig-385092372
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [k8s.io] Probing container
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/container_probe.go:48
+[It] should *not* be restarted with a exec "cat /tmp/health" liveness probe [Conformance]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating pod liveness-exec in namespace e2e-tests-container-probe-5gr5q
+Nov 29 08:21:55.520: INFO: Started pod liveness-exec in namespace e2e-tests-container-probe-5gr5q
+STEP: checking the pod's current state and verifying that restartCount is present
+Nov 29 08:21:55.521: INFO: Initial restart count of pod liveness-exec is 0
+STEP: deleting the pod
+[AfterEach] [k8s.io] Probing container
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Nov 29 08:23:55.632: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-container-probe-5gr5q" for this suite.
+Nov 29 08:24:01.641: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Nov 29 08:24:01.672: INFO: namespace: e2e-tests-container-probe-5gr5q, resource: bindings, ignored listing per whitelist
+Nov 29 08:24:01.695: INFO: namespace e2e-tests-container-probe-5gr5q deletion completed in 6.059111157s
+
+• [SLOW TEST:130.212 seconds]
+[k8s.io] Probing container
+/workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:669
+  should *not* be restarted with a exec "cat /tmp/health" liveness probe [Conformance]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SSSSSSSSS
+------------------------------
+[k8s.io] Probing container 
+  should *not* be restarted with a /healthz http liveness probe  [Conformance]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [k8s.io] Probing container
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Nov 29 08:24:01.695: INFO: >>> kubeConfig: /tmp/kubeconfig-385092372
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [k8s.io] Probing container
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/container_probe.go:48
+[It] should *not* be restarted with a /healthz http liveness probe  [Conformance]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating pod liveness-http in namespace e2e-tests-container-probe-s7b2l
+Nov 29 08:24:03.781: INFO: Started pod liveness-http in namespace e2e-tests-container-probe-s7b2l
+STEP: checking the pod's current state and verifying that restartCount is present
+Nov 29 08:24:03.783: INFO: Initial restart count of pod liveness-http is 0
+STEP: deleting the pod
+[AfterEach] [k8s.io] Probing container
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Nov 29 08:26:03.911: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-container-probe-s7b2l" for this suite.
+Nov 29 08:26:09.919: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Nov 29 08:26:09.955: INFO: namespace: e2e-tests-container-probe-s7b2l, resource: bindings, ignored listing per whitelist
+Nov 29 08:26:09.970: INFO: namespace e2e-tests-container-probe-s7b2l deletion completed in 6.056940094s
+
+• [SLOW TEST:128.275 seconds]
+[k8s.io] Probing container
+/workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:669
+  should *not* be restarted with a /healthz http liveness probe  [Conformance]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SSSSS
+------------------------------
+[sig-storage] Downward API volume 
+  should provide container's memory request  [Conformance]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+[BeforeEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
+STEP: Creating a kubernetes client
+Nov 29 08:26:09.970: INFO: >>> kubeConfig: /tmp/kubeconfig-385092372
+STEP: Building a namespace api object
+STEP: Waiting for a default service account to be provisioned in namespace
+[BeforeEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downwardapi_volume.go:38
+[It] should provide container's memory request  [Conformance]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+STEP: Creating a pod to test downward API volume plugin
+Nov 29 08:26:10.054: INFO: Waiting up to 5m0s for pod "downwardapi-volume-6cd4e969-f3b0-11e8-9124-e6180d057dc8" in namespace "e2e-tests-downward-api-mbphj" to be "success or failure"
+Nov 29 08:26:10.060: INFO: Pod "downwardapi-volume-6cd4e969-f3b0-11e8-9124-e6180d057dc8": Phase="Pending", Reason="", readiness=false. Elapsed: 6.052626ms
+Nov 29 08:26:12.064: INFO: Pod "downwardapi-volume-6cd4e969-f3b0-11e8-9124-e6180d057dc8": Phase="Succeeded", Reason="", readiness=false. Elapsed: 2.010319538s
+STEP: Saw pod success
+Nov 29 08:26:12.064: INFO: Pod "downwardapi-volume-6cd4e969-f3b0-11e8-9124-e6180d057dc8" satisfied condition "success or failure"
+Nov 29 08:26:12.065: INFO: Trying to get logs from node worker-266bbc56-f3aa-11e8-ab5c-0a406d6cb422 pod downwardapi-volume-6cd4e969-f3b0-11e8-9124-e6180d057dc8 container client-container: <nil>
+STEP: delete the pod
+Nov 29 08:26:12.078: INFO: Waiting for pod downwardapi-volume-6cd4e969-f3b0-11e8-9124-e6180d057dc8 to disappear
+Nov 29 08:26:12.079: INFO: Pod downwardapi-volume-6cd4e969-f3b0-11e8-9124-e6180d057dc8 no longer exists
+[AfterEach] [sig-storage] Downward API volume
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
+Nov 29 08:26:12.079: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
+STEP: Destroying namespace "e2e-tests-downward-api-mbphj" for this suite.
+Nov 29 08:26:18.087: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
+Nov 29 08:26:18.101: INFO: namespace: e2e-tests-downward-api-mbphj, resource: bindings, ignored listing per whitelist
+Nov 29 08:26:18.138: INFO: namespace e2e-tests-downward-api-mbphj deletion completed in 6.056336668s
+
+• [SLOW TEST:8.168 seconds]
+[sig-storage] Downward API volume
+/workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/downwardapi_volume.go:33
+  should provide container's memory request  [Conformance]
+  /workspace/anago-v1.10.5-beta.0.53+32ac1c9073b132/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:674
+------------------------------
+SSSSSSNov 29 08:26:18.138: INFO: Running AfterSuite actions on all node
+Nov 29 08:26:18.138: INFO: Running AfterSuite actions on node 1
+Nov 29 08:26:18.138: INFO: Skipping dumping logs from cluster
+
+Ran 139 of 890 Specs in 3126.910 seconds
+SUCCESS! -- 139 Passed | 0 Failed | 0 Pending | 751 Skipped PASS
+
+Ginkgo ran 1 suite in 52m7.298999079s
+Test Suite Passed

--- a/v1.11/cloud-pks/junit_01.xml
+++ b/v1.11/cloud-pks/junit_01.xml
@@ -1,0 +1,2395 @@
+<?xml version="1.0" encoding="UTF-8"?>
+  <testsuite tests="139" failures="0" time="3126.909554203">
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] should disable node pool autoscaling [Feature:ClusterSizeAutoscalingScaleUp]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Projected should be consumable from pods in volume with mappings [Conformance]" classname="Kubernetes e2e suite" time="10.154178295"></testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Simple pod should support port-forward" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] DNS should support configurable pod resolv.conf" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Downward API volume should set DefaultMode on files  [Conformance]" classname="Kubernetes e2e suite" time="8.115033946"></testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: gce-localssd-scsi-fs] [Serial] Two pods mounting a local volume at the same time should be able to write from pod1 and read from pod2" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [Feature:Example] [k8s.io] Secret should create a pod that reads a secret" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Storage Policy Based Volume Provisioning [Feature:vsphere] verify VSAN storage capability with valid diskStripes and objectSpaceReservation values and a VSAN datastore is honored for dynamically provisioned pvc using storageclass" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: nfs] should support creating multiple subpath from same volumes [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl Port forwarding [k8s.io] With a server listening on localhost should support forwarding over websockets" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Dynamic Provisioning DynamicProvisioner Default should be disabled by removing the default annotation[Slow] [Serial] [Disruptive]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [Feature:Example] [k8s.io] Hazelcast should create and scale hazelcast" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Simple pod should support inline execution and attach" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Services [Feature:GCEAlphaFeature][Slow] should be able to create and tear down a standard-tier load balancer [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Regional PD [Feature:RegionalPD] RegionalPD should failover to a different zone when all nodes in one zone become unreachable [Slow] [Disruptive]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volume plugin streaming [Slow] iSCSI [Feature:Volumes] should write files of various sizes, verify size, validate content" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl Port forwarding [k8s.io] With a server listening on 0.0.0.0 [k8s.io] that expects a client request should support a client that connects, sends DATA, and disconnects" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Downward API [Serial] [Disruptive] Downward API tests for local ephemeral storage should provide default limits.ephemeral-storage from node allocatable" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volume plugin streaming [Slow] Ceph-RBD [Feature:Volumes] should write files of various sizes, verify size, validate content" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-auth] [Feature:NodeAuthorizer] Getting an existent secret should exit with the Forbidden error" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: nfsPVC] should fail if subpath with backstepping is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Pod Disks should be able to delete a non-existent PD without error" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] ReplicationController should release no longer matching pods" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Sysctls should support unsafe sysctls which are actually whitelisted" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: dir] One pod requesting one prebound PVC should be able to mount volume and write from pod1" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] [Serial] Volume metrics should create volume metrics with the correct PVC ref" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Garbage collector should keep the rc around until all its pods are deleted if the deleteOptions says so [Conformance]" classname="Kubernetes e2e suite" time="12.108084782"></testcase>
+      <testcase name="[sig-network] Firewall rule [Slow] [Serial] should create valid firewall rules for LoadBalancer type service" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Networking should check kube-proxy urls" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [sig-node] Security Context [Feature:SecurityContext] should support seccomp default which is unconfined [Feature:Seccomp]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] StatefulSet [k8s.io] Basic StatefulSet functionality [StatefulSetBasic] should not deadlock when a pod&#39;s predecessor fails" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Pods should be submitted and removed  [Conformance]" classname="Kubernetes e2e suite" time="15.120752331"></testcase>
+      <testcase name="[sig-auth] Metadata Concealment should run a check-metadata-concealment job to completion" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: nfs] should support existing directories when readOnly specified in the volumeSource" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scalability] Density [Feature:ManualPerformance] should allow starting 100 pods per node using { ReplicationController} with 0 secrets, 0 configmaps and 0 daemons" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Services should work after restarting kube-proxy [Disruptive]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Networking Granular Checks: Pods should function for node-pod communication: http  [Conformance]" classname="Kubernetes e2e suite" time="44.276130424"></testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: nfsPVC] should support readOnly directory specified in the volumeMount" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gcePDPartitioned] should support readOnly file specified in the volumeMount" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cluster-lifecycle] Reboot [Disruptive] [Feature:Reboot] each node by ordering clean reboot and ensure they function upon restart" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cluster-lifecycle] Reboot [Disruptive] [Feature:Reboot] each node by switching off the network interface and ensure they function upon switch on" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] EmptyDir volumes should support (non-root,0666,default) [Conformance]" classname="Kubernetes e2e suite" time="10.137264105"></testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gcePDPartitioned] should support creating multiple subpath from same volumes [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scalability] Load capacity [Feature:ManualPerformance] should be able to handle 30 pods per node {extensions Deployment} with 0 secrets, 2 configmaps and 0 daemons" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] should increase cluster size if pending pods are small [Feature:ClusterSizeAutoscalingScaleUp]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: nfs] should fail if subpath with backstepping is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Kubectl create quota should reject quota with invalid scopes" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [sig-node] Pods Extended [k8s.io] Delete Grace Period should be submitted and removed  [Flaky] [Conformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] ConfigMap should be consumable via the environment  [Conformance]" classname="Kubernetes e2e suite" time="10.122001325"></testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: hostPathSymlink] should support restarting containers using file as subpath [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Projected should provide node allocatable (cpu) as default cpu limit if the limit is not set [Conformance]" classname="Kubernetes e2e suite" time="8.176857572"></testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] should add new node and new node pool on too big pod, scale down to 1 and scale down to 0 [Feature:ClusterSizeAutoscalingScaleWithNAP]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] should add node to the particular mig [Feature:ClusterSizeAutoscalingScaleUp]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Pod Disks schedule pods each with a PD, delete pod and verify detach [Slow] for read-only PD with pod delete grace period of &#34;immediate (0s)&#34;" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-instrumentation] Cluster level logging implemented by Stackdriver should ingest logs" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] SchedulerPredicates [Serial] validates that NodeSelector is respected if not matching  [Conformance]" classname="Kubernetes e2e suite" time="83.135653069"></testcase>
+      <testcase name="[sig-storage] EmptyDir volumes should support (non-root,0644,default) [Conformance]" classname="Kubernetes e2e suite" time="8.174829186"></testcase>
+      <testcase name="[sig-scheduling] Rescheduler [Serial] should ensure that critical pod is scheduled in case there is no resources available" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Deployment RollingUpdateDeployment should delete old pods and create new ones" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] [HPA] Horizontal pod autoscaling (scale resource: CPU) [sig-autoscaling] ReplicationController light Should scale from 2 pods to 1 pod" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Update Demo should create and stop a replication controller  [Conformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] NetworkPolicy NetworkPolicy between server and client should support allow-all policy [Feature:NetworkPolicy]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] DNS should provide DNS for the cluster  [Conformance]" classname="Kubernetes e2e suite" time="26.150490775"></testcase>
+      <testcase name="[sig-storage] Flexvolumes [Disruptive] should be mountable when attachable" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] [HPA] Horizontal pod autoscaling (scale resource: Custom Metrics from Stackdriver) should scale down with Custom Metric of type Pod from Stackdriver with Prometheus [Feature:CustomMetricsAutoscaling]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] ConfigMap should be consumable via environment variable  [Conformance]" classname="Kubernetes e2e suite" time="10.124163238"></testcase>
+      <testcase name="[sig-storage] ConfigMap should be consumable from pods in volume with mappings  [Conformance]" classname="Kubernetes e2e suite" time="8.175125825"></testcase>
+      <testcase name="[k8s.io] [sig-node] Security Context [Feature:SecurityContext] should support seccomp alpha unconfined annotation on the pod [Feature:Seccomp]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Projected should be consumable from pods in volume [Conformance]" classname="Kubernetes e2e suite" time="8.125817152"></testcase>
+      <testcase name="[sig-apps] DisruptionController should create a PodDisruptionBudget" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] should create new node if there is no node for node selector [Feature:ClusterSizeAutoscalingScaleWithNAP]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Networking Granular Checks: Services [Slow] should function for endpoint-Service: udp" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PV Protection Verify &#34;immediate&#34; deletion of a PV that is not bound to a PVC" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] EquivalenceCache [Serial] validates pod affinity works properly when new replica pod is scheduled" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Dynamic Provisioning DynamicProvisioner deletion should be idempotent" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Job should run a job to completion when tasks sometimes fail and are locally restarted" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scalability] Load capacity [Feature:ManualPerformance] should be able to handle 30 pods per node {batch Job} with 0 secrets, 0 configmaps and 0 daemons" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Networking Granular Checks: Pods should function for node-pod communication: udp  [Conformance]" classname="Kubernetes e2e suite" time="39.154492304"></testcase>
+      <testcase name="[sig-network] DNS should provide DNS for services  [Conformance]" classname="Kubernetes e2e suite" time="48.214819794"></testcase>
+      <testcase name="[sig-network] Loadbalancing: L7 GCE [Slow] [Feature:Ingress] multicluster ingress should get instance group annotation" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cluster-lifecycle] Upgrade [Feature:Upgrade] master upgrade should maintain a functioning cluster [Feature:MasterUpgrade]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Projected should provide podname only [Conformance]" classname="Kubernetes e2e suite" time="8.126573033"></testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] Should be able to scale a node group down to 0[Feature:ClusterSizeAutoscalingScaleDown]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-instrumentation] Monitoring should verify monitoring pods and all cluster nodes are available on influxdb using heapster." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] AdmissionWebhook Should mutate custom resource" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Storage Policy Based Volume Provisioning [Feature:vsphere] verify if a SPBM policy is not honored on a non-compatible datastore for dynamically provisioned pvc using storageclass" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] ConfigMap binary data should be reflected in volume " classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: hostPath] should support restarting containers using directory as subpath [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes NFS with multiple PVs and PVCs all in same ns should create 4 PVs and 2 PVCs: test write access [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volumes GlusterFS should be mountable" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Services should be able to change the type from NodePort to ExternalName" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] SchedulerPredicates [Serial] validates local ephemeral storage resource limits of pods that are allowed to run [Feature:LocalStorageCapacityIsolation]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] SchedulerPredicates [Serial] validates resource limits of pods that are allowed to run  [Conformance]" classname="Kubernetes e2e suite" time="85.152100912"></testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: nfs] should fail for new directories when readOnly specified in the volumeSource" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gcePDPVC] should support readOnly directory specified in the volumeMount" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: emptyDir] should support existing single file" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes [Feature:LabelSelector] [sig-storage] Selector-Label Volume Binding:vsphere should bind volume with claim for given label" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] ReplicationController should serve a basic image on each replica with a private image" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Downward API volume should provide podname only  [Conformance]" classname="Kubernetes e2e suite" time="8.108831765"></testcase>
+      <testcase name="[sig-scheduling] ResourceQuota should verify ResourceQuota with best effort scope." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gcePDPVC] should unmount if pod is force deleted while kubelet is down [Disruptive][Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gluster] should support readOnly directory specified in the volumeMount" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] ConfigMap should be consumable from pods in volume with mappings as non-root  [Conformance]" classname="Kubernetes e2e suite" time="8.114844367"></testcase>
+      <testcase name="[sig-network] ESIPP [Slow] [DisabledForLargeClusters] should handle updates to ExternalTrafficPolicy field" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [sig-node] Events should be sent by kubelets and the scheduler about pods scheduling and running  [Conformance]" classname="Kubernetes e2e suite" time="30.169168061"></testcase>
+      <testcase name="[sig-storage] PVC Protection Verify that PVC in active use by a pod is not removed immediately" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] CronJob should not emit unexpected warnings" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cluster-lifecycle] Nodes [Disruptive] Resize [Slow] should be able to add nodes" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] InitContainer should invoke init containers on a RestartNever pod" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [sig-node] Security Context [Feature:SecurityContext] should support pod.Spec.SecurityContext.RunAsUser And pod.Spec.SecurityContext.RunAsGroup [Feature:RunAsGroup]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [Feature:Example] [k8s.io] Cassandra should create and scale cassandra" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Services should use same NodePort with same port but different protocols" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Networking Granular Checks: Services [Slow] should update endpoints: udp" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath Atomic writer volumes should support subpaths with configmap pod" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gluster] should support creating multiple subpath from same volumes [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: hostPath] should support non-existent path" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gcePDPVC] should support readOnly file specified in the volumeMount" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Loadbalancing: L7 Scalability GCE [Slow] [Serial] [Feature:IngressScale] Creating and updating ingresses should happen promptly with small/medium/large amount of ingresses" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: nfs] should fail if non-existent subpath is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] should correctly scale down after a node is not needed [Feature:ClusterSizeAutoscalingScaleDown]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] HostPath should support r/w" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Services should only allow access from service loadbalancer source ranges [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] ESIPP [Slow] [DisabledForLargeClusters] should work from pods" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Secrets should be consumable in multiple volumes in a pod  [Conformance]" classname="Kubernetes e2e suite" time="8.1629944"></testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: nfs] should support readOnly file specified in the volumeMount" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cluster-lifecycle] Restart [Disruptive] should restart all nodes and ensure all nodes and pods recover" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] SchedulerPredicates [Serial] validates that NodeAffinity is respected if not matching" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cluster-lifecycle] Addon update should propagate add-on file changes [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gluster] should support readOnly file specified in the volumeMount" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Services should preserve source pod IP for traffic thru service cluster IP" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Networking IPerf IPv4 [Experimental] [Feature:Networking-IPv4] [Slow] [Feature:Networking-Performance] should transfer ~ 1GB onto the service endpoint 1 servers (maximum of 1 clients)" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Downward API should provide pod UID as env vars  [Conformance]" classname="Kubernetes e2e suite" time="10.13531723"></testcase>
+      <testcase name="[sig-api-machinery] Garbage collector should delete RS created by deployment when not orphaning [Conformance]" classname="Kubernetes e2e suite" time="6.673447834"></testcase>
+      <testcase name="[sig-network] DNS configMap federations should be able to change federation configuration [Slow][Serial]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] ConfigMap should be consumable from pods in volume  [Conformance]" classname="Kubernetes e2e suite" time="8.120202608"></testcase>
+      <testcase name="[sig-network] Services should serve multiport endpoints from pods  [Conformance]" classname="Kubernetes e2e suite" time="27.244455907"></testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gluster] should support existing directory" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] StatefulSet [k8s.io] Basic StatefulSet functionality [StatefulSetBasic] should perform rolling updates and roll backs of template modifications [Conformance]" classname="Kubernetes e2e suite" time="136.651471817"></testcase>
+      <testcase name="[sig-api-machinery] Initializers [Feature:Initializers] will be set to nil if a patch removes the last pending initializer" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gcePDPVC] should support file as subpath" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] NetworkPolicy NetworkPolicy between server and client should enforce policy based on Ports [Feature:NetworkPolicy]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Projected should be consumable from pods in volume with mappings and Item mode set [Conformance]" classname="Kubernetes e2e suite" time="10.122029516"></testcase>
+      <testcase name="[k8s.io] GKE local SSD [Feature:GKELocalSSD] should write and read from node local SSD [Feature:GKELocalSSD]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-instrumentation] Stackdriver Monitoring should have accelerator metrics [Feature:StackdriverAcceleratorMonitoring]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Downward API should provide container&#39;s limits.cpu/memory and requests.cpu/memory as env vars  [Conformance]" classname="Kubernetes e2e suite" time="12.11803148"></testcase>
+      <testcase name="[sig-storage] Storage Policy Based Volume Provisioning [Feature:vsphere] verify VSAN storage capability with invalid hostFailuresToTolerate value is not honored for dynamically provisioned pvc using storageclass" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Proxy version v1 should proxy to cadvisor using proxy subresource" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Network Partition [Disruptive] [Slow] [k8s.io] [Job] should create new pods when node is partitioned" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Dynamic Provisioning DynamicProvisioner Default should create and delete default persistent volumes [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volume Attach Verify [Feature:vsphere][Serial][Disruptive] verify volume remains attached after master kubelet restart" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gluster] should unmount if pod is force deleted while kubelet is down [Disruptive][Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] InitContainer should invoke init containers on a RestartAlways pod" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gcePDPartitioned] should support file as subpath" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cluster-lifecycle] [Feature:BootstrapTokens] should sign the new added bootstrap tokens" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gcePDPartitioned] should fail if non-existent subpath is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] [HPA] Horizontal pod autoscaling (scale resource: Custom Metrics from Stackdriver) should scale down with Custom Metric of type Pod from Stackdriver [Feature:CustomMetricsAutoscaling]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: hostPath] should fail if subpath directory is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Projected should be consumable from pods in volume with mappings as non-root [Conformance]" classname="Kubernetes e2e suite" time="8.123744676"></testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: hostPath] should fail if non-existent subpath is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] ReplicaSet should adopt matching pods on creation and release no longer matching pods" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] shouldn&#39;t scale down when non expendable pod is running [Feature:ClusterSizeAutoscalingScaleDown]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes[Disruptive][Flaky] when kube-controller-manager restarts should delete a bound PVC from a clientPod, restart the kube-control-manager, and ensure the kube-controller-manager does not crash" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: hostPathSymlink] should support readOnly file specified in the volumeMount" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] StatefulSet [k8s.io] Deploy clustered applications [Feature:StatefulSet] [Slow] should creating a working redis cluster" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] AdmissionWebhook Should not be able to prevent deleting validating-webhook-configurations or mutating-webhook-configurations" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] ConfigMap should be consumable from pods in volume with mappings as non-root with FSGroup [Feature:FSGroup]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] shouldn&#39;t scale up when expendable pod is preempted [Feature:ClusterSizeAutoscalingScaleUp]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: emptyDir] should support readOnly file specified in the volumeMount" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Cluster size autoscaler scalability [Slow] CA ignores unschedulable pods while scheduling schedulable pods [Feature:ClusterAutoscalerScalability6]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] [Serial] Volume metrics should create prometheus metrics for volume provisioning and attach/detach" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Loadbalancing: L7 GCE [Slow] [Feature:kubemci] should conform to Ingress spec" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: gce-localssd-scsi-fs] [Serial] One pod requesting one prebound PVC should be able to mount volume and read from pod1" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gcePDPVC] should support existing single file" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-auth] PodSecurityPolicy should enforce the restricted policy.PodSecurityPolicy" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: block] [Feature:BlockVolume] Two pods mounting a local volume at the same time should be able to write from pod1 and read from pod2" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: nfs] should support readOnly directory specified in the volumeMount" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volumes PD should be mountable with ext3" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] [HPA] Horizontal pod autoscaling (scale resource: Custom Metrics from Stackdriver) should scale up with two metrics of type Pod from Stackdriver [Feature:CustomMetricsAutoscaling]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gcePDPVC] should support restarting containers using file as subpath [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] [HPA] Horizontal pod autoscaling (scale resource: CPU) [sig-autoscaling] [Serial] [Slow] ReplicationController Should scale from 5 pods to 3 pods and from 3 to 1 and verify decision stability" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Downward API volume should set mode on item file  [Conformance]" classname="Kubernetes e2e suite" time="8.144153137"></testcase>
+      <testcase name="[k8s.io] Pods should allow activeDeadlineSeconds to be updated  [Conformance]" classname="Kubernetes e2e suite" time="12.616026201"></testcase>
+      <testcase name="[sig-network] Services should be able to change the type from ClusterIP to ExternalName" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] ResourceQuota should create a ResourceQuota and capture the life of a persistent volume claim. [sig-storage]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: emptyDir] should support readOnly directory specified in the volumeMount" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gcePDPartitioned] should support existing directory" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: hostPathSymlink] should support non-existent path" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scalability] Load capacity [Feature:ManualPerformance] should be able to handle 30 pods per node {extensions Deployment} with 2 secrets, 0 configmaps and 0 daemons" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Kubectl describe should check if kubectl describe prints relevant information for rc and pods  [Conformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-instrumentation] MetricsGrabber should grab all metrics from a Kubelet." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cluster-lifecycle] etcd Upgrade [Feature:EtcdUpgrade] etcd upgrade should maintain a functioning cluster" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-service-catalog] [Feature:PodPreset] PodPreset should not modify the pod on conflict" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] AdmissionWebhook Should mutate pod and apply defaults after mutation" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: block] [Feature:BlockVolume] Two pods mounting a local volume one after the other should be able to write from pod1 and read from pod2" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Job should adopt matching orphans and release non-matching pods" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: hostPathSymlink] should fail if subpath with backstepping is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Kubectl expose should create services for rc  [Conformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] should correctly scale down after a node is not needed and one node is broken [Feature:ClusterSizeAutoscalingScaleDown]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] SchedulerPriorities [Serial] Pod should perfer to scheduled to nodes pod can tolerate" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] EmptyDir volumes should support (non-root,0777,default) [Conformance]" classname="Kubernetes e2e suite" time="10.121541154"></testcase>
+      <testcase name="[sig-apps] DisruptionController should update PodDisruptionBudget status" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Docker Containers should be able to override the image&#39;s default command and arguments  [Conformance]" classname="Kubernetes e2e suite" time="10.117427972"></testcase>
+      <testcase name="[sig-storage] Subpath Atomic writer volumes should support subpaths with secret pod" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: nfs] should support restarting containers using file as subpath [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scalability] Load capacity [Feature:ManualPerformance] should be able to handle 30 pods per node { Random} with 0 secrets, 0 configmaps and 0 daemons with quotas" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Loadbalancing: L7 GCE [Slow] [Feature:NEG] rolling update backend pods should not cause service disruption" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] EmptyDir wrapper volumes should not conflict" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cluster-lifecycle] [Feature:BootstrapTokens] should resign the bootstrap tokens when the clusterInfo ConfigMap updated [Serial][Disruptive]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] shouldn&#39;t increase cluster size if pending pod is too large [Feature:ClusterSizeAutoscalingScaleUp]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Daemon set [Serial] should update pod when spec was updated and update strategy is RollingUpdate [Conformance]" classname="Kubernetes e2e suite" time="29.176532264"></testcase>
+      <testcase name="[k8s.io] [sig-node] Pod garbage collector [Feature:PodGarbageCollector] [Slow] should handle the creation of 1000 pods" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [Feature:Example] [k8s.io] RethinkDB should create and stop rethinkdb servers" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] should increase cluster size if pending pods are small and one node is broken [Feature:ClusterSizeAutoscalingScaleUp]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Projected should be consumable from pods in volume with mappings and Item Mode set [Conformance]" classname="Kubernetes e2e suite" time="8.115119983"></testcase>
+      <testcase name="[sig-storage] Projected should set mode on item file [Conformance]" classname="Kubernetes e2e suite" time="8.124642974"></testcase>
+      <testcase name="[sig-apps] DaemonRestart [Disruptive] Controller Manager should not create/delete replicas across restart" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gluster] should support existing directories when readOnly specified in the volumeSource" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] should increase cluster size if pending pods are small and there is another node pool that is not autoscaled [Feature:ClusterSizeAutoscalingScaleUp]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Pod Disks schedule a pod w/ RW PD(s) mounted to 1 or more containers, write to PD, verify content, delete pod, and repeat in rapid succession [Slow] using 4 containers and 1 PDs" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-instrumentation] MetricsGrabber should grab all metrics from a ControllerManager." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Pods should support retrieving logs from the container over websockets" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-instrumentation] Cluster level logging implemented by Stackdriver [Feature:StackdriverLogging] [Soak] should ingest logs from applications running for a prolonged amount of time" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] Should be able to scale a node group up from 0[Feature:ClusterSizeAutoscalingScaleUp]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Kubectl create quota should create a quota with scopes" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scalability] Load capacity [Feature:ManualPerformance] should be able to handle 30 pods per node { Random} with 0 secrets, 0 configmaps and 0 daemons" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Garbage collector should not delete dependents that have both valid owner and owner that&#39;s waiting for dependents to be deleted [Conformance]" classname="Kubernetes e2e suite" time="16.135989472"></testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: gce-localssd-scsi-fs] [Serial] One pod requesting one prebound PVC should be able to mount volume and write from pod1" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Deployment deployment reaping should cascade to its replica sets and pods" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] DNS should provide DNS for ExternalName services" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cluster-lifecycle] HA-master [Feature:HAMaster] survive addition/removal replicas multizone workers [Serial][Disruptive]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Networking should provide unchanging, static URL paths for kubernetes api services" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Pod Disks schedule pods each with a PD, delete pod and verify detach [Slow] for read-only PD with pod delete grace period of &#34;default (30s)&#34;" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Downward API volume should provide podname as non-root with fsgroup [Feature:FSGroup]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Downward API volume should provide node allocatable (cpu) as default cpu limit if the limit is not set  [Conformance]" classname="Kubernetes e2e suite" time="8.114716764"></testcase>
+      <testcase name="[k8s.io] Pods should contain environment variables for services  [Conformance]" classname="Kubernetes e2e suite" time="28.162137428"></testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: emptyDir] should fail if subpath with backstepping is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Docker Containers should be able to override the image&#39;s default arguments (docker cmd)  [Conformance]" classname="Kubernetes e2e suite" time="8.137489391"></testcase>
+      <testcase name="[sig-storage] Dynamic Provisioning DynamicProvisioner should test that deleting a claim before the volume is provisioned deletes the volume." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] AdmissionWebhook Should be able to deny custom resource creation" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes:vsphere should test that a file written to the vspehre volume mount before kubelet restart can be read after restart [Disruptive]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Kubectl logs should be able to retrieve and filter logs  [Conformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  Local volume provisioner [Serial] should create and recreate local persistent volume" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Namespaces [Serial] should ensure that all services are removed when a namespace is deleted." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Garbage collector should delete pods created by rc when not orphaning [Conformance]" classname="Kubernetes e2e suite" time="16.130898648"></testcase>
+      <testcase name="[k8s.io] EquivalenceCache [Serial] validates pod anti-affinity works properly when new replica pod is scheduled" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: hostPath] should support readOnly file specified in the volumeMount" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Projected should provide container&#39;s cpu request [Conformance]" classname="Kubernetes e2e suite" time="8.165121387"></testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gcePDPartitioned] should unmount if pod is gracefully deleted while kubelet is down [Disruptive][Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volume Disk Format [Feature:vsphere] verify disk format type - zeroedthick is honored for dynamically provisioned pv using storageclass" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] should be able to scale down when rescheduling a pod is required and pdb allows for it[Feature:ClusterSizeAutoscalingScaleDown]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] should increase cluster size if pods are pending due to host port conflict [Feature:ClusterSizeAutoscalingScaleUp]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Probing container should have monotonically increasing restart count  [Slow] [Conformance]" classname="Kubernetes e2e suite" time="120.257900306"></testcase>
+      <testcase name="[sig-storage] Volume Disk Format [Feature:vsphere] verify disk format type - eagerzeroedthick is honored for dynamically provisioned pv using storageclass" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] ResourceQuota should create a ResourceQuota and capture the life of a persistent volume claim with a storage class. [sig-storage]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath Atomic writer volumes should support subpaths with configmap pod with mountPath of existing file" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gluster] should fail if non-existent subpath is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-instrumentation] Stackdriver Monitoring should run Stackdriver Metadata Agent [Feature:StackdriverMetadataAgent]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scalability] Load capacity [Feature:Performance] should be able to handle 30 pods per node { ReplicationController} with 0 secrets, 0 configmaps and 0 daemons" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Kubectl run --rm job should create a job from an image, then delete the job  [Conformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Pods should be updated  [Conformance]" classname="Kubernetes e2e suite" time="24.658955634"></testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: nfs] should unmount if pod is force deleted while kubelet is down [Disruptive][Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Networking Granular Checks: Services [Slow] should function for client IP based session affinity: http" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [sig-node] SSH should SSH to all nodes and run commands" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Cluster size autoscaler scalability [Slow] should scale down empty nodes [Feature:ClusterAutoscalerScalability3]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-auth] [Feature:NodeAuthorizer] Getting a secret for a workload the node has access to should succeed" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: nfsPVC] should unmount if pod is force deleted while kubelet is down [Disruptive][Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: hostPathSymlink] should fail if non-existent subpath is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Downward API volume should provide container&#39;s memory limit  [Conformance]" classname="Kubernetes e2e suite" time="8.167259024"></testcase>
+      <testcase name="[sig-storage] EmptyDir volumes should support (root,0777,tmpfs) [Conformance]" classname="Kubernetes e2e suite" time="8.110103438"></testcase>
+      <testcase name="[sig-network] Networking Granular Checks: Services [Slow] should function for pod-Service: http" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] ConfigMap should be consumable from pods in volume as non-root  [Conformance]" classname="Kubernetes e2e suite" time="8.133052592"></testcase>
+      <testcase name="[sig-scheduling] SchedulerPredicates [Serial] validates that there exists conflict between pods with same hostPort and protocol but one using 0.0.0.0 hostIP" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] EmptyDir volumes should support (root,0666,default) [Conformance]" classname="Kubernetes e2e suite" time="8.109661827"></testcase>
+      <testcase name="[sig-storage] Dynamic Provisioning DynamicProvisioner External should let an external dynamic provisioner create and delete persistent volumes [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: nfs] should support existing directory" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: nfsPVC] should support existing directories when readOnly specified in the volumeSource" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] AdmissionWebhook Should mutate configmap" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Cluster size autoscaler scalability [Slow] should scale down underutilized nodes [Feature:ClusterAutoscalerScalability4]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Simple pod should support exec" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [sig-node] Security Context [Feature:SecurityContext] should support pod.Spec.SecurityContext.RunAsUser" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [sig-node] Security Context [Feature:SecurityContext] should support volume SELinux relabeling" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] GCP Volumes GlusterFS should be mountable" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] AdmissionWebhook Should unconditionally reject operations on fail closed webhook" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-instrumentation] MetricsGrabber should grab all metrics from a Scheduler." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] StatefulSet [k8s.io] Basic StatefulSet functionality [StatefulSetBasic] Scaling should happen in predictable order and halt if any stateful pod is unhealthy [Conformance]" classname="Kubernetes e2e suite" time="87.132315024"></testcase>
+      <testcase name="[sig-scheduling] ResourceQuota should create a ResourceQuota and capture the life of a replica set." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] should be able to scale down by draining multiple pods one by one as dictated by pdb[Feature:ClusterSizeAutoscalingScaleDown]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: hostPathSymlink] should fail for new directories when readOnly specified in the volumeSource" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] ResourceQuota should create a ResourceQuota and capture the life of a secret." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] ConfigMap should be consumable from pods in volume with mappings and Item mode set [Conformance]" classname="Kubernetes e2e suite" time="8.113253562"></testcase>
+      <testcase name="[sig-api-machinery] Initializers [Feature:Initializers] should dynamically register and apply initializers to pods [Serial]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cluster-lifecycle] Downgrade [Feature:Downgrade] cluster downgrade should maintain a functioning cluster [Feature:ClusterDowngrade]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Docker Containers should use the image defaults if command and args are blank  [Conformance]" classname="Kubernetes e2e suite" time="8.115018358"></testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: nfsPVC] should fail if subpath directory is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Proxy version v1 should proxy logs on node with explicit kubelet port using proxy subresource  [Conformance]" classname="Kubernetes e2e suite" time="6.122120682"></testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: hostPathSymlink] should support existing single file" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] DisruptionController evictions: no PDB =&gt; should allow an eviction" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scalability] Density [Feature:ManualPerformance] should allow starting 30 pods per node using {extensions Deployment} with 0 secrets, 0 configmaps and 0 daemons" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cluster-lifecycle] Reboot [Disruptive] [Feature:Reboot] each node by dropping all outbound packets for a while and ensure they function afterwards" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volume plugin streaming [Slow] GlusterFS should write files of various sizes, verify size, validate content" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [Feature:Example] [k8s.io] Spark should start spark master, driver and workers" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Kubectl run CronJob should create a CronJob" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: emptyDir] should unmount if pod is gracefully deleted while kubelet is down [Disruptive][Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: emptyDir] should fail if subpath file is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volume Provisioning on Datastore [Feature:vsphere] verify dynamically provisioned pv using storageclass fails on an invalid datastore" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Projected should be consumable in multiple volumes in the same pod [Conformance]" classname="Kubernetes e2e suite" time="8.135836626"></testcase>
+      <testcase name="[sig-apps] StatefulSet [k8s.io] Deploy clustered applications [Feature:StatefulSet] [Slow] should creating a working zookeeper cluster" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-instrumentation] MetricsGrabber should grab all metrics from API server." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] StatefulSet [k8s.io] Basic StatefulSet functionality [StatefulSetBasic] should perform canary updates and phased rolling updates of template modifications [Conformance]" classname="Kubernetes e2e suite" time="86.25581347"></testcase>
+      <testcase name="[sig-storage] EmptyDir volumes volume on default medium should have the correct mode [Conformance]" classname="Kubernetes e2e suite" time="8.112257868"></testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Simple pod should return command exit codes" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [sig-node] Mount propagation should propagate mounts to the host" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Simple pod should support exec through kubectl proxy" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Deployment deployment should support proportional scaling" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [sig-node] Pods Extended [k8s.io] Pods Set QOS Class should be submitted and removed  [Conformance]" classname="Kubernetes e2e suite" time="22.165158697"></testcase>
+      <testcase name="[sig-storage] EmptyDir wrapper volumes should not cause race condition when used for git_repo [Serial] [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: hostPath] should unmount if pod is force deleted while kubelet is down [Disruptive][Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] ConfigMap should be consumable in multiple volumes in the same pod  [Conformance]" classname="Kubernetes e2e suite" time="8.123697145"></testcase>
+      <testcase name="[k8s.io] [sig-node] Security Context [Feature:SecurityContext] should support pod.Spec.SecurityContext.SupplementalGroups" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gcePDPartitioned] should fail if subpath directory is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volume FStype [Feature:vsphere] verify fstype - default value should be ext4" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volumes ConfigMap should be mountable" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Networking Granular Checks: Services [Slow] should function for endpoint-Service: http" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volumes PD should be mountable with xfs" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: hostPath] should unmount if pod is gracefully deleted while kubelet is down [Disruptive][Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scalability] Density [Feature:ManualPerformance] should allow starting 30 pods per node using {batch Job} with 0 secrets, 0 configmaps and 0 daemons" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] Multi-AZ Cluster Volumes [sig-storage] should only be allowed to provision PDs in zones where nodes exist" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Downward API volume should provide container&#39;s cpu request  [Conformance]" classname="Kubernetes e2e suite" time="8.11940074"></testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Update Demo should do a rolling update of a replication controller  [Conformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Networking Granular Checks: Services [Slow] should update nodePort: http [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Kubectl run deployment should create a deployment from an image  [Conformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cluster-lifecycle] Nodes [Disruptive] Resize [Slow] should be able to delete nodes" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: emptyDir] should support non-existent path" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Variable Expansion should allow composing env vars into new env vars  [Conformance]" classname="Kubernetes e2e suite" time="10.171702841"></testcase>
+      <testcase name="[sig-apps] Job should run a job to completion when tasks succeed" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] NetworkPolicy NetworkPolicy between server and client should enforce policy based on NamespaceSelector [Feature:NetworkPolicy]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cluster-lifecycle] Reboot [Disruptive] [Feature:Reboot] each node by dropping all inbound packets for a while and ensure they function afterwards" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [sig-node] PreStop should call prestop when killing a pod  [Conformance]" classname="Kubernetes e2e suite" time="51.140545464"></testcase>
+      <testcase name="[sig-network] Services should prevent NodePort collisions" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] [Feature:GPU] run Nvidia GPU tests on Container Optimized OS only" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-ui] Kubernetes Dashboard should check that the kubernetes-dashboard instance is alive" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Pods should get a host IP  [Conformance]" classname="Kubernetes e2e suite" time="26.096189145"></testcase>
+      <testcase name="[sig-auth] PodSecurityPolicy should allow pods under the privileged extensions.PodSecurityPolicy" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Dynamic Provisioning DynamicProvisioner Default should be disabled by changing the default annotation[Slow] [Serial] [Disruptive]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Pod Disks detach in a disrupted environment [Slow] [Disruptive] when pod is evicted" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] EmptyDir volumes should support (non-root,0644,tmpfs) [Conformance]" classname="Kubernetes e2e suite" time="8.124332547"></testcase>
+      <testcase name="[sig-storage] Dynamic Provisioning DynamicProvisioner should provision storage with non-default reclaim policy Retain" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: hostPath] should fail for new directories when readOnly specified in the volumeSource" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] ResourceQuota should create a ResourceQuota and capture the life of a service." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Deployment RecreateDeployment should delete old pods and create new ones" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: hostPathSymlink] should unmount if pod is gracefully deleted while kubelet is down [Disruptive][Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Projected updates should be reflected in volume [Conformance]" classname="Kubernetes e2e suite" time="26.11314994"></testcase>
+      <testcase name="[sig-storage] Volume Placement should create and delete pod with the same volume source on the same worker node" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: hostPathSymlink] should support restarting containers using directory as subpath [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Services should be able to create an internal type load balancer [Slow] [DisabledForLargeClusters]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Garbage collector should orphan pods created by rc if deleteOptions.OrphanDependents is nil" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl Port forwarding [k8s.io] With a server listening on localhost [k8s.io] that expects NO client request should support a client that connects, sends DATA, and disconnects" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-service-catalog] [Feature:PodPreset] PodPreset should create a pod preset" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gcePDPartitioned] should support existing single file" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Kubectl label should update the label on a resource  [Conformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] ResourceQuota [Feature:Initializers] should create a ResourceQuota and capture the life of an uninitialized pod." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] ResourceQuota should create a ResourceQuota and ensure its status is promptly calculated." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volumes Cinder [Feature:Volumes] should be mountable" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] DisruptionController evictions: too few pods, absolute =&gt; should not allow an eviction" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-auth] Certificates API should support building a client with a CSR" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Loadbalancing: L7 GCE [Slow] [Feature:Ingress] should conform to Ingress spec" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] EmptyDir volumes should support (non-root,0777,tmpfs) [Conformance]" classname="Kubernetes e2e suite" time="8.107985578"></testcase>
+      <testcase name="[sig-cluster-lifecycle] HA-master [Feature:HAMaster] survive addition/removal replicas different zones [Serial][Disruptive]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] EmptyDir volumes should support (root,0777,default) [Conformance]" classname="Kubernetes e2e suite" time="8.132122828"></testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Kubectl apply should reuse port when apply to an existing SVC" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Secrets should be consumable from pods in volume with mappings and Item Mode set  [Conformance]" classname="Kubernetes e2e suite" time="8.163922707"></testcase>
+      <testcase name="[sig-storage] Projected should be consumable from pods in volume with defaultMode set [Conformance]" classname="Kubernetes e2e suite" time="8.172642268"></testcase>
+      <testcase name="[sig-apps] CronJob should remove from active list jobs that have been deleted" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] InitContainer should not start app containers and fail the pod if init containers fail on a RestartNever pod" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] HostPath should support subPath" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Garbage collector should delete jobs and pods created by cronjob" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Daemon set [Serial] should run and stop simple daemon [Conformance]" classname="Kubernetes e2e suite" time="26.15399925"></testcase>
+      <testcase name="[sig-storage] Volume Provisioning On Clustered Datastore [Feature:vsphere] verify dynamic provision with spbm policy on clustered datastore" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scalability] Density [Feature:ManualPerformance] should allow starting 50 pods per node using { ReplicationController} with 0 secrets, 0 configmaps and 0 daemons" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] [HPA] Horizontal pod autoscaling (scale resource: CPU) [sig-autoscaling] [Serial] [Slow] Deployment Should scale from 5 pods to 3 pods and from 3 to 1" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scalability] Load capacity [Feature:ManualPerformance] should be able to handle 30 pods per node { ReplicationController} with 0 secrets, 0 configmaps and 0 daemons with quotas" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Secrets should be able to mount in a volume regardless of a different secret existing with same name in different namespace" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scalability] Load capacity [Feature:ManualPerformance] should be able to handle 3 pods per node { ReplicationController} with 0 secrets, 0 configmaps and 0 daemons" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] SchedulerPreemption [Serial] [Feature:PodPreemption] validates pod anti-affinity works in preemption" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Storage Policy Based Volume Provisioning [Feature:vsphere] verify VSAN storage capability with invalid capability name objectSpaceReserve is not honored for dynamically provisioned pvc using storageclass" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] StatefulSet [k8s.io] Basic StatefulSet functionality [StatefulSetBasic] should provide basic identity" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] shouldn&#39;t be able to scale down when rescheduling a pod is required, but pdb doesn&#39;t allow drain[Feature:ClusterSizeAutoscalingScaleDown]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] KubeletManagedEtcHosts should test kubelet managed /etc/hosts file  [Conformance]" classname="Kubernetes e2e suite" time="58.382988572"></testcase>
+      <testcase name="[sig-apps] ReplicationController should surface a failure condition on a common issue like exceeded quota" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Storage Policy Based Volume Provisioning [Feature:vsphere] verify clean up of stale dummy VM for dynamically provisioned pvc using SPBM policy" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gluster] should support restarting containers using file as subpath [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] vcp-performance [Feature:vsphere] vcp performance tests" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gcePDPartitioned] should support restarting containers using file as subpath [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] [Serial] Volume metrics PVController should create unbound pvc count metrics for pvc controller after creating pvc only" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] EmptyDir volumes should support (non-root,0666,tmpfs) [Conformance]" classname="Kubernetes e2e suite" time="8.218637701"></testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Kubectl taint [Serial] should update the taint on a node" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] NetworkPolicy NetworkPolicy between server and client should allow egress access on one named port [Feature:NetworkPolicy]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] NetworkPolicy NetworkPolicy between server and client should enforce multiple, stacked policies with overlapping podSelectors [Feature:NetworkPolicy]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] ESIPP [Slow] [DisabledForLargeClusters] should work for type=NodePort" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] NetworkPolicy NetworkPolicy between server and client should enforce policy based on PodSelector [Feature:NetworkPolicy]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Kubectl patch should add annotations for pods in rc  [Conformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-auth] PodSecurityPolicy should enforce the restricted extensions.PodSecurityPolicy" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] DaemonRestart [Disruptive] Scheduler should continue assigning pods to nodes across restart" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Pod Disks schedule pods each with a PD, delete pod and verify detach [Slow] for RW PD with pod delete grace period of &#34;immediate (0s)&#34;" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] StatefulSet [k8s.io] Basic StatefulSet functionality [StatefulSetBasic] Burst scaling should run to completion even with unhealthy pods [Conformance]" classname="Kubernetes e2e suite" time="67.048904664"></testcase>
+      <testcase name="[sig-network] ESIPP [Slow] [DisabledForLargeClusters] should work for type=LoadBalancer" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Downward API volume should provide node allocatable (memory) as default memory limit if the limit is not set  [Conformance]" classname="Kubernetes e2e suite" time="8.117325662"></testcase>
+      <testcase name="[sig-storage] Downward API volume should provide container&#39;s cpu limit  [Conformance]" classname="Kubernetes e2e suite" time="10.121122069"></testcase>
+      <testcase name="[sig-apps] DisruptionController evictions: enough pods, replicaSet, percentage =&gt; should allow an eviction" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: emptyDir] should support existing directory" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  Local volume that cannot be mounted [Slow] should fail due to wrong node" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [sig-node] Security Context [Feature:SecurityContext] should support volume SELinux relabeling when using hostPID" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Proxy version v1 should proxy logs on node using proxy subresource  [Conformance]" classname="Kubernetes e2e suite" time="6.118525363"></testcase>
+      <testcase name="[sig-storage] CSI Volumes [Flaky] Sanity CSI plugin test using hostPath CSI driver should provision storage with a hostPath CSI driver" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Services should serve a basic endpoint from pods  [Conformance]" classname="Kubernetes e2e suite" time="25.181528564"></testcase>
+      <testcase name="[sig-api-machinery] Secrets should be consumable via the environment  [Conformance]" classname="Kubernetes e2e suite" time="10.189932742"></testcase>
+      <testcase name="[sig-apps] CronJob should replace jobs when ReplaceConcurrent" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes GCEPD should test that deleting the PV before the pod does not cause pod deletion to fail on PD detach" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volume plugin streaming [Slow] NFS should write files of various sizes, verify size, validate content" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Cluster size autoscaler scalability [Slow] shouldn&#39;t scale down with underutilized nodes due to host port conflicts [Feature:ClusterAutoscalerScalability5]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] GCP Volumes NFSv4 should be mountable for NFSv4" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes [Feature:ReclaimPolicy] [sig-storage] persistentvolumereclaim:vsphere should not detach and unmount PV when associated pvc with delete as reclaimPolicy is deleted when it is in use by the pod" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] StatefulSet [k8s.io] Deploy clustered applications [Feature:StatefulSet] [Slow] should creating a working mysql cluster" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [sig-node] Kubelet [Serial] [Slow] [k8s.io] [sig-node] regular resource usage tracking resource tracking for 100 pods per node" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volume Disk Format [Feature:vsphere] verify disk format type - thin is honored for dynamically provisioned pv using storageclass" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: emptyDir] should support existing directories when readOnly specified in the volumeSource" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Projected should provide container&#39;s cpu limit [Conformance]" classname="Kubernetes e2e suite" time="8.186654284"></testcase>
+      <testcase name="[sig-apps] StatefulSet [k8s.io] Deploy clustered applications [Feature:StatefulSet] [Slow] should creating a working CockroachDB cluster" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] EmptyDir volumes when FSGroup is specified new files should be created with FSGroup ownership when container is non-root" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volumes Azure Disk [Feature:Volumes] should be mountable [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gluster] should fail if subpath file is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Proxy version v1 should proxy through a service and a pod  [Conformance]" classname="Kubernetes e2e suite" time="28.196608717"></testcase>
+      <testcase name="[sig-network] NetworkPolicy NetworkPolicy between server and client should allow ingress access on one named port [Feature:NetworkPolicy]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Dynamic Provisioning DynamicProvisioner should provision storage with mount options" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] shouldn&#39;t trigger additional scale-ups during processing scale-up [Feature:ClusterSizeAutoscalingScaleUp]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] DisruptionController evictions: too few pods, replicaSet, percentage =&gt; should not allow an eviction" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] CronJob should schedule multiple jobs concurrently" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gluster] should unmount if pod is gracefully deleted while kubelet is down [Disruptive][Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Probing container should be restarted with a /healthz http liveness probe  [Conformance]" classname="Kubernetes e2e suite" time="32.128960215"></testcase>
+      <testcase name="[sig-network] Loadbalancing: L7 GCE [Slow] [Feature:Ingress] should create ingress with backside re-encryption" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scalability] Load capacity [Feature:ManualPerformance] should be able to handle 30 pods per node { ReplicationController} with 0 secrets, 0 configmaps and 2 daemons" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gluster] should fail for new directories when readOnly specified in the volumeSource" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: tmpfs] One pod requesting one prebound PVC should be able to mount volume and read from pod1" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Guestbook application should create and stop a working application  [Conformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gcePDPVC] should fail if subpath with backstepping is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] CronJob should not schedule jobs when suspended [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] Multi-AZ Clusters should spread the pods of a service across zones" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Network Partition [Disruptive] [Slow] [k8s.io] Pods should return to running and ready state after network partition is healed All pods on the unreachable node should be marked as NotReady upon the node turn NotReady AND all pods should be mark back to Ready when the node get back to Ready before pod eviction timeout" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes NFS with multiple PVs and PVCs all in same ns should create 2 PVs and 4 PVCs: test write access" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] SchedulerPredicates [Serial] validates that required NodeAffinity setting is respected if matching" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Projected should be consumable in multiple volumes in a pod [Conformance]" classname="Kubernetes e2e suite" time="8.120067395"></testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Simple pod should handle in-cluster config" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] HostPath should support existing directory subPath" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] SchedulerPriorities [Serial] Pod should avoid to schedule to node that have avoidPod annotation" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scalability] Load capacity [Feature:ManualPerformance] should be able to handle 30 pods per node {extensions Deployment} with 0 secrets, 0 configmaps and 0 daemons" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes [Feature:ReclaimPolicy] [sig-storage] persistentvolumereclaim:vsphere should delete persistent volume when reclaimPolicy set to delete and associated claim is deleted" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] DNS should provide DNS for pods for Hostname and Subdomain" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] SchedulerPreemption [Serial] [Feature:PodPreemption] validates basic preemption works" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volumes PD should be mountable with ext4" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: nfsPVC] should support non-existent path" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-instrumentation] Cadvisor should be healthy on every node." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Servers with support for Table transformation should return chunks of table results for list calls" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-instrumentation] Stackdriver Monitoring should have cluster metrics [Feature:StackdriverMonitoring]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath Atomic writer volumes should support subpaths with downward pod" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] GCP Volumes NFSv3 should be mountable for NFSv3" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: nfsPVC] should support restarting containers using file as subpath [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Networking Granular Checks: Pods should function for intra-pod communication: http  [Conformance]" classname="Kubernetes e2e suite" time="44.228451895"></testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: nfs] should unmount if pod is gracefully deleted while kubelet is down [Disruptive][Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] ESIPP [Slow] [DisabledForLargeClusters] should only target nodes with endpoints" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Kubectl create quota should create a quota without scopes" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Projected should be consumable from pods in volume as non-root [Conformance]" classname="Kubernetes e2e suite" time="8.158190141"></testcase>
+      <testcase name="[k8s.io] Downward API [Serial] [Disruptive] Downward API tests for local ephemeral storage should provide container&#39;s limits.ephemeral-storage and requests.ephemeral-storage as env vars" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-auth] [Feature:NodeAuthorizer] A node shouldn&#39;t be able to delete an other node" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] should correctly scale down after a node is not needed when there is non autoscaled pool[Feature:ClusterSizeAutoscalingScaleDown]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [sig-node] AppArmor load AppArmor profiles can disable an AppArmor profile, using unconfined" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] stateful Upgrade [Feature:StatefulUpgrade] [k8s.io] stateful upgrade should maintain a functioning cluster" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] vsphere cloud provider stress [Feature:vsphere] vsphere stress tests" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: block] [Feature:BlockVolume] One pod requesting one prebound PVC should be able to mount volume and read from pod1" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Projected should be consumable from pods in volume as non-root with defaultMode and fsGroup set [Conformance]" classname="Kubernetes e2e suite" time="8.163472008"></testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Kubectl api-versions should check if v1 is in available api versions  [Conformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Services should be able to change the type and ports of a service [Slow] [DisabledForLargeClusters]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cluster-lifecycle] HA-master [Feature:HAMaster] survive addition/removal replicas same zone [Serial][Disruptive]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Loadbalancing: L7 GCE [Slow] [Feature:NEG] should conform to Ingress spec" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Secrets should be consumable from pods in volume with mappings  [Conformance]" classname="Kubernetes e2e suite" time="8.114650562"></testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gcePDPVC] should support non-existent path" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: nfsPVC] should fail for new directories when readOnly specified in the volumeSource" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: hostPath] should support creating multiple subpath from same volumes [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Generated clientset should create pods, set the deletionTimestamp and deletionGracePeriodSeconds of the pod" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: nfsPVC] should support readOnly file specified in the volumeMount" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] should increase cluster size if pods are pending due to pod anti-affinity [Feature:ClusterSizeAutoscalingScaleUp]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scalability] Density [Feature:ManualPerformance] should allow starting 30 pods per node using {extensions Deployment} with 0 secrets, 2 configmaps and 0 daemons" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Servers with support for Table transformation should return pod details" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-auth] [Feature:NodeAuthorizer] A node shouldn&#39;t be able to create an other node" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Services should work after restarting apiserver [Disruptive]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gcePDPVC] should support restarting containers using directory as subpath [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: hostPath] should fail if subpath file is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Projected should be able to mount in a volume regardless of a different secret existing with same name in different namespace" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] LimitRange should create a LimitRange with defaults and ensure pod has those defaults applied." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] ClusterDns [Feature:Example] should create pod that uses dns" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Networking Granular Checks: Services [Slow] should function for client IP based session affinity: udp" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: hostPath] should support existing directory" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PVC Protection Verify that scheduling of a pod that uses PVC that is being deleted fails and the pod becomes Unschedulable" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Ephemeralstorage When pod refers to non-existent ephemeral storage should allow deletion of pod with invalid volume : projected" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes[Disruptive][Flaky] when kubelet restarts Should test that a volume mounted to a pod that is deleted while the kubelet is down unmounts when the kubelet returns." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Services should create endpoints for unready pods" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Pods should cap back-off at MaxContainerBackOff [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Garbage collector should not be blocked by dependency circle [Conformance]" classname="Kubernetes e2e suite" time="11.188169979"></testcase>
+      <testcase name="[sig-autoscaling] [HPA] Horizontal pod autoscaling (scale resource: CPU) [sig-autoscaling] [Serial] [Slow] Deployment Should scale from 1 pod to 3 pods and from 3 to 5" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] GKE node pools [Feature:GKENodePool] should create a cluster with multiple node pools [Feature:GKENodePool]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes:vsphere should test that a vspehre volume mounted to a pod that is deleted while the kubelet is down unmounts when the kubelet returns [Disruptive]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: hostPathSymlink] should unmount if pod is force deleted while kubelet is down [Disruptive][Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl Port forwarding [k8s.io] With a server listening on 0.0.0.0 [k8s.io] that expects a client request should support a client that connects, sends NO DATA, and disconnects" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scalability] Density [Feature:HighDensityPerformance] should allow starting 95 pods per node using { ReplicationController} with 0 secrets, 0 configmaps and 0 daemons" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] SchedulerPriorities [Serial] Pod should be schedule to node that don&#39;t match the PodAntiAffinity terms" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Storage Policy Based Volume Provisioning [Feature:vsphere] verify VSAN storage capability with valid hostFailuresToTolerate and cacheReservation values is honored for dynamically provisioned pvc using storageclass" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes GCEPD should test that deleting the Namespace of a PVC and Pod causes the successful detach of Persistent Disk" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Kubectl run pod should create a pod from an image when restart is Never  [Conformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] DNS horizontal autoscaling [DisabledForLargeClusters] kube-dns-autoscaler should scale kube-dns pods in both nonfaulty and faulty scenarios" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gcePDPartitioned] should support readOnly directory specified in the volumeMount" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Storage Policy Based Volume Provisioning [Feature:vsphere] verify an existing and compatible SPBM policy is honored for dynamically provisioned pvc using storageclass" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] ReplicaSet should serve a basic image on each replica with a private image" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: hostPathSymlink] should support existing directory" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Daemon set [Serial] should run and stop complex daemon [Conformance]" classname="Kubernetes e2e suite" time="24.224976522"></testcase>
+      <testcase name="[sig-apps] Deployment deployment should support rollback" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] InitContainer should not start app containers if init containers fail on a RestartAlways pod" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] StatefulSet [k8s.io] Basic StatefulSet functionality [StatefulSetBasic] should implement legacy replacement when the update strategy is OnDelete" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gcePDPartitioned] should fail if subpath with backstepping is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Etcd failure [Disruptive] should recover from SIGKILL" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gcePDPVC] should fail if subpath directory is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Probing container should be restarted with a exec &#34;cat /tmp/health&#34; liveness probe [Conformance]" classname="Kubernetes e2e suite" time="62.178731815"></testcase>
+      <testcase name="[sig-cluster-lifecycle] kube-proxy migration [Feature:KubeProxyDaemonSetMigration] Downgrade kube-proxy from a DaemonSet to static pods should maintain a functioning cluster [Feature:KubeProxyDaemonSetDowngrade]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Projected optional updates should be reflected in volume [Conformance]" classname="Kubernetes e2e suite" time="28.140296371"></testcase>
+      <testcase name="[k8s.io] Pods should support remote command execution over websockets" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [sig-node] Kubelet [Serial] [Slow] [k8s.io] [sig-node] regular resource usage tracking resource tracking for 0 pods per node" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Docker Containers should be able to override the image&#39;s default command (docker entrypoint)  [Conformance]" classname="Kubernetes e2e suite" time="8.17056126"></testcase>
+      <testcase name="[sig-storage] PersistentVolumes:vsphere should test that deleting a PVC before the pod does not cause pod deletion to fail on vsphere volume detach" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Projected should provide node allocatable (memory) as default memory limit if the limit is not set [Conformance]" classname="Kubernetes e2e suite" time="8.117522534"></testcase>
+      <testcase name="[sig-storage] Secrets should be consumable from pods in volume  [Conformance]" classname="Kubernetes e2e suite" time="8.123217855"></testcase>
+      <testcase name="[sig-scalability] Density [Feature:Performance] should allow starting 30 pods per node using { ReplicationController} with 0 secrets, 0 configmaps and 0 daemons" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] StatefulSet [k8s.io] Basic StatefulSet functionality [StatefulSetBasic] should adopt matching orphans and release non-matching pods" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Initializers [Feature:Initializers] should be invisible to controllers by default" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Downward API should provide default limits.cpu/memory from node allocatable  [Conformance]" classname="Kubernetes e2e suite" time="10.196163038"></testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: tmpfs] One pod requesting one prebound PVC should be able to mount volume and write from pod1" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [Feature:Example] [k8s.io] Redis should create and stop redis servers" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Generated clientset should create v1beta1 cronJobs, delete cronJobs, watch cronJobs" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: emptyDir] should support file as subpath" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Services should be able to up and down services" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [sig-node] kubelet [k8s.io] [sig-node] host cleanup with volume mounts [sig-storage][HostCleanup][Flaky] Host cleanup after disrupting NFS volume [NFS] after stopping the nfs-server and deleting the (active) client pod, the NFS mount and the pod&#39;s UID directory should be removed." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Projected should set DefaultMode on files [Conformance]" classname="Kubernetes e2e suite" time="8.111756343"></testcase>
+      <testcase name="[sig-scalability] Density [Feature:ManualPerformance] should allow starting 3 pods per node using { ReplicationController} with 0 secrets, 0 configmaps and 0 daemons" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] ReplicationController should serve a basic image on each replica with a public image  [Conformance]" classname="Kubernetes e2e suite" time="16.152772785"></testcase>
+      <testcase name="[sig-storage] Pod Disks schedule a pod w/ RW PD(s) mounted to 1 or more containers, write to PD, verify content, delete pod, and repeat in rapid succession [Slow] using 1 containers and 2 PDs" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: hostPathSymlink] should support readOnly directory specified in the volumeMount" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Dynamic Provisioning DynamicProvisioner should provision storage with different parameters [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volume Operations Storm [Feature:vsphere] should create pod with many volumes and verify no attach call fails" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Loadbalancing: L7 GCE [Slow] [Feature:Ingress] should update ingress while sync failures occur on other ingresses" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Downward API should provide host IP as an env var  [Conformance]" classname="Kubernetes e2e suite" time="10.135888738"></testcase>
+      <testcase name="[sig-apps] ReplicaSet should surface a failure condition on a common issue like exceeded quota" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: hostPathSymlink] should fail if subpath file is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] EmptyDir volumes volume on tmpfs should have the correct mode [Conformance]" classname="Kubernetes e2e suite" time="8.121974778"></testcase>
+      <testcase name="[sig-storage] PersistentVolumes NFS with Single PV - PVC pairs should create a non-pre-bound PV and PVC: test write access " classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Kubectl run rc should create an rc from an image  [Conformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl Port forwarding [k8s.io] With a server listening on localhost [k8s.io] that expects a client request should support a client that connects, sends NO DATA, and disconnects" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [sig-node] Security Context [Feature:SecurityContext] should support container.SecurityContext.RunAsUser" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-instrumentation] Kibana Logging Instances Is Alive [Feature:Elasticsearch] should check that the Kibana logging instance is alive" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volume FStype [Feature:vsphere] verify invalid fstype" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volume expand [Feature:ExpandPersistentVolumes] [Slow] Verify if editing PVC allows resize" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Projected optional updates should be reflected in volume [Conformance]" classname="Kubernetes e2e suite" time="26.133175072"></testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: hostPathSymlink] should fail if subpath directory is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Storage Policy Based Volume Provisioning [Feature:vsphere] verify VSAN storage capability with invalid diskStripes value is not honored for dynamically provisioned pvc using storageclass" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Kubectl rolling-update should support rolling-update to same image  [Conformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-instrumentation] Cluster level logging implemented by Stackdriver should ingest events" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] ServiceLoadBalancer [Feature:ServiceLoadBalancer] should support simple GET on Ingress ips" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: dir] Two pods mounting a local volume at the same time should be able to write from pod1 and read from pod2" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Job should exceed backoffLimit" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] ReplicationController should adopt matching pods on creation" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] PrivilegedPod should enable privileged commands" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Flexvolumes [Disruptive] should be mountable when non-attachable" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: nfs] should support file as subpath" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Storage Policy Based Volume Provisioning [Feature:vsphere] verify an if a SPBM policy and VSAN capabilities cannot be honored for dynamically provisioned pvc using storageclass" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gcePDPartitioned] should fail if subpath file is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Garbage collector should orphan pods created by rc if delete options say so [Conformance]" classname="Kubernetes e2e suite" time="46.172743044"></testcase>
+      <testcase name="[k8s.io] Sysctls should reject invalid sysctls" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: emptyDir] should unmount if pod is force deleted while kubelet is down [Disruptive][Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] SchedulerPredicates [Serial] validates that NodeSelector is respected if matching  [Conformance]" classname="Kubernetes e2e suite" time="86.156943152"></testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Kubectl cluster-info should check if Kubernetes master services is included in cluster-info  [Conformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] should increase cluster size if pod requesting EmptyDir volume is pending [Feature:ClusterSizeAutoscalingScaleUp]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Garbage collector should orphan RS created by deployment when deleteOptions.PropagationPolicy is Orphan [Conformance]" classname="Kubernetes e2e suite" time="11.16179768"></testcase>
+      <testcase name="[k8s.io] [sig-node] Security Context [Feature:SecurityContext] should support seccomp alpha docker/default annotation [Feature:Seccomp]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] ConfigMap updates should be reflected in volume  [Conformance]" classname="Kubernetes e2e suite" time="26.152708365"></testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gcePDPartitioned] should support non-existent path" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Projected should be consumable from pods in volume with mappings as non-root with FSGroup [Feature:FSGroup]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] [HPA] Horizontal pod autoscaling (scale resource: CPU) [sig-autoscaling] [Serial] [Slow] ReplicaSet Should scale from 5 pods to 3 pods and from 3 to 1" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gcePDPVC] should support creating multiple subpath from same volumes [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: block] [Feature:BlockVolume] One pod requesting one prebound PVC should be able to mount volume and write from pod1" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  Local volume that cannot be mounted [Slow] should fail due to non-existent path" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Dynamic Provisioning DynamicProvisioner should not provision a volume in an unmanaged GCE zone. [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cluster-lifecycle] kube-proxy migration [Feature:KubeProxyDaemonSetMigration] Upgrade kube-proxy from static pods to a DaemonSet should maintain a functioning cluster [Feature:KubeProxyDaemonSetUpgrade]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl Port forwarding [k8s.io] With a server listening on 0.0.0.0 [k8s.io] that expects NO client request should support a client that connects, sends DATA, and disconnects" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: nfsPVC] should support existing single file" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [sig-node] Kubelet [Serial] [Slow] [k8s.io] [sig-node] experimental resource usage tracking [Feature:ExperimentalResourceUsageTracking] resource tracking for 100 pods per node" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volumes vsphere [Feature:Volumes] should be mountable" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: tmpfs] Two pods mounting a local volume at the same time should be able to write from pod1 and read from pod2" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl Port forwarding [k8s.io] With a server listening on 0.0.0.0 should support forwarding over websockets" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Projected should update annotations on modification [Conformance]" classname="Kubernetes e2e suite" time="26.638091231"></testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: nfs] should fail if subpath file is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [Feature:Example] [k8s.io] Downward API should create a pod that prints his name and namespace" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Kubectl version should check is all data is printed  [Conformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Projected should be consumable from pods in volume with mappings [Conformance]" classname="Kubernetes e2e suite" time="8.171449685"></testcase>
+      <testcase name="[sig-scheduling] SchedulerPredicates [Serial] validates that taints-tolerations is respected if not matching" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: nfsPVC] should unmount if pod is gracefully deleted while kubelet is down [Disruptive][Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes[Disruptive][Flaky] when kubelet restarts Should test that a file written to the mount before kubelet restart is readable after restart." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Networking should provide Internet connection for containers [Feature:Networking-IPv4]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] AdmissionWebhook Should deny crd creation" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Proxy server should support --unix-socket=/path  [Conformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] CronJob should not schedule new jobs when ForbidConcurrent [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Secrets should be consumable from pods in volume with defaultMode set  [Conformance]" classname="Kubernetes e2e suite" time="8.127745249"></testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gcePDPartitioned] should support existing directories when readOnly specified in the volumeSource" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Services should be able to update NodePorts with two same port numbers but different protocols" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cluster-lifecycle] [Feature:BootstrapTokens] should delete the token secret when the secret expired" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Secrets should be consumable from pods in env vars  [Conformance]" classname="Kubernetes e2e suite" time="10.12011885"></testcase>
+      <testcase name="[sig-storage] EmptyDir volumes should support (root,0644,tmpfs) [Conformance]" classname="Kubernetes e2e suite" time="8.165319689"></testcase>
+      <testcase name="[sig-network] Networking Granular Checks: Services [Slow] should function for pod-Service: udp" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] ResourceQuota should create a ResourceQuota and capture the life of a pod." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: nfsPVC] should fail if subpath file is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  StatefulSet with pod anti-affinity should use volumes spread across nodes" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Network Partition [Disruptive] [Slow] [k8s.io] [ReplicationController] should recreate pods scheduled on the unreachable node AND allow scheduling of pods on a node after it rejoins the cluster" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Kubectl apply should apply a new configuration to an existing RC" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gcePDPVC] should support existing directories when readOnly specified in the volumeSource" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: hostPath] should support existing directories when readOnly specified in the volumeSource" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Networking should provide Internet connection for containers [Feature:Networking-IPv6][Experimental]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes NFS with Single PV - PVC pairs create a PV and a pre-bound PVC: test write access" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Services should be able to create a functioning NodePort service" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  Pod with node different from PV&#39;s NodeAffinity should fail scheduling due to different NodeAffinity" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: nfsPVC] should support restarting containers using directory as subpath [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cluster-lifecycle] gpu Upgrade [Feature:GPUUpgrade] cluster upgrade should be able to run gpu pod after upgrade [Feature:GPUClusterUpgrade]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] SchedulerPredicates [Serial] validates that taints-tolerations is respected if matching" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] [Feature:GPUDevicePlugin] run Nvidia GPU Device Plugin tests on Container Optimized OS only" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [sig-node] AppArmor load AppArmor profiles should enforce an AppArmor profile" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl alpha client [k8s.io] Kubectl run CronJob should create a CronJob" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: nfs] should support non-existent path" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  Stress with local volume provisioner [Serial] should use be able to process many pods and reuse local volumes" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Network Partition [Disruptive] [Slow] [k8s.io] [ReplicationController] should eagerly create replacement pod during network partition when termination grace is non-zero" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [sig-node] Security Context [Feature:SecurityContext] should support seccomp alpha unconfined annotation on the container [Feature:Seccomp]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] [HPA] Horizontal pod autoscaling (scale resource: CPU) [sig-autoscaling] ReplicationController light Should scale from 1 pod to 2 pods" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] should be able to scale down by draining system pods with pdb[Feature:ClusterSizeAutoscalingScaleDown]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] [Serial] Volume metrics PVController should create unbound pv count metrics for pvc controller after creating pv only" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] ReplicaSet should serve a basic image on each replica with a public image  [Conformance]" classname="Kubernetes e2e suite" time="16.104558312"></testcase>
+      <testcase name="[sig-storage] Pod Disks detach in a disrupted environment [Slow] [Disruptive] when node&#39;s API object is deleted" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-auth] PodSecurityPolicy should forbid pod creation when no PSP is available" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Variable Expansion should allow substituting values in a container&#39;s command  [Conformance]" classname="Kubernetes e2e suite" time="10.122751044"></testcase>
+      <testcase name="[sig-storage] Projected should project all components that make up the projection API [Projection] [Conformance]" classname="Kubernetes e2e suite" time="10.14987574"></testcase>
+      <testcase name="[sig-storage] Projected should update labels on modification [Conformance]" classname="Kubernetes e2e suite" time="26.619542782"></testcase>
+      <testcase name="[sig-storage] PersistentVolumes NFS when invoking the Recycle reclaim policy should test that a PV becomes Available and is clean after the PVC is deleted." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [sig-node] Security Context [Feature:SecurityContext] should support container.SecurityContext.RunAsUser And container.SecurityContext.RunAsGroup [Feature:RunAsGroup]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] EmptyDir wrapper volumes should not cause race condition when used for configmaps [Serial] [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volumes iSCSI [Feature:Volumes] should be mountable" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: hostPathSymlink] should support file as subpath" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Projected should be consumable from pods in volume as non-root with defaultMode and fsGroup set [Feature:FSGroup]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volume Placement should create and delete pod with multiple volumes from different datastore" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: emptyDir] should fail if subpath directory is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [Feature:Example] [k8s.io] Storm should create and stop Zookeeper, Nimbus and Storm worker servers" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Downward API volume should update annotations on modification  [Conformance]" classname="Kubernetes e2e suite" time="28.618950436"></testcase>
+      <testcase name="[sig-instrumentation] Cluster level logging using Elasticsearch [Feature:Elasticsearch] should check that logs from containers are ingested into Elasticsearch" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] Shouldn&#39;t perform scale up operation and should list unhealthy status if most of the cluster is broken[Feature:ClusterSizeAutoscalingScaleUp]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes:vsphere should test that deleting the PV before the pod does not cause pod deletion to fail on vspehre volume detach" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Loadbalancing: L7 GCE [Slow] [Feature:NEG] should be able to switch between IG and NEG modes" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Downward API volume should update labels on modification  [Conformance]" classname="Kubernetes e2e suite" time="28.67606375"></testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gcePDPVC] should support existing directory" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-auth] [Feature:NodeAuthorizer] Getting a non-existent secret should exit with the Forbidden error, not a NotFound error" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-auth] PodSecurityPolicy should allow pods under the privileged policy.PodSecurityPolicy" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Mounted volume expand [Feature:ExpandPersistentVolumes] [Slow] Should verify mounted devices can be resized" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PVC Protection Verify &#34;immediate&#34; deletion of a PVC that is not in active use by a pod" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Proxy server should support proxy with --port 0  [Conformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Etcd failure [Disruptive] should recover from network partition with master" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-auth] ServiceAccounts should ensure a single API token exists" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Storage Policy Based Volume Provisioning [Feature:vsphere] verify VSAN storage capability with valid objectSpaceReservation and iopsLimit values is honored for dynamically provisioned pvc using storageclass" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: dir] One pod requesting one prebound PVC should be able to mount volume and read from pod1" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] NetworkPolicy NetworkPolicy between server and client should support a &#39;default-deny&#39; policy [Feature:NetworkPolicy]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Probing container should be restarted with a docker exec liveness probe with timeout  [Conformance]" classname="Kubernetes e2e suite" time="6.084985122">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gluster] should support non-existent path" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gluster] should support existing single file" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Job should run a job to completion when tasks sometimes fail and are not locally restarted" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [Feature:Example] [k8s.io] CassandraStatefulSet should create statefulset" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gcePDPartitioned] should unmount if pod is force deleted while kubelet is down [Disruptive][Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Daemon set [Serial] should rollback without unnecessary restarts [Conformance]" classname="Kubernetes e2e suite" time="6.108985074">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Sysctls should not launch unsafe, but not explicitly enabled sysctls on the node" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Kubectl replace should update a single-container pod&#39;s image  [Conformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cluster-lifecycle] gpu Upgrade [Feature:GPUUpgrade] master upgrade should NOT disrupt gpu pod [Feature:GPUMasterUpgrade]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Projected should be consumable from pods in volume as non-root with FSGroup [Feature:FSGroup]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Services should be able to change the type from ExternalName to ClusterIP" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: tmpfs] Two pods mounting a local volume one after the other should be able to write from pod1 and read from pod2" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scalability] Empty [Feature:Empty] starts a pod" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] ResourceQuota should create a ResourceQuota and capture the life of a configMap." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volumes Ceph RBD [Feature:Volumes] should be mountable" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: gce-localssd-scsi-fs] [Serial] Two pods mounting a local volume one after the other should be able to write from pod1 and read from pod2" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Namespaces [Serial] should ensure that all pods are removed when a namespace is deleted." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] vsphere statefulset vsphere statefulset testing" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] EmptyDir volumes should support (root,0666,tmpfs) [Conformance]" classname="Kubernetes e2e suite" time="8.171384892"></testcase>
+      <testcase name="[sig-apps] Job should delete a job" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Firewall rule should have correct firewall rules for e2e cluster" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: emptyDir] should support restarting containers using file as subpath [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: hostPathSymlink] should support existing directories when readOnly specified in the volumeSource" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Network Partition [Disruptive] [Slow] [k8s.io] Pods should be evicted from unready Node [Feature:TaintEviction] All pods on the unreachable node should be marked as NotReady upon the node turn NotReady AND all pods should be evicted after eviction timeout passes" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Networking Granular Checks: Services [Slow] should update nodePort: udp [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Services should release NodePorts on delete" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Kubectl run job should create a job from an image when restart is OnFailure  [Conformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gcePDPVC] should fail if non-existent subpath is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Namespaces [Serial] should delete fast enough (90 percent of 100 namespaces in 150 seconds)" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: nfs] should support restarting containers using directory as subpath [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Kubectl taint [Serial] should remove all the taints with the same key off a node" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Networking Granular Checks: Services [Slow] should function for node-Service: http" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Services should check NodePort out-of-range" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] EmptyDir volumes when FSGroup is specified nonexistent volume subPath should have the correct mode and owner using FSGroup" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-auth] ServiceAccounts should allow opting out of API token automount  [Conformance]" classname="Kubernetes e2e suite" time="6.67514105"></testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gluster] should support file as subpath" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Sysctls should support sysctls" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] EmptyDir volumes when FSGroup is specified volume on default medium should have the correct mode using FSGroup" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PV Protection Verify that PV bound to a PVC is not removed immediately" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] EmptyDir volumes when FSGroup is specified new files should be created with FSGroup ownership when container is root" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Cluster size autoscaler scalability [Slow] should scale up at all [Feature:ClusterAutoscalerScalability1]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] DNS configMap nameserver should be able to change stubDomain configuration [Slow][Serial]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Daemon set [Serial] should not update pod when spec was updated and update strategy is OnDelete" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  Pod with node different from PV&#39;s NodeAffinity should fail scheduling due to different NodeSelector" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Servers with support for API chunking should return chunks of results for list calls" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Storage Policy Based Volume Provisioning [Feature:vsphere] verify if a non-existing SPBM policy is not honored for dynamically provisioned pvc using storageclass" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Projected should be consumable from pods in volume [Conformance]" classname="Kubernetes e2e suite" time="8.114148106"></testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Update Demo should scale a replication controller  [Conformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gcePDPVC] should fail if subpath file is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [sig-node] Security Context [Feature:SecurityContext] should support volume SELinux relabeling when using hostIPC" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Pod Disks schedule pods each with a PD, delete pod and verify detach [Slow] for RW PD with pod delete grace period of &#34;default (30s)&#34;" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: nfs] should support existing single file" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] DisruptionController evictions: maxUnavailable allow single eviction, percentage =&gt; should allow an eviction" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] DisruptionController evictions: enough pods, absolute =&gt; should allow an eviction" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volumes CephFS [Feature:Volumes] should be mountable" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: nfsPVC] should fail if non-existent subpath is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] StatefulSet [k8s.io] Basic StatefulSet functionality [StatefulSetBasic] Should recreate evicted statefulset [Conformance]" classname="Kubernetes e2e suite" time="35.013983412"></testcase>
+      <testcase name="[sig-storage] Volume Placement should create and delete pod with the same volume source attach/detach to different worker nodes" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Storage Policy Based Volume Provisioning [Feature:vsphere] verify VSAN storage capability with valid diskStripes and objectSpaceReservation values is honored for dynamically provisioned pvc using storageclass" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes-local  [Volume type: dir] Two pods mounting a local volume one after the other should be able to write from pod1 and read from pod2" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] ResourceQuota should verify ResourceQuota with terminating scopes." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gcePDPVC] should unmount if pod is gracefully deleted while kubelet is down [Disruptive][Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Deployment deployment should support rollover" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] [HPA] Horizontal pod autoscaling (scale resource: Custom Metrics from Stackdriver) should scale down with Custom Metric of type Object from Stackdriver [Feature:CustomMetricsAutoscaling]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volume Placement should create and delete pod with multiple volumes from same datastore" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Deployment iterative rollouts should eventually progress" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cluster-lifecycle] Reboot [Disruptive] [Feature:Reboot] each node by ordering unclean reboot and ensure they function upon restart" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Kubectl apply apply set/view last-applied" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes NFS with multiple PVs and PVCs all in same ns should create 3 PVs and 3 PVCs: test write access" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gluster] should support restarting containers using directory as subpath [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Servers with support for Table transformation should return generic metadata details across all namespaces for nodes" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Deployment test Deployment ReplicaSet orphaning and adoption regarding controllerRef" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volumes NFS should be mountable" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: emptyDir] should support restarting containers using directory as subpath [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: hostPath] should support existing single file" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: nfsPVC] should support existing directory" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scalability] Density [Feature:ManualPerformance] should allow starting 30 pods per node using {extensions Deployment} with 2 secrets, 0 configmaps and 0 daemons" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] HostPath should support existing single file subPath" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Pod Disks detach in a disrupted environment [Slow] [Disruptive] when node is deleted" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Secrets should be consumable from pods in volume as non-root with defaultMode and fsGroup set  [Conformance]" classname="Kubernetes e2e suite" time="8.19118671"></testcase>
+      <testcase name="[sig-storage] ConfigMap should be consumable from pods in volume with defaultMode set  [Conformance]" classname="Kubernetes e2e suite" time="8.276716198"></testcase>
+      <testcase name="[sig-storage] PersistentVolumes NFS with Single PV - PVC pairs create a PVC and a pre-bound PV: test write access" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Loadbalancing: L7 GCE [Slow] [Feature:Ingress] should not reconcile manually modified health check for ingress" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Networking IPerf IPv6 [Experimental] [Feature:Networking-IPv6] [Slow] [Feature:Networking-Performance] should transfer ~ 1GB onto the service endpoint 1 servers (maximum of 1 clients)" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Networking Granular Checks: Pods should function for intra-pod communication: udp  [Conformance]" classname="Kubernetes e2e suite" time="40.214892945"></testcase>
+      <testcase name="[sig-storage] EmptyDir volumes when FSGroup is specified files with FSGroup ownership should support (root,0644,tmpfs)" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volume Placement test back to back pod creation and deletion with different volume sources on the same worker node" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Projected should be consumable from pods in volume with defaultMode set [Conformance]" classname="Kubernetes e2e suite" time="8.123938126"></testcase>
+      <testcase name="[sig-storage] ConfigMap should be consumable from pods in volume as non-root with defaultMode and fsGroup set [Feature:FSGroup]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cluster-lifecycle] [Feature:BootstrapTokens] should not delete the token secret when the secret is not expired" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] CustomResourceDefinition resources Simple CustomResourceDefinition creating/deleting custom resource definition objects works  [Conformance]" classname="Kubernetes e2e suite" time="7.169299824"></testcase>
+      <testcase name="[sig-storage] Ephemeralstorage When pod refers to non-existent ephemeral storage should allow deletion of pod with invalid volume : secret" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Daemon set [Serial] should retry creating failed daemon pods [Conformance]" classname="Kubernetes e2e suite" time="17.235291599"></testcase>
+      <testcase name="[sig-scheduling] Multi-AZ Clusters should spread the pods of a replication controller across zones" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: hostPath] should support readOnly directory specified in the volumeMount" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Variable Expansion should allow substituting values in a container&#39;s args  [Conformance]" classname="Kubernetes e2e suite" time="10.119608813"></testcase>
+      <testcase name="[sig-network] Network should set TCP CLOSE_WAIT timeout" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scalability] Density [Feature:ManualPerformance] should allow starting 30 pods per node using { ReplicationController} with 0 secrets, 0 configmaps and 2 daemons" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes[Disruptive][Flaky] when kubelet restarts Should test that a volume mounted to a pod that is force deleted while the kubelet is down unmounts when the kubelet returns." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] NoSNAT [Feature:NoSNAT] [Slow] Should be able to send traffic between Pods without SNAT" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Deployment deployment should delete old replica sets" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scalability] Density [Feature:ManualPerformance] should allow starting 30 pods per node using { ReplicationController} with 0 secrets, 0 configmaps and 0 daemons with quotas" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] CronJob should delete successful finished jobs with limit of one successful job" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cluster-lifecycle] ingress Upgrade [Feature:IngressUpgrade] ingress upgrade should maintain a functioning ingress" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Secrets optional updates should be reflected in volume  [Conformance]" classname="Kubernetes e2e suite" time="28.137001737"></testcase>
+      <testcase name="[sig-storage] HostPath should give a volume the correct mode [Conformance]" classname="Kubernetes e2e suite" time="8.166841092"></testcase>
+      <testcase name="[sig-storage] Storage Policy Based Volume Provisioning [Feature:vsphere] verify VSAN storage capability with non-vsan datastore is not honored for dynamically provisioned pvc using storageclass" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: nfsPVC] should support file as subpath" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] SchedulerPreemption [Serial] [Feature:PodPreemption] validates lower priority pod preemption by critical pod" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: emptyDir] should fail if non-existent subpath is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] EmptyDir volumes should support (root,0644,default) [Conformance]" classname="Kubernetes e2e suite" time="8.114815742"></testcase>
+      <testcase name="[sig-storage] Regional PD [Feature:RegionalPD] RegionalPD should provision storage [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gcePDPartitioned] should fail for new directories when readOnly specified in the volumeSource" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [sig-node] kubelet [k8s.io] [sig-node] Clean up pods on node kubelet should be able to delete 10 pods per node in 1m0s." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-auth] Advanced Audit should audit API calls [DisabledForLargeClusters]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] ResourceQuota should create a ResourceQuota and capture the life of a replication controller." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Projected should provide container&#39;s memory request [Conformance]" classname="Kubernetes e2e suite" time="8.260140275"></testcase>
+      <testcase name="[sig-autoscaling] [Feature:ClusterSizeAutoscalingScaleUp] [Slow] Autoscaling [sig-autoscaling] Autoscaling a service from 1 pod and 3 nodes to 8 pods and &gt;=4 nodes takes less than 15 minutes" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Network Partition [Disruptive] [Slow] [k8s.io] [StatefulSet] should not reschedule stateful pods if there is a network partition [Slow] [Disruptive]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] ConfigMap optional updates should be reflected in volume  [Conformance]" classname="Kubernetes e2e suite" time="26.133119518"></testcase>
+      <testcase name="[sig-instrumentation] Stackdriver Monitoring should run Custom Metrics - Stackdriver Adapter [Feature:StackdriverCustomMetrics]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Network Partition [Disruptive] [Slow] [k8s.io] [StatefulSet] should come back up if node goes down [Slow] [Disruptive]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cluster-lifecycle] Upgrade [Feature:Upgrade] node upgrade should maintain a functioning cluster [Feature:NodeUpgrade]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Garbage collector should support cascading deletion of custom resources" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] vcp at scale [Feature:vsphere]  vsphere scale tests" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Projected should provide container&#39;s memory limit [Conformance]" classname="Kubernetes e2e suite" time="8.116441327"></testcase>
+      <testcase name="[k8s.io] Cluster size autoscaler scalability [Slow] should scale up twice [Feature:ClusterAutoscalerScalability2]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes NFS with Single PV - PVC pairs create a PVC and non-pre-bound PV: test write access" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: hostPath] should fail if subpath with backstepping is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [sig-node] kubelet [k8s.io] [sig-node] host cleanup with volume mounts [sig-storage][HostCleanup][Flaky] Host cleanup after disrupting NFS volume [NFS] after stopping the nfs-server and deleting the (sleeping) client pod, the NFS mount and the pod&#39;s UID directory should be removed." classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] should scale up correct target pool [Feature:ClusterSizeAutoscalingScaleUp]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: nfs] should fail if subpath directory is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] DisruptionController evictions: maxUnavailable deny evictions, integer =&gt; should not allow an eviction" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Kubectl run default should create an rc or deployment from an image  [Conformance]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath Atomic writer volumes should support subpaths with projected pod" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Aggregator Should be able to support the 1.7 Sample API Server using the current Aggregator" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volume Provisioning On Clustered Datastore [Feature:vsphere] verify static provisioning on clustered datastore" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Flexvolumes [Disruptive] should install plugin without kubelet restart" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] should scale down when expendable pod is running [Feature:ClusterSizeAutoscalingScaleDown]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Namespaces [Serial] should always delete fast (ALL of 100 namespaces in 150 seconds) [Feature:ComprehensiveNamespaceDraining]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] [Feature:Example] [k8s.io] Liveness liveness pods should be automatically restarted" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Ephemeralstorage When pod refers to non-existent ephemeral storage should allow deletion of pod with invalid volume : configmap" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Pods should have their auto-restart back-off timer reset on image update [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Daemon set [Serial] should run and stop complex daemon with node affinity" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: hostPathSymlink] should support creating multiple subpath from same volumes [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes GCEPD should test that deleting a PVC before the pod does not cause pod deletion to fail on PD detach" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] SchedulerPredicates [Serial] validates MaxPods limit number of pods that are allowed to run [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] EmptyDir volumes when FSGroup is specified volume on tmpfs should have the correct mode using FSGroup" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] EquivalenceCache [Serial] validates GeneralPredicates is properly invalidated when a pod is scheduled [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-auth] ServiceAccounts should mount an API token into pods  [Conformance]" classname="Kubernetes e2e suite" time="12.685251222"></testcase>
+      <testcase name="[sig-network] Loadbalancing: L7 GCE [Slow] [Feature:NEG] should sync endpoints to NEG" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] SchedulerPredicates [Serial] validates that there is no conflict between pods with same hostPort but different hostIP and protocol" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Probing container with readiness probe should not be ready before initial delay and never restart  [Conformance]" classname="Kubernetes e2e suite" time="48.155311506"></testcase>
+      <testcase name="[sig-cluster-lifecycle] Upgrade [Feature:Upgrade] cluster upgrade should maintain a functioning cluster [Feature:ClusterUpgrade]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gcePDPartitioned] should support restarting containers using directory as subpath [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volume Disk Size [Feature:vsphere] verify dynamically provisioned pv using storageclass with an invalid disk size fails" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Downward API volume should provide podname as non-root with fsgroup and defaultMode [Feature:FSGroup]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] shouldn&#39;t add new node group if not needed [Feature:ClusterSizeAutoscalingScaleWithNAP]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cluster-lifecycle] [Feature:BootstrapTokens] should delete the signed bootstrap tokens from clusterInfo ConfigMap when bootstrap token is deleted" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Node Poweroff [Feature:vsphere] [Slow] [Disruptive] verify volume status after node power off" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Loadbalancing: L7 GCE [Slow] [Feature:Ingress] should create ingress with given static-ip" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cluster-lifecycle] ingress Downgrade [Feature:IngressDowngrade] ingress downgrade should maintain a functioning ingress" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-instrumentation] Cluster level logging implemented by Stackdriver should ingest system logs from all nodes [Feature:StackdriverLogging]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] Job should exceed active deadline" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Services should be able to change the type from ExternalName to NodePort" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gluster] should fail if subpath with backstepping is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Node Unregister [Feature:vsphere] [Slow] [Disruptive] node unregister" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Projected should provide podname as non-root with fsgroup [Feature:FSGroup]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-scheduling] Multi-AZ Cluster Volumes [sig-storage] should schedule pods in the same zones as statically provisioned PVs" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: hostPath] should support restarting containers using file as subpath [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gcePDPVC] should fail for new directories when readOnly specified in the volumeSource" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Service endpoints latency should not be very high  [Conformance]" classname="Kubernetes e2e suite" time="29.798050099"></testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: emptyDir] should fail for new directories when readOnly specified in the volumeSource" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] [HPA] Horizontal pod autoscaling (scale resource: CPU) [sig-autoscaling] [Serial] [Slow] ReplicaSet Should scale from 1 pod to 3 pods and from 3 to 5" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl client [k8s.io] Simple pod should support exec through an HTTP proxy" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volume FStype [Feature:vsphere] verify fstype - ext3 formatted volume" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Downward API should provide pod name, namespace and IP address as env vars  [Conformance]" classname="Kubernetes e2e suite" time="10.120612631"></testcase>
+      <testcase name="[k8s.io] Probing container with readiness probe that fails should never be ready and never restart  [Conformance]" classname="Kubernetes e2e suite" time="82.098690978"></testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] should scale up when non expendable pod is created [Feature:ClusterSizeAutoscalingScaleUp]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Volume Provisioning On Clustered Datastore [Feature:vsphere] verify dynamic provision with default parameter on clustered datastore" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Loadbalancing: L7 GCE [Slow] [Feature:Ingress] should create ingress with pre-shared certificate" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: nfsPVC] should support creating multiple subpath from same volumes [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: hostPath] should support file as subpath" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Services should provide secure master service  [Conformance]" classname="Kubernetes e2e suite" time="6.103111386"></testcase>
+      <testcase name="[sig-network] Loadbalancing: L7 [Slow] Nginx should conform to Ingress spec" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] [Serial] Volume metrics PVController should create none metrics for pvc controller before creating any PV or PVC" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Networking Granular Checks: Services [Slow] should update endpoints: http" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Probing container should *not* be restarted with a exec &#34;cat /tmp/health&#34; liveness probe [Conformance]" classname="Kubernetes e2e suite" time="130.21223267"></testcase>
+      <testcase name="[sig-storage] [Serial] Volume metrics PVController should create bound pv/pvc count metrics for pvc controller after creating both pv and pvc" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] shouldn&#39;t scale up if cores limit too low, should scale up after limit is changed [Feature:ClusterSizeAutoscalingScaleWithNAP]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cli] Kubectl Port forwarding [k8s.io] With a server listening on localhost [k8s.io] that expects a client request should support a client that connects, sends DATA, and disconnects" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] should increase cluster size if pod requesting volume is pending [Feature:ClusterSizeAutoscalingScaleUp]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-apps] DaemonRestart [Disruptive] Kubelet should not restart containers across restart" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Servers with support for Table transformation should return a 406 for a backend which does not implement metadata" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Projected should provide podname as non-root with fsgroup and defaultMode [Feature:FSGroup]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-instrumentation] Logging soak [Performance] [Slow] [Disruptive] should survive logging 1KB every 1s seconds, for a duration of 2m0s, scaling up to 1 pods per node" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] ConfigMap should be consumable from pods in volume as non-root with FSGroup [Feature:FSGroup]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[k8s.io] Probing container should *not* be restarted with a /healthz http liveness probe  [Conformance]" classname="Kubernetes e2e suite" time="128.27526937"></testcase>
+      <testcase name="[sig-api-machinery] AdmissionWebhook Should be able to deny pod and configmap creation" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-network] Networking Granular Checks: Services [Slow] should function for node-Service: udp" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] [HPA] Horizontal pod autoscaling (scale resource: CPU) [sig-autoscaling] [Serial] [Slow] ReplicationController Should scale from 1 pod to 3 pods and from 3 to 5 and verify decision stability" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-api-machinery] Initializers [Feature:Initializers] don&#39;t cause replicaset controller creating extra pods if the initializer is not handled [Serial]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] Cluster size autoscaling [Slow] shouldn&#39;t scale up when expendable pod is created [Feature:ClusterSizeAutoscalingScaleUp]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Downward API volume should provide container&#39;s memory request  [Conformance]" classname="Kubernetes e2e suite" time="8.167780751"></testcase>
+      <testcase name="[sig-storage] PersistentVolumes:vsphere should test that deleting the Namespace of a PVC and Pod causes the successful detach of vsphere volume" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: gluster] should fail if subpath directory is outside the volume [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] PersistentVolumes [Feature:ReclaimPolicy] [sig-storage] persistentvolumereclaim:vsphere should retain persistent volume when reclaimPolicy set to retain when associated claim is deleted" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-autoscaling] DNS horizontal autoscaling [Serial] [Slow] kube-dns-autoscaler should scale kube-dns pods when cluster size changed" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-cluster-lifecycle] Reboot [Disruptive] [Feature:Reboot] each node by triggering kernel panic and ensure they function upon restart" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+      <testcase name="[sig-storage] Subpath [Volume type: emptyDir] should support creating multiple subpath from same volumes [Slow]" classname="Kubernetes e2e suite" time="0">
+          <skipped></skipped>
+      </testcase>
+  </testsuite>

--- a/v1.11/cloud-pks/version.txt
+++ b/v1.11/cloud-pks/version.txt
@@ -1,0 +1,2 @@
+Client Version: version.Info{Major:"1", Minor:"11", GitVersion:"v1.11.5", GitCommit:"753b2dbc622f5cc417845f0ff8a77f539a4213ea", GitTreeState:"archive", BuildDate:"2018-11-28T18:36:50Z", GoVersion:"go1.10.3", Compiler:"gc", Platform:"linux/amd64"}
+Server Version: version.Info{Major:"1", Minor:"11", GitVersion:"v1.11.5", GitCommit:"753b2dbc622f5cc417845f0ff8a77f539a4213ea", GitTreeState:"archive", BuildDate:"2018-11-28T18:36:50Z", GoVersion:"go1.10.3", Compiler:"gc", Platform:"linux/amd64"}


### PR DESCRIPTION
These are the conformance tests for Kubernetes 1.11.5 for VMware Cloud PKS.
VMware Cloud PKS was formerly known as VMware Kubernetes Engine (VKE),
and conformance tests for Kubernetes 1.10 were in the v1.10/vke directory.