### PR TITLE
chore: set name for verify-conformance workflow

### DIFF
--- a/.github/workflows/verify-conformance.yml
+++ b/.github/workflows/verify-conformance.yml
@@ -1,3 +1,4 @@
+name: verify-conformance
 on:
   workflow_dispatch: {}
   schedule:


### PR DESCRIPTION
display as name instead of path of workflow
