### PR TITLE
chore: only run workflows on cncf/k8s-conformance

### DIFF
--- a/.github/workflows/check-conformance-test-suite-documentation.yml
+++ b/.github/workflows/check-conformance-test-suite-documentation.yml
@@ -7,6 +7,7 @@ on:
 
 jobs:
   check-conformance-test-suite-documentation:
+    if: ${{ github.repository == 'cncf/k8s-conformance' }}
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/.github/workflows/verify-conformance.yml
+++ b/.github/workflows/verify-conformance.yml
@@ -10,6 +10,7 @@ on:
 
 jobs:
   verify-conformance:
+    if: ${{ github.repository == 'cncf/k8s-conformance' }}
     runs-on: ubuntu-latest
     steps:
       - name: write-config


### PR DESCRIPTION
prevent running on forks
