### PR TITLE
fix: Exoscale product name

### DIFF
--- a/v1.29/exoscale/PRODUCT.yaml
+++ b/v1.29/exoscale/PRODUCT.yaml
@@ -1,5 +1,5 @@
 vendor: Exoscale
-name: Exoscale Simple Kubernetes Service
+name: Exoscale Scalable Kubernetes Service
 version: v1.29.0
 website_url: https://www.exoscale.com/sks/
 documentation_url: https://community.exoscale.com/documentation/sks/


### PR DESCRIPTION
As per the official documentation, the correct product name for Exoscale SKS is "Scalable" Kubernetes Service (instead of "Simple").

REF: https://community.exoscale.com/documentation/sks/overview/#presentation

### Pre-submission checklist:

*Please check each of these after submitting your pull request:*

* [ ] If this is a new entry, have you submitted a signed [participation form](https://github.com/cncf/k8s-conformance/tree/master/participation-form)?
* [ ] Did you include the product/project logo in SVG, EPS or AI format?  
* [ ] Does your logo clearly state the name of the product/project and follow the other logo [guidelines](https://github.com/cncf/landscape#logos)?
* [ ] If your product/project is open source, did you include the `repo_url`?
* [ ] Did you copy and paste the [installation and configuration instructions](https://github.com/cncf/k8s-conformance/blob/master/faq.md#can-i-provide-a-link-to-the-installation-directions) into the README.md file in addition to linking to them?

For a full list of requirements, please refer to these sections of the docs: [_Contents of the PR_](https://github.com/cncf/k8s-conformance/blob/master/instructions.md#contents-of-the-pr), and [_Requirements_](https://github.com/cncf/k8s-conformance/blob/master/instructions.md#requirements).
