### PR TITLE
Move konvoy product's Vendor to Nutanix

### DIFF
--- a/v1.27/konvoy/PRODUCT.yaml
+++ b/v1.27/konvoy/PRODUCT.yaml
@@ -1,4 +1,4 @@
-vendor: D2iQ
+vendor: Nutanix
 name: Konvoy
 version: v2.7.0-dev.4
 website_url: https://d2iq.com/products/konvoy


### PR DESCRIPTION
The Konvoy product is no longer managed by D2IQ. This product will be own and managed by Nutanix going forward.
The product and documentation URL will remain the same.
Updating Vendor entry for 1.27 k8s conformance tests. 
### Pre-submission checklist:
```
vendor: Nutanix
name: Konvoy
version: v2.7.0-dev.4
website_url: https://d2iq.com/products/konvoy
documentation_url: https://d2iq.com/products/konvoy
product_logo_url: https://assets.d2iq.com/production/assets/D2iQ-logo.svg
type: distribution
description: 'Konvoy is a standalone distribution of Kubernetes that includes a native Kubernetes cluster pre-packaged for deployment with a complement of best-in-class add-on services enabled by default and ready for immediate use.'
contact_email_address: eng-tag@d2iq.com

```
*Please check each of these after submitting your pull request:*

* [ ] If this is a new entry, have you submitted a signed [participation form](https://github.com/cncf/k8s-conformance/tree/master/participation-form)?
* [X] Did you include the product/project logo in SVG, EPS or AI format?  
* [X] Does your logo clearly state the name of the product/project and follow the other logo [guidelines](https://github.com/cncf/landscape#logos)?
* [ ] If your product/project is open source, did you include the `repo_url`?
* [x] Did you copy and paste the [installation and configuration instructions](https://github.com/cncf/k8s-conformance/blob/master/faq.md#can-i-provide-a-link-to-the-installation-directions) into the README.md file in addition to linking to them?

For a full list of requirements, please refer to these sections of the docs: [_Contents of the PR_](https://github.com/cncf/k8s-conformance/blob/master/instructions.md#contents-of-the-pr), and [_Requirements_](https://github.com/cncf/k8s-conformance/blob/master/instructions.md#requirements).
