### PR TITLE
Update stable.txt url

### DIFF
--- a/docs/check-conformance-test-suite-docs.sh
+++ b/docs/check-conformance-test-suite-docs.sh
@@ -12,7 +12,7 @@ echo "GITHUB_WORKSPACE=$GITHUB_WORKSPACE"
 function init_settings() {
   TEST_SUITE_DOCUMENT="unchecked"
 
-  STABLE_VERSION="$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)"
+  STABLE_VERSION="$(curl -s https://dl.k8s.io/release/stable.txt)"
   echo "STABLE_VERSION: $STABLE_VERSION"
   
   RELEASE_VERSION="$(echo "$STABLE_VERSION" | awk -F '.' '{print $1 "." $2}').0"


### PR DESCRIPTION
The location used to check the current stable version of Kubernetes has been moved to [dl.k8s.io](https://dl.k8s.io/release/stable.txt) from [storage.googleapis.com](https://storage.googleapis.com/kubernetes-release/release/stable.txt)

This PR addresses the above change.
