### PR TITLE
Use go install for installing sonobuoy

### DIFF
--- a/instructions.md
+++ b/instructions.md
@@ -19,7 +19,7 @@ currently supported versions of kubernetes.
 Download a [binary release](https://github.com/vmware-tanzu/sonobuoy/releases) of the CLI, or build it yourself by running:
 
 ```
-go get -u -v github.com/vmware-tanzu/sonobuoy
+go install github.com/vmware-tanzu/sonobuoy@latest
 ```
 
 Deploy a Sonobuoy pod to your cluster with:
@@ -170,7 +170,7 @@ Combining the steps provided here, the process looks like this:
 $ k8s_version=vX.Y
 $ prod_name=example
 
-$ go get -u -v github.com/vmware-tanzu/sonobuoy
+$ go install github.com/vmware-tanzu/sonobuoy@latest
 
 $ sonobuoy run --mode=certified-conformance --wait
 $ outfile=$(sonobuoy retrieve)


### PR DESCRIPTION
As `go get` is deperecated to use outside of a module, see:
```
go: go.mod file not found in current directory or any parent directory.
        'go get' is no longer supported outside a module.
        To build and install a command, use 'go install' with a version,
        like 'go install example.com/cmd@latest'
        For more information, see https://golang.org/doc/go-get-install-deprecation
        or run 'go help get' or 'go help install'.
```
A more convenient way to install sonobuoy is via `go install`.