### PR TITLE
Changing links for AKS Engine support on Azure Stack to avoid confusion with Azure support

### DIFF
--- a/v1.13/aks-engine-azurestack/PRODUCT.yaml
+++ b/v1.13/aks-engine-azurestack/PRODUCT.yaml
@@ -1,6 +1,6 @@
 vendor: Microsoft
-name: AKS Engine for Azure Stack
+name: Azure Stack
 version: v0.36.2
-website_url: https://github.com/msazurestackworkloads/aks-engine
-documentation_url: https://github.com/msazurestackworkloads/aks-engine/blob/master/README.md
-product_logo_url: https://landscape.cncf.io/logos/azure-aks-engine.svg
+website_url: https://azure.microsoft.com/en-us/overview/azure-stack/
+documentation_url: https://aka.ms/aksenginedoc
+product_logo_url: https://i1.wp.com/buildazure.com/wp-content/uploads/2017/09/Azure.png


### PR DESCRIPTION
The current tile in Landscape app to show support of Kubernetes on Azure Stack via the AKS Engine is confusing with the original AKS Engine support on Azure (see image attached). Changing description, links and log to make it clear. Notice that the Azure Stack generic logo is the same as the Azure generic log.
![CNCFLanscapeForMicrosoft tiles](https://user-images.githubusercontent.com/1017810/60305077-4c3ab680-98f0-11e9-8a71-8fe5d2fa9449.jpg)
