### PR TITLE
Fix broken link to participation form

### DIFF
--- a/faq.md
+++ b/faq.md
@@ -38,7 +38,7 @@ No. If the software is the same, and just the name has changed, you just need to
 
 ## Is a participation form required per company or per product?
 
-Per product. Each separate product (i.e., different product name) from your company requires a different [participation form](https://github.com/cncf/k8s-conformance/blob/master/participation-form/Certified_Kubernetes_Form.md). We don't need a new form for new versions of an existing product.
+Per product. Each separate product (i.e., different product name) from your company requires a different [participation form](https://github.com/cncf/k8s-conformance/blob/master/participation-form/Certified_Kubernetes_Form.pdf). We don't need a new form for new versions of an existing product.
 
 ## Are there any limitations regarding the logo?
 


### PR DESCRIPTION
this was going to a md page, but it now goes to a pdf

### Pre-submission checklist:

*Please check each of these after submitting your pull request:*

* [x] If this is a new entry, have you submitted a signed [participation form](https://github.com/cncf/k8s-conformance/tree/master/participation-form)?
* [x] Did you include the product/project logo in SVG, EPS or AI format?  
* [x] Does your logo clearly state the name of the product/project and follow the other logo [guidelines](https://github.com/cncf/landscape#logos)?
* [x] If your product/project is open source, did you include the `repo_url`?
* [x] Did you copy and paste the [installation and configuration instructions](https://github.com/cncf/k8s-conformance/blob/master/faq.md#can-i-provide-a-link-to-the-installation-directions) into the README.md file in addition to linking to them?
