### PR TITLE
Fix README.md to reference correct nightly conformance tests

### DIFF
--- a/v1.11/openshift/README.md
+++ b/v1.11/openshift/README.md
@@ -22,4 +22,4 @@ To recreate these results
 
     test/extended/conformance-k8s.sh
 
-Nightly conformance tests are run against release branches and reported https://openshift-gce-devel.appspot.com/builds/origin-ci-test/logs/test_branch_origin_extended_conformance_k8s/
+Nightly conformance tests are run against release branches and reported https://openshift-gce-devel.appspot.com/builds/origin-ci-test/logs/periodic-ci-origin-conformance-release-3.11-k8s/


### PR DESCRIPTION
The URL points to a dead build link. The correct one has been inserted.