### PR TITLE
Require e2e test version to match conformance version

### DIFF
--- a/reviewing.md
+++ b/reviewing.md
@@ -12,8 +12,8 @@ Kubernetes for which conformance is being claimed, referenced as the
 3. Verify that the Conformance Version is the current or previous two versions of Kubernetes.
 
 4. Look at `e2e.log`.  Verify that the `major.minor` component of the
-`kube-apiserver version:` log exactly matches the Conformance Version. The
-patch version does not matter.
+`kube-apiserver version:` log and `e2e test version:` both exactly match
+the Conformance Version. The patch version does not matter.
 
 5. Verify that the last line of `e2e.log` says "SUCCESS! -- `N` Passed | 0
 Failed | 0 Pending | `M` Skipped PASS".  The exact value of `N` and `M` don't


### PR DESCRIPTION
I believe this change matches the original intent.