### PR TITLE
Fix Kubermatic product logo links

### DIFF
--- a/v1.17/kubermatic/PRODUCT.yaml
+++ b/v1.17/kubermatic/PRODUCT.yaml
@@ -6,4 +6,4 @@ website_url: https://kubermatic.com
 documentation_url: https://docs.kubermatic.com/kubermatic/
 repo_url: https://github.com/kubermatic/kubermatic
 type: Distribution
-product_logo_url: https://drive.google.com/file/d/1Y73nNAI4qkLA3bbf6mmLN7hagjd2Z3s_/view?usp=sharing
+product_logo_url: https://www.kubermatic.com/static/kubermatic-kubernetes-platform.svg

--- a/v1.18/kubermatic/PRODUCT.yaml
+++ b/v1.18/kubermatic/PRODUCT.yaml
@@ -6,4 +6,4 @@ website_url: https://kubermatic.com
 documentation_url: https://docs.kubermatic.com/kubermatic/
 repo_url: https://github.com/kubermatic/kubermatic
 type: Distribution
-product_logo_url: https://drive.google.com/file/d/1Y73nNAI4qkLA3bbf6mmLN7hagjd2Z3s_/view?usp=sharing
+product_logo_url: https://www.kubermatic.com/static/kubermatic-kubernetes-platform.svg

--- a/v1.19/kubermatic/PRODUCT.yaml
+++ b/v1.19/kubermatic/PRODUCT.yaml
@@ -6,4 +6,4 @@ website_url: https://kubermatic.com
 documentation_url: https://docs.kubermatic.com/kubermatic/
 repo_url: https://github.com/kubermatic/kubermatic
 type: Distribution
-product_logo_url: https://drive.google.com/file/d/1Y73nNAI4qkLA3bbf6mmLN7hagjd2Z3s_/view?usp=sharing
+product_logo_url: https://www.kubermatic.com/static/kubermatic-kubernetes-platform.svg

--- a/v1.20/kubermatic/PRODUCT.yaml
+++ b/v1.20/kubermatic/PRODUCT.yaml
@@ -6,4 +6,4 @@ website_url: https://kubermatic.com
 documentation_url: https://docs.kubermatic.com/kubermatic/
 repo_url: https://github.com/kubermatic/kubermatic
 type: Distribution
-product_logo_url: https://drive.google.com/file/d/1Y73nNAI4qkLA3bbf6mmLN7hagjd2Z3s_/view?usp=sharing
+product_logo_url: https://www.kubermatic.com/static/kubermatic-kubernetes-platform.svg

--- a/v1.21/kubermatic/PRODUCT.yaml
+++ b/v1.21/kubermatic/PRODUCT.yaml
@@ -6,4 +6,4 @@ website_url: https://kubermatic.com
 documentation_url: https://docs.kubermatic.com/kubermatic/
 repo_url: https://github.com/kubermatic/kubermatic
 type: Distribution
-product_logo_url: https://drive.google.com/file/d/1Y73nNAI4qkLA3bbf6mmLN7hagjd2Z3s_/view?usp=sharing
+product_logo_url: https://www.kubermatic.com/static/kubermatic-kubernetes-platform.svg

--- a/v1.22/kubermatic/PRODUCT.yaml
+++ b/v1.22/kubermatic/PRODUCT.yaml
@@ -6,4 +6,4 @@ website_url: https://kubermatic.com
 documentation_url: https://docs.kubermatic.com/kubermatic/
 repo_url: https://github.com/kubermatic/kubermatic
 type: Distribution
-product_logo_url: https://drive.google.com/file/d/1Y73nNAI4qkLA3bbf6mmLN7hagjd2Z3s_/view?usp=sharing
+product_logo_url: https://www.kubermatic.com/static/kubermatic-kubernetes-platform.svg


### PR DESCRIPTION
We accidentally (re)moved the logo in our Google Drive and broke the link. This PR fixes the logo across all Kubermatic releases. I'm sorry for the inconvenience.

### Pre-submission checklist:

*Please check each of these after submitting your pull request:*

* [x] If this is a new entry, have you submitted a signed [participation form](https://github.com/cncf/k8s-conformance/tree/master/participation-form)?
* [x] Did you include the product/project logo in SVG, EPS or AI format?  
* [x] Does your logo clearly state the name of the product/project and follow the other logo [guidelines](https://github.com/cncf/landscape#logos)?
* [x] If your product/project is open source, did you include the `repo_url`?
* [x] Did you copy and paste the [installation and configuration instructions](https://github.com/cncf/k8s-conformance/blob/master/faq.md#can-i-provide-a-link-to-the-installation-directions) into the README.md file in addition to linking to them?
