### PR TITLE
update verify conformance for k8s v1.37

### DIFF
--- a/.github/workflows/verify-conformance.yml
+++ b/.github/workflows/verify-conformance.yml
@@ -17,7 +17,7 @@ jobs:
   verify-conformance:
     if: ${{ github.repository == 'cncf/k8s-conformance' }}
     env:
-      IMAGE: gcr.io/k8s-staging-apisnoop/verify-conformance@sha256:9b83ebc4d8a59c5c78738bf8dbb5819ca55ef3f2f4a7f6c90028cfbedd832baa
+      IMAGE: gcr.io/k8s-staging-apisnoop/verify-conformance@sha256:a66e554437893eeede7447e73fff739e389a683371cdc17d3d253450fa89fa63
     runs-on: ubuntu-latest
     steps:
       - name: write-config


### PR DESCRIPTION
Verify conformance update for Kubernetes v1.37

The supported versions will be: v1.37, v1.36, and v1.35 after the merge.