### PR TITLE
Update conformance test instructions for v1.28/ibm-openshift

### DIFF
--- a/v1.28/ibm-openshift/README.md
+++ b/v1.28/ibm-openshift/README.md
@@ -38,6 +38,13 @@ ibmcloud oc cluster get --cluster conformance
 ibmcloud oc workers --cluster conformance
 ```
 
+If you created a cluster on VPC infrastructure, you must disable outbound traffic
+protection in order to run the conformance tests.
+
+```
+ibmcloud oc vpc outbound-traffic-protection disable -f --cluster conformance
+```
+
 Wait for the OpenShift cluster operators to become available.
 
 ```


### PR DESCRIPTION
Add instructions for disabling outbound traffic protection in order to run conformance testing on a cluster created on VPC infrastructure.

Signed-off-by: Richard Theis <rtheis@us.ibm.com>
