### PR TITLE
ci(verify-conformance): permissions: {}

### DIFF
--- a/.github/workflows/verify-conformance.yml
+++ b/.github/workflows/verify-conformance.yml
@@ -9,6 +9,10 @@ on:
 
 # TODO(BobyMCbobs): auto update image, but don't use latest tag
 
+# Authentication uses a GitHub App (GH_APP_ID + GH_APP_PRIVATE_KEY + GH_APP_HMAC);
+# default GITHUB_TOKEN is unused. No checkout step.
+permissions: {}
+
 jobs:
   verify-conformance:
     if: ${{ github.repository == 'cncf/k8s-conformance' }}


### PR DESCRIPTION
The scheduled verify-conformance workflow authenticates exclusively through a dedicated GitHub App (`GH_APP_ID` + `GH_APP_PRIVATE_KEY` + `GH_APP_HMAC` secrets passed to the `verify-conformance` container) and never uses the default `GITHUB_TOKEN`. There's also no checkout step, so `permissions: {}` (deny-all) is the most accurate scope for the default token.

YAML validated locally.