### PR TITLE
Rename Loodse to Kubermatic

### DIFF
--- a/v1.10/kubermatic/PRODUCT.yaml
+++ b/v1.10/kubermatic/PRODUCT.yaml
@@ -1,4 +1,4 @@
-vendor: Loodse
+vendor: Kubermatic
 name: Kubermatic Container Engine
 version: v2.5.8
 website_url: https://loodse.com

--- a/v1.10/kubermatic/PRODUCT.yaml
+++ b/v1.10/kubermatic/PRODUCT.yaml
@@ -1,5 +1,5 @@
 vendor: Kubermatic
-name: Kubermatic Container Engine
+name: Kubermatic Kubernetes Platform
 version: v2.5.8
 website_url: https://loodse.com
 documentation_url: https://loodse.com

--- a/v1.11/kubermatic/PRODUCT.yaml
+++ b/v1.11/kubermatic/PRODUCT.yaml
@@ -1,4 +1,4 @@
-vendor: Loodse
+vendor: Kubermatic
 name: Kubermatic Container Engine
 version: v2.6
 website_url: https://loodse.com

--- a/v1.11/kubermatic/PRODUCT.yaml
+++ b/v1.11/kubermatic/PRODUCT.yaml
@@ -1,5 +1,5 @@
 vendor: Kubermatic
-name: Kubermatic Container Engine
+name: Kubermatic Kubernetes Platform
 version: v2.6
 website_url: https://loodse.com
 documentation_url: https://docs.kubermatic.io/

--- a/v1.12/kubermatic/PRODUCT.yaml
+++ b/v1.12/kubermatic/PRODUCT.yaml
@@ -1,4 +1,4 @@
-vendor: Loodse
+vendor: Kubermatic
 name: Kubermatic Container Engine
 version: v2.8
 website_url: https://loodse.com

--- a/v1.12/kubermatic/PRODUCT.yaml
+++ b/v1.12/kubermatic/PRODUCT.yaml
@@ -1,5 +1,5 @@
 vendor: Kubermatic
-name: Kubermatic Container Engine
+name: Kubermatic Kubernetes Platform
 version: v2.8
 website_url: https://loodse.com
 documentation_url: https://docs.kubermatic.io/

--- a/v1.13/kubermatic/PRODUCT.yaml
+++ b/v1.13/kubermatic/PRODUCT.yaml
@@ -1,5 +1,5 @@
 vendor: Kubermatic
-name: Kubermatic Container Engine
+name: Kubermatic Kubernetes Platform
 version: v2.10
 website_url: https://loodse.com
 documentation_url: https://docs.kubermatic.io/

--- a/v1.13/kubermatic/PRODUCT.yaml
+++ b/v1.13/kubermatic/PRODUCT.yaml
@@ -1,4 +1,4 @@
-vendor: Loodse
+vendor: Kubermatic
 name: Kubermatic Container Engine
 version: v2.10
 website_url: https://loodse.com

--- a/v1.14/kubeone/PRODUCT.yaml
+++ b/v1.14/kubeone/PRODUCT.yaml
@@ -1,4 +1,4 @@
-vendor: Loodse
+vendor: Kubermatic
 name: KubeOne
 version: v0.8.0
 website_url: https://kubeone.io

--- a/v1.14/kubermatic/PRODUCT.yaml
+++ b/v1.14/kubermatic/PRODUCT.yaml
@@ -1,5 +1,5 @@
 vendor: Kubermatic
-name: Kubermatic Container Engine
+name: Kubermatic Kubernetes Platform
 version: v2.10
 website_url: https://loodse.com
 documentation_url: https://docs.kubermatic.io/

--- a/v1.14/kubermatic/PRODUCT.yaml
+++ b/v1.14/kubermatic/PRODUCT.yaml
@@ -1,4 +1,4 @@
-vendor: Loodse
+vendor: Kubermatic
 name: Kubermatic Container Engine
 version: v2.10
 website_url: https://loodse.com

--- a/v1.15/kubeone/PRODUCT.yaml
+++ b/v1.15/kubeone/PRODUCT.yaml
@@ -1,4 +1,4 @@
-vendor: Loodse
+vendor: Kubermatic
 name: KubeOne
 version: v0.9.2
 website_url: https://kubeone.io

--- a/v1.15/kubermatic/PRODUCT.yaml
+++ b/v1.15/kubermatic/PRODUCT.yaml
@@ -1,4 +1,4 @@
-vendor: Loodse
+vendor: Kubermatic
 name: Kubermatic Container Engine
 version: v2.11
 website_url: https://loodse.com

--- a/v1.15/kubermatic/PRODUCT.yaml
+++ b/v1.15/kubermatic/PRODUCT.yaml
@@ -1,5 +1,5 @@
 vendor: Kubermatic
-name: Kubermatic Container Engine
+name: Kubermatic Kubernetes Platform
 version: v2.11
 website_url: https://loodse.com
 documentation_url: https://docs.kubermatic.io/

--- a/v1.16/kubeone/PRODUCT.yaml
+++ b/v1.16/kubeone/PRODUCT.yaml
@@ -1,4 +1,4 @@
-vendor: Loodse
+vendor: Kubermatic
 name: KubeOne
 version: v0.10.0
 website_url: https://kubeone.io

--- a/v1.16/kubermatic/PRODUCT.yaml
+++ b/v1.16/kubermatic/PRODUCT.yaml
@@ -1,5 +1,5 @@
 vendor: Kubermatic
-name: Kubermatic Container Engine
+name: Kubermatic Kubernetes Platform
 version: v2.12
 website_url: https://loodse.com
 documentation_url: https://docs.kubermatic.io/

--- a/v1.16/kubermatic/PRODUCT.yaml
+++ b/v1.16/kubermatic/PRODUCT.yaml
@@ -1,4 +1,4 @@
-vendor: Loodse
+vendor: Kubermatic
 name: Kubermatic Container Engine
 version: v2.12
 website_url: https://loodse.com

--- a/v1.17/kubeone/PRODUCT.yaml
+++ b/v1.17/kubeone/PRODUCT.yaml
@@ -1,4 +1,4 @@
-vendor: Loodse
+vendor: Kubermatic
 name: KubeOne
 version: v0.11.0
 website_url: https://kubeone.io

--- a/v1.18/kubeone/PRODUCT.yaml
+++ b/v1.18/kubeone/PRODUCT.yaml
@@ -1,4 +1,4 @@
-vendor: Loodse
+vendor: Kubermatic
 name: KubeOne
 version: v0.11.1
 website_url: https://kubeone.io

--- a/v1.7/kubermatic/PRODUCT.yaml
+++ b/v1.7/kubermatic/PRODUCT.yaml
@@ -1,4 +1,4 @@
-vendor: Loodse
+vendor: Kubermatic
 name: Kubermatic Container Engine 
 version: v1.4
 website_url: https://loodse.io

--- a/v1.7/kubermatic/PRODUCT.yaml
+++ b/v1.7/kubermatic/PRODUCT.yaml
@@ -1,5 +1,5 @@
 vendor: Kubermatic
-name: Kubermatic Container Engine 
+name: Kubermatic Kubernetes Platform 
 version: v1.4
 website_url: https://loodse.io
 documentation_url: https://loodse.io

--- a/v1.8/kubermatic/PRODUCT.yaml
+++ b/v1.8/kubermatic/PRODUCT.yaml
@@ -1,4 +1,4 @@
-vendor: Loodse
+vendor: Kubermatic
 name: Kubermatic Container Engine
 version: v2.0
 website_url: https://loodse.io

--- a/v1.8/kubermatic/PRODUCT.yaml
+++ b/v1.8/kubermatic/PRODUCT.yaml
@@ -1,5 +1,5 @@
 vendor: Kubermatic
-name: Kubermatic Container Engine
+name: Kubermatic Kubernetes Platform
 version: v2.0
 website_url: https://loodse.io
 documentation_url: https://loodse.io

--- a/v1.9/kubermatic/PRODUCT.yaml
+++ b/v1.9/kubermatic/PRODUCT.yaml
@@ -1,4 +1,4 @@
-vendor: Loodse
+vendor: Kubermatic
 name: Kubermatic Container Engine
 version: v2.3
 website_url: https://loodse.com

--- a/v1.9/kubermatic/PRODUCT.yaml
+++ b/v1.9/kubermatic/PRODUCT.yaml
@@ -1,5 +1,5 @@
 vendor: Kubermatic
-name: Kubermatic Container Engine
+name: Kubermatic Kubernetes Platform
 version: v2.3
 website_url: https://loodse.com
 documentation_url: https://loodse.com


### PR DESCRIPTION
This PR renames Loodse to Kubermatic, as the company got renamed in June. For the source and confirmation on the name change, you check [our announcement blog post](https://www.kubermatic.com/blog/kubermatic-open-sources-kubermatic-kubernetes-platform/).

The v1.19 entry for KubeOne has already has the vendor set to Kubermatic.